### PR TITLE
fix target branch for changelog

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -19,5 +19,5 @@ jobs:
           docker run --rm -v "${GITHUB_WORKSPACE}":"/usr/local/src/your-app" ferrarimarco/github-changelog-generator -u weaveworks -p weave-gitops
           git add .
           git commit -m "Created changelog"
-          git push origin HEAD:master
+          git push origin HEAD:main
 


### PR DESCRIPTION
I tested the changelog generation on a repository with a master branch and forgot to set it to "main" when I put it back into WEGO