### PR TITLE
Use k8s env when doing server tests

### DIFF
--- a/pkg/server/suite_test.go
+++ b/pkg/server/suite_test.go
@@ -8,11 +8,19 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	wego "github.com/weaveworks/weave-gitops/api/v1alpha1"
 	pb "github.com/weaveworks/weave-gitops/pkg/api/applications"
-	"github.com/weaveworks/weave-gitops/pkg/kube/kubefakes"
+	"github.com/weaveworks/weave-gitops/pkg/kube"
 	"github.com/weaveworks/weave-gitops/pkg/server"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/test/bufconn"
+	apiruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+
+	corev1 "k8s.io/api/core/v1"
 )
 
 func TestServer(t *testing.T) {
@@ -28,22 +36,63 @@ var lis *bufconn.Listener
 
 var s *grpc.Server
 var apps pb.ApplicationsServer
-var client pb.ApplicationsClient
+var appsClient pb.ApplicationsClient
 var conn *grpc.ClientConn
 var err error
-var kubeClient *kubefakes.FakeKube
+var k8sClient client.Client
+var testEnv *envtest.Environment
+var testClustername = "test-cluster"
+var cfg *rest.Config
+var scheme *apiruntime.Scheme
+var k kube.Kube
+var k8sManager ctrl.Manager
 
 func bufDialer(context.Context, string) (net.Conn, error) {
 	return lis.Dial()
 }
 
+var _ = BeforeSuite(func(done Done) {
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths: []string{
+			"../../manifests/crds",
+			"../../tools/testcrds",
+		},
+	}
+
+	var err error
+	cfg, err = testEnv.Start()
+	Expect(err).ToNot(HaveOccurred())
+	Expect(cfg).ToNot(BeNil())
+
+	scheme = kube.CreateScheme()
+
+	k8sManager, err = ctrl.NewManager(cfg, ctrl.Options{
+		ClientDisableCacheFor: []client.Object{
+			&wego.Application{},
+			&corev1.Namespace{},
+			&corev1.Secret{},
+		},
+		Scheme: scheme,
+	})
+	Expect(err).ToNot(HaveOccurred())
+
+	go func() {
+		err = k8sManager.Start(ctrl.SetupSignalHandler())
+		Expect(err).ToNot(HaveOccurred())
+	}()
+
+	k8sClient = k8sManager.GetClient()
+	Expect(k8sClient).ToNot(BeNil())
+	close(done)
+}, 60)
+
 var _ = BeforeEach(func() {
 	lis = bufconn.Listen(bufSize)
 	s = grpc.NewServer()
 
-	kubeClient = &kubefakes.FakeKube{}
+	k = &kube.KubeHTTP{Client: k8sClient, ClusterName: testClustername}
 
-	apps = server.NewApplicationsServer(kubeClient)
+	apps = server.NewApplicationsServer(k)
 	pb.RegisterApplicationsServer(s, apps)
 
 	go func() {
@@ -57,7 +106,7 @@ var _ = BeforeEach(func() {
 
 	Expect(err).NotTo(HaveOccurred())
 
-	client = pb.NewApplicationsClient(conn)
+	appsClient = pb.NewApplicationsClient(conn)
 })
 
 var _ = AfterEach(func() {

--- a/tools/testcrds/kustomize.toolkit.fluxcd.io_kustomizations.yaml
+++ b/tools/testcrds/kustomize.toolkit.fluxcd.io_kustomizations.yaml
@@ -1,0 +1,428 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.5.0
+  creationTimestamp: null
+  name: kustomizations.kustomize.toolkit.fluxcd.io
+spec:
+  group: kustomize.toolkit.fluxcd.io
+  names:
+    kind: Kustomization
+    listKind: KustomizationList
+    plural: kustomizations
+    shortNames:
+      - ks
+    singular: kustomization
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].message
+          name: Status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: Kustomization is the Schema for the kustomizations API.
+          properties:
+            apiVersion:
+              description: "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+              type: string
+            kind:
+              description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: KustomizationSpec defines the desired state of a kustomization.
+              properties:
+                decryption:
+                  description: Decrypt Kubernetes secrets before applying them on the cluster.
+                  properties:
+                    provider:
+                      description: Provider is the name of the decryption engine.
+                      enum:
+                        - sops
+                      type: string
+                    secretRef:
+                      description: The secret name containing the private OpenPGP keys used for decryption.
+                      properties:
+                        name:
+                          description: Name of the referent
+                          type: string
+                      required:
+                        - name
+                      type: object
+                  required:
+                    - provider
+                  type: object
+                dependsOn:
+                  description: DependsOn may contain a dependency.CrossNamespaceDependencyReference slice with references to Kustomization resources that must be ready before this Kustomization can be reconciled.
+                  items:
+                    description: CrossNamespaceDependencyReference holds the reference to a dependency.
+                    properties:
+                      name:
+                        description: Name holds the name reference of a dependency.
+                        type: string
+                      namespace:
+                        description: Namespace holds the namespace reference of a dependency.
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
+                force:
+                  default: false
+                  description: Force instructs the controller to recreate resources when patching fails due to an immutable field change.
+                  type: boolean
+                healthChecks:
+                  description: A list of resources to be included in the health assessment.
+                  items:
+                    description: NamespacedObjectKindReference contains enough information to let you locate the typed referenced object in any namespace
+                    properties:
+                      apiVersion:
+                        description: API version of the referent, if not specified the Kubernetes preferred version will be used
+                        type: string
+                      kind:
+                        description: Kind of the referent
+                        type: string
+                      name:
+                        description: Name of the referent
+                        type: string
+                      namespace:
+                        description: Namespace of the referent, when not specified it acts as LocalObjectReference
+                        type: string
+                    required:
+                      - kind
+                      - name
+                    type: object
+                  type: array
+                images:
+                  description: Images is a list of (image name, new name, new tag or digest) for changing image names, tags or digests. This can also be achieved with a patch, but this operator is simpler to specify.
+                  items:
+                    description: Image contains an image name, a new name, a new tag or digest, which will replace the original name and tag.
+                    properties:
+                      digest:
+                        description: Digest is the value used to replace the original image tag. If digest is present NewTag value is ignored.
+                        type: string
+                      name:
+                        description: Name is a tag-less image name.
+                        type: string
+                      newName:
+                        description: NewName is the value used to replace the original name.
+                        type: string
+                      newTag:
+                        description: NewTag is the value used to replace the original tag.
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
+                interval:
+                  description: The interval at which to reconcile the Kustomization.
+                  type: string
+                kubeConfig:
+                  description: The KubeConfig for reconciling the Kustomization on a remote cluster. When specified, KubeConfig takes precedence over ServiceAccountName.
+                  properties:
+                    secretRef:
+                      description: SecretRef holds the name to a secret that contains a 'value' key with the kubeconfig file as the value. It must be in the same namespace as the Kustomization. It is recommended that the kubeconfig is self-contained, and the secret is regularly updated if credentials such as a cloud-access-token expire. Cloud specific `cmd-path` auth helpers will not function without adding binaries and credentials to the Pod that is responsible for reconciling the Kustomization.
+                      properties:
+                        name:
+                          description: Name of the referent
+                          type: string
+                      required:
+                        - name
+                      type: object
+                  type: object
+                patches:
+                  description: Strategic merge and JSON patches, defined as inline YAML objects, capable of targeting objects based on kind, label and annotation selectors.
+                  items:
+                    description: Patch contains either a StrategicMerge or a JSON6902 patch, either a file or inline, and the target the patch should be applied to.
+                    properties:
+                      patch:
+                        description: Patch contains the JSON6902 patch document with an array of operation objects.
+                        type: string
+                      target:
+                        description: Target points to the resources that the patch document should be applied to.
+                        properties:
+                          annotationSelector:
+                            description: AnnotationSelector is a string that follows the label selection expression https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api It matches with the resource annotations.
+                            type: string
+                          group:
+                            description: Group is the API group to select resources from. Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources. https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                            type: string
+                          kind:
+                            description: Kind of the API Group to select resources from. Together with Group and Version it is capable of unambiguously identifying and/or selecting resources. https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                            type: string
+                          labelSelector:
+                            description: LabelSelector is a string that follows the label selection expression https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api It matches with the resource labels.
+                            type: string
+                          name:
+                            description: Name to match resources with.
+                            type: string
+                          namespace:
+                            description: Namespace to select resources from.
+                            type: string
+                          version:
+                            description: Version of the API Group to select resources from. Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources. https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                            type: string
+                        type: object
+                    type: object
+                  type: array
+                patchesJson6902:
+                  description: JSON 6902 patches, defined as inline YAML objects.
+                  items:
+                    description: JSON6902Patch contains a JSON6902 patch and the target the patch should be applied to.
+                    properties:
+                      patch:
+                        description: Patch contains the JSON6902 patch document with an array of operation objects.
+                        items:
+                          description: JSON6902 is a JSON6902 operation object. https://tools.ietf.org/html/rfc6902#section-4
+                          properties:
+                            from:
+                              type: string
+                            op:
+                              enum:
+                                - test
+                                - remove
+                                - add
+                                - replace
+                                - move
+                                - copy
+                              type: string
+                            path:
+                              type: string
+                            value:
+                              x-kubernetes-preserve-unknown-fields: true
+                          required:
+                            - op
+                            - path
+                          type: object
+                        type: array
+                      target:
+                        description: Target points to the resources that the patch document should be applied to.
+                        properties:
+                          annotationSelector:
+                            description: AnnotationSelector is a string that follows the label selection expression https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api It matches with the resource annotations.
+                            type: string
+                          group:
+                            description: Group is the API group to select resources from. Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources. https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                            type: string
+                          kind:
+                            description: Kind of the API Group to select resources from. Together with Group and Version it is capable of unambiguously identifying and/or selecting resources. https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                            type: string
+                          labelSelector:
+                            description: LabelSelector is a string that follows the label selection expression https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api It matches with the resource labels.
+                            type: string
+                          name:
+                            description: Name to match resources with.
+                            type: string
+                          namespace:
+                            description: Namespace to select resources from.
+                            type: string
+                          version:
+                            description: Version of the API Group to select resources from. Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources. https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                            type: string
+                        type: object
+                    required:
+                      - patch
+                      - target
+                    type: object
+                  type: array
+                patchesStrategicMerge:
+                  description: Strategic merge patches, defined as inline YAML objects.
+                  items:
+                    x-kubernetes-preserve-unknown-fields: true
+                  type: array
+                path:
+                  description: Path to the directory containing the kustomization.yaml file, or the set of plain YAMLs a kustomization.yaml should be generated for. Defaults to 'None', which translates to the root path of the SourceRef.
+                  type: string
+                postBuild:
+                  description: PostBuild describes which actions to perform on the YAML manifest generated by building the kustomize overlay.
+                  properties:
+                    substitute:
+                      additionalProperties:
+                        type: string
+                      description: Substitute holds a map of key/value pairs. The variables defined in your YAML manifests that match any of the keys defined in the map will be substituted with the set value. Includes support for bash string replacement functions e.g. ${var:=default}, ${var:position} and ${var/substring/replacement}.
+                      type: object
+                    substituteFrom:
+                      description: SubstituteFrom holds references to ConfigMaps and Secrets containing the variables and their values to be substituted in the YAML manifests. The ConfigMap and the Secret data keys represent the var names and they must match the vars declared in the manifests for the substitution to happen.
+                      items:
+                        description: SubstituteReference contains a reference to a resource containing the variables name and value.
+                        properties:
+                          kind:
+                            description: Kind of the values referent, valid values are ('Secret', 'ConfigMap').
+                            enum:
+                              - Secret
+                              - ConfigMap
+                            type: string
+                          name:
+                            description: Name of the values referent. Should reside in the same namespace as the referring resource.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                        required:
+                          - kind
+                          - name
+                        type: object
+                      type: array
+                  type: object
+                prune:
+                  description: Prune enables garbage collection.
+                  type: boolean
+                retryInterval:
+                  description: The interval at which to retry a previously failed reconciliation. When not specified, the controller uses the KustomizationSpec.Interval value to retry failures.
+                  type: string
+                serviceAccountName:
+                  description: The name of the Kubernetes service account to impersonate when reconciling this Kustomization.
+                  type: string
+                sourceRef:
+                  description: Reference of the source where the kustomization file is.
+                  properties:
+                    apiVersion:
+                      description: API version of the referent
+                      type: string
+                    kind:
+                      description: Kind of the referent
+                      enum:
+                        - GitRepository
+                        - Bucket
+                      type: string
+                    name:
+                      description: Name of the referent
+                      type: string
+                    namespace:
+                      description: Namespace of the referent, defaults to the Kustomization namespace
+                      type: string
+                  required:
+                    - kind
+                    - name
+                  type: object
+                suspend:
+                  description: This flag tells the controller to suspend subsequent kustomize executions, it does not apply to already started executions. Defaults to false.
+                  type: boolean
+                targetNamespace:
+                  description: TargetNamespace sets or overrides the namespace in the kustomization.yaml file.
+                  maxLength: 63
+                  minLength: 1
+                  type: string
+                timeout:
+                  description: Timeout for validation, apply and health checking operations. Defaults to 'Interval' duration.
+                  type: string
+                validation:
+                  description: Validate the Kubernetes objects before applying them on the cluster. The validation strategy can be 'client' (local dry-run), 'server' (APIServer dry-run) or 'none'. When 'Force' is 'true', validation will fallback to 'client' if set to 'server' because server-side validation is not supported in this scenario.
+                  enum:
+                    - none
+                    - client
+                    - server
+                  type: string
+              required:
+                - interval
+                - prune
+                - sourceRef
+              type: object
+            status:
+              description: KustomizationStatus defines the observed state of a kustomization.
+              properties:
+                conditions:
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                lastAppliedRevision:
+                  description: The last successfully applied revision. The revision format for Git sources is <branch|tag>/<commit-sha>.
+                  type: string
+                lastAttemptedRevision:
+                  description: LastAttemptedRevision is the revision of the last reconciliation attempt.
+                  type: string
+                lastHandledReconcileAt:
+                  description: LastHandledReconcileAt holds the value of the most recent reconcile request value, so a change can be detected.
+                  type: string
+                observedGeneration:
+                  description: ObservedGeneration is the last reconciled generation.
+                  format: int64
+                  type: integer
+                snapshot:
+                  description: The last successfully applied revision metadata.
+                  properties:
+                    checksum:
+                      description: The manifests sha1 checksum.
+                      type: string
+                    entries:
+                      description: A list of Kubernetes kinds grouped by namespace.
+                      items:
+                        description: Snapshot holds the metadata of namespaced Kubernetes objects
+                        properties:
+                          kinds:
+                            additionalProperties:
+                              type: string
+                            description: The list of Kubernetes kinds.
+                            type: object
+                          namespace:
+                            description: The namespace of this entry.
+                            type: string
+                        required:
+                          - kinds
+                        type: object
+                      type: array
+                  required:
+                    - checksum
+                    - entries
+                  type: object
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/tools/testcrds/source.toolkit.fluxcd.io_buckets.yaml
+++ b/tools/testcrds/source.toolkit.fluxcd.io_buckets.yaml
@@ -1,0 +1,184 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.5.0
+  creationTimestamp: null
+  name: buckets.source.toolkit.fluxcd.io
+spec:
+  group: source.toolkit.fluxcd.io
+  names:
+    kind: Bucket
+    listKind: BucketList
+    plural: buckets
+    singular: bucket
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.url
+          name: URL
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].message
+          name: Status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: Bucket is the Schema for the buckets API
+          properties:
+            apiVersion:
+              description: "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+              type: string
+            kind:
+              description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: BucketSpec defines the desired state of an S3 compatible bucket
+              properties:
+                bucketName:
+                  description: The bucket name.
+                  type: string
+                endpoint:
+                  description: The bucket endpoint address.
+                  type: string
+                ignore:
+                  description: Ignore overrides the set of excluded patterns in the .sourceignore format (which is the same as .gitignore). If not provided, a default will be used, consult the documentation for your version to find out what those are.
+                  type: string
+                insecure:
+                  description: Insecure allows connecting to a non-TLS S3 HTTP endpoint.
+                  type: boolean
+                interval:
+                  description: The interval at which to check for bucket updates.
+                  type: string
+                provider:
+                  default: generic
+                  description: The S3 compatible storage provider name, default ('generic').
+                  enum:
+                    - generic
+                    - aws
+                  type: string
+                region:
+                  description: The bucket region.
+                  type: string
+                secretRef:
+                  description: The name of the secret containing authentication credentials for the Bucket.
+                  properties:
+                    name:
+                      description: Name of the referent
+                      type: string
+                  required:
+                    - name
+                  type: object
+                suspend:
+                  description: This flag tells the controller to suspend the reconciliation of this source.
+                  type: boolean
+                timeout:
+                  default: 20s
+                  description: The timeout for download operations, defaults to 20s.
+                  type: string
+              required:
+                - bucketName
+                - endpoint
+                - interval
+              type: object
+            status:
+              description: BucketStatus defines the observed state of a bucket
+              properties:
+                artifact:
+                  description: Artifact represents the output of the last successful Bucket sync.
+                  properties:
+                    checksum:
+                      description: Checksum is the SHA1 checksum of the artifact.
+                      type: string
+                    lastUpdateTime:
+                      description: LastUpdateTime is the timestamp corresponding to the last update of this artifact.
+                      format: date-time
+                      type: string
+                    path:
+                      description: Path is the relative file path of this artifact.
+                      type: string
+                    revision:
+                      description: Revision is a human readable identifier traceable in the origin source system. It can be a Git commit SHA, Git tag, a Helm index timestamp, a Helm chart version, etc.
+                      type: string
+                    url:
+                      description: URL is the HTTP address of this artifact.
+                      type: string
+                  required:
+                    - path
+                    - url
+                  type: object
+                conditions:
+                  description: Conditions holds the conditions for the Bucket.
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                lastHandledReconcileAt:
+                  description: LastHandledReconcileAt holds the value of the most recent reconcile request value, so a change can be detected.
+                  type: string
+                observedGeneration:
+                  description: ObservedGeneration is the last observed generation.
+                  format: int64
+                  type: integer
+                url:
+                  description: URL is the download link for the artifact output of the last Bucket sync.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/tools/testcrds/source.toolkit.fluxcd.io_gitrepositories.yaml
+++ b/tools/testcrds/source.toolkit.fluxcd.io_gitrepositories.yaml
@@ -1,0 +1,267 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.5.0
+  creationTimestamp: null
+  name: gitrepositories.source.toolkit.fluxcd.io
+spec:
+  group: source.toolkit.fluxcd.io
+  names:
+    kind: GitRepository
+    listKind: GitRepositoryList
+    plural: gitrepositories
+    shortNames:
+      - gitrepo
+    singular: gitrepository
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.url
+          name: URL
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].message
+          name: Status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: GitRepository is the Schema for the gitrepositories API
+          properties:
+            apiVersion:
+              description: "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+              type: string
+            kind:
+              description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: GitRepositorySpec defines the desired state of a Git repository.
+              properties:
+                gitImplementation:
+                  default: go-git
+                  description: Determines which git client library to use. Defaults to go-git, valid values are ('go-git', 'libgit2').
+                  enum:
+                    - go-git
+                    - libgit2
+                  type: string
+                ignore:
+                  description: Ignore overrides the set of excluded patterns in the .sourceignore format (which is the same as .gitignore). If not provided, a default will be used, consult the documentation for your version to find out what those are.
+                  type: string
+                include:
+                  description: Extra git repositories to map into the repository
+                  items:
+                    description: GitRepositoryInclude defines a source with a from and to path.
+                    properties:
+                      fromPath:
+                        description: The path to copy contents from, defaults to the root directory.
+                        type: string
+                      repository:
+                        description: Reference to a GitRepository to include.
+                        properties:
+                          name:
+                            description: Name of the referent
+                            type: string
+                        required:
+                          - name
+                        type: object
+                      toPath:
+                        description: The path to copy contents to, defaults to the name of the source ref.
+                        type: string
+                    required:
+                      - repository
+                    type: object
+                  type: array
+                interval:
+                  description: The interval at which to check for repository updates.
+                  type: string
+                recurseSubmodules:
+                  description: When enabled, after the clone is created, initializes all submodules within, using their default settings. This option is available only when using the 'go-git' GitImplementation.
+                  type: boolean
+                ref:
+                  description: The Git reference to checkout and monitor for changes, defaults to master branch.
+                  properties:
+                    branch:
+                      default: master
+                      description: The Git branch to checkout, defaults to master.
+                      type: string
+                    commit:
+                      description: The Git commit SHA to checkout, if specified Tag filters will be ignored.
+                      type: string
+                    semver:
+                      description: The Git tag semver expression, takes precedence over Tag.
+                      type: string
+                    tag:
+                      description: The Git tag to checkout, takes precedence over Branch.
+                      type: string
+                  type: object
+                secretRef:
+                  description: The secret name containing the Git credentials. For HTTPS repositories the secret must contain username and password fields. For SSH repositories the secret must contain identity, identity.pub and known_hosts fields.
+                  properties:
+                    name:
+                      description: Name of the referent
+                      type: string
+                  required:
+                    - name
+                  type: object
+                suspend:
+                  description: This flag tells the controller to suspend the reconciliation of this source.
+                  type: boolean
+                timeout:
+                  default: 20s
+                  description: The timeout for remote Git operations like cloning, defaults to 20s.
+                  type: string
+                url:
+                  description: The repository URL, can be a HTTP/S or SSH address.
+                  pattern: ^(http|https|ssh)://
+                  type: string
+                verify:
+                  description: Verify OpenPGP signature for the Git commit HEAD points to.
+                  properties:
+                    mode:
+                      description: Mode describes what git object should be verified, currently ('head').
+                      enum:
+                        - head
+                      type: string
+                    secretRef:
+                      description: The secret name containing the public keys of all trusted Git authors.
+                      properties:
+                        name:
+                          description: Name of the referent
+                          type: string
+                      required:
+                        - name
+                      type: object
+                  required:
+                    - mode
+                  type: object
+              required:
+                - interval
+                - url
+              type: object
+            status:
+              description: GitRepositoryStatus defines the observed state of a Git repository.
+              properties:
+                artifact:
+                  description: Artifact represents the output of the last successful repository sync.
+                  properties:
+                    checksum:
+                      description: Checksum is the SHA1 checksum of the artifact.
+                      type: string
+                    lastUpdateTime:
+                      description: LastUpdateTime is the timestamp corresponding to the last update of this artifact.
+                      format: date-time
+                      type: string
+                    path:
+                      description: Path is the relative file path of this artifact.
+                      type: string
+                    revision:
+                      description: Revision is a human readable identifier traceable in the origin source system. It can be a Git commit SHA, Git tag, a Helm index timestamp, a Helm chart version, etc.
+                      type: string
+                    url:
+                      description: URL is the HTTP address of this artifact.
+                      type: string
+                  required:
+                    - path
+                    - url
+                  type: object
+                conditions:
+                  description: Conditions holds the conditions for the GitRepository.
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                includedArtifacts:
+                  description: IncludedArtifacts represents the included artifacts from the last successful repository sync.
+                  items:
+                    description: Artifact represents the output of a source synchronisation.
+                    properties:
+                      checksum:
+                        description: Checksum is the SHA1 checksum of the artifact.
+                        type: string
+                      lastUpdateTime:
+                        description: LastUpdateTime is the timestamp corresponding to the last update of this artifact.
+                        format: date-time
+                        type: string
+                      path:
+                        description: Path is the relative file path of this artifact.
+                        type: string
+                      revision:
+                        description: Revision is a human readable identifier traceable in the origin source system. It can be a Git commit SHA, Git tag, a Helm index timestamp, a Helm chart version, etc.
+                        type: string
+                      url:
+                        description: URL is the HTTP address of this artifact.
+                        type: string
+                    required:
+                      - path
+                      - url
+                    type: object
+                  type: array
+                lastHandledReconcileAt:
+                  description: LastHandledReconcileAt holds the value of the most recent reconcile request value, so a change can be detected.
+                  type: string
+                observedGeneration:
+                  description: ObservedGeneration is the last observed generation.
+                  format: int64
+                  type: integer
+                url:
+                  description: URL is the download link for the artifact output of the last repository sync.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/tools/testcrds/source.toolkit.fluxcd.io_helmcharts.yaml
+++ b/tools/testcrds/source.toolkit.fluxcd.io_helmcharts.yaml
@@ -1,0 +1,195 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.5.0
+  creationTimestamp: null
+  name: helmcharts.source.toolkit.fluxcd.io
+spec:
+  group: source.toolkit.fluxcd.io
+  names:
+    kind: HelmChart
+    listKind: HelmChartList
+    plural: helmcharts
+    shortNames:
+      - hc
+    singular: helmchart
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.chart
+          name: Chart
+          type: string
+        - jsonPath: .spec.version
+          name: Version
+          type: string
+        - jsonPath: .spec.sourceRef.kind
+          name: Source Kind
+          type: string
+        - jsonPath: .spec.sourceRef.name
+          name: Source Name
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].message
+          name: Status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: HelmChart is the Schema for the helmcharts API
+          properties:
+            apiVersion:
+              description: "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+              type: string
+            kind:
+              description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: HelmChartSpec defines the desired state of a Helm chart.
+              properties:
+                chart:
+                  description: The name or path the Helm chart is available at in the SourceRef.
+                  type: string
+                interval:
+                  description: The interval at which to check the Source for updates.
+                  type: string
+                sourceRef:
+                  description: The reference to the Source the chart is available at.
+                  properties:
+                    apiVersion:
+                      description: APIVersion of the referent.
+                      type: string
+                    kind:
+                      description: Kind of the referent, valid values are ('HelmRepository', 'GitRepository', 'Bucket').
+                      enum:
+                        - HelmRepository
+                        - GitRepository
+                        - Bucket
+                      type: string
+                    name:
+                      description: Name of the referent.
+                      type: string
+                  required:
+                    - kind
+                    - name
+                  type: object
+                suspend:
+                  description: This flag tells the controller to suspend the reconciliation of this source.
+                  type: boolean
+                valuesFile:
+                  description: Alternative values file to use as the default chart values, expected to be a relative path in the SourceRef. Deprecated in favor of ValuesFiles, for backwards compatibility the file defined here is merged before the ValuesFiles items. Ignored when omitted.
+                  type: string
+                valuesFiles:
+                  description: Alternative list of values files to use as the chart values (values.yaml is not included by default), expected to be a relative path in the SourceRef. Values files are merged in the order of this list with the last file overriding the first. Ignored when omitted.
+                  items:
+                    type: string
+                  type: array
+                version:
+                  default: "*"
+                  description: The chart version semver expression, ignored for charts from GitRepository and Bucket sources. Defaults to latest when omitted.
+                  type: string
+              required:
+                - chart
+                - interval
+                - sourceRef
+              type: object
+            status:
+              description: HelmChartStatus defines the observed state of the HelmChart.
+              properties:
+                artifact:
+                  description: Artifact represents the output of the last successful chart sync.
+                  properties:
+                    checksum:
+                      description: Checksum is the SHA1 checksum of the artifact.
+                      type: string
+                    lastUpdateTime:
+                      description: LastUpdateTime is the timestamp corresponding to the last update of this artifact.
+                      format: date-time
+                      type: string
+                    path:
+                      description: Path is the relative file path of this artifact.
+                      type: string
+                    revision:
+                      description: Revision is a human readable identifier traceable in the origin source system. It can be a Git commit SHA, Git tag, a Helm index timestamp, a Helm chart version, etc.
+                      type: string
+                    url:
+                      description: URL is the HTTP address of this artifact.
+                      type: string
+                  required:
+                    - path
+                    - url
+                  type: object
+                conditions:
+                  description: Conditions holds the conditions for the HelmChart.
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                lastHandledReconcileAt:
+                  description: LastHandledReconcileAt holds the value of the most recent reconcile request value, so a change can be detected.
+                  type: string
+                observedGeneration:
+                  description: ObservedGeneration is the last observed generation.
+                  format: int64
+                  type: integer
+                url:
+                  description: URL is the download link for the last chart pulled.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/tools/testcrds/source.toolkit.fluxcd.io_helmrepositories.yaml
+++ b/tools/testcrds/source.toolkit.fluxcd.io_helmrepositories.yaml
@@ -1,0 +1,169 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.5.0
+  creationTimestamp: null
+  name: helmrepositories.source.toolkit.fluxcd.io
+spec:
+  group: source.toolkit.fluxcd.io
+  names:
+    kind: HelmRepository
+    listKind: HelmRepositoryList
+    plural: helmrepositories
+    shortNames:
+      - helmrepo
+    singular: helmrepository
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.url
+          name: URL
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].message
+          name: Status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: HelmRepository is the Schema for the helmrepositories API
+          properties:
+            apiVersion:
+              description: "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+              type: string
+            kind:
+              description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: HelmRepositorySpec defines the reference to a Helm repository.
+              properties:
+                interval:
+                  description: The interval at which to check the upstream for updates.
+                  type: string
+                passCredentials:
+                  description: PassCredentials allows the credentials from the SecretRef to be passed on to a host that does not match the host as defined in URL. This may be required if the host of the advertised chart URLs in the index differ from the defined URL. Enabling this should be done with caution, as it can potentially result in credentials getting stolen in a MITM-attack.
+                  type: boolean
+                secretRef:
+                  description: The name of the secret containing authentication credentials for the Helm repository. For HTTP/S basic auth the secret must contain username and password fields. For TLS the secret must contain a certFile and keyFile, and/or caCert fields.
+                  properties:
+                    name:
+                      description: Name of the referent
+                      type: string
+                  required:
+                    - name
+                  type: object
+                suspend:
+                  description: This flag tells the controller to suspend the reconciliation of this source.
+                  type: boolean
+                timeout:
+                  default: 60s
+                  description: The timeout of index downloading, defaults to 60s.
+                  type: string
+                url:
+                  description: The Helm repository URL, a valid URL contains at least a protocol and host.
+                  type: string
+              required:
+                - interval
+                - url
+              type: object
+            status:
+              description: HelmRepositoryStatus defines the observed state of the HelmRepository.
+              properties:
+                artifact:
+                  description: Artifact represents the output of the last successful repository sync.
+                  properties:
+                    checksum:
+                      description: Checksum is the SHA1 checksum of the artifact.
+                      type: string
+                    lastUpdateTime:
+                      description: LastUpdateTime is the timestamp corresponding to the last update of this artifact.
+                      format: date-time
+                      type: string
+                    path:
+                      description: Path is the relative file path of this artifact.
+                      type: string
+                    revision:
+                      description: Revision is a human readable identifier traceable in the origin source system. It can be a Git commit SHA, Git tag, a Helm index timestamp, a Helm chart version, etc.
+                      type: string
+                    url:
+                      description: URL is the HTTP address of this artifact.
+                      type: string
+                  required:
+                    - path
+                    - url
+                  type: object
+                conditions:
+                  description: Conditions holds the conditions for the HelmRepository.
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                lastHandledReconcileAt:
+                  description: LastHandledReconcileAt holds the value of the most recent reconcile request value, so a change can be detected.
+                  type: string
+                observedGeneration:
+                  description: ObservedGeneration is the last observed generation.
+                  format: int64
+                  type: integer
+                url:
+                  description: URL is the download link for the last index fetched.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []


### PR DESCRIPTION
The "sigs.k8s.io/controller-runtime/pkg/envtest" library provides the ability to test against a closer-to-reality version of kubernetes. It will catch certain classes of bugs around creating objects and validating object spec/labels/annotations, etc.

We already use this in the `kube` pkg tests, so no additional setup is required.