### PR TITLE
github workflow

### DIFF
--- a/.github/coverage.sh
+++ b/.github/coverage.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e -u
+
+perc=`go tool cover -func=coverage-check.out | tail -n 1 | sed -Ee 's!^[^[:digit:]]+([[:digit:]]+(\.[[:digit:]]+))%$!\1!'`
+res=`echo "$perc >= 80.0" | bc`
+test "$res" -eq 1 && exit 0
+echo "Insufficient coverage: $perc" >&2
+exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,63 @@
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+
+name: run tests
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.15.x
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Run linters
+      uses: golangci/golangci-lint-action@v2
+      with:
+        version: v1.29
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install Go
+      if: success()
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.15.x
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Run tests
+      run: go test ./...
+
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install Go
+      if: success()
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.15.x
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Calc coverage
+      run: |
+        go test -v -covermode=count -coverprofile=coverage.out
+    - name: copy coverage
+      run: cp coverage.out coverage-check.out
+    - name: Convert coverage.out to coverage.lcov
+      uses: jandelgado/gcov2lcov-action@v1.0.6
+    - name: Coveralls
+      uses: coverallsapp/github-action@v1.1.2
+      with:
+          github-token: ${{ secrets.github_token }}
+          path-to-lcov: coverage.lcov
+    - name: Check coverage percent
+      run: ./.github/coverage.sh

--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+# weave-gitops
+Weave GitOps core
+
+[![Coverage Status](https://coveralls.io/repos/github/weaveworks/weave-gitops/badge.svg?branch=master&t=Yv0GnU)](https://coveralls.io/github/weaveworks/weave-gitops?branch=master)


### PR DESCRIPTION
Added test to fail if code coverage is less than 80%
Added ability to manually kick off a workflow from ui
Upload coverage to coveralls
Add code coverage badge to readme

Not sure why github actions isnt running on this pr but since i was testing this code in a private repo i think i have to merge this to get them to start running. Then on future pr's it will work.