### PR TITLE
Add initial pr template.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+<!-- Describe what has changed in this PR -->
+**What changed?**
+
+
+<!-- Tell your future self why have you made these changes -->
+**Why?**
+
+
+<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
+**How did you test it?**
+
+<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
+**Release notes**
+
+<!-- Are there any documentation updates that should be made for these changes? -->
+**Documentation Changes**


### PR DESCRIPTION
I tend to ask similar questions on many of the PRs I review and thought others might do the same. So I thought having a PR template might help streamline our reviews.