### PR TITLE
Update make unit-tests and clean targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ install: bin bin/$(BINARY_NAME)_ui
 # Clean up images and binaries
 clean:
 	rm -f bin/wego pkg/flux/bin/flux
+	rm -rf cmd/ui/dist
 # Run go fmt against code
 fmt:
 	go fmt ./...

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ endif
 all: wego
 
 # Run tests
-unit-tests:
+unit-tests: wego cmd/ui/dist/main.js
 	CGO_ENABLED=0 go test -v -tags unittest ./...
 
 debug: 

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/onsi/gomega v1.13.0
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.7.0
-	github.com/spf13/cobra v1.1.1
+	github.com/spf13/cobra v1.1.3
 	github.com/stretchr/testify v1.7.0
 	github.com/weaveworks/go-checkpoint v0.0.0-20170503165305-ebbb8b0518ab
 	golang.org/x/net v0.0.0-20210510120150-4163338589ed // indirect

--- a/go.sum
+++ b/go.sum
@@ -489,8 +489,9 @@ github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
-github.com/spf13/cobra v1.1.1 h1:KfztREH0tPxJJ+geloSLaAkaPkr4ki2Er5quFV1TDo4=
 github.com/spf13/cobra v1.1.1/go.mod h1:WnodtKOvamDL/PwE2M4iKs8aMDBZ5Q5klgD3qfVJQMI=
+github.com/spf13/cobra v1.1.3 h1:xghbfqPkxzxP3C/f3n5DdpAbdKLj4ZE4BWQI362l53M=
+github.com/spf13/cobra v1.1.3/go.mod h1:pGADOWyqRD/YMrPZigI/zbliZ2wVD/23d+is3pSWzOo=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/pflag v0.0.0-20170130214245-9ff6c6923cff/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.1/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
@@ -586,7 +587,6 @@ golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHl
 golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f/go.mod h1:5qLYkcX4OjUUV8bRuDixDT3tpyyb+LUpUlRWLxfhWrs=
 golang.org/x/lint v0.0.0-20200130185559-910be7a94367/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
-golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 h1:VLliZ0d+/avPrXXH+OakdXhpJuEoBZuwh1m2j7U6Iug=
 golang.org/x/lint v0.0.0-20210508222113-6edffad5e616/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
 golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCcRqshq8CkpyQDoeVncDDYHnLhea+o=

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -7,7 +7,6 @@ import (
 	_ "github.com/grpc-ecosystem/protoc-gen-grpc-gateway-ts"
 	_ "github.com/jandelgado/gcov2lcov"
 	_ "github.com/maxbrunsfeld/counterfeiter/v6"
-	_ "google.golang.org/genproto"
 	_ "google.golang.org/grpc/cmd/protoc-gen-go-grpc"
 )
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
`make unit-tests` will now work on a completely clean environment.
`make clean` will now remove the ui/dist embed files

<!-- Tell your future self why have you made these changes -->
**Why?**
When cloning a new version of the repo the unit-tests would fail due to the missing ui/dist directory needed for embedding. This will make it easier for new developers.

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**
I ran the make commands locally.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
**Release notes**
No
<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
No