### PR TITLE
Check for an error directly indicating we couldn't talk to the cluster

### DIFF
--- a/pkg/kube/kube.go
+++ b/pkg/kube/kube.go
@@ -109,16 +109,18 @@ func (k *KubeClient) GetClusterName(ctx context.Context) (string, error) {
 
 func (k *KubeClient) GetClusterStatus(ctx context.Context) ClusterStatus {
 	// Checking wego presence
-	if k.resourceLookup("get crd apps.wego.weave.works") == nil {
+	if _, err := k.runKubectlCmd([]string{"get", "crd", "apps.wego.weave.works"}); err == nil {
 		return WeGOInstalled
 	}
 
 	// Checking flux presence
-	if k.resourceLookup("get namespace flux-system") == nil {
+	if _, err := k.runKubectlCmd([]string{"get", "namespace", "flux-system"}); err == nil {
 		return FluxInstalled
 	}
 
-	if k.resourceLookup("get deployment coredns -n kube-system") == nil {
+	hostPortError := "was refused - did you specify the right host or port?"
+	if out, err := k.runKubectlCmd([]string{"get", "deployment", "coredns", "-n", "kube-system"}); err == nil ||
+		!strings.Contains(string(out), hostPortError) {
 		return Unmodified
 	}
 
@@ -181,15 +183,6 @@ func (k *KubeClient) GetApplications(ctx context.Context, ns string) ([]wego.App
 	}
 
 	return a.Items, nil
-}
-
-func (k *KubeClient) resourceLookup(args string) error {
-	_, err := k.runKubectlCmd(strings.Split(args, " "))
-	if err != nil {
-		return err
-	}
-
-	return nil
 }
 
 func (k *KubeClient) runKubectlCmd(args []string) ([]byte, error) {

--- a/pkg/kube/kube_test.go
+++ b/pkg/kube/kube_test.go
@@ -104,7 +104,7 @@ var _ = Describe("GetClusterStatus", func() {
 
 	It("returns unknown when it cant talk to the cluster", func() {
 		runner.RunStub = func(cmd string, args ...string) ([]byte, error) {
-			return []byte("error"), fmt.Errorf("error")
+			return []byte("was refused - did you specify the right host or port?"), fmt.Errorf("error")
 		}
 
 		status := kubeClient.GetClusterStatus(context.Background())


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
We now decide whether or not we can talk to the cluster by actually checking for an error message indicating that we can't

<!-- Tell your future self why have you made these changes -->
**Why?**
The check for the `core-dns` deployment was unreliable; not every cluster has it running

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**
unit tests

The nightly will also test this

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
**Release notes**
No

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
No