### PR TITLE
Don't create a deploy key for a public repository

### DIFF
--- a/pkg/flux/flux_test.go
+++ b/pkg/flux/flux_test.go
@@ -97,7 +97,7 @@ var _ = Describe("CreateSourceGit", func() {
 		runner.RunStub = func(s1 string, s2 ...string) ([]byte, error) {
 			return []byte("out"), nil
 		}
-		out, err := fluxClient.CreateSourceGit("my-name", "https://github.com/foo/my-name", "main", "", "wego-system")
+		out, err := fluxClient.CreateSourceGit("my-name", "ssh://git@github.com/foo/my-name", "main", "", "wego-system")
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(out).To(Equal([]byte("out")))
 

--- a/pkg/flux/flux_test.go
+++ b/pkg/flux/flux_test.go
@@ -78,7 +78,7 @@ var _ = Describe("Uninstall", func() {
 })
 
 var _ = Describe("CreateSourceGit", func() {
-	It("creates a source git", func() {
+	It("creates a git source", func() {
 		runner.RunStub = func(s1 string, s2 ...string) ([]byte, error) {
 			return []byte("out"), nil
 		}
@@ -91,7 +91,22 @@ var _ = Describe("CreateSourceGit", func() {
 		cmd, args := runner.RunArgsForCall(0)
 		Expect(cmd).To(Equal(fluxPath()))
 
-		Expect(strings.Join(args, " ")).To(Equal("create source git my-name --url https://github.com/foo/my-name --branch main --secret-ref my-secret --namespace wego-system --interval 30s --export"))
+		Expect(strings.Join(args, " ")).To(Equal("create source git my-name --branch main --namespace wego-system --interval 30s --export --secret-ref my-secret --url https://github.com/foo/my-name"))
+	})
+	It("creates a git source for a public repo", func() {
+		runner.RunStub = func(s1 string, s2 ...string) ([]byte, error) {
+			return []byte("out"), nil
+		}
+		out, err := fluxClient.CreateSourceGit("my-name", "https://github.com/foo/my-name", "main", "", "wego-system")
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(out).To(Equal([]byte("out")))
+
+		Expect(runner.RunCallCount()).To(Equal(1))
+
+		cmd, args := runner.RunArgsForCall(0)
+		Expect(cmd).To(Equal(fluxPath()))
+
+		Expect(strings.Join(args, " ")).To(Equal("create source git my-name --branch main --namespace wego-system --interval 30s --export --url https://github.com/foo/my-name.git"))
 	})
 })
 

--- a/pkg/git/gitfakes/fake_git.go
+++ b/pkg/git/gitfakes/fake_git.go
@@ -91,19 +91,6 @@ type FakeGit struct {
 	pushReturnsOnCall map[int]struct {
 		result1 error
 	}
-	ReadStub        func(string) ([]byte, error)
-	readMutex       sync.RWMutex
-	readArgsForCall []struct {
-		arg1 string
-	}
-	readReturns struct {
-		result1 []byte
-		result2 error
-	}
-	readReturnsOnCall map[int]struct {
-		result1 []byte
-		result2 error
-	}
 	RemoveStub        func(string) error
 	removeMutex       sync.RWMutex
 	removeArgsForCall []struct {
@@ -522,70 +509,6 @@ func (fake *FakeGit) PushReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *FakeGit) Read(arg1 string) ([]byte, error) {
-	fake.readMutex.Lock()
-	ret, specificReturn := fake.readReturnsOnCall[len(fake.readArgsForCall)]
-	fake.readArgsForCall = append(fake.readArgsForCall, struct {
-		arg1 string
-	}{arg1})
-	stub := fake.ReadStub
-	fakeReturns := fake.readReturns
-	fake.recordInvocation("Read", []interface{}{arg1})
-	fake.readMutex.Unlock()
-	if stub != nil {
-		return stub(arg1)
-	}
-	if specificReturn {
-		return ret.result1, ret.result2
-	}
-	return fakeReturns.result1, fakeReturns.result2
-}
-
-func (fake *FakeGit) ReadCallCount() int {
-	fake.readMutex.RLock()
-	defer fake.readMutex.RUnlock()
-	return len(fake.readArgsForCall)
-}
-
-func (fake *FakeGit) ReadCalls(stub func(string) ([]byte, error)) {
-	fake.readMutex.Lock()
-	defer fake.readMutex.Unlock()
-	fake.ReadStub = stub
-}
-
-func (fake *FakeGit) ReadArgsForCall(i int) string {
-	fake.readMutex.RLock()
-	defer fake.readMutex.RUnlock()
-	argsForCall := fake.readArgsForCall[i]
-	return argsForCall.arg1
-}
-
-func (fake *FakeGit) ReadReturns(result1 []byte, result2 error) {
-	fake.readMutex.Lock()
-	defer fake.readMutex.Unlock()
-	fake.ReadStub = nil
-	fake.readReturns = struct {
-		result1 []byte
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeGit) ReadReturnsOnCall(i int, result1 []byte, result2 error) {
-	fake.readMutex.Lock()
-	defer fake.readMutex.Unlock()
-	fake.ReadStub = nil
-	if fake.readReturnsOnCall == nil {
-		fake.readReturnsOnCall = make(map[int]struct {
-			result1 []byte
-			result2 error
-		})
-	}
-	fake.readReturnsOnCall[i] = struct {
-		result1 []byte
-		result2 error
-	}{result1, result2}
-}
-
 func (fake *FakeGit) Remove(arg1 string) error {
 	fake.removeMutex.Lock()
 	ret, specificReturn := fake.removeReturnsOnCall[len(fake.removeArgsForCall)]
@@ -785,8 +708,6 @@ func (fake *FakeGit) Invocations() map[string][][]interface{} {
 	defer fake.openMutex.RUnlock()
 	fake.pushMutex.RLock()
 	defer fake.pushMutex.RUnlock()
-	fake.readMutex.RLock()
-	defer fake.readMutex.RUnlock()
 	fake.removeMutex.RLock()
 	defer fake.removeMutex.RUnlock()
 	fake.statusMutex.RLock()

--- a/pkg/gitproviders/gitprovidersfakes/fake_git_provider.go
+++ b/pkg/gitproviders/gitprovidersfakes/fake_git_provider.go
@@ -87,6 +87,21 @@ type FakeGitProvider struct {
 		result1 gitproviders.ProviderAccountType
 		result2 error
 	}
+	GetRepoInfoStub        func(gitproviders.ProviderAccountType, string, string) (*gitprovider.RepositoryInfo, error)
+	getRepoInfoMutex       sync.RWMutex
+	getRepoInfoArgsForCall []struct {
+		arg1 gitproviders.ProviderAccountType
+		arg2 string
+		arg3 string
+	}
+	getRepoInfoReturns struct {
+		result1 *gitprovider.RepositoryInfo
+		result2 error
+	}
+	getRepoInfoReturnsOnCall map[int]struct {
+		result1 *gitprovider.RepositoryInfo
+		result2 error
+	}
 	RepositoryExistsStub        func(string, string) (bool, error)
 	repositoryExistsMutex       sync.RWMutex
 	repositoryExistsArgsForCall []struct {
@@ -460,6 +475,72 @@ func (fake *FakeGitProvider) GetAccountTypeReturnsOnCall(i int, result1 gitprovi
 	}{result1, result2}
 }
 
+func (fake *FakeGitProvider) GetRepoInfo(arg1 gitproviders.ProviderAccountType, arg2 string, arg3 string) (*gitprovider.RepositoryInfo, error) {
+	fake.getRepoInfoMutex.Lock()
+	ret, specificReturn := fake.getRepoInfoReturnsOnCall[len(fake.getRepoInfoArgsForCall)]
+	fake.getRepoInfoArgsForCall = append(fake.getRepoInfoArgsForCall, struct {
+		arg1 gitproviders.ProviderAccountType
+		arg2 string
+		arg3 string
+	}{arg1, arg2, arg3})
+	stub := fake.GetRepoInfoStub
+	fakeReturns := fake.getRepoInfoReturns
+	fake.recordInvocation("GetRepoInfo", []interface{}{arg1, arg2, arg3})
+	fake.getRepoInfoMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeGitProvider) GetRepoInfoCallCount() int {
+	fake.getRepoInfoMutex.RLock()
+	defer fake.getRepoInfoMutex.RUnlock()
+	return len(fake.getRepoInfoArgsForCall)
+}
+
+func (fake *FakeGitProvider) GetRepoInfoCalls(stub func(gitproviders.ProviderAccountType, string, string) (*gitprovider.RepositoryInfo, error)) {
+	fake.getRepoInfoMutex.Lock()
+	defer fake.getRepoInfoMutex.Unlock()
+	fake.GetRepoInfoStub = stub
+}
+
+func (fake *FakeGitProvider) GetRepoInfoArgsForCall(i int) (gitproviders.ProviderAccountType, string, string) {
+	fake.getRepoInfoMutex.RLock()
+	defer fake.getRepoInfoMutex.RUnlock()
+	argsForCall := fake.getRepoInfoArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeGitProvider) GetRepoInfoReturns(result1 *gitprovider.RepositoryInfo, result2 error) {
+	fake.getRepoInfoMutex.Lock()
+	defer fake.getRepoInfoMutex.Unlock()
+	fake.GetRepoInfoStub = nil
+	fake.getRepoInfoReturns = struct {
+		result1 *gitprovider.RepositoryInfo
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeGitProvider) GetRepoInfoReturnsOnCall(i int, result1 *gitprovider.RepositoryInfo, result2 error) {
+	fake.getRepoInfoMutex.Lock()
+	defer fake.getRepoInfoMutex.Unlock()
+	fake.GetRepoInfoStub = nil
+	if fake.getRepoInfoReturnsOnCall == nil {
+		fake.getRepoInfoReturnsOnCall = make(map[int]struct {
+			result1 *gitprovider.RepositoryInfo
+			result2 error
+		})
+	}
+	fake.getRepoInfoReturnsOnCall[i] = struct {
+		result1 *gitprovider.RepositoryInfo
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeGitProvider) RepositoryExists(arg1 string, arg2 string) (bool, error) {
 	fake.repositoryExistsMutex.Lock()
 	ret, specificReturn := fake.repositoryExistsReturnsOnCall[len(fake.repositoryExistsArgsForCall)]
@@ -606,6 +687,8 @@ func (fake *FakeGitProvider) Invocations() map[string][][]interface{} {
 	defer fake.deployKeyExistsMutex.RUnlock()
 	fake.getAccountTypeMutex.RLock()
 	defer fake.getAccountTypeMutex.RUnlock()
+	fake.getRepoInfoMutex.RLock()
+	defer fake.getRepoInfoMutex.RUnlock()
 	fake.repositoryExistsMutex.RLock()
 	defer fake.repositoryExistsMutex.RUnlock()
 	fake.uploadDeployKeyMutex.RLock()

--- a/pkg/gitproviders/provider_test.go
+++ b/pkg/gitproviders/provider_test.go
@@ -484,10 +484,10 @@ var _ = Describe("Get User repo info", func() {
 	})
 
 	It("Succeed on getting user repo info", func() {
-		err = gitProvider.GetRepoInfo(AccountTypeUser, accounts.GithubUserName, repoName)
+		_, err = gitProvider.GetRepoInfo(AccountTypeUser, accounts.GithubUserName, repoName)
 		Expect(err).ShouldNot(HaveOccurred())
 
-		err = gitProvider.GetRepoInfo(AccountTypeUser, accounts.GithubUserName, "repoNotExisted")
+		_, err = gitProvider.GetRepoInfo(AccountTypeUser, accounts.GithubUserName, "repoNotExisted")
 		Expect(err).Should(HaveOccurred())
 
 	})
@@ -528,7 +528,8 @@ var _ = Describe("Test user deploy keys creation", func() {
 		err = gitProvider.CreateUserRepository(userRepoRef, repoInfo, opts)
 		Expect(err).ShouldNot(HaveOccurred())
 		err = utils.WaitUntil(os.Stdout, time.Second, time.Second*30, func() error {
-			return gitProvider.GetUserRepo(accounts.GithubUserName, repoName)
+			_, err := gitProvider.GetUserRepo(accounts.GithubUserName, repoName)
+			return err
 		})
 		Expect(err).ShouldNot(HaveOccurred())
 
@@ -595,7 +596,8 @@ var _ = Describe("Test org deploy keys creation", func() {
 		err = gitProvider.CreateOrgRepository(orgRepoRef, repoInfo, opts)
 		Expect(err).ShouldNot(HaveOccurred())
 		err = utils.WaitUntil(os.Stdout, time.Second, time.Second*30, func() error {
-			return gitProvider.GetOrgRepo(accounts.GithubOrgName, repoName)
+			_, err := gitProvider.GetOrgRepo(accounts.GithubOrgName, repoName)
+			return err
 		})
 		Expect(err).ShouldNot(HaveOccurred())
 

--- a/pkg/services/app/add.go
+++ b/pkg/services/app/add.go
@@ -511,6 +511,21 @@ func (a *App) createAndUploadDeployKey(info *AppResourceInfo, dryRun bool, repoU
 	}
 
 	repoName := urlToRepoName(repoUrl)
+
+	accountType, err := gitProvider.GetAccountType(owner)
+	if err != nil {
+		return "", err
+	}
+
+	repoInfo, err := gitProvider.GetRepoInfo(accountType, owner, repoName)
+	if err != nil {
+		return "", err
+	}
+
+	if repoInfo != nil && repoInfo.Visibility != nil && *repoInfo.Visibility == gitprovider.RepositoryVisibilityPublic {
+		return "", nil
+	}
+
 	deployKeyExists, err := gitProvider.DeployKeyExists(owner, repoName)
 	if err != nil {
 		return "", fmt.Errorf("failed check for existing deploy key: %w", err)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->

Resolves #551 

**What changed?**
If a user provides a public repository to wego, we no longer create a deploy key; instead, we hand `flux create source git` an `http` URL and don't create a secret

<!-- Tell your future self why have you made these changes -->
**Why?**
It's basically wrong to require creation of an unnecessary key and the current exclusive use of ssh URLs prevents adding an app from an upstream public repository (like sock-shop) for which we have no associated SSH keys.

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**
Manually adding the sock-shop app from the `github.com/microservices-demo/microservices-demo.git` repository

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
**Release notes**
Users would not have to change anything but some scenarios would now work that would have failed in the past

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
No