### PR TITLE
Do not attempt to create deploy key for helm repositories

### DIFF
--- a/pkg/gitproviders/common.go
+++ b/pkg/gitproviders/common.go
@@ -178,8 +178,6 @@ func (h defaultGitProviderHandler) DeployKeyExists(owner, repoName string) (bool
 	default:
 		return false, fmt.Errorf("account type not supported %s", ownerType)
 	}
-
-	return false, nil
 }
 
 func (h defaultGitProviderHandler) UploadDeployKey(owner, repoName string, deployKey []byte) error {

--- a/pkg/gitproviders/common_test.go
+++ b/pkg/gitproviders/common_test.go
@@ -485,7 +485,7 @@ var _ = Describe("Test for Org repo info", func() {
 })
 
 var _ = Describe("Test deploy keys creation", func() {
-	It("Upload a new deploy key for a brand new user repo and show proper message if trying to re-add it", func() {
+	It("Uploads a new deploy key for a brand new user repo, checks for presence of the key, and shows proper message if trying to re-add it", func() {
 
 		accounts := getAccounts()
 
@@ -507,11 +507,19 @@ var _ = Describe("Test deploy keys creation", func() {
 
 		deployKey := "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDBmym4XOiTj4rY3AcJKoJ8QupfgpFWtgNzDxzL0TrzfnurUQm+snozKLHGtOtS7PjMQsMaW9phyhhXv2KxadVI1uweFkC1TK4rPNWrqYX2g0JLXEScvaafSiv+SqozWLN/zhQ0e0jrtrYphtkd+H72RYsdq3mngY4WPJXM7z+HSjHSKilxj7XsxENt0dxT08LArxDC4OQXv9EYFgCyZ7SuLPBgA9160Co46Jm27enB/oBPx5zWd1MlkI+RtUi+XV2pLMzIpvYi2r2iWwOfDqE0N2cfpD0bY7cIOlv0iS7v6Qkmf7pBD+tRGTIZFcD5tGmZl1DOaeCZZ/VAN66aX+rN"
 
+		// exists, err := DeployKeyExists(accounts.GithubUserName, repoName)
+		// Expect(err).ShouldNot(HaveOccurred())
+		// Expect(exists).To(BeFalse())
+
 		stdout := utils.CaptureStdout(func() {
 			err = UploadDeployKey(accounts.GithubUserName, repoName, []byte(deployKey))
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 		Expect(stdout).To(Equal("uploading deploy key\n"))
+
+		// exists, err = DeployKeyExists(accounts.GithubUserName, repoName)
+		// Expect(err).ShouldNot(HaveOccurred())
+		// Expect(exists).To(BeTrue())
 
 		stdout = utils.CaptureStdout(func() {
 			err = UploadDeployKey(accounts.GithubUserName, repoName, []byte(deployKey))
@@ -547,11 +555,19 @@ var _ = Describe("Test deploy keys creation", func() {
 
 		deployKey := "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDBmym4XOiTj4rY3AcJKoJ8QupfgpFWtgNzDxzL0TrzfnurUQm+snozKLHGtOtS7PjMQsMaW9phyhhXv2KxadVI1uweFkC1TK4rPNWrqYX2g0JLXEScvaafSiv+SqozWLN/zhQ0e0jrtrYphtkd+H72RYsdq3mngY4WPJXM7z+HSjHSKilxj7XsxENt0dxT08LArxDC4OQXv9EYFgCyZ7SuLPBgA9160Co46Jm27enB/oBPx5zWd1MlkI+RtUi+XV2pLMzIpvYi2r2iWwOfDqE0N2cfpD0bY7cIOlv0iS7v6Qkmf7pBD+tRGTIZFcD5tGmZl1DOaeCZZ/VAN66aX+rN"
 
+		// exists, err := DeployKeyExists(accounts.GithubUserName, repoName)
+		// Expect(err).ShouldNot(HaveOccurred())
+		// Expect(exists).To(BeFalse())
+
 		stdout := utils.CaptureStdout(func() {
 			err = UploadDeployKey(accounts.GithubOrgName, repoName, []byte(deployKey))
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 		Expect(stdout).To(Equal("uploading deploy key\n"))
+
+		// exists, err = DeployKeyExists(accounts.GithubUserName, repoName)
+		// Expect(err).ShouldNot(HaveOccurred())
+		// Expect(exists).To(BeTrue())
 
 		stdout = utils.CaptureStdout(func() {
 			err = UploadDeployKey(accounts.GithubOrgName, repoName, []byte(deployKey))

--- a/pkg/gitproviders/common_test.go
+++ b/pkg/gitproviders/common_test.go
@@ -507,6 +507,8 @@ var _ = Describe("Test deploy keys creation", func() {
 
 		deployKey := "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDBmym4XOiTj4rY3AcJKoJ8QupfgpFWtgNzDxzL0TrzfnurUQm+snozKLHGtOtS7PjMQsMaW9phyhhXv2KxadVI1uweFkC1TK4rPNWrqYX2g0JLXEScvaafSiv+SqozWLN/zhQ0e0jrtrYphtkd+H72RYsdq3mngY4WPJXM7z+HSjHSKilxj7XsxENt0dxT08LArxDC4OQXv9EYFgCyZ7SuLPBgA9160Co46Jm27enB/oBPx5zWd1MlkI+RtUi+XV2pLMzIpvYi2r2iWwOfDqE0N2cfpD0bY7cIOlv0iS7v6Qkmf7pBD+tRGTIZFcD5tGmZl1DOaeCZZ/VAN66aX+rN"
 
+		// Uncomment these when the recording is fixed
+
 		// exists, err := DeployKeyExists(accounts.GithubUserName, repoName)
 		// Expect(err).ShouldNot(HaveOccurred())
 		// Expect(exists).To(BeFalse())

--- a/pkg/gitproviders/gitprovidersfakes/fake_git_provider_handler.go
+++ b/pkg/gitproviders/gitprovidersfakes/fake_git_provider_handler.go
@@ -21,6 +21,20 @@ type FakeGitProviderHandler struct {
 	createRepositoryReturnsOnCall map[int]struct {
 		result1 error
 	}
+	DeployKeyExistsStub        func(string, string) (bool, error)
+	deployKeyExistsMutex       sync.RWMutex
+	deployKeyExistsArgsForCall []struct {
+		arg1 string
+		arg2 string
+	}
+	deployKeyExistsReturns struct {
+		result1 bool
+		result2 error
+	}
+	deployKeyExistsReturnsOnCall map[int]struct {
+		result1 bool
+		result2 error
+	}
 	RepositoryExistsStub        func(string, string) (bool, error)
 	repositoryExistsMutex       sync.RWMutex
 	repositoryExistsArgsForCall []struct {
@@ -113,6 +127,71 @@ func (fake *FakeGitProviderHandler) CreateRepositoryReturnsOnCall(i int, result1
 	fake.createRepositoryReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
+}
+
+func (fake *FakeGitProviderHandler) DeployKeyExists(arg1 string, arg2 string) (bool, error) {
+	fake.deployKeyExistsMutex.Lock()
+	ret, specificReturn := fake.deployKeyExistsReturnsOnCall[len(fake.deployKeyExistsArgsForCall)]
+	fake.deployKeyExistsArgsForCall = append(fake.deployKeyExistsArgsForCall, struct {
+		arg1 string
+		arg2 string
+	}{arg1, arg2})
+	stub := fake.DeployKeyExistsStub
+	fakeReturns := fake.deployKeyExistsReturns
+	fake.recordInvocation("DeployKeyExists", []interface{}{arg1, arg2})
+	fake.deployKeyExistsMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeGitProviderHandler) DeployKeyExistsCallCount() int {
+	fake.deployKeyExistsMutex.RLock()
+	defer fake.deployKeyExistsMutex.RUnlock()
+	return len(fake.deployKeyExistsArgsForCall)
+}
+
+func (fake *FakeGitProviderHandler) DeployKeyExistsCalls(stub func(string, string) (bool, error)) {
+	fake.deployKeyExistsMutex.Lock()
+	defer fake.deployKeyExistsMutex.Unlock()
+	fake.DeployKeyExistsStub = stub
+}
+
+func (fake *FakeGitProviderHandler) DeployKeyExistsArgsForCall(i int) (string, string) {
+	fake.deployKeyExistsMutex.RLock()
+	defer fake.deployKeyExistsMutex.RUnlock()
+	argsForCall := fake.deployKeyExistsArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeGitProviderHandler) DeployKeyExistsReturns(result1 bool, result2 error) {
+	fake.deployKeyExistsMutex.Lock()
+	defer fake.deployKeyExistsMutex.Unlock()
+	fake.DeployKeyExistsStub = nil
+	fake.deployKeyExistsReturns = struct {
+		result1 bool
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeGitProviderHandler) DeployKeyExistsReturnsOnCall(i int, result1 bool, result2 error) {
+	fake.deployKeyExistsMutex.Lock()
+	defer fake.deployKeyExistsMutex.Unlock()
+	fake.DeployKeyExistsStub = nil
+	if fake.deployKeyExistsReturnsOnCall == nil {
+		fake.deployKeyExistsReturnsOnCall = make(map[int]struct {
+			result1 bool
+			result2 error
+		})
+	}
+	fake.deployKeyExistsReturnsOnCall[i] = struct {
+		result1 bool
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *FakeGitProviderHandler) RepositoryExists(arg1 string, arg2 string) (bool, error) {
@@ -253,6 +332,8 @@ func (fake *FakeGitProviderHandler) Invocations() map[string][][]interface{} {
 	defer fake.invocationsMutex.RUnlock()
 	fake.createRepositoryMutex.RLock()
 	defer fake.createRepositoryMutex.RUnlock()
+	fake.deployKeyExistsMutex.RLock()
+	defer fake.deployKeyExistsMutex.RUnlock()
 	fake.repositoryExistsMutex.RLock()
 	defer fake.repositoryExistsMutex.RUnlock()
 	fake.uploadDeployKeyMutex.RLock()

--- a/pkg/services/app/add_test.go
+++ b/pkg/services/app/add_test.go
@@ -22,10 +22,8 @@ var (
 	kubeClient   *kubefakes.FakeKube
 	gitProviders *gitprovidersfakes.FakeGitProviderHandler
 
-	appSrv           app.AppService
-	defaultParams    app.AddParams
-	deployKeyLookups int
-	deployKeyUploads int
+	appSrv        app.AppService
+	defaultParams app.AddParams
 )
 
 var _ = BeforeEach(func() {
@@ -279,8 +277,8 @@ var _ = Describe("Add", func() {
 
 				err := appSrv.Add(defaultParams)
 				Expect(err).ShouldNot(HaveOccurred())
-				Expect(deployKeyUploads).To(Equal(0))
-				Expect(deployKeyLookups).To(Equal(0))
+				Expect(gitProviders.UploadDeployKeyCallCount()).To(Equal(0))
+				Expect(gitProviders.DeployKeyExistsCallCount()).To(Equal(0))
 			})
 		})
 

--- a/pkg/services/app/add_test.go
+++ b/pkg/services/app/add_test.go
@@ -39,10 +39,6 @@ var _ = BeforeEach(func() {
 	}
 	gitProviders = &gitprovidersfakes.FakeGitProviderHandler{}
 
-	gitProviders.DeployKeyExistsStub = func(s1, s2 string) (bool, error) {
-		return false, nil
-	}
-
 	appSrv = app.New(gitClient, fluxClient, kubeClient, gitProviders)
 
 	defaultParams = app.AddParams{

--- a/pkg/services/app/add_test.go
+++ b/pkg/services/app/add_test.go
@@ -114,6 +114,7 @@ var _ = Describe("Add", func() {
 
 			err := appSrv.Add(defaultParams)
 			Expect(err).ShouldNot(HaveOccurred())
+			Expect(fluxClient.CreateSecretGitCallCount()).To(Equal(0))
 			Expect(gitProviders.UploadDeployKeyCallCount()).To(Equal(0))
 			Expect(gitProviders.DeployKeyExistsCallCount()).To(Equal(1))
 		})
@@ -123,6 +124,7 @@ var _ = Describe("Add", func() {
 
 			err := appSrv.Add(defaultParams)
 			Expect(err).ShouldNot(HaveOccurred())
+			Expect(fluxClient.CreateSecretGitCallCount()).To(Equal(1))
 			Expect(gitProviders.UploadDeployKeyCallCount()).To(Equal(1))
 			Expect(gitProviders.DeployKeyExistsCallCount()).To(Equal(1))
 		})
@@ -136,6 +138,7 @@ var _ = Describe("Add", func() {
 
 				err := appSrv.Add(defaultParams)
 				Expect(err).ShouldNot(HaveOccurred())
+				Expect(fluxClient.CreateSecretGitCallCount()).To(Equal(0))
 				Expect(gitProviders.UploadDeployKeyCallCount()).To(Equal(0))
 				Expect(gitProviders.DeployKeyExistsCallCount()).To(Equal(0))
 			})
@@ -277,6 +280,7 @@ var _ = Describe("Add", func() {
 
 				err := appSrv.Add(defaultParams)
 				Expect(err).ShouldNot(HaveOccurred())
+				Expect(fluxClient.CreateSecretGitCallCount()).To(Equal(0))
 				Expect(gitProviders.UploadDeployKeyCallCount()).To(Equal(0))
 				Expect(gitProviders.DeployKeyExistsCallCount()).To(Equal(0))
 			})


### PR DESCRIPTION
Also, check if deploy key exists before creating flux secret...

<!-- Describe what has changed in this PR -->
**What changed?**
- We were attempting to create a deploy key at the top of `Add`, before we determined the source type. Deploy keys are not meaningful for helm repositories, so the creation failed
- We created a flux secret for the deploy key before determining if the key already existed; this overwrote the secret containing the key in the cluster but we did not associate the new key with the repository

<!-- Tell your future self why have you made these changes -->
**Why?**
To fix the use of helm repositories and ensure we did not corrupt the flux secret for the repo if we added another app.

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**
Tested locally

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
**Release notes**
No

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
No