### PR TITLE
Fix status when multiple kustomizations or helm releases share a prefix

### DIFF
--- a/pkg/cmdimpl/status.go
+++ b/pkg/cmdimpl/status.go
@@ -24,7 +24,7 @@ type StatusParams struct {
 func Status(allParams StatusParams) error {
 	deploymentType, err := getDeploymentType(allParams.Namespace, allParams.Name)
 	if err != nil {
-		return fmt.Errorf("error getting deployment type [%s]", err)
+		return err
 	}
 
 	latestDeploymentTime, err := getLatestSuccessfulDeploymentTime(allParams.Namespace, allParams.Name, deploymentType)
@@ -86,9 +86,12 @@ func getDeploymentType(namespace, appName string) (DeploymentType, error) {
 
 	matches := re.FindAllStringSubmatch(string(stdout), -1)
 
-	if len(matches) != 1 {
+	switch len(matches) {
+	case 0:
+		return "", fmt.Errorf("no app found with name: %s\n", appName)
+	case 1:
+		return DeploymentType(matches[0][1]), nil
+	default:
 		return "", fmt.Errorf("error trying to get the deployment type of the app. raw output => %s", stdout)
 	}
-
-	return DeploymentType(matches[0][1]), nil
 }

--- a/pkg/cmdimpl/status.go
+++ b/pkg/cmdimpl/status.go
@@ -53,8 +53,8 @@ type Yaml struct {
 
 func getLatestSuccessfulDeploymentTime(namespace, appName string, deploymentType DeploymentType) (string, error) {
 	c := fmt.Sprintf(`kubectl \
-			-n %s \
-			get %s/%s -oyaml`,
+            -n %s \
+            get %s/%s -oyaml`,
 		namespace,
 		deploymentType,
 		appName,
@@ -82,7 +82,7 @@ func getDeploymentType(namespace, appName string) (DeploymentType, error) {
 		return "", err
 	}
 
-	var re = regexp.MustCompile(fmt.Sprintf(`(?m)(kustomization|helmrelease)\/%s`, appName))
+	var re = regexp.MustCompile(fmt.Sprintf(`(?m)(kustomization|helmrelease)\/%s[[:space:]]`, appName))
 
 	matches := re.FindAllStringSubmatch(string(stdout), -1)
 

--- a/pkg/cmdimpl/status_test.go
+++ b/pkg/cmdimpl/status_test.go
@@ -37,20 +37,20 @@ var _ = Describe("Run Command Status Test", func() {
 
 		// flux mocks
 		case0 := "get all -n wego-system"
-		output0 := `NAME                     	READY	MESSAGE                                                        	REVISION                                     SUSPENDED
-gitrepository/wego       	True 	Fetched revision: main/00b92bf6606e040c59404a7257508d65d300bc91	main/00b92bf6606e040c59404a7257508d65d300bc91False
-gitrepository/kustomize-app	True 	Fetched revision: main/a2b5b8c0919f405e52619bfc52b5304240d9ef76	main/a2b5b8c0919f405e52619bfc52b5304240d9ef76False
+		output0 := `NAME                        READY	MESSAGE                                                         REVISION                                     SUSPENDED
+gitrepository/wego          True    Fetched revision: main/00b92bf6606e040c59404a7257508d65d300bc91	main/00b92bf6606e040c59404a7257508d65d300bc91False
+gitrepository/kustomize-app	True    Fetched revision: main/a2b5b8c0919f405e52619bfc52b5304240d9ef76	main/a2b5b8c0919f405e52619bfc52b5304240d9ef76False
 
-NAME                     	READY	MESSAGE                                                        	REVISION                                     SUSPENDED
-kustomization/wego       	True 	Applied revision: main/00b92bf6606e040c59404a7257508d65d300bc91	main/00b92bf6606e040c59404a7257508d65d300bc91False
-kustomization/kustomize-app	True 	Applied revision: main/a2b5b8c0919f405e52619bfc52b5304240d9ef76	main/a2b5b8c0919f405e52619bfc52b5304240d9ef76False`
+NAME                        READY	MESSAGE                                                         REVISION                                     SUSPENDED
+kustomization/wego          True    Applied revision: main/00b92bf6606e040c59404a7257508d65d300bc91	main/00b92bf6606e040c59404a7257508d65d300bc91False
+kustomization/kustomize-app	True    Applied revision: main/a2b5b8c0919f405e52619bfc52b5304240d9ef76	main/a2b5b8c0919f405e52619bfc52b5304240d9ef76False`
 
 		case1 := "get all -A kustomize-app"
-		output1 := `NAMESPACE   	NAME                     	READY	MESSAGE                                                        	REVISION                                     	SUSPENDED
-wego-system	gitrepository/kustomize-app	True 	Fetched revision: main/a2b5b8c0919f405e52619bfc52b5304240d9ef76	main/a2b5b8c0919f405e52619bfc52b5304240d9ef76	False
+		output1 := `NAMESPACE       NAME                        READY	MESSAGE                                                         REVISION                                        SUSPENDED
+wego-system	gitrepository/kustomize-app	True    Fetched revision: main/a2b5b8c0919f405e52619bfc52b5304240d9ef76	main/a2b5b8c0919f405e52619bfc52b5304240d9ef76	False
 
-NAMESPACE   	NAME                     	READY	MESSAGE                                                        	REVISION                                     	SUSPENDED
-wego-system	kustomization/kustomize-app	True 	Applied revision: main/a2b5b8c0919f405e52619bfc52b5304240d9ef76	main/a2b5b8c0919f405e52619bfc52b5304240d9ef76	False
+NAMESPACE       NAME                        READY	MESSAGE                                                         REVISION                                        SUSPENDED
+wego-system	kustomization/kustomize-app	True    Applied revision: main/a2b5b8c0919f405e52619bfc52b5304240d9ef76	main/a2b5b8c0919f405e52619bfc52b5304240d9ef76	False
 `
 
 		fakeHandler := &fluxopsfakes.FakeFluxHandler{
@@ -77,17 +77,17 @@ wego-system	kustomization/kustomize-app	True 	Applied revision: main/a2b5b8c0919
   conditions:
   - lastTransitionTime: "2021-05-24T22:48:28Z"`
 		case1Kubectl := `kubectl \
-			-n wego-system \
-			get kustomization/kustomize-app -oyaml`
+            -n wego-system \
+            get kustomization/kustomize-app -oyaml`
 
 		_ = override.WithOverrides(func() override.Result {
 
 			expectedOutput := `Latest successful deployment time: 2021-05-24T22:48:28Z
-NAMESPACE   	NAME                     	READY	MESSAGE                                                        	REVISION                                     	SUSPENDED
-wego-system	gitrepository/kustomize-app	True 	Fetched revision: main/a2b5b8c0919f405e52619bfc52b5304240d9ef76	main/a2b5b8c0919f405e52619bfc52b5304240d9ef76	False
+NAMESPACE       NAME                        READY	MESSAGE                                                         REVISION                                        SUSPENDED
+wego-system	gitrepository/kustomize-app	True    Fetched revision: main/a2b5b8c0919f405e52619bfc52b5304240d9ef76	main/a2b5b8c0919f405e52619bfc52b5304240d9ef76	False
 
-NAMESPACE   	NAME                     	READY	MESSAGE                                                        	REVISION                                     	SUSPENDED
-wego-system	kustomization/kustomize-app	True 	Applied revision: main/a2b5b8c0919f405e52619bfc52b5304240d9ef76	main/a2b5b8c0919f405e52619bfc52b5304240d9ef76	False
+NAMESPACE       NAME                        READY	MESSAGE                                                         REVISION                                        SUSPENDED
+wego-system	kustomization/kustomize-app	True    Applied revision: main/a2b5b8c0919f405e52619bfc52b5304240d9ef76	main/a2b5b8c0919f405e52619bfc52b5304240d9ef76	False
 
 `
 
@@ -167,7 +167,7 @@ var _ = Describe("GetDeployment tests", func() {
 		fluxops.SetFluxHandler(fakeHandler)
 
 		deploymentType, err := getDeploymentType(ns, myAppName)
-		Expect(err).Should(MatchError("error trying to get the deployment type of the app. raw output => wronginfo"))
+		Expect(err).Should(MatchError("no app found with name: my-app-name\n"))
 		Expect(deploymentType).To(BeEmpty())
 
 	})


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
fixes #371 

**What changed?**
- We now match the explicit app name rather than just looking for a prefix
- We now tell the user that no app was found if we get no matches rather than an obscure error

<!-- Tell your future self why have you made these changes -->
**Why?**
To make status more useful for the user

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**
Tested locally

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
**Release notes**
No

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
No