### PR TITLE
Add makefile clean to workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,10 +18,8 @@ jobs:
         go-version: 1.16.x
     - name: Checkout code
       uses: actions/checkout@v2
-    - name: Install UI Deps
-      run: npm ci
-    - name: Build UI Assets
-      run: make cmd/ui/dist/index.html
+    - name: Clean
+      run: make clean
     - name: build
       run: |
         git_hash=$(git rev-parse --short "$GITHUB_SHA")

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -16,10 +16,10 @@ jobs:
         go-version: 1.16.x
     - name: Checkout code
       uses: actions/checkout@v2
-    - name: Install UI Deps
-      run: npm ci
-    - name: Build UI Assets
-      run: make cmd/ui/dist/main.js
+    - name: Clean
+      run: make clean
+    - name: Dependencies
+      run: make dependencies
     - name: Fake Install flux
       run: mkdir -p pkg/flux/bin && touch pkg/flux/bin/flux
     - name: Run linters
@@ -40,6 +40,8 @@ jobs:
         go-version: 1.16.x
     - name: Checkout code
       uses: actions/checkout@v2
+    - name: Clean
+      run: make clean
     - name: build
       run: make all BINARY_NAME=wego-${{matrix.os}}-nightly
     - name: Store wego binaries


### PR DESCRIPTION
Related to #450 

The `nightly` and `deploy` jobs had old `make` targets and were failing without a `clean` to trigger a full build.