### PR TITLE
Don't add files in user repo to commit when committing .wego contents

### DIFF
--- a/pkg/cmdimpl/add.go
+++ b/pkg/cmdimpl/add.go
@@ -219,7 +219,7 @@ func generateHelmManifestHelm(helmName, chart string) ([]byte, error) {
 	return fluxops.CallFlux(cmd)
 }
 
-func commitAndPush(ctx context.Context, gitClient git.Git) error {
+func commitAndPush(ctx context.Context, gitClient git.Git, filters ...func(string) bool) error {
 	fmt.Fprintf(shims.Stdout(), "Commiting and pushing wego resources for application...\n")
 	if params.DryRun {
 		return nil
@@ -227,7 +227,8 @@ func commitAndPush(ctx context.Context, gitClient git.Git) error {
 	_, err := gitClient.Commit(git.Commit{
 		Author:  git.Author{Name: "Weave Gitops", Email: "weave-gitops@weave.works"},
 		Message: "Add App manifests",
-	})
+	},
+		filters...)
 	if err != nil && err != git.ErrNoStagedFiles {
 		return fmt.Errorf("failed to commit sync manifests: %w", err)
 	}
@@ -368,13 +369,15 @@ func addAppWithConfigInUserRepo(ctx context.Context, gitClient git.Git) error {
 	if err != nil {
 		return wrapError(err, fmt.Sprintf("could not create GitOps automation for '%s'", params.Name))
 	}
-	if err := writeAppYaml(gitClient, appYaml, ".wego"); err != nil {
+	if err := writeAppYaml(gitClient, ".wego", appYaml); err != nil {
 		return err
 	}
 	if err := writeGoats(gitClient, ".wego", applicationGoat); err != nil {
 		return err
 	}
-	return commitAndPush(ctx, gitClient)
+	return commitAndPush(ctx, gitClient, func(fname string) bool {
+		return strings.HasPrefix(fname, ".wego")
+	})
 }
 
 func addAppWithConfigInExternalRepo(ctx context.Context, gitClient git.Git) error {
@@ -423,7 +426,7 @@ func addAppWithConfigInExternalRepo(ctx context.Context, gitClient git.Git) erro
 	if err != nil {
 		return wrapError(err, fmt.Sprintf("could not create GitOps automation for '%s'", params.Name))
 	}
-	if err := writeAppYaml(gitClient, appYaml, "."); err != nil {
+	if err := writeAppYaml(gitClient, ".", appYaml); err != nil {
 		return err
 	}
 	if err := writeGoats(gitClient, "", userRepoSource, userTargetKustomize, userAppKustomize, applicationGoat); err != nil {
@@ -547,7 +550,7 @@ func applyToCluster(manifests ...[]byte) error {
 	return nil
 }
 
-func writeAppYaml(gitClient git.Git, appYaml []byte, basePath string) error {
+func writeAppYaml(gitClient git.Git, basePath string, appYaml []byte) error {
 	appYamlPath := filepath.Join(basePath, "apps", params.Name, "app.yaml")
 	if params.DryRun {
 		fmt.Printf("Writing app.yaml to '%s'\n", appYamlPath)

--- a/pkg/cmdimpl/add_test.go
+++ b/pkg/cmdimpl/add_test.go
@@ -177,7 +177,7 @@ var failGitClient = gitfakes.FakeGit{
 		shims.Exit(1)
 		return false, nil
 	},
-	CommitStub: func(commit git.Commit) (string, error) {
+	CommitStub: func(commit git.Commit, filters ...func(string) bool) (string, error) {
 		fmt.Println("failing commit")
 		shims.Exit(1)
 		return "", nil
@@ -209,7 +209,7 @@ var ignoreGitClient = gitfakes.FakeGit{
 		fmt.Println("ignoring clone")
 		return false, nil
 	},
-	CommitStub: func(commit git.Commit) (string, error) {
+	CommitStub: func(commit git.Commit, filters ...func(string) bool) (string, error) {
 		fmt.Println("ignoring commit")
 		return "", nil
 	},

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -49,7 +49,7 @@ type Git interface {
 	Init(path, url, branch string) (bool, error)
 	Clone(ctx context.Context, path, url, branch string) (bool, error)
 	Write(path string, content []byte) error
-	Commit(message Commit) (string, error)
+	Commit(message Commit, filters ...func(string) bool) (string, error)
 	Push(ctx context.Context) error
 	Status() (bool, error)
 	Head() (string, error)

--- a/pkg/git/gitfakes/fake_git.go
+++ b/pkg/git/gitfakes/fake_git.go
@@ -26,10 +26,11 @@ type FakeGit struct {
 		result1 bool
 		result2 error
 	}
-	CommitStub        func(git.Commit) (string, error)
+	CommitStub        func(git.Commit, ...func(string) bool) (string, error)
 	commitMutex       sync.RWMutex
 	commitArgsForCall []struct {
 		arg1 git.Commit
+		arg2 []func(string) bool
 	}
 	commitReturns struct {
 		result1 string
@@ -185,18 +186,19 @@ func (fake *FakeGit) CloneReturnsOnCall(i int, result1 bool, result2 error) {
 	}{result1, result2}
 }
 
-func (fake *FakeGit) Commit(arg1 git.Commit) (string, error) {
+func (fake *FakeGit) Commit(arg1 git.Commit, arg2 ...func(string) bool) (string, error) {
 	fake.commitMutex.Lock()
 	ret, specificReturn := fake.commitReturnsOnCall[len(fake.commitArgsForCall)]
 	fake.commitArgsForCall = append(fake.commitArgsForCall, struct {
 		arg1 git.Commit
-	}{arg1})
+		arg2 []func(string) bool
+	}{arg1, arg2})
 	stub := fake.CommitStub
 	fakeReturns := fake.commitReturns
-	fake.recordInvocation("Commit", []interface{}{arg1})
+	fake.recordInvocation("Commit", []interface{}{arg1, arg2})
 	fake.commitMutex.Unlock()
 	if stub != nil {
-		return stub(arg1)
+		return stub(arg1, arg2...)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -210,17 +212,17 @@ func (fake *FakeGit) CommitCallCount() int {
 	return len(fake.commitArgsForCall)
 }
 
-func (fake *FakeGit) CommitCalls(stub func(git.Commit) (string, error)) {
+func (fake *FakeGit) CommitCalls(stub func(git.Commit, ...func(string) bool) (string, error)) {
 	fake.commitMutex.Lock()
 	defer fake.commitMutex.Unlock()
 	fake.CommitStub = stub
 }
 
-func (fake *FakeGit) CommitArgsForCall(i int) git.Commit {
+func (fake *FakeGit) CommitArgsForCall(i int) (git.Commit, []func(string) bool) {
 	fake.commitMutex.RLock()
 	defer fake.commitMutex.RUnlock()
 	argsForCall := fake.commitArgsForCall[i]
-	return argsForCall.arg1
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakeGit) CommitReturns(result1 string, result2 error) {

--- a/pkg/git/gogit_test.go
+++ b/pkg/git/gogit_test.go
@@ -73,6 +73,7 @@ var _ = Describe("Write", func() {
 })
 
 var _ = Describe("Commit", func() {
+
 	It("commits into a given repository", func() {
 		_, err = gitClient.Init(dir, "https://github.com/github/gitignore", "master")
 		Expect(err).ShouldNot(HaveOccurred())
@@ -94,6 +95,26 @@ var _ = Describe("Commit", func() {
 		Expect(err).ShouldNot(HaveOccurred())
 
 		Expect(string(out)).To(ContainSubstring("test commit"))
+	})
+	It("commits into a given repository skipping filtered files", func() {
+		_, err = gitClient.Init(dir, "https://github.com/github/gitignore", "master")
+		Expect(err).ShouldNot(HaveOccurred())
+
+		filePath := "/test.txt"
+		content := []byte("testing")
+		err = gitClient.Write(filePath, content)
+
+		_, err = gitClient.Commit(git.Commit{
+			Author:  git.Author{Name: "test", Email: "test@example.com"},
+			Message: "test commit",
+		},
+			func(fname string) bool {
+				return false
+			})
+		Expect(err).Should(HaveOccurred())
+		isClean, err := gitClient.Status()
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(isClean).To(BeFalse())
 	})
 })
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
We no longer gather up all files in a user's repo when committing .wego contents. This isn't the final solution. It wasn't clear how to avoid committing files already in the index. With this change, though, only files in the index will be picked up.

<!-- Tell your future self why have you made these changes -->
**Why?**
We shouldn't update the user's repository behind her back

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**
Tested locally and new gogit unit test

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
**Release notes**

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**