### PR TITLE
Disabling argument parsing on flux command

### DIFF
--- a/cmd/wego/flux/cmd.go
+++ b/cmd/wego/flux/cmd.go
@@ -11,10 +11,11 @@ import (
 )
 
 var Cmd = &cobra.Command{
-	Use:     "flux -- [flux commands or flags]",
-	Short:   "Use flux commands",
-	Example: "wego flux -- install -h",
-	Run:     runCmd,
+	Use:                "flux -- [flux commands or flags]",
+	Short:              "Use flux commands",
+	DisableFlagParsing: true,
+	Example:            "wego flux -- install -h",
+	Run:                runCmd,
 }
 
 var StatusCmd = &cobra.Command{
@@ -38,11 +39,8 @@ func runCmd(cmd *cobra.Command, args []string) {
 	c := exec.Command(exePath, args...)
 
 	// run command
-	if output, err := c.CombinedOutput(); err != nil {
-		fmt.Fprintf(shims.Stderr(), "Error: %v\n", err)
-	} else {
-		fmt.Printf("Output: %s\n", output)
-	}
+	output, _ := c.CombinedOutput()
+	fmt.Print(string(output))
 }
 
 func runStatusCmd(cmd *cobra.Command, args []string) {

--- a/cmd/wego/flux/cmd.go
+++ b/cmd/wego/flux/cmd.go
@@ -11,10 +11,10 @@ import (
 )
 
 var Cmd = &cobra.Command{
-	Use:                "flux -- [flux commands or flags]",
+	Use:                "flux [flux commands or flags]",
 	Short:              "Use flux commands",
 	DisableFlagParsing: true,
-	Example:            "wego flux -- install -h",
+	Example:            "wego flux install -h",
 	Run:                runCmd,
 }
 

--- a/pkg/cmdimpl/add.go
+++ b/pkg/cmdimpl/add.go
@@ -215,13 +215,14 @@ func generateSourceManifest() []byte {
 func generateKustomizeManifest() []byte {
 
 	cmd := fmt.Sprintf(`create kustomization "%s" \
-				--path="./" \
+				--path="%s" \
 				--source="%s" \
 				--prune=true \
 				--validation=client \
 				--interval=5m \
 				--export \
 				--namespace=%s`,
+		params.Path,
 		params.Name,
 		params.Name,
 		params.Namespace)

--- a/test/acceptance/test/smoke_tests.go
+++ b/test/acceptance/test/smoke_tests.go
@@ -109,8 +109,8 @@ var _ = Describe("WEGO Acceptance Tests", func() {
 
 	It("Verify that wego flux can print out version information", func() {
 
-		By("When I run 'wego flux -- -v", func() {
-			command := exec.Command(WEGO_BIN_PATH, "flux", "--", "-v")
+		By("When I run 'wego flux -v", func() {
+			command := exec.Command(WEGO_BIN_PATH, "flux", "-v")
 			session, err = gexec.Start(command, GinkgoWriter, GinkgoWriter)
 			Expect(err).ShouldNot(HaveOccurred())
 		})

--- a/test/acceptance/test/smoke_tests.go
+++ b/test/acceptance/test/smoke_tests.go
@@ -116,7 +116,7 @@ var _ = Describe("WEGO Acceptance Tests", func() {
 		})
 
 		By("Then I should see the wego flux version printed in format m.n.n with newline character", func() {
-			Eventually(session).Should(gbytes.Say("Output: flux version [0-3].[0-3][0-9].[0-9]\\d*\n"))
+			Eventually(session).Should(gbytes.Say("flux version [0-3].[0-3][0-9].[0-9]\\d*\n"))
 		})
 	})
 })


### PR DESCRIPTION
We no longer need to use `--` after a flux command.