### PR TITLE
Fixed app add using path

### DIFF
--- a/pkg/git/gogit.go
+++ b/pkg/git/gogit.go
@@ -174,7 +174,7 @@ func (g *GoGit) Commit(message Commit, filters ...func(string) bool) (string, er
 		}
 		skip := false
 		for _, filter := range filters {
-			if !filter(abspath) {
+			if !filter(file) {
 				skip = true
 				break
 			}

--- a/pkg/git/gogit_test.go
+++ b/pkg/git/gogit_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"strings"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -115,6 +116,27 @@ var _ = Describe("Commit", func() {
 		isClean, err := gitClient.Status()
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(isClean).To(BeFalse())
+	})
+
+	It("commits into a given repository skipping filtered files on .wego folder", func() {
+		_, err = gitClient.Init(dir, "https://github.com/github/gitignore", "master")
+		Expect(err).ShouldNot(HaveOccurred())
+
+		filePath := ".wego/test.txt"
+		content := []byte("testing")
+		err = gitClient.Write(filePath, content)
+
+		_, err = gitClient.Commit(git.Commit{
+			Author:  git.Author{Name: "test", Email: "test@example.com"},
+			Message: "test commit",
+		},
+			func(fname string) bool {
+				return strings.HasPrefix(fname, ".wego")
+			})
+		Expect(err).ShouldNot(HaveOccurred())
+		isClean, err := gitClient.Status()
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(isClean).To(BeTrue())
 	})
 })
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
Filters for commit now use only the file path relative to the root of the repo.

<!-- Tell your future self why have you made these changes -->
It was using an absolute path resulting in the filters skipping files from .wego folder.

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
I tested it manually using dot and absolute path as the location argument.
