### PR TITLE
Properly checking cluster status in the install command

### DIFF
--- a/pkg/kube/kube.go
+++ b/pkg/kube/kube.go
@@ -131,6 +131,8 @@ func (k *KubeClient) FluxPresent(ctx context.Context) (bool, error) {
 		if strings.Contains(string(out), "not found") {
 			return false, nil
 		}
+
+		return false, err
 	}
 
 	return true, nil


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- fixes #395 
- Properly checking cluster status in the install command

<!-- Tell your future self why have you made these changes -->
**Why?**
- wego was returning a misleading message when it couldn't talk to the cluster.

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**
`kind delete cluster --name wego`
`wego gitops install`


<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
**Release notes**

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**