### PR TITLE
Custom coverage check to show failure in actions history

### DIFF
--- a/.github/coverage.sh
+++ b/.github/coverage.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e -u
+
+perc=`go tool cover -func=coverage-check.out | tail -n 1 | sed -Ee 's!^[^[:digit:]]+([[:digit:]]+(\.[[:digit:]]+))%$!\1!'`
+res=`echo "$perc >= 80.0" | bc`
+test "$res" -eq 1 && exit 0
+echo "Insufficient coverage: $perc" >&2
+exit 1

--- a/.github/coverage.sh
+++ b/.github/coverage.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-set -e -u
-
-perc=`go tool cover -func=coverage-check.out | tail -n 1 | sed -Ee 's!^[^[:digit:]]+([[:digit:]]+(\.[[:digit:]]+))%$!\1!'`
-res=`echo "$perc >= 80.0" | bc`
-test "$res" -eq 1 && exit 0
-echo "Insufficient coverage: $perc" >&2
-exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,8 @@
 
 on:
   push:
+    branches:
+      - master
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,11 +1,7 @@
 
 on:
   push:
-    branches:
-      - master
   pull_request:
-    branches:
-      - master
   workflow_dispatch:
 
 name: run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,8 +48,6 @@ jobs:
     - name: Calc coverage
       run: |
         go test -v -covermode=count -coverprofile=coverage.out
-    - name: copy coverage
-      run: cp coverage.out coverage-check.out
     - name: Convert coverage.out to coverage.lcov
       uses: jandelgado/gcov2lcov-action@v1.0.6
     - name: Coveralls
@@ -57,5 +55,3 @@ jobs:
       with:
           github-token: ${{ secrets.github_token }}
           path-to-lcov: coverage.lcov
-    - name: Check coverage percent
-      run: ./.github/coverage.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,8 @@ jobs:
     - name: Calc coverage
       run: |
         go test -v -covermode=count -coverprofile=coverage.out
+    - name: copy coverage
+      run: cp coverage.out coverage-check.out
     - name: Convert coverage.out to coverage.lcov
       uses: jandelgado/gcov2lcov-action@v1.0.6
     - name: Coveralls
@@ -55,3 +57,5 @@ jobs:
       with:
           github-token: ${{ secrets.github_token }}
           path-to-lcov: coverage.lcov
+    - name: Check coverage percent
+      run: ./.github/coverage.sh

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/weaveworks/weave-gitops
+
+go 1.16
+
+require github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,11 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main.go
+++ b/main.go
@@ -2,6 +2,10 @@ package main
 
 import "fmt"
 
-func main(){
+func main() {
 	fmt.Println("Hello World!")
+}
+
+func test() string {
+	return "test"
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMain(t *testing.T) {
+	result := test()
+	require.Equal(t, "test", result)
+}


### PR DESCRIPTION
@jrryjcksn @palemtnrider I am leaving it up to you guys if this is something that we want. Circle ci was worked the same way as github actions where the coveralls check didnt show up in the history. It only shows up on the PR. If we want this custom step then it will show in the history if it failed.