### PR TITLE
Add API server logging  middleware

### DIFF
--- a/cmd/wego-server/main.go
+++ b/cmd/wego-server/main.go
@@ -3,28 +3,24 @@ package main
 import (
 	"context"
 	"fmt"
+	"log"
 	"math/rand"
 	"net/http"
 	"os"
 	"time"
 
+	"github.com/go-logr/zapr"
+	grpc_zap "github.com/grpc-ecosystem/go-grpc-middleware/logging/zap"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	pb "github.com/weaveworks/weave-gitops/pkg/api/applications"
 	"github.com/weaveworks/weave-gitops/pkg/kube"
+	"github.com/weaveworks/weave-gitops/pkg/middleware"
 	"github.com/weaveworks/weave-gitops/pkg/server"
+	"go.uber.org/zap"
 )
 
-func init() {
-	if os.Getenv("LOG_LEVEL") == "DEBUG" {
-		// Only log the debug severity or above.
-		log.SetLevel(log.DebugLevel)
-	} else if os.Getenv("LOG_LEVEL") == "WARN" {
-		// Only log the warning severity or above.
-		log.SetLevel(log.WarnLevel)
-	}
-}
+var customFunc grpc_zap.CodeToLevel
 
 func main() {
 	rand.Seed(time.Now().UnixNano())
@@ -52,38 +48,55 @@ func NewAPIServerCommand() *cobra.Command {
 var addr = "0.0.0.0:8000"
 
 func StartServer() error {
-	log.Infof("wego api server started. listen address: %s", addr)
-	return RunInProcessGateway(context.Background(), addr)
+	ctx := context.Background()
+
+	return RunInProcessGateway(ctx, addr)
 }
 
 // RunInProcessGateway starts the invoke in process http gateway.
-func RunInProcessGateway(ctx context.Context, addr string, opts ...runtime.ServeMuxOption) error {
-	mux := runtime.NewServeMux(opts...)
+func RunInProcessGateway(ctx context.Context, addr string) error {
+	zapLog, err := zap.NewDevelopment()
+	if err != nil {
+		log.Fatalf("could not create zap logger: %v", err)
+	}
+	log := zapr.NewLogger(zapLog)
 
 	kubeClient, err := kube.NewKubeHTTPClient()
 	if err != nil {
 		return fmt.Errorf("could not create kube http client: %w", err)
 	}
 
-	if err := pb.RegisterApplicationsHandlerServer(ctx, mux, server.NewApplicationsServer(kubeClient)); err != nil {
+	appsSrv := server.NewApplicationsServer(kubeClient)
+
+	mux := runtime.NewServeMux(middleware.InjectErrorIntoContext())
+	httpHandler := middleware.WithLogging(log, mux)
+
+	if err := pb.RegisterApplicationsHandlerServer(ctx, mux, appsSrv); err != nil {
 		return fmt.Errorf("could not register application: %w", err)
 	}
+
 	s := &http.Server{
 		Addr:    addr,
-		Handler: mux,
+		Handler: httpHandler,
 	}
 
 	go func() {
 		<-ctx.Done()
-		log.Infof("Shutting down the http gateway server")
+		log.Info("Shutting down the http gateway server")
 		if err := s.Shutdown(context.Background()); err != nil {
-			log.Errorf("Failed to shutdown http gateway server: %v", err)
+			log.Error(err, "failed to shutdown http gateway server")
 		}
 	}()
 
+	log.Info("wego api server started", "address", addr)
 	if err := s.ListenAndServe(); err != http.ErrServerClosed {
-		log.Errorf("Failed to listen and serve: %v", err)
+		log.Error(err, "failed to listen and serve")
 		return err
 	}
 	return nil
+}
+
+func CustomHTTPError(ctx context.Context, mux *runtime.ServeMux, marshaler runtime.Marshaler, w http.ResponseWriter, r *http.Request, err error) {
+
+	runtime.DefaultHTTPErrorHandler(ctx, mux, marshaler, w, r, err)
 }

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/go-logr/logr v0.4.0
 	github.com/go-logr/zapr v0.4.0
 	github.com/google/go-cmp v0.5.6
+	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.5.0
 	github.com/grpc-ecosystem/protoc-gen-grpc-gateway-ts v1.1.1
 	github.com/jandelgado/gcov2lcov v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -376,6 +376,8 @@ github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 h1:+ngKgrYPPJr
 github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
+github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 h1:+9834+KizmvFV7pXQGSXQTsaWhq2GjuNUt0aUU0YBYw=
+github.com/grpc-ecosystem/go-grpc-middleware v1.3.0/go.mod h1:z0ButlSOZa5vEBq9m2m2hlwIgKw+rp3sdCBRoJY+30Y=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
@@ -556,6 +558,7 @@ github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1y
 github.com/onsi/gomega v1.11.0/go.mod h1:azGKhqFUon9Vuj0YmTfLSmx0FUwqXYSTl5re8lQLTUg=
 github.com/onsi/gomega v1.13.0 h1:7lLHu94wT9Ij0o6EWWclhu0aOh32VxhkwEJvzuWPeak=
 github.com/onsi/gomega v1.13.0/go.mod h1:lRk9szgn8TxENtWd0Tp4c3wjlRfMTMH27I+3Je41yGY=
+github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/ory/go-acc v0.2.6 h1:YfI+L9dxI7QCtWn2RbawqO0vXhiThdXu/RgizJBbaq0=
 github.com/ory/go-acc v0.2.6/go.mod h1:4Kb/UnPcT8qRAk3IAxta+hvVapdxTLWtrr7bFLlEgpw=
 github.com/ory/viper v1.7.5 h1:+xVdq7SU3e1vNaCsk/ixsfxE4zylk1TJUiJrY647jUE=
@@ -1052,6 +1055,7 @@ google.golang.org/genproto v0.0.0-20200228133532-8c2c7df3a383/go.mod h1:55QSHmfG
 google.golang.org/genproto v0.0.0-20200305110556-506484158171/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/genproto v0.0.0-20200312145019-da6875a35672/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/genproto v0.0.0-20200331122359-1ee6d9798940/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
+google.golang.org/genproto v0.0.0-20200423170343-7949de9c1215/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/genproto v0.0.0-20200430143042-b979b6f78d84/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/genproto v0.0.0-20200511104702-f5ebc3bea380/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/genproto v0.0.0-20200513103714-09dca8ec2884/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -16,11 +16,14 @@ limitations under the License.
 
 package logger
 
+//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
+
 // Higher verbosity means the message is less important
 var LogLevelDebug int = 3
 var LogLevelWarn int = 2
 var LogLevelError int = 1
 
+//counterfeiter:generate . Logger
 type Logger interface {
 	Println(format string, a ...interface{})
 	Printf(format string, a ...interface{})

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -16,6 +16,11 @@ limitations under the License.
 
 package logger
 
+// Higher verbosity means the message is less important
+var LogLevelDebug int = 3
+var LogLevelWarn int = 2
+var LogLevelError int = 1
+
 type Logger interface {
 	Println(format string, a ...interface{})
 	Printf(format string, a ...interface{})

--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -2,7 +2,6 @@ package middleware
 
 import (
 	"context"
-	"errors"
 	"net/http"
 
 	"github.com/go-logr/logr"
@@ -20,35 +19,24 @@ func (r *statusRecorder) WriteHeader(status int) {
 	r.ResponseWriter.WriteHeader(status)
 }
 
-type grpcGatewayErrorMsg struct {
-	Code    int    `json:"code"`
-	Message string `json:"message"`
-}
+var RequestOkText = "request success"
+var RequestErrorText = "request error"
+var ServerErrorText = "server error"
 
-type key int
-
-const grpcRequestInfoContextKey key = iota
-
-type grpcRequestInfo struct {
-	Err error
-}
-
-// InjectErrorIntoContext injects the gRPC error message into the request context.
+// WithGrpcErrorLogging logs errors returned from server RPC handlers.
 // Our errors happen in gRPC land, so we cannot introspect into the content of
-// the error message in the WithLogging http.Handler. We need to extract the
-// error message and inject it into the request context to fetch it later in the logging middleware.
-// We can't log here because it would create duplicate log messages when combined with the WithLogging middleware.
+// the error message in the WithLogging http.Handler.
+// Normal gRPC middleware was not working for this:
 // https://github.com/grpc-ecosystem/grpc-gateway/issues/1043
-func InjectErrorIntoContext() runtime.ServeMuxOption {
+func WithGrpcErrorLogging(log logr.Logger) runtime.ServeMuxOption {
 	return runtime.WithErrorHandler(func(ctx context.Context, mux *runtime.ServeMux, marshaler runtime.Marshaler, w http.ResponseWriter, r *http.Request, err error) {
-		newCtx := context.WithValue(r.Context(), grpcRequestInfoContextKey, grpcRequestInfo{Err: err})
-		r = r.WithContext(newCtx)
+		log.Error(err, ServerErrorText)
 		// We don't want to change the behavior of error handling, just intercept for logging.
 		runtime.DefaultHTTPErrorHandler(ctx, mux, marshaler, w, r, err)
 	})
 }
 
-// Adds basic logging for HTTP requests.
+// WithLogging adds basic logging for HTTP requests.
 // Note that this accepts a grpc-gateway ServeMux instead of an http.Handler.
 func WithLogging(log logr.Logger, mux *runtime.ServeMux) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -61,23 +49,15 @@ func WithLogging(log logr.Logger, mux *runtime.ServeMux) http.Handler {
 		l := log.WithValues("uri", r.RequestURI, "status", recorder.Status)
 
 		if recorder.Status < 400 {
-			l.V(logger.LogLevelDebug).Info("request success")
+			l.V(logger.LogLevelDebug).Info(RequestOkText)
 		}
 
 		if recorder.Status >= 400 && recorder.Status < 500 {
-			l.V(logger.LogLevelWarn).Info("request error")
+			l.V(logger.LogLevelWarn).Info(RequestErrorText)
 		}
 
 		if recorder.Status >= 500 {
-			c := r.Context().Value(grpcRequestInfoContextKey)
-
-			vals, ok := c.(grpcRequestInfo)
-			if !ok {
-				l.Error(errors.New("could not get error from context"), "server error")
-				return
-
-			}
-			l.Error(vals.Err, "server error")
+			l.V(logger.LogLevelError).Info(ServerErrorText)
 		}
 	})
 }

--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -1,0 +1,83 @@
+package middleware
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/go-logr/logr"
+	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	"github.com/weaveworks/weave-gitops/pkg/logger"
+)
+
+type statusRecorder struct {
+	http.ResponseWriter
+	Status int
+}
+
+func (r *statusRecorder) WriteHeader(status int) {
+	r.Status = status
+	r.ResponseWriter.WriteHeader(status)
+}
+
+type grpcGatewayErrorMsg struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+type key int
+
+const grpcRequestInfoContextKey key = iota
+
+type grpcRequestInfo struct {
+	Err error
+}
+
+// InjectErrorIntoContext injects the gRPC error message into the request context.
+// Our errors happen in gRPC land, so we cannot introspect into the content of
+// the error message in the WithLogging http.Handler. We need to extract the
+// error message and inject it into the request context to fetch it later in the logging middleware.
+// We can't log here because it would create duplicate log messages when combined with the WithLogging middleware.
+// https://github.com/grpc-ecosystem/grpc-gateway/issues/1043
+func InjectErrorIntoContext() runtime.ServeMuxOption {
+	return runtime.WithErrorHandler(func(ctx context.Context, mux *runtime.ServeMux, marshaler runtime.Marshaler, w http.ResponseWriter, r *http.Request, err error) {
+		newCtx := context.WithValue(r.Context(), grpcRequestInfoContextKey, grpcRequestInfo{Err: err})
+		r = r.WithContext(newCtx)
+		// We don't want to change the behavior of error handling, just intercept for logging.
+		runtime.DefaultHTTPErrorHandler(ctx, mux, marshaler, w, r, err)
+	})
+}
+
+// Adds basic logging for HTTP requests.
+// Note that this accepts a grpc-gateway ServeMux instead of an http.Handler.
+func WithLogging(log logr.Logger, mux *runtime.ServeMux) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		recorder := &statusRecorder{
+			ResponseWriter: w,
+			Status:         200,
+		}
+		mux.ServeHTTP(recorder, r)
+
+		l := log.WithValues("uri", r.RequestURI, "status", recorder.Status)
+
+		if recorder.Status < 400 {
+			l.V(logger.LogLevelDebug).Info("request success")
+		}
+
+		if recorder.Status >= 400 && recorder.Status < 500 {
+			l.V(logger.LogLevelWarn).Info("request error")
+		}
+
+		if recorder.Status >= 500 {
+			c := r.Context().Value(grpcRequestInfoContextKey)
+
+			vals, ok := c.(grpcRequestInfo)
+			if !ok {
+				l.Error(errors.New("could not get error from context"), "server error")
+				return
+
+			}
+			l.Error(vals.Err, "server error")
+		}
+	})
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -52,7 +52,7 @@ func (s *server) ListApplications(ctx context.Context, msg *pb.ListApplicationsR
 func (s *server) GetApplication(ctx context.Context, msg *pb.GetApplicationRequest) (*pb.GetApplicationResponse, error) {
 	app, err := s.kube.GetApplication(ctx, types.NamespacedName{Name: msg.Name, Namespace: msg.Namespace})
 	if err != nil {
-		return nil, fmt.Errorf("could not get application \"%s\": %w", app.Name, err)
+		return nil, fmt.Errorf("could not get application \"%s\": %w", msg.Name, err)
 	}
 
 	src, deployment, err := findFluxObjects(app)

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -2,12 +2,23 @@ package server_test
 
 import (
 	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
 
+	"github.com/go-logr/logr"
+	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	wego "github.com/weaveworks/weave-gitops/api/v1alpha1"
 	"github.com/weaveworks/weave-gitops/pkg/api/applications"
+	pb "github.com/weaveworks/weave-gitops/pkg/api/applications"
 	"github.com/weaveworks/weave-gitops/pkg/kube"
+	"github.com/weaveworks/weave-gitops/pkg/kube/kubefakes"
+	"github.com/weaveworks/weave-gitops/pkg/middleware"
+	"github.com/weaveworks/weave-gitops/pkg/server"
+	fakelogr "github.com/weaveworks/weave-gitops/pkg/vendorfakes/logr"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
@@ -60,4 +71,124 @@ var _ = Describe("ApplicationsServer", func() {
 
 		Expect(res.Application.Name).To(Equal(name))
 	})
+	Describe("middleware", func() {
+		Describe("logging", func() {
+			var log *fakelogr.FakeLogger
+			var kubeClient *kubefakes.FakeKube
+			var appsSrv pb.ApplicationsServer
+			var mux *runtime.ServeMux
+			var httpHandler http.Handler
+			var err error
+
+			BeforeEach(func() {
+				log = &fakelogr.FakeLogger{}
+				log.WithValuesStub = func(i ...interface{}) logr.Logger {
+					return log
+				}
+
+				log.VStub = func(i int) logr.Logger {
+					return log
+				}
+
+				kubeClient = &kubefakes.FakeKube{}
+				appsSrv = server.NewApplicationsServer(kubeClient)
+				mux = runtime.NewServeMux(middleware.WithGrpcErrorLogging(log))
+				httpHandler = middleware.WithLogging(log, mux)
+				err = pb.RegisterApplicationsHandlerServer(context.Background(), mux, appsSrv)
+				Expect(err).NotTo(HaveOccurred())
+			})
+			It("logs invalid requests", func() {
+				ts := httptest.NewServer(httpHandler)
+				defer ts.Close()
+
+				// Test a 404 here
+				path := "/foo"
+				url := ts.URL + path
+
+				res, err := http.Get(url)
+				Expect(res.StatusCode).To(Equal(http.StatusNotFound))
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(log.InfoCallCount()).To(BeNumerically(">", 0))
+				vals := log.WithValuesArgsForCall(0)
+
+				expectedStatus := strconv.Itoa(res.StatusCode)
+
+				list := formatLogVals(vals)
+				Expect(list).To(ConsistOf("uri", path, "status", expectedStatus))
+
+			})
+			It("logs server errors", func() {
+				ts := httptest.NewServer(httpHandler)
+				defer ts.Close()
+
+				errMsg := "there was a big problem"
+
+				// Pretend something went horribly wrong
+				kubeClient.GetApplicationsStub = func(c context.Context, s string) ([]wego.Application, error) {
+					return nil, errors.New(errMsg)
+				}
+
+				path := "/v1/applications"
+				url := ts.URL + path
+
+				res, err := http.Get(url)
+				// err is still nil even if we get a 5XX.
+				Expect(err).NotTo(HaveOccurred())
+				Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
+
+				Expect(log.ErrorCallCount()).To(BeNumerically(">", 0))
+				vals := log.WithValuesArgsForCall(0)
+				list := formatLogVals(vals)
+
+				expectedStatus := strconv.Itoa(res.StatusCode)
+				Expect(list).To(ConsistOf("uri", path, "status", expectedStatus))
+
+				err, msg, _ := log.ErrorArgsForCall(0)
+				// This is the meat of this test case.
+				// Check that the same error passed by kubeClient is logged.
+				Expect(err.Error()).To(Equal(errMsg))
+				Expect(msg).To(Equal(middleware.ServerErrorText))
+
+			})
+			It("logs ok requests", func() {
+				ts := httptest.NewServer(httpHandler)
+				defer ts.Close()
+
+				// A valid URL for our server
+				path := "/v1/applications"
+				url := ts.URL + path
+
+				res, err := http.Get(url)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(res.StatusCode).To(Equal(http.StatusOK))
+
+				Expect(log.InfoCallCount()).To(BeNumerically(">", 0))
+				msg, _ := log.InfoArgsForCall(0)
+				Expect(msg).To(ContainSubstring(middleware.RequestOkText))
+
+				vals := log.WithValuesArgsForCall(0)
+				list := formatLogVals(vals)
+
+				expectedStatus := strconv.Itoa(res.StatusCode)
+				Expect(list).To(ConsistOf("uri", path, "status", expectedStatus))
+			})
+		})
+
+	})
 })
+
+func formatLogVals(vals []interface{}) []string {
+	list := []string{}
+	for _, v := range vals {
+		// vals is a slice of empty interfaces. convert them.
+		s, ok := v.(string)
+		if !ok {
+			// Last value is a status code represented as an int
+			n := v.(int)
+			s = strconv.Itoa(n)
+		}
+		list = append(list, s)
+	}
+	return list
+}

--- a/pkg/vendorfakes/logr/fake_logger.go
+++ b/pkg/vendorfakes/logr/fake_logger.go
@@ -1,0 +1,407 @@
+package fakelogr
+
+import (
+	"sync"
+
+	"github.com/go-logr/logr"
+)
+
+type FakeLogger struct {
+	EnabledStub        func() bool
+	enabledMutex       sync.RWMutex
+	enabledArgsForCall []struct {
+	}
+	enabledReturns struct {
+		result1 bool
+	}
+	enabledReturnsOnCall map[int]struct {
+		result1 bool
+	}
+	ErrorStub        func(error, string, ...interface{})
+	errorMutex       sync.RWMutex
+	errorArgsForCall []struct {
+		arg1 error
+		arg2 string
+		arg3 []interface{}
+	}
+	InfoStub        func(string, ...interface{})
+	infoMutex       sync.RWMutex
+	infoArgsForCall []struct {
+		arg1 string
+		arg2 []interface{}
+	}
+	VStub        func(int) logr.Logger
+	vMutex       sync.RWMutex
+	vArgsForCall []struct {
+		arg1 int
+	}
+	vReturns struct {
+		result1 logr.Logger
+	}
+	vReturnsOnCall map[int]struct {
+		result1 logr.Logger
+	}
+	WithNameStub        func(string) logr.Logger
+	withNameMutex       sync.RWMutex
+	withNameArgsForCall []struct {
+		arg1 string
+	}
+	withNameReturns struct {
+		result1 logr.Logger
+	}
+	withNameReturnsOnCall map[int]struct {
+		result1 logr.Logger
+	}
+	WithValuesStub        func(...interface{}) logr.Logger
+	withValuesMutex       sync.RWMutex
+	withValuesArgsForCall []struct {
+		arg1 []interface{}
+	}
+	withValuesReturns struct {
+		result1 logr.Logger
+	}
+	withValuesReturnsOnCall map[int]struct {
+		result1 logr.Logger
+	}
+	invocations      map[string][][]interface{}
+	invocationsMutex sync.RWMutex
+}
+
+func (fake *FakeLogger) Enabled() bool {
+	fake.enabledMutex.Lock()
+	ret, specificReturn := fake.enabledReturnsOnCall[len(fake.enabledArgsForCall)]
+	fake.enabledArgsForCall = append(fake.enabledArgsForCall, struct {
+	}{})
+	stub := fake.EnabledStub
+	fakeReturns := fake.enabledReturns
+	fake.recordInvocation("Enabled", []interface{}{})
+	fake.enabledMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeLogger) EnabledCallCount() int {
+	fake.enabledMutex.RLock()
+	defer fake.enabledMutex.RUnlock()
+	return len(fake.enabledArgsForCall)
+}
+
+func (fake *FakeLogger) EnabledCalls(stub func() bool) {
+	fake.enabledMutex.Lock()
+	defer fake.enabledMutex.Unlock()
+	fake.EnabledStub = stub
+}
+
+func (fake *FakeLogger) EnabledReturns(result1 bool) {
+	fake.enabledMutex.Lock()
+	defer fake.enabledMutex.Unlock()
+	fake.EnabledStub = nil
+	fake.enabledReturns = struct {
+		result1 bool
+	}{result1}
+}
+
+func (fake *FakeLogger) EnabledReturnsOnCall(i int, result1 bool) {
+	fake.enabledMutex.Lock()
+	defer fake.enabledMutex.Unlock()
+	fake.EnabledStub = nil
+	if fake.enabledReturnsOnCall == nil {
+		fake.enabledReturnsOnCall = make(map[int]struct {
+			result1 bool
+		})
+	}
+	fake.enabledReturnsOnCall[i] = struct {
+		result1 bool
+	}{result1}
+}
+
+func (fake *FakeLogger) Error(arg1 error, arg2 string, arg3 ...interface{}) {
+	fake.errorMutex.Lock()
+	fake.errorArgsForCall = append(fake.errorArgsForCall, struct {
+		arg1 error
+		arg2 string
+		arg3 []interface{}
+	}{arg1, arg2, arg3})
+	stub := fake.ErrorStub
+	fake.recordInvocation("Error", []interface{}{arg1, arg2, arg3})
+	fake.errorMutex.Unlock()
+	if stub != nil {
+		fake.ErrorStub(arg1, arg2, arg3...)
+	}
+}
+
+func (fake *FakeLogger) ErrorCallCount() int {
+	fake.errorMutex.RLock()
+	defer fake.errorMutex.RUnlock()
+	return len(fake.errorArgsForCall)
+}
+
+func (fake *FakeLogger) ErrorCalls(stub func(error, string, ...interface{})) {
+	fake.errorMutex.Lock()
+	defer fake.errorMutex.Unlock()
+	fake.ErrorStub = stub
+}
+
+func (fake *FakeLogger) ErrorArgsForCall(i int) (error, string, []interface{}) {
+	fake.errorMutex.RLock()
+	defer fake.errorMutex.RUnlock()
+	argsForCall := fake.errorArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeLogger) Info(arg1 string, arg2 ...interface{}) {
+	fake.infoMutex.Lock()
+	fake.infoArgsForCall = append(fake.infoArgsForCall, struct {
+		arg1 string
+		arg2 []interface{}
+	}{arg1, arg2})
+	stub := fake.InfoStub
+	fake.recordInvocation("Info", []interface{}{arg1, arg2})
+	fake.infoMutex.Unlock()
+	if stub != nil {
+		fake.InfoStub(arg1, arg2...)
+	}
+}
+
+func (fake *FakeLogger) InfoCallCount() int {
+	fake.infoMutex.RLock()
+	defer fake.infoMutex.RUnlock()
+	return len(fake.infoArgsForCall)
+}
+
+func (fake *FakeLogger) InfoCalls(stub func(string, ...interface{})) {
+	fake.infoMutex.Lock()
+	defer fake.infoMutex.Unlock()
+	fake.InfoStub = stub
+}
+
+func (fake *FakeLogger) InfoArgsForCall(i int) (string, []interface{}) {
+	fake.infoMutex.RLock()
+	defer fake.infoMutex.RUnlock()
+	argsForCall := fake.infoArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeLogger) V(arg1 int) logr.Logger {
+	fake.vMutex.Lock()
+	ret, specificReturn := fake.vReturnsOnCall[len(fake.vArgsForCall)]
+	fake.vArgsForCall = append(fake.vArgsForCall, struct {
+		arg1 int
+	}{arg1})
+	stub := fake.VStub
+	fakeReturns := fake.vReturns
+	fake.recordInvocation("V", []interface{}{arg1})
+	fake.vMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeLogger) VCallCount() int {
+	fake.vMutex.RLock()
+	defer fake.vMutex.RUnlock()
+	return len(fake.vArgsForCall)
+}
+
+func (fake *FakeLogger) VCalls(stub func(int) logr.Logger) {
+	fake.vMutex.Lock()
+	defer fake.vMutex.Unlock()
+	fake.VStub = stub
+}
+
+func (fake *FakeLogger) VArgsForCall(i int) int {
+	fake.vMutex.RLock()
+	defer fake.vMutex.RUnlock()
+	argsForCall := fake.vArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeLogger) VReturns(result1 logr.Logger) {
+	fake.vMutex.Lock()
+	defer fake.vMutex.Unlock()
+	fake.VStub = nil
+	fake.vReturns = struct {
+		result1 logr.Logger
+	}{result1}
+}
+
+func (fake *FakeLogger) VReturnsOnCall(i int, result1 logr.Logger) {
+	fake.vMutex.Lock()
+	defer fake.vMutex.Unlock()
+	fake.VStub = nil
+	if fake.vReturnsOnCall == nil {
+		fake.vReturnsOnCall = make(map[int]struct {
+			result1 logr.Logger
+		})
+	}
+	fake.vReturnsOnCall[i] = struct {
+		result1 logr.Logger
+	}{result1}
+}
+
+func (fake *FakeLogger) WithName(arg1 string) logr.Logger {
+	fake.withNameMutex.Lock()
+	ret, specificReturn := fake.withNameReturnsOnCall[len(fake.withNameArgsForCall)]
+	fake.withNameArgsForCall = append(fake.withNameArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	stub := fake.WithNameStub
+	fakeReturns := fake.withNameReturns
+	fake.recordInvocation("WithName", []interface{}{arg1})
+	fake.withNameMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeLogger) WithNameCallCount() int {
+	fake.withNameMutex.RLock()
+	defer fake.withNameMutex.RUnlock()
+	return len(fake.withNameArgsForCall)
+}
+
+func (fake *FakeLogger) WithNameCalls(stub func(string) logr.Logger) {
+	fake.withNameMutex.Lock()
+	defer fake.withNameMutex.Unlock()
+	fake.WithNameStub = stub
+}
+
+func (fake *FakeLogger) WithNameArgsForCall(i int) string {
+	fake.withNameMutex.RLock()
+	defer fake.withNameMutex.RUnlock()
+	argsForCall := fake.withNameArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeLogger) WithNameReturns(result1 logr.Logger) {
+	fake.withNameMutex.Lock()
+	defer fake.withNameMutex.Unlock()
+	fake.WithNameStub = nil
+	fake.withNameReturns = struct {
+		result1 logr.Logger
+	}{result1}
+}
+
+func (fake *FakeLogger) WithNameReturnsOnCall(i int, result1 logr.Logger) {
+	fake.withNameMutex.Lock()
+	defer fake.withNameMutex.Unlock()
+	fake.WithNameStub = nil
+	if fake.withNameReturnsOnCall == nil {
+		fake.withNameReturnsOnCall = make(map[int]struct {
+			result1 logr.Logger
+		})
+	}
+	fake.withNameReturnsOnCall[i] = struct {
+		result1 logr.Logger
+	}{result1}
+}
+
+func (fake *FakeLogger) WithValues(arg1 ...interface{}) logr.Logger {
+	fake.withValuesMutex.Lock()
+	ret, specificReturn := fake.withValuesReturnsOnCall[len(fake.withValuesArgsForCall)]
+	fake.withValuesArgsForCall = append(fake.withValuesArgsForCall, struct {
+		arg1 []interface{}
+	}{arg1})
+	stub := fake.WithValuesStub
+	fakeReturns := fake.withValuesReturns
+	fake.recordInvocation("WithValues", []interface{}{arg1})
+	fake.withValuesMutex.Unlock()
+	if stub != nil {
+		return stub(arg1...)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeLogger) WithValuesCallCount() int {
+	fake.withValuesMutex.RLock()
+	defer fake.withValuesMutex.RUnlock()
+	return len(fake.withValuesArgsForCall)
+}
+
+func (fake *FakeLogger) WithValuesCalls(stub func(...interface{}) logr.Logger) {
+	fake.withValuesMutex.Lock()
+	defer fake.withValuesMutex.Unlock()
+	fake.WithValuesStub = stub
+}
+
+func (fake *FakeLogger) WithValuesArgsForCall(i int) []interface{} {
+	fake.withValuesMutex.RLock()
+	defer fake.withValuesMutex.RUnlock()
+	argsForCall := fake.withValuesArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeLogger) WithValuesReturns(result1 logr.Logger) {
+	fake.withValuesMutex.Lock()
+	defer fake.withValuesMutex.Unlock()
+	fake.WithValuesStub = nil
+	fake.withValuesReturns = struct {
+		result1 logr.Logger
+	}{result1}
+}
+
+func (fake *FakeLogger) WithValuesReturnsOnCall(i int, result1 logr.Logger) {
+	fake.withValuesMutex.Lock()
+	defer fake.withValuesMutex.Unlock()
+	fake.WithValuesStub = nil
+	if fake.withValuesReturnsOnCall == nil {
+		fake.withValuesReturnsOnCall = make(map[int]struct {
+			result1 logr.Logger
+		})
+	}
+	fake.withValuesReturnsOnCall[i] = struct {
+		result1 logr.Logger
+	}{result1}
+}
+
+func (fake *FakeLogger) Invocations() map[string][][]interface{} {
+	fake.invocationsMutex.RLock()
+	defer fake.invocationsMutex.RUnlock()
+	fake.enabledMutex.RLock()
+	defer fake.enabledMutex.RUnlock()
+	fake.errorMutex.RLock()
+	defer fake.errorMutex.RUnlock()
+	fake.infoMutex.RLock()
+	defer fake.infoMutex.RUnlock()
+	fake.vMutex.RLock()
+	defer fake.vMutex.RUnlock()
+	fake.withNameMutex.RLock()
+	defer fake.withNameMutex.RUnlock()
+	fake.withValuesMutex.RLock()
+	defer fake.withValuesMutex.RUnlock()
+	copiedInvocations := map[string][][]interface{}{}
+	for key, value := range fake.invocations {
+		copiedInvocations[key] = value
+	}
+	return copiedInvocations
+}
+
+func (fake *FakeLogger) recordInvocation(key string, args []interface{}) {
+	fake.invocationsMutex.Lock()
+	defer fake.invocationsMutex.Unlock()
+	if fake.invocations == nil {
+		fake.invocations = map[string][][]interface{}{}
+	}
+	if fake.invocations[key] == nil {
+		fake.invocations[key] = [][]interface{}{}
+	}
+	fake.invocations[key] = append(fake.invocations[key], args)
+}
+
+var _ logr.Logger = new(FakeLogger)


### PR DESCRIPTION
Closes #515 

Adds middleware to log when error messages occur. In development mode, a human-readable stack trace is printed on `log.Error`:

![Screenshot from 2021-07-29 16-46-16 - 1](https://user-images.githubusercontent.com/2802257/127579288-5016bb17-79ce-4f79-9d22-1f262400e8eb.png)

In prod mode, this will be a one-line log entry.

@luizbafilho I won't pretend to understand how these log levels are supposed to work. I doubt the objective is to do the `Debug`, `Warn` and `Error` levels like I have done here. Any guidance on the subject is appreciated.

Unit tests for the middleware were added to the `server` package. It wasn't clear to me how to test the middleware logic outside of a generated gPRC server. Yet another instance of gRPC making everything slightly harder. As a result, concerns are not as separated as they would be ideally, at least we have the coverage.

Also if there is a way to do this style of logging: `status=400 error=some error` instead of the default JSON, that would be my preference.