### PR TITLE
Add -B to "make dependencies" so the release process has a flux binary from which to get a version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
           go-version: 1.16.x
       - name: Set env var
         run: |
-          make dependencies
+          make -B dependencies
           echo "BRANCH=$(git rev-parse --abbrev-ref HEAD)" >> $GITHUB_ENV
           echo "FLUX_VERSION=$($(pwd)/tools/bin/stoml $(pwd)/tools/dependencies.toml flux.version)" >> $GITHUB_ENV
       - name: Run GoReleaser


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Now that we don't always download dependencies, the release process failed as it wasn't getting a flux binary from which to obtain a version. This adds the `-B` flag so that we always download.

<!-- Tell your future self why have you made these changes -->
**Why?**
So releasing will work

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**
Built a release in a fork

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
**Release notes**
No

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
None.