### PR TITLE
Add Github Auth Device Flow

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/weaveworks/go-checkpoint v0.0.0-20170503165305-ebbb8b0518ab
 	go.uber.org/zap v1.17.0
-	golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b
+	golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97
 	golang.org/x/net v0.0.0-20210510120150-4163338589ed // indirect
 	golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b
 	google.golang.org/genproto v0.0.0-20210617175327-b9e0b3197ced

--- a/go.sum
+++ b/go.sum
@@ -736,8 +736,9 @@ golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
-golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b h1:7mWr3k41Qtv8XlltBkDkl8LoP3mpSgBW8BUoxtEdbXg=
 golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
+golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97 h1:/UOmuWzQfxxo9UtlXMwuQU8CMgg1eZXqTRwkSQJWKOI=
+golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,7 +1,7 @@
 {
   "name": "weave-gitops",
   "version": "0.0.1",
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@babel/code-frame": {

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -1,0 +1,27 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/weaveworks/weave-gitops/pkg/gitproviders"
+)
+
+// BlockingCLIAuthHandler takes over the terminal experience and returns a token when the user completes the flow.
+type BlockingCLIAuthHandler func(context.Context, io.Writer) (string, error)
+
+type AuthProvider interface {
+	DoCLIAuth(ctx context.Context, stdout io.Writer) (string, error)
+}
+
+func NewAuthProvider(name gitproviders.GitProviderName) (BlockingCLIAuthHandler, error) {
+	switch name {
+	case gitproviders.GitProviderGitHub:
+		return NewGithubDeviceFlowHandler(http.DefaultClient), nil
+
+	}
+
+	return nil, fmt.Errorf("unsupported auth provider \"%s\"", name)
+}

--- a/pkg/auth/github.go
+++ b/pkg/auth/github.go
@@ -1,0 +1,174 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+// codeResponse represents response body from the Github API
+type codeResponse struct {
+	DeviceCode     string `json:"device_code"`
+	UserCode       string `json:"user_code"`
+	VerficationURI string `json:"verification_uri"`
+	Interval       int    `json:"interval"`
+}
+
+// Uniquely identifies us as a GitHub app.
+// This does not need to be obfuscated because it is publicly available
+// to anyone who does an OAuth request via wego.
+// See the auth ADR for more details:
+// https://github.com/weaveworks/weave-gitops/blob/main/doc/adr/0005-wego-core-auth-strategy.md#design
+const WeGOGithubClientID = "edcb13588d46f254052c"
+
+// Encapsulate shared logic between doCodeRequest and doAuthRequest
+func doRequest(req *http.Request, client *http.Client) ([]byte, error) {
+	req.Header.Set("Accept", "application/json")
+
+	res, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if res.StatusCode != http.StatusOK {
+		// err is falsey even on 4XX or 5XX
+		return nil, err
+	}
+
+	rb, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	return rb, nil
+}
+
+const codeRequestURL = "https://github.com/login/device/code?%s"
+
+// doCodeRequest does the initial request of the Device Flow
+func doCodeRequest(client *http.Client, scope string) (*codeResponse, error) {
+	query := url.Values.Encode(map[string][]string{
+		"client_id": {WeGOGithubClientID},
+		"scope":     {scope},
+	})
+
+	req, err := http.NewRequest("POST", fmt.Sprintf(codeRequestURL, query), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	b, err := doRequest(req, client)
+	if err != nil {
+		return nil, fmt.Errorf("error doing code request: %w", err)
+	}
+
+	d := &codeResponse{}
+
+	if err := json.Unmarshal(b, d); err != nil {
+		return nil, fmt.Errorf("could not unmarshal code response: %w", err)
+	}
+
+	return d, nil
+}
+
+var ErrAuthPending = errors.New("auth pending")
+
+const accessTokenUrl = "https://github.com/login/oauth/access_token?%s"
+const githubRequiredGrantType = "urn:ietf:params:oauth:grant-type:device_code"
+
+// It appears we need `repo` scope, which is VERY permissive.
+// We need to be able to push a deploy key and merge commits. No other scopes matched.
+// Available scopes: https://docs.github.com/en/developers/apps/building-oauth-apps/scopes-for-oauth-apps
+const githubOAuthScope = "repo"
+
+type githubAuthResponse struct {
+	AccessToken string `json:"access_token"`
+	Error       string `json:"error"`
+}
+
+// doAuthRequest is used to poll for the status of the device flow.
+func doAuthRequest(client *http.Client, deviceCode string) (string, error) {
+	query := url.Values.Encode(map[string][]string{
+		"client_id":   {WeGOGithubClientID},
+		"device_code": {deviceCode},
+		"grant_type":  {githubRequiredGrantType},
+	})
+	url := fmt.Sprintf(accessTokenUrl, query)
+
+	req, err := http.NewRequest("POST", url, nil)
+	if err != nil {
+		return "", fmt.Errorf("could not create auth request: %w", err)
+	}
+
+	b, err := doRequest(req, client)
+	if err != nil {
+		return "", fmt.Errorf("error doing auth request: %w", err)
+	}
+
+	p := githubAuthResponse{}
+
+	if err := json.Unmarshal(b, &p); err != nil {
+		return "", fmt.Errorf("err marshaling request body: %w", err)
+	}
+
+	if p.Error == "authorization_pending" {
+		// This is expected until the user completes the auth flow.
+		return "", ErrAuthPending
+	}
+
+	if p.AccessToken != "" {
+		return p.AccessToken, nil
+	}
+
+	// Note p.Error is a string here
+	return "", fmt.Errorf("error doing auth request: %s", p.Error)
+}
+
+// NewGithubDeviceFlowHandler returns a function which will initiate the Github Device Flow for the CLI.
+func NewGithubDeviceFlowHandler(client *http.Client) BlockingCLIAuthHandler {
+	return func(ctx context.Context, w io.Writer) (string, error) {
+		codeRes, err := doCodeRequest(client, githubOAuthScope)
+		if err != nil {
+			return "", fmt.Errorf("could not do code request: %w", err)
+		}
+
+		fmt.Fprintln(w)
+		fmt.Fprintf(w, "Visit this URL to authenticate with Github:\n\n")
+		fmt.Fprintf(w, "%s\n\n", codeRes.VerficationURI)
+		fmt.Fprintf(w, "Type the following code into the page at the URL above: %s\n\n", codeRes.UserCode)
+		fmt.Fprintf(w, "Waiting for authentication flow completion...\n\n")
+
+		// GH complains if you retry RIGHT at the given interval.
+		// We will get a `slow_down` error from the backend without the one second padding.
+		retryInterval := time.Duration(codeRes.Interval+1) * time.Second
+
+		ticker := time.NewTicker(retryInterval)
+
+		for range ticker.C {
+			authToken, err := doAuthRequest(client, codeRes.DeviceCode)
+			if err != nil {
+				if err == ErrAuthPending {
+					// This is expected while the user goes to the webpage.
+					continue
+				}
+
+				// An unexpected error happened, return it.
+				ticker.Stop()
+				return "", err
+			}
+
+			ticker.Stop()
+			fmt.Fprintf(w, "Authentication successful!\n\n")
+			return authToken, nil
+
+		}
+
+		return "", errors.New("failed to get github auth token")
+	}
+}

--- a/pkg/auth/github_test.go
+++ b/pkg/auth/github_test.go
@@ -1,0 +1,94 @@
+package auth
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestGitProviderAuth(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Auth Suite")
+}
+
+type testServerTransport struct {
+	testServeUrl string
+	roundTripper http.RoundTripper
+}
+
+func (t *testServerTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	// Fake out the client but preserve the URL, as the URLs are key to validating that
+	// the authHandler is working.
+	tsUrl, err := url.Parse(t.testServeUrl)
+	if err != nil {
+		return nil, err
+	}
+	tsUrl.Path = r.URL.Path
+
+	r.URL = tsUrl
+	return t.roundTripper.RoundTrip(r)
+}
+
+var _ = Describe("Github Device Flow", func() {
+	var ts *httptest.Server
+	var client *http.Client
+	token := "gho_sUpErSecRetToKeN"
+	userCode := "ABC-123"
+	verificationUri := "http://somegithuburl.com"
+
+	var _ = BeforeEach(func() {
+		ts = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			// Quick and dirty router to simulate the Github API
+			if strings.Contains(r.URL.Path, "/device/code") {
+				err := json.NewEncoder(w).Encode(&codeResponse{
+					DeviceCode:     "123456789",
+					UserCode:       userCode,
+					VerficationURI: verificationUri,
+					Interval:       1,
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+			}
+
+			if strings.Contains(r.URL.Path, "/oauth/access_token") {
+				err := json.NewEncoder(w).Encode(&githubAuthResponse{
+					AccessToken: token,
+					Error:       "",
+				})
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			w.WriteHeader(http.StatusBadRequest)
+		}))
+
+		client = ts.Client()
+		client.Transport = &testServerTransport{testServeUrl: ts.URL, roundTripper: client.Transport}
+	})
+
+	var _ = AfterEach(func() {
+		ts.Close()
+	})
+
+	It("does the auth flow", func() {
+		authHandler := NewGithubDeviceFlowHandler(client)
+
+		var cliOutput bytes.Buffer
+		result, err := authHandler(context.Background(), &cliOutput)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(token))
+		// We need to ensure the user code and verification url are in the CLI ouput.
+		// Check for the prescense of substrings to avoid failing tests on trivial output changes.
+		Expect(cliOutput.String()).To(ContainSubstring(userCode))
+		Expect(cliOutput.String()).To(ContainSubstring(verificationUri))
+	})
+})

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -54,4 +54,5 @@ type Git interface {
 	Push(ctx context.Context) error
 	Status() (bool, error)
 	Head() (string, error)
+	GetRemoteUrl(dir string, remoteName string) (string, error)
 }

--- a/pkg/git/gitfakes/fake_git.go
+++ b/pkg/git/gitfakes/fake_git.go
@@ -40,6 +40,20 @@ type FakeGit struct {
 		result1 string
 		result2 error
 	}
+	GetRemoteUrlStub        func(string, string) (string, error)
+	getRemoteUrlMutex       sync.RWMutex
+	getRemoteUrlArgsForCall []struct {
+		arg1 string
+		arg2 string
+	}
+	getRemoteUrlReturns struct {
+		result1 string
+		result2 error
+	}
+	getRemoteUrlReturnsOnCall map[int]struct {
+		result1 string
+		result2 error
+	}
 	HeadStub        func() (string, error)
 	headMutex       sync.RWMutex
 	headArgsForCall []struct {
@@ -257,6 +271,71 @@ func (fake *FakeGit) CommitReturnsOnCall(i int, result1 string, result2 error) {
 		})
 	}
 	fake.commitReturnsOnCall[i] = struct {
+		result1 string
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeGit) GetRemoteUrl(arg1 string, arg2 string) (string, error) {
+	fake.getRemoteUrlMutex.Lock()
+	ret, specificReturn := fake.getRemoteUrlReturnsOnCall[len(fake.getRemoteUrlArgsForCall)]
+	fake.getRemoteUrlArgsForCall = append(fake.getRemoteUrlArgsForCall, struct {
+		arg1 string
+		arg2 string
+	}{arg1, arg2})
+	stub := fake.GetRemoteUrlStub
+	fakeReturns := fake.getRemoteUrlReturns
+	fake.recordInvocation("GetRemoteUrl", []interface{}{arg1, arg2})
+	fake.getRemoteUrlMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeGit) GetRemoteUrlCallCount() int {
+	fake.getRemoteUrlMutex.RLock()
+	defer fake.getRemoteUrlMutex.RUnlock()
+	return len(fake.getRemoteUrlArgsForCall)
+}
+
+func (fake *FakeGit) GetRemoteUrlCalls(stub func(string, string) (string, error)) {
+	fake.getRemoteUrlMutex.Lock()
+	defer fake.getRemoteUrlMutex.Unlock()
+	fake.GetRemoteUrlStub = stub
+}
+
+func (fake *FakeGit) GetRemoteUrlArgsForCall(i int) (string, string) {
+	fake.getRemoteUrlMutex.RLock()
+	defer fake.getRemoteUrlMutex.RUnlock()
+	argsForCall := fake.getRemoteUrlArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeGit) GetRemoteUrlReturns(result1 string, result2 error) {
+	fake.getRemoteUrlMutex.Lock()
+	defer fake.getRemoteUrlMutex.Unlock()
+	fake.GetRemoteUrlStub = nil
+	fake.getRemoteUrlReturns = struct {
+		result1 string
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeGit) GetRemoteUrlReturnsOnCall(i int, result1 string, result2 error) {
+	fake.getRemoteUrlMutex.Lock()
+	defer fake.getRemoteUrlMutex.Unlock()
+	fake.GetRemoteUrlStub = nil
+	if fake.getRemoteUrlReturnsOnCall == nil {
+		fake.getRemoteUrlReturnsOnCall = make(map[int]struct {
+			result1 string
+			result2 error
+		})
+	}
+	fake.getRemoteUrlReturnsOnCall[i] = struct {
 		result1 string
 		result2 error
 	}{result1, result2}
@@ -700,6 +779,8 @@ func (fake *FakeGit) Invocations() map[string][][]interface{} {
 	defer fake.cloneMutex.RUnlock()
 	fake.commitMutex.RLock()
 	defer fake.commitMutex.RUnlock()
+	fake.getRemoteUrlMutex.RLock()
+	defer fake.getRemoteUrlMutex.RUnlock()
 	fake.headMutex.RLock()
 	defer fake.headMutex.RUnlock()
 	fake.initMutex.RLock()

--- a/pkg/gitproviders/provider.go
+++ b/pkg/gitproviders/provider.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -470,4 +471,24 @@ func (p defaultGitProvider) waitUntilRepoCreated(ownerType ProviderAccountType, 
 		return fmt.Errorf("could not verify repo existence %s", err)
 	}
 	return nil
+}
+
+// DetectGitProviderFromUrl accepts a url related to a git repo and
+// returns the name of the provider associated.
+// The raw URL is assumed to be something like ssh://git@github.com/myorg/myrepo.git.
+// The common `git clone` variant of `git@github.com:myorg/myrepo.git` is not supported.
+func DetectGitProviderFromUrl(raw string) (GitProviderName, error) {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", fmt.Errorf("could not parse git repo url %q", raw)
+	}
+
+	switch u.Hostname() {
+	case "github.com":
+		return GitProviderGitHub, nil
+	case "gitlab.com":
+		return GitProviderGitLab, nil
+	}
+
+	return "", fmt.Errorf("no git providers found for \"%s\"", raw)
 }

--- a/pkg/gitproviders/provider_test.go
+++ b/pkg/gitproviders/provider_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/fluxcd/go-git-providers/github"
 	"github.com/fluxcd/go-git-providers/gitprovider"
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 )
 
@@ -636,4 +637,16 @@ var _ = Describe("Test org deploy keys creation", func() {
 		err = recorder.Stop()
 		Expect(err).ShouldNot(HaveOccurred())
 	})
+})
+
+var _ = Describe("helpers", func() {
+	DescribeTable("DetectGitProviderFromUrl", func(input string, expected GitProviderName) {
+		result, err := DetectGitProviderFromUrl(input)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(expected))
+	},
+		Entry("ssh+github", "ssh://git@github.com/weaveworks/weave-gitops.git", GitProviderGitHub),
+		Entry("ssh+gitlab", "ssh://git@gitlab.com/weaveworks/weave-gitops.git", GitProviderGitLab),
+	)
+
 })

--- a/pkg/osys/osys.go
+++ b/pkg/osys/osys.go
@@ -1,6 +1,7 @@
 package osys
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -61,10 +62,13 @@ func (o *OsysClient) Setenv(envVar, value string) error {
 // local versions of UserHomeDir, LookupEnv, and Stdin and so that they can also
 // be mocked (e.g. we might want to mock the private key password handing).
 
+var ErrNoGitProviderTokenSet = errors.New("no git provider token env variable set")
+
 func (o *OsysClient) GetGitProviderToken() (string, error) {
 	providerToken, found := o.LookupEnv("GITHUB_TOKEN")
-	if !found {
-		return "", fmt.Errorf("GITHUB_TOKEN not set in environment")
+
+	if !found || providerToken == "" {
+		return "", ErrNoGitProviderTokenSet
 	}
 
 	return providerToken, nil

--- a/pkg/services/app/add.go
+++ b/pkg/services/app/add.go
@@ -226,7 +226,7 @@ func (a *App) updateParametersIfNecessary(gitProvider gitproviders.GitProvider, 
 	// making sure the config url is in good format
 	if strings.ToUpper(params.AppConfigUrl) != string(ConfigTypeNone) &&
 		strings.ToUpper(params.AppConfigUrl) != string(ConfigTypeUserRepo) {
-		params.AppConfigUrl = sanitizeRepoUrl(params.AppConfigUrl)
+		params.AppConfigUrl = utils.SanitizeRepoUrl(params.AppConfigUrl)
 	}
 
 	switch {
@@ -251,7 +251,7 @@ func (a *App) updateParametersIfNecessary(gitProvider gitproviders.GitProvider, 
 		params.Url = url
 	default:
 		// making sure url is in the correct format
-		params.Url = sanitizeRepoUrl(params.Url)
+		params.Url = utils.SanitizeRepoUrl(params.Url)
 
 		// resetting Dir param since Url has priority over it
 		params.Dir = ""
@@ -300,7 +300,7 @@ func (a *App) getGitRemoteUrl(params AddParams) (string, error) {
 		return "", fmt.Errorf("remote config in %s does not have an url", params.Dir)
 	}
 
-	return sanitizeRepoUrl(urls[0]), nil
+	return utils.SanitizeRepoUrl(urls[0]), nil
 }
 
 func (a *App) addAppWithNoConfigRepo(info *AppResourceInfo, dryRun bool, secretRef string, appHash string) error {
@@ -530,7 +530,7 @@ func (a *App) createAndUploadDeployKey(info *AppResourceInfo, dryRun bool, repoU
 		return secretRefName, nil
 	}
 
-	repoUrl = sanitizeRepoUrl(repoUrl)
+	repoUrl = utils.SanitizeRepoUrl(repoUrl)
 
 	owner, err := utils.GetOwnerFromUrl(repoUrl)
 	if err != nil {
@@ -645,7 +645,7 @@ func (a *App) cloneRepo(url string, branch string, dryRun bool) (func(), error) 
 		return func() {}, nil
 	}
 
-	url = sanitizeRepoUrl(url)
+	url = utils.SanitizeRepoUrl(url)
 
 	repoDir, err := ioutil.TempDir("", "user-repo-")
 	if err != nil {
@@ -716,30 +716,6 @@ func generateAppYaml(info *AppResourceInfo, appHash string) ([]byte, error) {
 
 func generateResourceName(url string) string {
 	return strings.ReplaceAll(utils.UrlToRepoName(url), "_", "-")
-}
-
-func sanitizeRepoUrl(url string) string {
-	trimmed := ""
-
-	if !strings.HasSuffix(url, ".git") {
-		url = url + ".git"
-	}
-
-	sshPrefix := "git@github.com:"
-	if strings.HasPrefix(url, sshPrefix) {
-		trimmed = strings.TrimPrefix(url, sshPrefix)
-	}
-
-	httpsPrefix := "https://github.com/"
-	if strings.HasPrefix(url, httpsPrefix) {
-		trimmed = strings.TrimPrefix(url, httpsPrefix)
-	}
-
-	if trimmed != "" {
-		return "ssh://git@github.com/" + trimmed
-	}
-
-	return url
 }
 
 func (a *App) createPullRequestToRepo(info *AppResourceInfo, gitProvider gitproviders.GitProvider, repo string, appHash string, appYaml []byte, goatSource, goatDeploy []byte) error {

--- a/pkg/services/app/app.go
+++ b/pkg/services/app/app.go
@@ -3,16 +3,19 @@ package app
 import (
 	"context"
 	"fmt"
+	"io"
 
 	helmv2 "github.com/fluxcd/helm-controller/api/v2beta1"
 	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1beta1"
 	wego "github.com/weaveworks/weave-gitops/api/v1alpha1"
+	"github.com/weaveworks/weave-gitops/pkg/auth"
 	"github.com/weaveworks/weave-gitops/pkg/flux"
 	"github.com/weaveworks/weave-gitops/pkg/git"
 	"github.com/weaveworks/weave-gitops/pkg/gitproviders"
 	"github.com/weaveworks/weave-gitops/pkg/kube"
 	"github.com/weaveworks/weave-gitops/pkg/logger"
 	"github.com/weaveworks/weave-gitops/pkg/osys"
+	"github.com/weaveworks/weave-gitops/pkg/utils"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -161,4 +164,22 @@ func (a *App) pauseOrUnpause(suspendAction wego.SuspendActionType, name, namespa
 		return nil
 	}
 	return fmt.Errorf("invalid suspend action")
+}
+
+// DoAppRepoCLIAuth is a helper function that encapsulates the CLI auth flow.
+// This is meant to be re-used in whichever commands need to authenticate with a Git Provider.
+func DoAppRepoCLIAuth(url string, w io.Writer) (string, error) {
+	providerName, err := gitproviders.DetectGitProviderFromUrl(utils.SanitizeRepoUrl(url))
+	if err != nil {
+		return "", fmt.Errorf("could not determine provider name from url %s: %w", url, err)
+	}
+
+	// CLI auth experience will vary between Git Providers.
+	authHandler, err := auth.NewAuthProvider(providerName)
+	if err != nil {
+		return "", fmt.Errorf("could not get auth handler for provider %s: %w", providerName, err)
+	}
+
+	// authHandler will take over the CLI and block until the flow is complete.
+	return authHandler(context.Background(), w)
 }

--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -82,3 +82,30 @@ func ValidateNamespace(ns string) error {
 
 	return nil
 }
+
+// SanitizeRepoUrl accepts a url like git@github.com:someuser/podinfo.git and converts it into
+// a string like ssh://git@github.com/someuser/podinfo.git. This helps standardize the different
+// user inputs that might be provided.
+func SanitizeRepoUrl(url string) string {
+	trimmed := ""
+
+	if !strings.HasSuffix(url, ".git") {
+		url = url + ".git"
+	}
+
+	sshPrefix := "git@github.com:"
+	if strings.HasPrefix(url, sshPrefix) {
+		trimmed = strings.TrimPrefix(url, sshPrefix)
+	}
+
+	httpsPrefix := "https://github.com/"
+	if strings.HasPrefix(url, httpsPrefix) {
+		trimmed = strings.TrimPrefix(url, httpsPrefix)
+	}
+
+	if trimmed != "" {
+		return "ssh://git@github.com/" + trimmed
+	}
+
+	return url
+}

--- a/pkg/utils/common_test.go
+++ b/pkg/utils/common_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 )
 
@@ -97,3 +98,15 @@ error occurred some error, retrying in 1s
 
 	})
 })
+
+var _ = DescribeTable("SanitizeRepoUrl", func(input string, expected string) {
+	result := SanitizeRepoUrl(input)
+	Expect(result).To(Equal(expected))
+},
+	Entry("git clone style", "git@github.com:someuser/podinfo.git", "ssh://git@github.com/someuser/podinfo.git"),
+	Entry("url style", "ssh://git@github.com/someuser/podinfo.git", "ssh://git@github.com/someuser/podinfo.git"),
+	// TODO: there is other code relying on everything looking like an SSH url.
+	// We need to refactor the SanitizeRepoUrl function .
+	// https://github.com/weaveworks/weave-gitops/issues/577
+	Entry("https style", "https://github.com/weaveworks/weave-gitops.git", "ssh://git@github.com/weaveworks/weave-gitops.git"),
+)


### PR DESCRIPTION
Adds an authentication flow to the `wego app add` command.

Key notes:
* Removes the `ssh` key lookup entirely from the `add` command. Instead, we use a personal access token or temporary access token obtained via the CLI auth flow. Other `git` operations can be done with the deploy key that we push up.
* Lays the ground work for other Git Provider auth flows to be added
* This represents the first step to enabling API/UI auth

**To test, ensure you unset your `GITHUB_TOKEN` env variable**

Here is what the user will see when they run the command without a `GITHUB_TOKEN` set:

```
$ wego app add .

Visit this URL to authenticate with Github:

https://github.com/login/device

Type the following code into the page at the URL above: 82AB-434E

Waiting for authentication flow completion...

```

Then the user enters the code:
![Screenshot from 2021-08-04 15-32-06](https://user-images.githubusercontent.com/2802257/128264021-6970d237-ecf6-428a-819a-3a9f8290c427.png)


Then on to the Auth page:

![Screenshot from 2021-08-04 15-31-38](https://user-images.githubusercontent.com/2802257/128264053-6e7789ee-f555-4876-bb0d-ebe602b7d01a.png)

Once they visit the page and enter the code, their access token is returned:

```
Authentication successful!

Adding application:
```