### PR TITLE
Avoid multiple arch builds on an os competing

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -38,8 +38,6 @@ builds:
       - linux
     goarch:
       - amd64
-      - arm64
-      - arm
     goarm:
       - 7
   - <<: *build_defaults
@@ -48,4 +46,4 @@ builds:
       - darwin
     goarch:
       - amd64
-      - arm64
+   


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Use only one arch for each os type
