### PR TITLE
Make install should put binaries in "${GOPATH}/bin"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,10 @@ bin:
 # Build wego binary
 wego: dependencies bin
 
+# Install binaries to GOPATH
+install: bin bin/$(BINARY_NAME)_ui
+	cp bin/$(BINARY_NAME) bin/$(BINARY_NAME)_ui ${GOPATH}/bin/
+
 # Clean up images and binaries
 clean:
 	rm -f bin/wego
@@ -64,6 +68,6 @@ bin/$(BINARY_NAME)_ui: cmd/ui/main.go
 
 ui-dev:
 	reflex -r '.go' -s -- sh -c 'go run cmd/ui/main.go'
-	
+
 lint:
 	golangci-lint run --out-format=github-actions --build-tags acceptance


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Makefile target "install" sends wego binaries to ${GOPATH}/bin instead of .../weave-gitops/bin/

<!-- Tell your future self why have you made these changes -->
**Why?**
Original binary output wasn't in most developers PATH

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**
Ran `make install` and verified that binaries are correctly being installed in ${GOPATH}

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
**Release notes**
Users who've previously used `make install` should migrate binaries from old path to ${GOPATH)

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
There are currently no documents covering this.