### PR TITLE
Skip building UI on unit-tests target

### DIFF
--- a/.github/workflows/docker_scan.yaml
+++ b/.github/workflows/docker_scan.yaml
@@ -7,29 +7,6 @@ on:
   pull_request:
 
 jobs:
-  push_to_registry:
-    name: Push Docker image to Docker Hub
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./controllers/wego-controller
-    steps:
-      - name: Login to GitHub Packages Docker Registry
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      - name: Build and push
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          push: true
-          tags: weaveworks/wego-controller:${{ github.sha }}
-
   fossa:
     name: FOSSA
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: ui-dev
+.PHONY: debug bin wego install clean fmt vet depencencies lint ui ui-lint ui-test ui-dev unit-tests proto proto-deps api-dev ui-dev fakes crd
 VERSION=$(shell git describe --always --match "v*")
 GOOS=$(shell go env GOOS)
 GOARCH=$(shell go env GOARCH)
@@ -28,14 +28,14 @@ endif
 all: wego
 
 # Run tests
-unit-tests: wego cmd/ui/dist/main.js
+unit-tests: dependencies cmd/ui/dist/index.html
 	# To avoid downloading depencencies every time use `SKIP_FETCH_TOOLS=1 unit-tests`
 	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) CGO_ENABLED=0 go test -v -tags unittest ./...
 
 debug:
 	go build -ldflags $(LDFLAGS) -o bin/$(BINARY_NAME) -gcflags='all=-N -l' cmd/wego/*.go
 
-bin:
+bin: ui
 	go build -ldflags $(LDFLAGS) -o bin/$(BINARY_NAME) cmd/wego/*.go
 
 # Build wego binary
@@ -49,6 +49,8 @@ install: bin bin/$(BINARY_NAME)_ui
 clean:
 	rm -f bin/wego pkg/flux/bin/flux
 	rm -rf cmd/ui/dist
+	rm -rf coverage
+	rm -rf node_modules
 # Run go fmt against code
 fmt:
 	go fmt ./...
@@ -59,7 +61,7 @@ vet:
 dependencies:
 	$(CURRENT_DIR)/tools/download-deps.sh $(CURRENT_DIR)/tools/dependencies.toml
 
-package-lock.json:
+node_modules:
 	npm install
 
 cmd/ui/dist:
@@ -68,7 +70,7 @@ cmd/ui/dist:
 cmd/ui/dist/index.html: cmd/ui/dist
 	touch cmd/ui/dist/index.html
 
-cmd/ui/dist/main.js: package-lock.json
+cmd/ui/dist/main.js:
 	npm run build
 
 bin/$(BINARY_NAME)_ui: cmd/ui/main.go
@@ -85,6 +87,8 @@ ui-test:
 
 ui-audit:
 	npm audit
+
+ui: node_modules cmd/ui/dist/main.js
 
 # JS coverage info
 coverage/lcov.info:


### PR DESCRIPTION
Adds some specificity to the `Makefile` to avoid rebuilding UI assets on every `make unit-tests`. Also refactors to be smarter about building assets in general.

Edit: The scope has expanded to remove the Docker Scan job, as it was superfluous. I chatted with @josecordaz about it before proceeding.