### PR TITLE
Look in well known locations for ssh key file or allow the user to specify it's path on the command line

### DIFF
--- a/cmd/wego/add/cmd.go
+++ b/cmd/wego/add/cmd.go
@@ -6,14 +6,16 @@ package add
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
-	"github.com/go-git/go-git/v5/plumbing/transport/http"
+	"github.com/go-git/go-git/v5/plumbing/transport/ssh"
 	"github.com/lithammer/dedent"
 	"github.com/spf13/cobra"
 	"github.com/weaveworks/weave-gitops/pkg/cmdimpl"
 	"github.com/weaveworks/weave-gitops/pkg/git"
 	"github.com/weaveworks/weave-gitops/pkg/shims"
+	"github.com/weaveworks/weave-gitops/pkg/utils"
 )
 
 var params cmdimpl.AddParamSet
@@ -36,6 +38,7 @@ func init() {
 	Cmd.Flags().StringVar(&params.Branch, "branch", "main", "Branch to watch within git repository")
 	Cmd.Flags().StringVar(&params.DeploymentType, "deployment-type", "kustomize", "deployment type [kustomize, helm]")
 	Cmd.Flags().StringVar(&params.Chart, "chart", "", "Specify chart for helm source")
+	Cmd.Flags().StringVar(&params.PrivateKey, "private-key", "", "Private key to access git repository over ssh")
 	Cmd.Flags().StringVar(&params.AppConfigUrl, "app-config-url", "", "URL of external repository (if any) which will hold automation manifests; NONE to store only in the cluster")
 	Cmd.Flags().BoolVar(&params.DryRun, "dry-run", false, "If set, 'wego add' will not make any changes to the system; it will just display the actions that would have been taken")
 }
@@ -43,10 +46,20 @@ func init() {
 func runCmd(cmd *cobra.Command, args []string) {
 	params.Namespace, _ = cmd.Parent().Flags().GetString("namespace")
 
-	gitClient := git.New(&http.BasicAuth{
-		Username: "weaveworks", // this can't be empty
-		Password: os.Getenv("GITHUB_TOKEN"),
-	})
+	if strings.HasPrefix(params.PrivateKey, "~/") {
+		dir := getHomeDir()
+		params.PrivateKey = filepath.Join(dir, params.PrivateKey[2:])
+	} else if params.PrivateKey == "" {
+		params.PrivateKey = findPrivateKeyFile()
+	}
+
+	authMethod, err := ssh.NewPublicKeysFromFile("git", params.PrivateKey, params.PrivateKeyPass)
+	if err != nil {
+		fmt.Fprintf(shims.Stderr(), "failed reading ssh keys: %s\n", err)
+		shims.Exit(1)
+	}
+
+	gitClient := git.New(authMethod)
 
 	deps := &cmdimpl.AddDependencies{
 		GitClient: gitClient,
@@ -55,4 +68,28 @@ func runCmd(cmd *cobra.Command, args []string) {
 		fmt.Fprintf(shims.Stderr(), "%v\n", err)
 		shims.Exit(1)
 	}
+}
+
+func getHomeDir() string {
+	dir, err := os.UserHomeDir()
+	if err != nil {
+		fmt.Fprintf(shims.Stderr(), "could not determine user home directory\n")
+		shims.Exit(1)
+	}
+	return dir
+}
+
+func findPrivateKeyFile() string {
+	dir := getHomeDir()
+	modernFilePath := filepath.Join(dir, ".ssh", "id_ed25519")
+	if utils.Exists(modernFilePath) {
+		return modernFilePath
+	}
+	legacyFilePath := filepath.Join(dir, ".ssh", "id_rsa")
+	if utils.Exists(legacyFilePath) {
+		return legacyFilePath
+	}
+	fmt.Fprintf(shims.Stderr(), "could not locate ssh key file; please specify '--private-key'\n")
+	shims.Exit(1)
+	return ""
 }

--- a/pkg/cmdimpl/add.go
+++ b/pkg/cmdimpl/add.go
@@ -52,6 +52,8 @@ type AddParamSet struct {
 	Url            string
 	Path           string
 	Branch         string
+	PrivateKey     string
+	PrivateKeyPass string
 	DeploymentType string
 	Chart          string
 	SourceType     string


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
We now use a generated deploy key for flux but allow specification of an ssh key to talk to git repositories over ssh. 

<!-- Tell your future self why have you made these changes -->
**Why?**
By default, darwin does not store the user's default ssh key in the ssh-agent so we need to allow it to be specified.

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**
It's tested every time we run `wego app add` (particularly on darwin)
