### PR TITLE
Remove source-type CLI arg

### DIFF
--- a/cmd/wego/app/add/cmd.go
+++ b/cmd/wego/app/add/cmd.go
@@ -57,7 +57,6 @@ func init() {
 	Cmd.Flags().StringVar(&params.Path, "path", "./", "Path of files within git repository")
 	Cmd.Flags().StringVar(&params.Branch, "branch", "main", "Branch to watch within git repository")
 	Cmd.Flags().StringVar(&params.DeploymentType, "deployment-type", "kustomize", "deployment type [kustomize, helm]")
-	Cmd.Flags().StringVar(&params.SourceType, "source-type", "git", "source type [git, helm]")
 	Cmd.Flags().StringVar(&params.Chart, "chart", "", "Specify chart for helm source")
 	Cmd.Flags().StringVar(&params.PrivateKey, "private-key", "", "Private key to access git repository over ssh")
 	Cmd.Flags().StringVar(&params.AppConfigUrl, "app-config-url", "", "URL of external repository (if any) which will hold automation manifests; NONE to store only in the cluster")


### PR DESCRIPTION
The `--source-type` arg was added naively here #497 . We already fill out this parameter elsewhere by detecting the `--chart` argument