### PR TITLE
Switch kind action for darwin support

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,11 +18,11 @@ jobs:
       with:
         go-version: 1.16.x
     - name: Setup Kubernetes
-      uses: engineerd/setup-kind@v0.5.0
+      uses: helm/kind-action@v1.1.0
       with:
-        name: "${{ format('katc-{0}', github.run_id) }}"
+        cluster_name: "${{ format('katc-{0}', github.run_id) }}"
         version: "v0.10.0"
-        image: kindest/node:v1.20.2@sha256:8f7ea6e7642c0da54f04a7ee10431549c0257315b3a634f6ef2fecaaedb19bab
+        node_image: kindest/node:v1.20.2@sha256:8f7ea6e7642c0da54f04a7ee10431549c0257315b3a634f6ef2fecaaedb19bab
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Set up ssh agent

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,6 @@ jobs:
       with:
         cluster_name: "${{ format('katc-{0}', github.run_id) }}"
         version: "v0.10.0"
-        node_image: kindest/node:v1.20.2@sha256:8f7ea6e7642c0da54f04a7ee10431549c0257315b3a634f6ef2fecaaedb19bab
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Set up ssh agent

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,7 +71,6 @@ jobs:
       with:
         cluster_name: "${{ format('katc-{0}', github.run_id) }}"
         version: "v0.10.0"
-        node_image: kindest/node:v1.20.2@sha256:8f7ea6e7642c0da54f04a7ee10431549c0257315b3a634f6ef2fecaaedb19bab
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Set up ssh agent

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,11 +67,11 @@ jobs:
       with:
         go-version: 1.16.x
     - name: Setup Kubernetes
-      uses: engineerd/setup-kind@v0.5.0
+      uses: helm/kind-action@v1.1.0
       with:
-        name: "${{ format('katc-{0}', github.run_id) }}"
+        cluster_name: "${{ format('katc-{0}', github.run_id) }}"
         version: "v0.10.0"
-        image: kindest/node:v1.20.2@sha256:8f7ea6e7642c0da54f04a7ee10431549c0257315b3a634f6ef2fecaaedb19bab
+        node_image: kindest/node:v1.20.2@sha256:8f7ea6e7642c0da54f04a7ee10431549c0257315b3a634f6ef2fecaaedb19bab
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Set up ssh agent


### PR DESCRIPTION
The action we were using to start `kind` only worked on Linux; the new one _should_ work on Mac. The explicit kind node image was also remove which should help.