### PR TITLE
532 Sanitize config url for helm cases

### DIFF
--- a/pkg/kube/kube_test.go
+++ b/pkg/kube/kube_test.go
@@ -9,9 +9,9 @@ import (
 	wego "github.com/weaveworks/weave-gitops/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/types"
 
-	. "github.com/onsi/gomega"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
 
 	"github.com/weaveworks/weave-gitops/pkg/kube"
 	"github.com/weaveworks/weave-gitops/pkg/runner/runnerfakes"
@@ -133,7 +133,7 @@ var _ = Describe("GetClusterName", func() {
 
 var _ = Describe("FixInvalidClusterName", func() {
 	DescribeTable("checks to verify that cluster names are sanitized",
-		func(invalid string, valid string, expected bool)  {
+		func(invalid string, valid string, expected bool) {
 			runner.RunStub = func(cmd string, args ...string) ([]byte, error) {
 				return []byte(invalid), nil
 			}

--- a/pkg/services/app/add.go
+++ b/pkg/services/app/add.go
@@ -218,6 +218,7 @@ func (a *App) updateParametersIfNecessary(params AddParams) (AddParams, error) {
 		if params.Name == "" {
 			params.Name = params.Chart
 		}
+
 		return params, nil
 	}
 
@@ -233,6 +234,7 @@ func (a *App) updateParametersIfNecessary(params AddParams) (AddParams, error) {
 	} else {
 		// making sure url is in the correct format
 		params.Url = sanitizeRepoUrl(params.Url)
+
 		// resetting Dir param since Url has priority over it
 		params.Dir = ""
 	}

--- a/pkg/services/app/add.go
+++ b/pkg/services/app/add.go
@@ -205,6 +205,12 @@ func (a *App) printAddSummary(params AddParams) {
 func (a *App) updateParametersIfNecessary(params AddParams) (AddParams, error) {
 	params.SourceType = string(wego.SourceTypeGit)
 
+	// making sure the config url is in good format
+	if strings.ToUpper(params.AppConfigUrl) != string(ConfigTypeNone) &&
+		strings.ToUpper(params.AppConfigUrl) != string(ConfigTypeUserRepo) {
+		params.AppConfigUrl = sanitizeRepoUrl(params.AppConfigUrl)
+	}
+
 	if params.Chart != "" {
 		params.SourceType = string(wego.SourceTypeHelm)
 		params.DeploymentType = string(wego.DeploymentTypeHelm)
@@ -212,7 +218,6 @@ func (a *App) updateParametersIfNecessary(params AddParams) (AddParams, error) {
 		if params.Name == "" {
 			params.Name = params.Chart
 		}
-
 		return params, nil
 	}
 
@@ -228,15 +233,8 @@ func (a *App) updateParametersIfNecessary(params AddParams) (AddParams, error) {
 	} else {
 		// making sure url is in the correct format
 		params.Url = sanitizeRepoUrl(params.Url)
-
 		// resetting Dir param since Url has priority over it
 		params.Dir = ""
-	}
-
-	// making sure the config url is in good format
-	if strings.ToUpper(params.AppConfigUrl) != string(ConfigTypeNone) &&
-		strings.ToUpper(params.AppConfigUrl) != string(ConfigTypeUserRepo) {
-		params.AppConfigUrl = sanitizeRepoUrl(params.AppConfigUrl)
 	}
 
 	if params.Name == "" {


### PR DESCRIPTION
Fix #532 

<!-- Describe what has changed in this PR -->
**What changed?**
It now sanitize config repository urls when `chart` parameter is passed in.

<!-- Tell your future self why have you made these changes -->
**Why?**
Using different formats on repository config urls was causing auth issues in flux when trying to clone them. 

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**
Manually adding two helm charts using different url formats. It worked as expected.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
**Release notes**

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**