### PR TITLE
Use path for kustomize apps and chart for helm apps

### DIFF
--- a/pkg/services/app/add.go
+++ b/pkg/services/app/add.go
@@ -113,7 +113,7 @@ func (a *App) Add(params AddParams) error {
 		return errors.Wrap(err, "could not generate deploy key")
 	}
 
-	appHash, err := utils.GetAppHash(params.Url, params.Path, params.Branch)
+	appHash, err := getAppHash(params)
 	if err != nil {
 		return err
 	}
@@ -130,6 +130,23 @@ func (a *App) Add(params AddParams) error {
 	default:
 		return a.addAppWithConfigInExternalRepo(params, clusterName, secretRef, appHash)
 	}
+}
+
+func getAppHash(params AddParams) (string, error) {
+	var appHash string
+	var err error
+	if DeploymentType(params.DeploymentType) == DeployTypeHelm {
+		appHash, err = utils.GetAppHash(params.Url, params.Chart, params.Branch)
+		if err != nil {
+			return "", err
+		}
+	} else {
+		appHash, err = utils.GetAppHash(params.Url, params.Path, params.Branch)
+		if err != nil {
+			return "", err
+		}
+	}
+	return appHash, nil
 }
 
 func (a *App) printAddSummary(params AddParams) {

--- a/pkg/services/app/add_test.go
+++ b/pkg/services/app/add_test.go
@@ -674,4 +674,40 @@ var _ = Describe("Add", func() {
 			Expect(kubeClient.ApplyCallCount()).To(Equal(0))
 		})
 	})
+
+	Describe("Test app hash", func() {
+		It("should return right hash for a helm app", func() {
+
+			addParams.Url = "https://github.com/owner/repo1"
+			addParams.Chart = "nginx"
+			addParams.Branch = "main"
+			addParams.SourceType = string(DeployTypeHelm)
+
+			appHash, err := getAppHash(addParams)
+			Expect(err).NotTo(HaveOccurred())
+
+			expectedHash, err := utils.GetAppHash(addParams.Url, addParams.Chart, addParams.Branch)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(appHash).To(Equal(expectedHash))
+
+		})
+
+		It("should return right hash for a kustomize app", func() {
+
+			addParams.Url = "https://github.com/owner/repo1"
+			addParams.Path = "custompath"
+			addParams.Branch = "main"
+			addParams.DeploymentType = string(DeployTypeKustomize)
+
+			appHash, err := getAppHash(addParams)
+			Expect(err).NotTo(HaveOccurred())
+
+			expectedHash, err := utils.GetAppHash(addParams.Url, addParams.Path, addParams.Branch)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(appHash).To(Equal(expectedHash))
+
+		})
+	})
 })

--- a/pkg/services/app/add_test.go
+++ b/pkg/services/app/add_test.go
@@ -681,7 +681,7 @@ var _ = Describe("Add", func() {
 			addParams.Url = "https://github.com/owner/repo1"
 			addParams.Chart = "nginx"
 			addParams.Branch = "main"
-			addParams.SourceType = string(DeployTypeHelm)
+			addParams.DeploymentType = string(DeployTypeHelm)
 
 			appHash, err := getAppHash(addParams)
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
App hash generator will use Chart parameter for helm type apps

<!-- Tell your future self why have you made these changes -->
**Why?**
The hash generator was using Path parameter all the time, which had the same value when adding more than 1 helm app, leading to  duplicate app hashes, resulting in failures when trying to add two different charts from the same helm repository.

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**
Manually

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
**Release notes**

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**