### PR TITLE
Use wego pkg constants instead of redeclaring

### DIFF
--- a/pkg/services/app/add.go
+++ b/pkg/services/app/add.go
@@ -124,7 +124,7 @@ func (a *App) Add(params AddParams) error {
 	}
 
 	var secretRef string
-	if SourceType(params.SourceType) == SourceTypeGit {
+	if wego.SourceType(params.SourceType) == wego.SourceTypeGit {
 		secretRef, err = a.createAndUploadDeployKey(info, params.DryRun, info.Spec.URL, gitProvider)
 		if err != nil {
 			return fmt.Errorf("could not generate deploy key: %w", err)
@@ -167,7 +167,7 @@ func getAppHash(info *AppResourceInfo) (string, error) {
 		return hex.EncodeToString(h.Sum(nil)), nil
 	}
 
-	if DeploymentType(info.Spec.DeploymentType) == DeployTypeHelm {
+	if info.Spec.DeploymentType == wego.DeploymentTypeHelm {
 		appHash, err = getHash(info.Spec.URL, info.Name, info.Spec.Branch)
 		if err != nil {
 			return "", err
@@ -197,11 +197,11 @@ func (a *App) printAddSummary(params AddParams) {
 }
 
 func (a *App) updateParametersIfNecessary(params AddParams) (AddParams, error) {
-	params.SourceType = string(SourceTypeGit)
+	params.SourceType = string(wego.SourceTypeGit)
 
 	if params.Chart != "" {
-		params.SourceType = string(SourceTypeHelm)
-		params.DeploymentType = string(DeployTypeHelm)
+		params.SourceType = string(wego.SourceTypeHelm)
+		params.DeploymentType = string(wego.DeploymentTypeHelm)
 		params.Path = params.Chart
 		if params.Name == "" {
 			params.Name = params.Chart
@@ -518,15 +518,15 @@ func (a *App) createAndUploadDeployKey(info *AppResourceInfo, dryRun bool, repoU
 }
 
 func (a *App) generateSource(info *AppResourceInfo, secretRef string) ([]byte, error) {
-	switch SourceType(info.Spec.SourceType) {
-	case SourceTypeGit:
+	switch info.Spec.SourceType {
+	case wego.SourceTypeGit:
 		sourceManifest, err := a.flux.CreateSourceGit(info.Name, info.Spec.URL, info.Spec.Branch, secretRef, info.Namespace)
 		if err != nil {
 			return nil, fmt.Errorf("could not create git source: %w", err)
 		}
 
 		return sourceManifest, nil
-	case SourceTypeHelm:
+	case wego.SourceTypeHelm:
 		return a.flux.CreateSourceHelm(info.Name, info.Spec.URL, info.Namespace)
 	default:
 		return nil, fmt.Errorf("unknown source type: %v", info.Spec.SourceType)
@@ -534,14 +534,14 @@ func (a *App) generateSource(info *AppResourceInfo, secretRef string) ([]byte, e
 }
 
 func (a *App) generateApplicationGoat(info *AppResourceInfo) ([]byte, error) {
-	switch string(info.Spec.DeploymentType) {
-	case string(DeployTypeKustomize):
+	switch info.Spec.DeploymentType {
+	case wego.DeploymentTypeKustomize:
 		return a.flux.CreateKustomization(info.Name, info.Name, info.Spec.Path, info.Namespace)
-	case string(DeployTypeHelm):
-		switch string(info.Spec.SourceType) {
-		case string(SourceTypeHelm):
+	case wego.DeploymentTypeHelm:
+		switch info.Spec.SourceType {
+		case wego.SourceTypeHelm:
 			return a.flux.CreateHelmReleaseHelmRepository(info.Name, info.Spec.Path, info.Namespace)
-		case string(SourceTypeGit):
+		case wego.SourceTypeGit:
 			return a.flux.CreateHelmReleaseGitRepository(info.Name, info.Name, info.Spec.Path, info.Namespace)
 		default:
 			return nil, fmt.Errorf("invalid source type: %v", info.Spec.SourceType)

--- a/pkg/services/app/add_test.go
+++ b/pkg/services/app/add_test.go
@@ -85,7 +85,7 @@ var _ = Describe("Add", func() {
 
 	Describe("checks for existing deploy key before creating secret", func() {
 		It("looks up deploy key and skips creating secret if found", func() {
-			addParams.SourceType = string(SourceTypeGit)
+			addParams.SourceType = string(wego.SourceTypeGit)
 
 			gitProviders.DeployKeyExistsStub = func(s1, s2 string) (bool, error) {
 				return true, nil
@@ -104,7 +104,7 @@ var _ = Describe("Add", func() {
 		})
 
 		It("looks up deploy key and creates secret if not found", func() {
-			addParams.SourceType = string(SourceTypeGit)
+			addParams.SourceType = string(wego.SourceTypeGit)
 
 			err := appSrv.Add(addParams)
 			Expect(err).ShouldNot(HaveOccurred())
@@ -132,7 +132,7 @@ var _ = Describe("Add", func() {
 
 		Describe("generates source manifest", func() {
 			It("creates GitRepository when source type is git", func() {
-				addParams.SourceType = string(SourceTypeGit)
+				addParams.SourceType = string(wego.SourceTypeGit)
 
 				err := appSrv.Add(addParams)
 				Expect(err).ShouldNot(HaveOccurred())
@@ -192,7 +192,7 @@ var _ = Describe("Add", func() {
 
 			It("creates a helm release using a git source if source type is git", func() {
 				addParams.Path = "./charts/my-chart"
-				addParams.DeploymentType = string(DeployTypeHelm)
+				addParams.DeploymentType = string(wego.DeploymentTypeHelm)
 
 				err := appSrv.Add(addParams)
 				Expect(err).ShouldNot(HaveOccurred())
@@ -275,7 +275,7 @@ var _ = Describe("Add", func() {
 
 		Describe("generates source manifest", func() {
 			It("creates GitRepository when source type is git", func() {
-				addParams.SourceType = string(SourceTypeGit)
+				addParams.SourceType = string(wego.SourceTypeGit)
 
 				err := appSrv.Add(addParams)
 				Expect(err).ShouldNot(HaveOccurred())
@@ -348,7 +348,7 @@ var _ = Describe("Add", func() {
 
 			It("creates a helm release using a git source if source type is git", func() {
 				addParams.Path = "./charts/my-chart"
-				addParams.DeploymentType = string(DeployTypeHelm)
+				addParams.DeploymentType = string(wego.DeploymentTypeHelm)
 
 				err := appSrv.Add(addParams)
 				Expect(err).ShouldNot(HaveOccurred())
@@ -457,7 +457,7 @@ var _ = Describe("Add", func() {
 
 		Describe("generates source manifest", func() {
 			It("creates GitRepository when source type is git", func() {
-				addParams.SourceType = string(SourceTypeGit)
+				addParams.SourceType = string(wego.SourceTypeGit)
 
 				err := appSrv.Add(addParams)
 				Expect(err).ShouldNot(HaveOccurred())
@@ -571,7 +571,7 @@ var _ = Describe("Add", func() {
 
 			It("creates a helm release using a git source if source type is git", func() {
 				addParams.Path = "./charts/my-chart"
-				addParams.DeploymentType = string(DeployTypeHelm)
+				addParams.DeploymentType = string(wego.DeploymentTypeHelm)
 
 				err := appSrv.Add(addParams)
 				Expect(err).ShouldNot(HaveOccurred())
@@ -704,7 +704,7 @@ var _ = Describe("Add", func() {
 			addParams.Url = "https://github.com/owner/repo1"
 			addParams.Chart = "nginx"
 			addParams.Branch = "main"
-			addParams.DeploymentType = string(DeployTypeHelm)
+			addParams.DeploymentType = string(wego.DeploymentTypeHelm)
 
 			info := getAppResourceInfo(makeWegoApplication(addParams), "")
 
@@ -722,7 +722,7 @@ var _ = Describe("Add", func() {
 			addParams.Url = "https://github.com/owner/repo1"
 			addParams.Path = "custompath"
 			addParams.Branch = "main"
-			addParams.DeploymentType = string(DeployTypeKustomize)
+			addParams.DeploymentType = string(wego.DeploymentTypeKustomize)
 
 			info := getAppResourceInfo(makeWegoApplication(addParams), "")
 

--- a/pkg/services/app/app.go
+++ b/pkg/services/app/app.go
@@ -12,19 +12,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-type DeploymentType string
-type SourceType string
-
-const (
-	// TODO: use wego.DeployType and wego.SourceType everywhere
-	// Convert these for now to avoid having to change large parts of the code base to the wego types
-	DeployTypeKustomize DeploymentType = DeploymentType(wego.DeploymentTypeKustomize)
-	DeployTypeHelm      DeploymentType = DeploymentType(wego.DeploymentTypeHelm)
-
-	SourceTypeGit  SourceType = SourceType(wego.SourceTypeGit)
-	SourceTypeHelm SourceType = SourceType(wego.SourceTypeHelm)
-)
-
 // AppService entity that manages applications
 type AppService interface {
 	// Add adds a new application to the cluster

--- a/pkg/services/app/status_test.go
+++ b/pkg/services/app/status_test.go
@@ -29,7 +29,7 @@ var _ = Describe("Status", func() {
 
 		kubeClient.GetApplicationStub = func(ctx context.Context, name types.NamespacedName) (*wego.Application, error) {
 			return &wego.Application{
-				Spec: wego.ApplicationSpec{DeploymentType: wego.DeploymentType(DeployTypeKustomize)},
+				Spec: wego.ApplicationSpec{DeploymentType: wego.DeploymentTypeKustomize},
 			}, nil
 		}
 	})
@@ -74,7 +74,7 @@ var _ = Describe("Status", func() {
 		It("returns when using helm", func() {
 			kubeClient.GetApplicationStub = func(ctx context.Context, name types.NamespacedName) (*wego.Application, error) {
 				return &wego.Application{
-					Spec: wego.ApplicationSpec{DeploymentType: wego.DeploymentType(DeployTypeHelm)},
+					Spec: wego.ApplicationSpec{DeploymentType: wego.DeploymentTypeHelm},
 				}, nil
 			}
 


### PR DESCRIPTION
Closes #507 

We were declaring `SourceType` and `DeploymentType` in both the `wego` package, as well as in the `services/app` package. This removes the `services/app/ declarations in favor of the `wego` ones.