### PR TITLE
Added subcommand app and fixes on giving the app location

### DIFF
--- a/cmd/wego/main.go
+++ b/cmd/wego/main.go
@@ -37,15 +37,23 @@ func configureLogger() {
 	}
 }
 
+var ApplicationCmd = &cobra.Command{
+	Use:  "app [subcommand]",
+	Args: cobra.MinimumNArgs(1),
+}
+
 func main() {
 	fluxBin.SetupFluxBin()
 	rootCmd.PersistentFlags().BoolVarP(&options.verbose, "verbose", "v", false, "Enable verbose output")
 	rootCmd.PersistentFlags().String("namespace", "wego-system", "gitops runtime namespace")
 	rootCmd.AddCommand(install.Cmd)
-	rootCmd.AddCommand(add.Cmd)
 	rootCmd.AddCommand(version.Cmd)
 	rootCmd.AddCommand(flux.Cmd)
-	rootCmd.AddCommand(status.Cmd)
+
+	ApplicationCmd.AddCommand(status.Cmd)
+	ApplicationCmd.AddCommand(add.Cmd)
+
+	rootCmd.AddCommand(ApplicationCmd)
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)

--- a/cmd/wego/status/cmd.go
+++ b/cmd/wego/status/cmd.go
@@ -7,7 +7,7 @@ import (
 
 var Cmd = &cobra.Command{
 	Use:     "status <app-name>",
-	Short:   "Get status of a resource",
+	Short:   "Get status of an app",
 	Args:    cobra.MinimumNArgs(1),
 	Example: "wego app status podinfo",
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/wego/status/cmd.go
+++ b/cmd/wego/status/cmd.go
@@ -6,16 +6,10 @@ import (
 )
 
 var Cmd = &cobra.Command{
-	Use:     "status [subcommands]",
-	Short:   "status of a resource",
+	Use:     "status <app-name>",
+	Short:   "Get status of a resource",
 	Args:    cobra.MinimumNArgs(1),
-	Example: "wego status application podinfo",
-}
-
-var ApplicationCmd = &cobra.Command{
-	Use:   "application [name]",
-	Short: "status of an application resource",
-	Args:  cobra.MinimumNArgs(1),
+	Example: "wego app status podinfo",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		params.Namespace, _ = cmd.Parent().Parent().Flags().GetString("namespace")
 		params.Name = args[0]
@@ -24,7 +18,3 @@ var ApplicationCmd = &cobra.Command{
 }
 
 var params cmdimpl.AddParamSet
-
-func init() {
-	Cmd.AddCommand(ApplicationCmd)
-}

--- a/pkg/cmdimpl/status.go
+++ b/pkg/cmdimpl/status.go
@@ -13,6 +13,7 @@ import (
 
 // Status provides the implementation for the wego status application command
 func Status(allParams AddParamSet) error {
+
 	deploymentType, err := getDeploymentType(allParams.Namespace, allParams.Name)
 	if err != nil {
 		return fmt.Errorf("error getting deployment type [%s]", err)

--- a/test/acceptance/test/add_tests.go
+++ b/test/acceptance/test/add_tests.go
@@ -30,7 +30,7 @@ var _ = Describe("Weave GitOps Add Tests", func() {
 		private := true
 		appManifestFilePath := "./data/nginx.yaml"
 		defaultSshKeyPath := os.Getenv("HOME") + "/.ssh/id_rsa"
-		addCommand := "add . "
+		addCommand := "app add . "
 		appRepoName := "wego-test-app-" + RandString(8)
 		wegoRepoName := getClusterName() + "-wego"
 		appName := wegoRepoName + "-" + appRepoName
@@ -118,7 +118,7 @@ var _ = Describe("Weave GitOps Add Tests", func() {
 		private := true
 		appManifestFilePath := "./data/nginx.yaml"
 		defaultSshKeyPath := os.Getenv("HOME") + "/.ssh/id_rsa"
-		addCommand := "add . --private=true"
+		addCommand := "app add . --private=true"
 		appRepoName := "wego-test-app-" + RandString(8)
 		wegoRepoName := getClusterName() + "-wego"
 		appName := wegoRepoName + "-" + appRepoName
@@ -168,7 +168,7 @@ var _ = Describe("Weave GitOps Add Tests", func() {
 		appManifestFilePath1 := "./data/nginx.yaml"
 		appManifestFilePath2 := "./data/nginx2.yaml"
 		defaultSshKeyPath := os.Getenv("HOME") + "/.ssh/id_rsa"
-		addCommand := "add . "
+		addCommand := "app add . "
 		appRepoName1 := "wego-test-app-" + RandString(8)
 		appRepoName2 := "wego-test-app-" + RandString(8)
 		wegoRepoName := getClusterName() + "-wego"
@@ -244,7 +244,7 @@ var _ = Describe("Weave GitOps Add Tests", func() {
 		appManifestFilePath := "./data/helm-repo/hello-world"
 		defaultSshKeyPath := os.Getenv("HOME") + "/.ssh/id_rsa"
 		appName := "my-helm-app"
-		addCommand := "add . --deployment-type=helm --path=./hello-world --name=" + appName
+		addCommand := "app add . --deployment-type=helm --path=./hello-world --name=" + appName
 		appRepoName := "wego-test-app-" + RandString(8)
 		wegoRepoName := getClusterName() + "-wego"
 
@@ -284,7 +284,7 @@ var _ = Describe("Weave GitOps Add Tests", func() {
 		private := true
 		appManifestFilePath := "./data/nginx.yaml"
 		defaultSshKeyPath := os.Getenv("HOME") + "/.ssh/id_rsa"
-		addCommand := "add . "
+		addCommand := "app add . "
 		appRepoName := "wego-test-app-" + RandString(8)
 		wegoRepoName := getClusterName() + "-wego"
 		var addCommandOutput string


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
- change on wego add and wego status to be:
  wego app add
  wego app status
- Fixes to support two ways of defining an application location
  1.- using url flag
  2.- using the location argument

<!-- Tell your future self why have you made these changes -->
Easier for the user and it avoid sthe need of having a repo cloned so it can be added.

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
Tests were manually with the different options involved. For `wego app add ` in the first scenario I used only the URL and a second one using just the location argument. All results were as expected.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
Changes in the use of add and status:
`wego add` --> `wego app add...`
`wego status` -- > `wego app status...`
