### PR TITLE
Use go struct and yaml marshalling for adding applications

### DIFF
--- a/api/v1alpha1/application_types.go
+++ b/api/v1alpha1/application_types.go
@@ -22,6 +22,8 @@ import (
 
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
+const ApplicationKind = "Application"
+
 // ApplicationSpec defines the desired state of Application
 type ApplicationSpec struct {
 	// URL is the address of the git repository for this application

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/fluxcd/source-controller/api v0.15.2
 	github.com/go-git/go-billy/v5 v5.3.1
 	github.com/go-git/go-git/v5 v5.4.1
+	github.com/google/go-cmp v0.5.6
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.5.0
 	github.com/grpc-ecosystem/protoc-gen-grpc-gateway-ts v1.1.1
 	github.com/jandelgado/gcov2lcov v1.0.5

--- a/pkg/services/app/add_test.go
+++ b/pkg/services/app/add_test.go
@@ -1,4 +1,4 @@
-package app_test
+package app
 
 import (
 	"context"
@@ -17,7 +17,6 @@ import (
 	"github.com/weaveworks/weave-gitops/pkg/kube"
 	"github.com/weaveworks/weave-gitops/pkg/kube/kubefakes"
 	"github.com/weaveworks/weave-gitops/pkg/logger"
-	"github.com/weaveworks/weave-gitops/pkg/services/app"
 )
 
 var (
@@ -26,8 +25,8 @@ var (
 	kubeClient   *kubefakes.FakeKube
 	gitProviders *gitprovidersfakes.FakeGitProviderHandler
 
-	appSrv        app.AppService
-	defaultParams app.AddParams
+	appSrv        AppService
+	defaultParams AddParams
 )
 
 var _ = BeforeEach(func() {
@@ -43,9 +42,9 @@ var _ = BeforeEach(func() {
 	}
 	gitProviders = &gitprovidersfakes.FakeGitProviderHandler{}
 
-	appSrv = app.New(logger.New(os.Stderr), gitClient, fluxClient, kubeClient, gitProviders)
+	appSrv = New(logger.New(os.Stderr), gitClient, fluxClient, kubeClient, gitProviders)
 
-	defaultParams = app.AddParams{
+	defaultParams = AddParams{
 		Url:            "https://github.com/foo/bar",
 		Path:           "./kustomize",
 		Branch:         "main",
@@ -107,7 +106,7 @@ var _ = Describe("Add", func() {
 
 	Describe("checks for existing deploy key before creating secret", func() {
 		It("looks up deploy key and skips creating secret if found", func() {
-			defaultParams.SourceType = string(app.SourceTypeGit)
+			defaultParams.SourceType = string(SourceTypeGit)
 
 			gitProviders.DeployKeyExistsStub = func(s1, s2 string) (bool, error) {
 				return true, nil
@@ -126,7 +125,7 @@ var _ = Describe("Add", func() {
 		})
 
 		It("looks up deploy key and creates secret if not found", func() {
-			defaultParams.SourceType = string(app.SourceTypeGit)
+			defaultParams.SourceType = string(SourceTypeGit)
 
 			err := appSrv.Add(defaultParams)
 			Expect(err).ShouldNot(HaveOccurred())
@@ -154,7 +153,7 @@ var _ = Describe("Add", func() {
 
 		Describe("generates source manifest", func() {
 			It("creates GitRepository when source type is git", func() {
-				defaultParams.SourceType = string(app.SourceTypeGit)
+				defaultParams.SourceType = string(SourceTypeGit)
 
 				err := appSrv.Add(defaultParams)
 				Expect(err).ShouldNot(HaveOccurred())
@@ -214,7 +213,7 @@ var _ = Describe("Add", func() {
 
 			It("creates a helm release using a git source if source type is git", func() {
 				defaultParams.Path = "./charts/my-chart"
-				defaultParams.DeploymentType = string(app.DeployTypeHelm)
+				defaultParams.DeploymentType = string(DeployTypeHelm)
 
 				err := appSrv.Add(defaultParams)
 				Expect(err).ShouldNot(HaveOccurred())
@@ -297,7 +296,7 @@ var _ = Describe("Add", func() {
 
 		Describe("generates source manifest", func() {
 			It("creates GitRepository when source type is git", func() {
-				defaultParams.SourceType = string(app.SourceTypeGit)
+				defaultParams.SourceType = string(SourceTypeGit)
 
 				err := appSrv.Add(defaultParams)
 				Expect(err).ShouldNot(HaveOccurred())
@@ -370,7 +369,7 @@ var _ = Describe("Add", func() {
 
 			It("creates a helm release using a git source if source type is git", func() {
 				defaultParams.Path = "./charts/my-chart"
-				defaultParams.DeploymentType = string(app.DeployTypeHelm)
+				defaultParams.DeploymentType = string(DeployTypeHelm)
 
 				err := appSrv.Add(defaultParams)
 				Expect(err).ShouldNot(HaveOccurred())
@@ -494,7 +493,7 @@ var _ = Describe("Add", func() {
 
 		Describe("generates source manifest", func() {
 			It("creates GitRepository when source type is git", func() {
-				defaultParams.SourceType = string(app.SourceTypeGit)
+				defaultParams.SourceType = string(SourceTypeGit)
 
 				err := appSrv.Add(defaultParams)
 				Expect(err).ShouldNot(HaveOccurred())
@@ -568,7 +567,7 @@ var _ = Describe("Add", func() {
 
 			It("creates a helm release using a git source if source type is git", func() {
 				defaultParams.Path = "./charts/my-chart"
-				defaultParams.DeploymentType = string(app.DeployTypeHelm)
+				defaultParams.DeploymentType = string(DeployTypeHelm)
 
 				err := appSrv.Add(defaultParams)
 				Expect(err).ShouldNot(HaveOccurred())

--- a/pkg/services/app/app_suite_test.go
+++ b/pkg/services/app/app_suite_test.go
@@ -1,4 +1,4 @@
-package app_test
+package app
 
 import (
 	"testing"

--- a/pkg/services/app/get_test.go
+++ b/pkg/services/app/get_test.go
@@ -1,4 +1,4 @@
-package app_test
+package app
 
 import (
 	"context"


### PR DESCRIPTION
Changes our templating implementation to use the struct. This will ensure that any changes to the CRD will be reflected in the file that gets applied/saved.

The scope of this PR has expanded to move the `app_test` package into the `app` package to allow for testing private functions. This was necessary to add test coverage for things like the app hash label.

Shout-out to @bigkevmcd for the `cmp` package for struct comparison