### PR TITLE
Change .Add() to return an error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,3 +64,6 @@ bin/$(BINARY_NAME)_ui: cmd/ui/main.go
 
 ui-dev:
 	reflex -r '.go' -s -- sh -c 'go run cmd/ui/main.go'
+	
+lint:
+	golangci-lint run --out-format=github-actions --build-tags acceptance

--- a/cmd/wego/add/cmd.go
+++ b/cmd/wego/add/cmd.go
@@ -4,6 +4,7 @@ package add
 // wego installed, the user will be prompted to install wego and then the repository will be added.
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/lithammer/dedent"
 	"github.com/spf13/cobra"
+	"github.com/weaveworks/weave-gitops/pkg/shims"
 )
 
 var params cmdimpl.AddParamSet
@@ -40,5 +42,8 @@ func init() {
 
 func runCmd(cmd *cobra.Command, args []string) {
 	params.Namespace, _ = cmd.Parent().Flags().GetString("namespace")
-	cmdimpl.Add(args, params)
+	if err := cmdimpl.Add(args, params); err != nil {
+		fmt.Fprintf(shims.Stderr(), "%v\n", err)
+		shims.Exit(1)
+	}
 }

--- a/pkg/cmdimpl/add.go
+++ b/pkg/cmdimpl/add.go
@@ -415,7 +415,7 @@ func Add(args []string, allParams AddParamSet) error {
 	case string(DeployTypeKustomize):
 		appManifests, err = generateKustomizeManifest()
 	default:
-		return fmt.Errorf("deployment type not supported [%s]", params.DeploymentType)
+		return fmt.Errorf("deployment type not supported: %s", params.DeploymentType)
 	}
 
 	if err != nil {

--- a/pkg/cmdimpl/add_test.go
+++ b/pkg/cmdimpl/add_test.go
@@ -203,7 +203,7 @@ var _ = Describe("Dry Run Add Test", func() {
 			defer os.Remove(privateKeyFileName)
 			_ = override.WithOverrides(
 				func() override.Result {
-					Add([]string{"."},
+					err := Add([]string{"."},
 						AddParamSet{
 							Name:           "wanda",
 							Url:            "ssh://git@github.com/foobar/quux.git",
@@ -214,6 +214,8 @@ var _ = Describe("Dry Run Add Test", func() {
 							Namespace:      "wego-system",
 							DeploymentType: DeployTypeKustomize,
 						})
+
+					Expect(err).To(BeNil())
 					return override.Result{}
 				},
 				utils.OverrideFailure(utils.CallCommandForEffectWithInputPipeOp),
@@ -240,7 +242,7 @@ var _ = Describe("Add repo with custom access test", func() {
 			defer os.Remove(privateKeyFileName)
 			_ = override.WithOverrides(
 				func() override.Result {
-					Add([]string{"."},
+					err := Add([]string{"."},
 						AddParamSet{
 							Name:           "wanda",
 							Url:            "ssh://git@github.com/foobar/quux.git",
@@ -252,6 +254,8 @@ var _ = Describe("Add repo with custom access test", func() {
 							Namespace:      "wego-system",
 							DeploymentType: DeployTypeKustomize,
 						})
+
+					Expect(err).To(BeNil())
 					return override.Result{}
 				},
 				utils.OverrideFailure(utils.CallCommandForEffectWithInputPipeOp),
@@ -279,13 +283,15 @@ var _ = Describe("Add repo with custom access test", func() {
 				func() override.Result {
 					err := Add([]string{"."},
 						AddParamSet{
-							Name:       "wanda",
-							Url:        "ssh://git@github.com/foobar/quux.git",
-							Path:       "./",
-							Branch:     "main",
-							PrivateKey: privateKeyFileName,
-							DryRun:     true,
-							Namespace:  "wego-system"})
+							Name:           "wanda",
+							Url:            "ssh://git@github.com/foobar/quux.git",
+							Path:           "./",
+							Branch:         "main",
+							PrivateKey:     privateKeyFileName,
+							DryRun:         true,
+							Namespace:      "wego-system",
+							DeploymentType: DeployTypeKustomize,
+						})
 
 					Expect(err).Should(BeNil())
 					return override.Result{}

--- a/pkg/cmdimpl/add_test.go
+++ b/pkg/cmdimpl/add_test.go
@@ -277,18 +277,17 @@ var _ = Describe("Add repo with custom access test", func() {
 			defer os.Remove(privateKeyFileName)
 			_ = override.WithOverrides(
 				func() override.Result {
-					Add([]string{"."},
+					err := Add([]string{"."},
 						AddParamSet{
-							Name:           "wanda",
-							Url:            "ssh://git@github.com/foobar/quux.git",
-							Path:           "./",
-							Branch:         "main",
-							PrivateKey:     privateKeyFileName,
-							DryRun:         true,
-							IsPrivate:      false,
-							Namespace:      "wego-system",
-							DeploymentType: DeployTypeKustomize,
-						})
+							Name:       "wanda",
+							Url:        "ssh://git@github.com/foobar/quux.git",
+							Path:       "./",
+							Branch:     "main",
+							PrivateKey: privateKeyFileName,
+							DryRun:     true,
+							Namespace:  "wego-system"})
+
+					Expect(err).Should(BeNil())
 					return override.Result{}
 				},
 				utils.OverrideFailure(utils.CallCommandForEffectWithInputPipeOp),

--- a/test/acceptance/test/core_operations_test.go
+++ b/test/acceptance/test/core_operations_test.go
@@ -168,12 +168,12 @@ func setupTest() error {
 			return err
 		}
 		defer tmpFile.Close()
-		err = ioutil.WriteFile(tmpFile.Name(), []byte(key), 600)
+		err = ioutil.WriteFile(tmpFile.Name(), []byte(key), 0600)
 		keyFilePath = tmpFile.Name()
 		if err != nil {
 			return err
 		}
-		err = ioutil.WriteFile(keyFilePath, []byte(key), 700)
+		err = ioutil.WriteFile(keyFilePath, []byte(key), 0700)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
In order to wrap the `.Add()` action in a HTTP server, we will need the individual steps to return errors instead of exiting the program. This PR is a first pass at that behavior.

We may need to pass in an `io.Writer` to capture logs in the future, but for now logging via `fmt` is probably fine.