### PR TITLE
Sanitize cluster name

### DIFF
--- a/pkg/kube/kube.go
+++ b/pkg/kube/kube.go
@@ -119,7 +119,7 @@ func (k *KubeClient) GetClusterName(ctx context.Context) (string, error) {
 }
 
 func sanitize(name string) string {
-	reRemoveUnAllowed := regexp.MustCompile(`![^a-z0-9\s-]+$`)
+	reRemoveUnAllowed := regexp.MustCompile(`[^a-z0-9\s-]+`)
 	reNoDupDashes := regexp.MustCompile(`^--+`)
 	reNoOutsideDashes := regexp.MustCompile(`^-+|-$`)
 

--- a/pkg/kube/kube.go
+++ b/pkg/kube/kube.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"encoding/json"
@@ -113,7 +114,19 @@ func (k *KubeClient) GetClusterName(ctx context.Context) (string, error) {
 		return "", errors.Wrap(err, "failed to get kubectl current-context")
 	}
 
-	return string(bytes.TrimSuffix(out, []byte("\n"))), nil
+	clusterName := sanitize(string(bytes.TrimSuffix(out, []byte("\n"))))
+	return clusterName, nil
+}
+
+func sanitize(name string) string {
+	reRemoveUnAllowed := regexp.MustCompile(`![^a-z0-9\s-]+$`)
+	reNoDupDashes := regexp.MustCompile(`^--+`)
+	reNoOutsideDashes := regexp.MustCompile(`^-+|-$`)
+
+	replaceUnderscores := strings.ReplaceAll(strings.ToLower(name), "_", "-")
+	notAllowed := reRemoveUnAllowed.ReplaceAllString(replaceUnderscores, "")
+	noDupDashes := reNoDupDashes.ReplaceAllString(notAllowed, "")
+	return reNoOutsideDashes.ReplaceAllString(noDupDashes, "")
 }
 
 func (k *KubeClient) GetClusterStatus(ctx context.Context) ClusterStatus {

--- a/pkg/kube/kube_test.go
+++ b/pkg/kube/kube_test.go
@@ -129,6 +129,39 @@ var _ = Describe("GetClusterName", func() {
 	})
 })
 
+var _ = Describe("FixInvalidClusterName", func() {
+	It("returns a valid cluster name", func() {
+
+		for _, each := range []struct{
+			Invalid string
+			Valid   string
+		}{
+			{"cluster_name\n", "cluster-name"},
+			{"Cluster@name\n", "clustername"},
+			{"--cluster-name\n", "cluster-name"},
+			{"cluster-name-\n", "cluster-name"},
+			{"cluster-name$\n", "cluster-name"},
+			{"$cluster-name\n", "cluster-name"},
+			{"clustner-name@1\n", "cluster-name1"},
+			{"1@#$%^&*(_+w2\n", "1-w2"},
+		} {
+
+			runner.RunStub = func(cmd string, args ...string) ([]byte, error) {
+				return []byte(each.Invalid), nil
+			}
+
+			out, err := kubeClient.GetClusterName(context.Background())
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(string(out)).To(Equal(each.Valid))
+
+			cmd, args := runner.RunArgsForCall(0)
+			Expect(cmd).To(Equal("kubectl"))
+
+			Expect(strings.Join(args, " ")).To(Equal("config current-context"))
+		}
+	})
+})
+
 var _ = Describe("FluxPresent", func() {
 	It("looks for flux-system namespace", func() {
 		_, err := kubeClient.FluxPresent(context.Background())

--- a/pkg/kube/kube_test.go
+++ b/pkg/kube/kube_test.go
@@ -142,7 +142,7 @@ var _ = Describe("FixInvalidClusterName", func() {
 			{"cluster-name-\n", "cluster-name"},
 			{"cluster-name$\n", "cluster-name"},
 			{"$cluster-name\n", "cluster-name"},
-			{"clustner-name@1\n", "cluster-name1"},
+			{"cluster-name@1\n", "cluster-name1"},
 			{"1@#$%^&*(_+w2\n", "1-w2"},
 		} {
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Sanitized the cluster names, which comply now with RFC 1053 naming used by K8s

<!-- Tell your future self why have you made these changes -->
**Why?**
Creating clusters with invalid cluster names would cause failures

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**
Create unit-test case for this with a number of examples.
<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
**Release notes**

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
Probably should add language about the validation possibly changing the cluster name in weave-gitops-docs