### PR TITLE
Early exit if wego is not installed when uninstalling

### DIFF
--- a/pkg/services/gitops/uninstall.go
+++ b/pkg/services/gitops/uninstall.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/weaveworks/weave-gitops/manifests"
+	"github.com/weaveworks/weave-gitops/pkg/kube"
 )
 
 type UinstallParams struct {
@@ -13,6 +14,10 @@ type UinstallParams struct {
 }
 
 func (g *Gitops) Uninstall(params UinstallParams) error {
+	if g.kube.GetClusterStatus() != kube.WeGOInstalled {
+		return fmt.Errorf("Wego is not installed... exiting")
+	}
+
 	err := g.flux.Uninstall(params.Namespace, params.DryRun)
 	if err != nil {
 		return fmt.Errorf("error on flux install %s", err)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- closes #400 
- Checking if wego is installed before uninstalling

<!-- Tell your future self why have you made these changes -->
**Why?**
- To avoid unclear error when trying to delete wego resources

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**
- in a clean cluster run `wego gitops uninstall`

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
**Release notes**

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**