### PR TITLE
Remove deps file from version control

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ clean:
 	rm -rf cmd/ui/dist
 	rm -rf coverage
 	rm -rf node_modules
-	rm .deps
+	rm -f .deps
 # Run go fmt against code
 fmt:
 	go fmt ./...


### PR DESCRIPTION
The `.deps` file is used for `Makefile` shenanigans to get dependencies to download only once. It should not have been added to version control.