### PR TITLE
Fixed url sanitization

### DIFF
--- a/pkg/services/app/add.go
+++ b/pkg/services/app/add.go
@@ -477,28 +477,30 @@ func urlToRepoName(url string) string {
 	return strings.TrimSuffix(filepath.Base(url), ".git")
 }
 
-func sanitizeRepoUrl(url string) string {
-	trimmed := ""
+func sanitizeRepoUrl(sourceURL string) string {
 
-	if !strings.HasSuffix(url, ".git") {
-		url = url + ".git"
+	gitSuffix := ".git"
+	if strings.HasSuffix(sourceURL, gitSuffix) {
+		sourceURL = strings.TrimSuffix(sourceURL, gitSuffix)
 	}
 
-	sshPrefix := "git@github.com:"
-	if strings.HasPrefix(url, sshPrefix) {
-		trimmed = strings.TrimPrefix(url, sshPrefix)
+	gitSSHPrefix := "git@github.com:"
+	if strings.HasPrefix(sourceURL, gitSSHPrefix) {
+		sourceURL = strings.TrimPrefix(sourceURL, gitSSHPrefix)
 	}
 
 	httpsPrefix := "https://github.com/"
-	if strings.HasPrefix(url, httpsPrefix) {
-		trimmed = strings.TrimPrefix(url, httpsPrefix)
+	if strings.HasPrefix(sourceURL, httpsPrefix) {
+		sourceURL = strings.TrimPrefix(sourceURL, httpsPrefix)
 	}
 
-	if trimmed != "" {
-		return "ssh://git@github.com/" + trimmed
+	sshPrefix := "ssh://git@github.com/"
+	if strings.HasPrefix(sourceURL, sshPrefix) {
+		return sourceURL
 	}
 
-	return url
+	return sshPrefix + sourceURL
+
 }
 
 // NOTE: ready to save the targets automation in phase 2

--- a/pkg/services/app/add.go
+++ b/pkg/services/app/add.go
@@ -479,20 +479,11 @@ func urlToRepoName(url string) string {
 
 func sanitizeRepoUrl(sourceURL string) string {
 
-	gitSuffix := ".git"
-	if strings.HasSuffix(sourceURL, gitSuffix) {
-		sourceURL = strings.TrimSuffix(sourceURL, gitSuffix)
-	}
+	sourceURL = strings.TrimSuffix(sourceURL, ".git")
 
-	gitSSHPrefix := "git@github.com:"
-	if strings.HasPrefix(sourceURL, gitSSHPrefix) {
-		sourceURL = strings.TrimPrefix(sourceURL, gitSSHPrefix)
-	}
+	sourceURL = strings.TrimPrefix(sourceURL, "git@github.com:")
 
-	httpsPrefix := "https://github.com/"
-	if strings.HasPrefix(sourceURL, httpsPrefix) {
-		sourceURL = strings.TrimPrefix(sourceURL, httpsPrefix)
-	}
+	sourceURL = strings.TrimPrefix(sourceURL, "https://github.com/")
 
 	sshPrefix := "ssh://git@github.com/"
 	if strings.HasPrefix(sourceURL, sshPrefix) {

--- a/pkg/services/app/add_test.go
+++ b/pkg/services/app/add_test.go
@@ -437,7 +437,7 @@ var _ = Describe("Add", func() {
 
 				name, url, branch, secretRef, namespace = fluxClient.CreateSourceGitArgsForCall(1)
 				Expect(name).To(Equal("bar"))
-				Expect(url).To(Equal("ssh://git@github.com/foo/bar.git"))
+				Expect(url).To(Equal("ssh://git@github.com/foo/bar"))
 				Expect(branch).To(Equal("main"))
 				Expect(secretRef).To(Equal("weave-gitops-test-cluster"))
 				Expect(namespace).To(Equal("wego-system"))

--- a/pkg/services/app/add_test.go
+++ b/pkg/services/app/add_test.go
@@ -90,7 +90,7 @@ var _ = Describe("Add", func() {
 
 		secretRef, repoUrl, namespace := fluxClient.CreateSecretGitArgsForCall(0)
 		Expect(secretRef).To(Equal("weave-gitops-test-cluster"))
-		Expect(repoUrl).To(Equal("ssh://git@github.com/foo/bar.git"))
+		Expect(repoUrl).To(Equal("ssh://git@github.com/foo/bar"))
 		Expect(namespace).To(Equal("wego-system"))
 
 		owner, repoName, deployKey := gitProviders.UploadDeployKeyArgsForCall(0)
@@ -111,7 +111,7 @@ var _ = Describe("Add", func() {
 
 				name, url, branch, secretRef, namespace := fluxClient.CreateSourceGitArgsForCall(0)
 				Expect(name).To(Equal("bar"))
-				Expect(url).To(Equal("ssh://git@github.com/foo/bar.git"))
+				Expect(url).To(Equal("ssh://git@github.com/foo/bar"))
 				Expect(branch).To(Equal("main"))
 				Expect(secretRef).To(Equal("weave-gitops-test-cluster"))
 				Expect(namespace).To(Equal("wego-system"))
@@ -241,7 +241,7 @@ var _ = Describe("Add", func() {
 
 				name, url, branch, secretRef, namespace := fluxClient.CreateSourceGitArgsForCall(0)
 				Expect(name).To(Equal("bar"))
-				Expect(url).To(Equal("ssh://git@github.com/foo/bar.git"))
+				Expect(url).To(Equal("ssh://git@github.com/foo/bar"))
 				Expect(branch).To(Equal("main"))
 				Expect(secretRef).To(Equal("weave-gitops-test-cluster"))
 				Expect(namespace).To(Equal("wego-system"))
@@ -370,7 +370,7 @@ var _ = Describe("Add", func() {
 				_, repoDir, url, branch := gitClient.CloneArgsForCall(0)
 
 				Expect(repoDir).To(ContainSubstring("user-repo-"))
-				Expect(url).To(Equal("ssh://git@github.com/foo/bar.git"))
+				Expect(url).To(Equal("ssh://git@github.com/foo/bar"))
 				Expect(branch).To(Equal("main"))
 			})
 		})
@@ -389,7 +389,7 @@ var _ = Describe("Add", func() {
 			Expect(gitClient.WriteCallCount()).To(Equal(2))
 
 			path, content := gitClient.WriteArgsForCall(0)
-			Expect(path).To(Equal(".wego/apps/bar/yaml"))
+			Expect(path).To(Equal(".wego/apps/bar/app.yaml"))
 			Expect(string(content)).To(ContainSubstring("kind: Application"))
 
 			path, content = gitClient.WriteArgsForCall(1)
@@ -430,7 +430,7 @@ var _ = Describe("Add", func() {
 
 				name, url, branch, secretRef, namespace := fluxClient.CreateSourceGitArgsForCall(0)
 				Expect(name).To(Equal("repo"))
-				Expect(url).To(Equal("ssh://git@github.com/user/repo.git"))
+				Expect(url).To(Equal("ssh://git@github.com/user/repo"))
 				Expect(branch).To(Equal("main"))
 				Expect(secretRef).To(Equal("weave-gitops-test-cluster"))
 				Expect(namespace).To(Equal("wego-system"))
@@ -551,7 +551,7 @@ var _ = Describe("Add", func() {
 			_, repoDir, url, branch := gitClient.CloneArgsForCall(0)
 
 			Expect(repoDir).To(ContainSubstring("user-repo-"))
-			Expect(url).To(Equal("ssh://git@github.com/foo/bar.git"))
+			Expect(url).To(Equal("ssh://git@github.com/foo/bar"))
 			Expect(branch).To(Equal("main"))
 		})
 
@@ -569,7 +569,7 @@ var _ = Describe("Add", func() {
 			Expect(gitClient.WriteCallCount()).To(Equal(2))
 
 			path, content := gitClient.WriteArgsForCall(0)
-			Expect(path).To(Equal("apps/repo/yaml"))
+			Expect(path).To(Equal("apps/repo/app.yaml"))
 			Expect(string(content)).To(ContainSubstring("kind: Application"))
 
 			path, content = gitClient.WriteArgsForCall(1)


### PR DESCRIPTION
URL sanitation was miss behaving leading to URLs with suffix `.git` that go-git doesn't accept causing errors when attempting to clone the repo. It was tested by adding unit tests  for all possible combinations and making sure smoke and accept tests passed.