### PR TITLE
Limit changes in release notes to changes since the previous release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Generate release notes
         run: |
           echo 'CHANGELOG' > /tmp/release.txt
-          github-release-notes -org weaveworks -repo weave-gitops -include-author >> /tmp/release.txt
+          github-release-notes -org weaveworks -repo weave-gitops -include-author -since-latest-release >> /tmp/release.txt
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Set env var


### PR DESCRIPTION
Now that we have multiple release, we want the release notes to only contain changes since the previous release.

<!-- Describe what has changed in this PR -->
**What changed?**
The `-since-latest-release` flag to `github-release-notes` was removed earlier due to it failing if there was no prior release. Now we're adding it back.


<!-- Tell your future self why have you made these changes -->
**Why?**
So the release notes for Weave GitOps accurately reflect the latest changes.

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**
I will test it by generating a test release once it is in place.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
**Release notes**
No

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
No