### PR TITLE
remove timeout restrictions

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -51,7 +51,6 @@ jobs:
   test-eks:
     needs: [lint, build]
     runs-on: ${{matrix.os}}
-    timeout-minutes: 60
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest]
@@ -136,7 +135,6 @@ jobs:
   test-gke:
     needs: [lint, build]
     runs-on: ${{matrix.os}}
-    timeout-minutes: 60
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest]


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
the default timeout for nightly jobs

<!-- Tell your future self why have you made these changes -->
**Why?**
As the acceptance test suite is getting richer, it needs a bit more time to complete in nightlies. 