### PR TITLE
set eventually default timeout to 1 min

### DIFF
--- a/test/acceptance/test/acceptance_suite_test.go
+++ b/test/acceptance/test/acceptance_suite_test.go
@@ -22,6 +22,7 @@ func TestAcceptance(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
+	SetDefaultEventuallyTimeout(EVENTUALLY_DEFAULT_TIME_OUT)
 	WEGO_BIN_PATH = os.Getenv("WEGO_BIN_PATH")
 	if WEGO_BIN_PATH == "" {
 		WEGO_BIN_PATH = "/usr/local/bin/wego"

--- a/test/acceptance/test/utils.go
+++ b/test/acceptance/test/utils.go
@@ -2,3 +2,7 @@
 * All common util functions and golbal constants will go here.
 **/
 package acceptance
+
+import "time"
+
+const EVENTUALLY_DEFAULT_TIME_OUT time.Duration = 60 * time.Second


### PR DESCRIPTION
This PR sets the default timeout for eventually assertions to 1 minute.