### PR TITLE
The external config repository is always SourceTypeGit -- we shouldn't use the source type parameter

### DIFF
--- a/pkg/services/app/add.go
+++ b/pkg/services/app/add.go
@@ -112,7 +112,6 @@ func (a *App) Add(params AddParams) error {
 		return err
 	}
 
-	fmt.Printf("Generating deploy key for repo %s ...\n", params.Url)
 	secretRef, err := a.createAndUploadDeployKey(params.Url, SourceType(params.SourceType), clusterName, params.Namespace, params.DryRun)
 	if err != nil {
 		return errors.Wrap(err, "could not generate deploy key")
@@ -277,7 +276,7 @@ func (a *App) addAppWithConfigInExternalRepo(params AddParams, clusterName strin
 		return err
 	}
 
-	appConfigSecretName, err := a.createAndUploadDeployKey(params.AppConfigUrl, SourceType(params.SourceType), clusterName, params.Namespace, params.DryRun)
+	appConfigSecretName, err := a.createAndUploadDeployKey(params.AppConfigUrl, SourceTypeGit, clusterName, params.Namespace, params.DryRun)
 	if err != nil {
 		return errors.Wrap(err, "could not generate deploy key")
 	}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
We no longer consult the source type parameter when deciding whether or not to create a deploy key in the external repo case. For a helm repository, we were failing to create a deploy key, even though the config repository is necessarily a git repository.

<!-- Tell your future self why have you made these changes -->
**Why?**
To correct the behavior when adding an upstream helm repository with an external configuration repository

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**
I tested it locally and there will be a new acceptance test going back shortly (which exposed the issue).

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
**Release notes**
No

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
No