### PR TITLE
add --helm-release-target-namespace for helm releases and validate all namespaces

### DIFF
--- a/api/v1alpha1/application_types.go
+++ b/api/v1alpha1/application_types.go
@@ -38,6 +38,8 @@ type ApplicationSpec struct {
 	DeploymentType DeploymentType `json:"deployment_type,omitempty"`
 	// SourceType is the type of repository containing the app manifests
 	SourceType SourceType `json:"source_type,omitempty"`
+	// HelmTargetNamespace is the namespace in which to deploy an added Helm Chart
+	HelmTargetNamespace string `json:"helm_target_namespace,omitempty"`
 }
 
 // +kubebuilder:validation:Enum=helm;kustomize

--- a/cmd/wego/app/add/cmd.go
+++ b/cmd/wego/app/add/cmd.go
@@ -61,6 +61,7 @@ func init() {
 	Cmd.Flags().StringVar(&params.Chart, "chart", "", "Specify chart for helm source")
 	Cmd.Flags().StringVar(&params.PrivateKey, "private-key", "", "Private key to access git repository over ssh")
 	Cmd.Flags().StringVar(&params.AppConfigUrl, "app-config-url", "", "URL of external repository (if any) which will hold automation manifests; NONE to store only in the cluster")
+	Cmd.Flags().StringVar(&params.HelmReleaseTargetNamespace, "helm-release-target-namespace", "", "Namespace in which to deploy a helm chart; defaults to the wego installation namespace")
 	Cmd.Flags().BoolVar(&params.DryRun, "dry-run", false, "If set, 'wego add' will not make any changes to the system; it will just display the actions that would have been taken")
 	Cmd.Flags().BoolVar(&params.AutoMerge, "auto-merge", false, "If set, 'wego add' will merge automatically into the set --branch")
 }

--- a/cmd/wego/main.go
+++ b/cmd/wego/main.go
@@ -14,6 +14,7 @@ import (
 	fluxBin "github.com/weaveworks/weave-gitops/pkg/flux"
 	"github.com/weaveworks/weave-gitops/pkg/osys"
 	"github.com/weaveworks/weave-gitops/pkg/runner"
+	"github.com/weaveworks/weave-gitops/pkg/utils"
 )
 
 var options struct {
@@ -63,6 +64,13 @@ var rootCmd = &cobra.Command{
 `,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		configureLogger()
+
+		ns, _ := cmd.Flags().GetString("namespace")
+
+		if nserr := utils.ValidateNamespace(ns); nserr != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", nserr)
+			os.Exit(1)
+		}
 	},
 }
 

--- a/cmd/wego/main.go
+++ b/cmd/wego/main.go
@@ -67,6 +67,10 @@ var rootCmd = &cobra.Command{
 
 		ns, _ := cmd.Flags().GetString("namespace")
 
+		if ns == "" {
+			return
+		}
+
 		if nserr := utils.ValidateNamespace(ns); nserr != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", nserr)
 			os.Exit(1)

--- a/manifests/crds/wego.weave.works_apps.yaml
+++ b/manifests/crds/wego.weave.works_apps.yaml
@@ -51,6 +51,10 @@ spec:
                 - helm
                 - kustomize
                 type: string
+              helm_target_namespace:
+                description: HelmTargetNamespace is the namespace in which to deploy
+                  an added Helm Chart
+                type: string
               path:
                 description: Path is the path in the repository where the k8s yaml
                   files for this application are stored.

--- a/pkg/flux/flux.go
+++ b/pkg/flux/flux.go
@@ -23,8 +23,8 @@ type Flux interface {
 	CreateSourceGit(name string, url string, branch string, secretRef string, namespace string) ([]byte, error)
 	CreateSourceHelm(name string, url string, namespace string) ([]byte, error)
 	CreateKustomization(name string, source string, path string, namespace string) ([]byte, error)
-	CreateHelmReleaseGitRepository(name string, source string, path string, namespace string) ([]byte, error)
-	CreateHelmReleaseHelmRepository(name string, chart string, namespace string) ([]byte, error)
+	CreateHelmReleaseGitRepository(name, source, path, namespace, targetNamespace string) ([]byte, error)
+	CreateHelmReleaseHelmRepository(name, chart, namespace, targetNamespace string) ([]byte, error)
 	CreateSecretGit(name string, url string, namespace string) ([]byte, error)
 	GetVersion() (string, error)
 	GetAllResourcesStatus(name string, namespace string) ([]byte, error)
@@ -170,7 +170,7 @@ func (f *FluxClient) CreateKustomization(name string, source string, path string
 	return out, nil
 }
 
-func (f *FluxClient) CreateHelmReleaseGitRepository(name string, source string, chartPath string, namespace string) ([]byte, error) {
+func (f *FluxClient) CreateHelmReleaseGitRepository(name, source, chartPath, namespace, targetNamespace string) ([]byte, error) {
 	args := []string{
 		"create", "helmrelease", name,
 		"--source", "GitRepository/" + source,
@@ -178,6 +178,10 @@ func (f *FluxClient) CreateHelmReleaseGitRepository(name string, source string, 
 		"--namespace", namespace,
 		"--interval", "5m",
 		"--export",
+	}
+
+	if targetNamespace != "" {
+		args = append(args, "--target-namespace", targetNamespace)
 	}
 
 	out, err := f.runFluxCmd(args...)
@@ -188,7 +192,7 @@ func (f *FluxClient) CreateHelmReleaseGitRepository(name string, source string, 
 	return out, nil
 }
 
-func (f *FluxClient) CreateHelmReleaseHelmRepository(name string, chart string, namespace string) ([]byte, error) {
+func (f *FluxClient) CreateHelmReleaseHelmRepository(name, chart, namespace, targetNamespace string) ([]byte, error) {
 	args := []string{
 		"create", "helmrelease", name,
 		"--source", "HelmRepository/" + name,
@@ -196,6 +200,10 @@ func (f *FluxClient) CreateHelmReleaseHelmRepository(name string, chart string, 
 		"--namespace", namespace,
 		"--interval", "5m",
 		"--export",
+	}
+
+	if targetNamespace != "" {
+		args = append(args, "--target-namespace", targetNamespace)
 	}
 
 	out, err := f.runFluxCmd(args...)

--- a/pkg/flux/flux_test.go
+++ b/pkg/flux/flux_test.go
@@ -151,7 +151,7 @@ var _ = Describe("CreateHelmReleaseGitRepository", func() {
 		runner.RunStub = func(s1 string, s2 ...string) ([]byte, error) {
 			return []byte("out"), nil
 		}
-		out, err := fluxClient.CreateHelmReleaseGitRepository("my-name", "my-source", "./chart-path", "wego-system")
+		out, err := fluxClient.CreateHelmReleaseGitRepository("my-name", "my-source", "./chart-path", "wego-system", "")
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(out).To(Equal([]byte("out")))
 
@@ -162,6 +162,22 @@ var _ = Describe("CreateHelmReleaseGitRepository", func() {
 
 		Expect(strings.Join(args, " ")).To(Equal("create helmrelease my-name --source GitRepository/my-source --chart ./chart-path --namespace wego-system --interval 5m --export"))
 	})
+
+	It("creates a helm release with a git repository and a target namespace", func() {
+		runner.RunStub = func(s1 string, s2 ...string) ([]byte, error) {
+			return []byte("out"), nil
+		}
+		out, err := fluxClient.CreateHelmReleaseGitRepository("my-name", "my-source", "./chart-path", "wego-system", "sock-shop")
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(out).To(Equal([]byte("out")))
+
+		Expect(runner.RunCallCount()).To(Equal(1))
+
+		cmd, args := runner.RunArgsForCall(0)
+		Expect(cmd).To(Equal(fluxPath()))
+
+		Expect(strings.Join(args, " ")).To(Equal("create helmrelease my-name --source GitRepository/my-source --chart ./chart-path --namespace wego-system --interval 5m --export --target-namespace sock-shop"))
+	})
 })
 
 var _ = Describe("CreateHelmReleaseHelmRepository", func() {
@@ -169,7 +185,7 @@ var _ = Describe("CreateHelmReleaseHelmRepository", func() {
 		runner.RunStub = func(s1 string, s2 ...string) ([]byte, error) {
 			return []byte("out"), nil
 		}
-		out, err := fluxClient.CreateHelmReleaseHelmRepository("my-name", "my-chart", "wego-system")
+		out, err := fluxClient.CreateHelmReleaseHelmRepository("my-name", "my-chart", "wego-system", "")
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(out).To(Equal([]byte("out")))
 
@@ -179,6 +195,22 @@ var _ = Describe("CreateHelmReleaseHelmRepository", func() {
 		Expect(cmd).To(Equal(fluxPath()))
 
 		Expect(strings.Join(args, " ")).To(Equal("create helmrelease my-name --source HelmRepository/my-name --chart my-chart --namespace wego-system --interval 5m --export"))
+	})
+
+	It("creates a helm release with a helm repository and a target namespace", func() {
+		runner.RunStub = func(s1 string, s2 ...string) ([]byte, error) {
+			return []byte("out"), nil
+		}
+		out, err := fluxClient.CreateHelmReleaseHelmRepository("my-name", "my-chart", "wego-system", "sock-shop")
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(out).To(Equal([]byte("out")))
+
+		Expect(runner.RunCallCount()).To(Equal(1))
+
+		cmd, args := runner.RunArgsForCall(0)
+		Expect(cmd).To(Equal(fluxPath()))
+
+		Expect(strings.Join(args, " ")).To(Equal("create helmrelease my-name --source HelmRepository/my-name --chart my-chart --namespace wego-system --interval 5m --export --target-namespace sock-shop"))
 	})
 })
 

--- a/pkg/flux/fluxfakes/fake_flux.go
+++ b/pkg/flux/fluxfakes/fake_flux.go
@@ -9,13 +9,14 @@ import (
 )
 
 type FakeFlux struct {
-	CreateHelmReleaseGitRepositoryStub        func(string, string, string, string) ([]byte, error)
+	CreateHelmReleaseGitRepositoryStub        func(string, string, string, string, string) ([]byte, error)
 	createHelmReleaseGitRepositoryMutex       sync.RWMutex
 	createHelmReleaseGitRepositoryArgsForCall []struct {
 		arg1 string
 		arg2 string
 		arg3 string
 		arg4 string
+		arg5 string
 	}
 	createHelmReleaseGitRepositoryReturns struct {
 		result1 []byte
@@ -25,12 +26,13 @@ type FakeFlux struct {
 		result1 []byte
 		result2 error
 	}
-	CreateHelmReleaseHelmRepositoryStub        func(string, string, string) ([]byte, error)
+	CreateHelmReleaseHelmRepositoryStub        func(string, string, string, string) ([]byte, error)
 	createHelmReleaseHelmRepositoryMutex       sync.RWMutex
 	createHelmReleaseHelmRepositoryArgsForCall []struct {
 		arg1 string
 		arg2 string
 		arg3 string
+		arg4 string
 	}
 	createHelmReleaseHelmRepositoryReturns struct {
 		result1 []byte
@@ -215,7 +217,7 @@ type FakeFlux struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeFlux) CreateHelmReleaseGitRepository(arg1 string, arg2 string, arg3 string, arg4 string) ([]byte, error) {
+func (fake *FakeFlux) CreateHelmReleaseGitRepository(arg1 string, arg2 string, arg3 string, arg4 string, arg5 string) ([]byte, error) {
 	fake.createHelmReleaseGitRepositoryMutex.Lock()
 	ret, specificReturn := fake.createHelmReleaseGitRepositoryReturnsOnCall[len(fake.createHelmReleaseGitRepositoryArgsForCall)]
 	fake.createHelmReleaseGitRepositoryArgsForCall = append(fake.createHelmReleaseGitRepositoryArgsForCall, struct {
@@ -223,13 +225,14 @@ func (fake *FakeFlux) CreateHelmReleaseGitRepository(arg1 string, arg2 string, a
 		arg2 string
 		arg3 string
 		arg4 string
-	}{arg1, arg2, arg3, arg4})
+		arg5 string
+	}{arg1, arg2, arg3, arg4, arg5})
 	stub := fake.CreateHelmReleaseGitRepositoryStub
 	fakeReturns := fake.createHelmReleaseGitRepositoryReturns
-	fake.recordInvocation("CreateHelmReleaseGitRepository", []interface{}{arg1, arg2, arg3, arg4})
+	fake.recordInvocation("CreateHelmReleaseGitRepository", []interface{}{arg1, arg2, arg3, arg4, arg5})
 	fake.createHelmReleaseGitRepositoryMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3, arg4)
+		return stub(arg1, arg2, arg3, arg4, arg5)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -243,17 +246,17 @@ func (fake *FakeFlux) CreateHelmReleaseGitRepositoryCallCount() int {
 	return len(fake.createHelmReleaseGitRepositoryArgsForCall)
 }
 
-func (fake *FakeFlux) CreateHelmReleaseGitRepositoryCalls(stub func(string, string, string, string) ([]byte, error)) {
+func (fake *FakeFlux) CreateHelmReleaseGitRepositoryCalls(stub func(string, string, string, string, string) ([]byte, error)) {
 	fake.createHelmReleaseGitRepositoryMutex.Lock()
 	defer fake.createHelmReleaseGitRepositoryMutex.Unlock()
 	fake.CreateHelmReleaseGitRepositoryStub = stub
 }
 
-func (fake *FakeFlux) CreateHelmReleaseGitRepositoryArgsForCall(i int) (string, string, string, string) {
+func (fake *FakeFlux) CreateHelmReleaseGitRepositoryArgsForCall(i int) (string, string, string, string, string) {
 	fake.createHelmReleaseGitRepositoryMutex.RLock()
 	defer fake.createHelmReleaseGitRepositoryMutex.RUnlock()
 	argsForCall := fake.createHelmReleaseGitRepositoryArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
 }
 
 func (fake *FakeFlux) CreateHelmReleaseGitRepositoryReturns(result1 []byte, result2 error) {
@@ -282,20 +285,21 @@ func (fake *FakeFlux) CreateHelmReleaseGitRepositoryReturnsOnCall(i int, result1
 	}{result1, result2}
 }
 
-func (fake *FakeFlux) CreateHelmReleaseHelmRepository(arg1 string, arg2 string, arg3 string) ([]byte, error) {
+func (fake *FakeFlux) CreateHelmReleaseHelmRepository(arg1 string, arg2 string, arg3 string, arg4 string) ([]byte, error) {
 	fake.createHelmReleaseHelmRepositoryMutex.Lock()
 	ret, specificReturn := fake.createHelmReleaseHelmRepositoryReturnsOnCall[len(fake.createHelmReleaseHelmRepositoryArgsForCall)]
 	fake.createHelmReleaseHelmRepositoryArgsForCall = append(fake.createHelmReleaseHelmRepositoryArgsForCall, struct {
 		arg1 string
 		arg2 string
 		arg3 string
-	}{arg1, arg2, arg3})
+		arg4 string
+	}{arg1, arg2, arg3, arg4})
 	stub := fake.CreateHelmReleaseHelmRepositoryStub
 	fakeReturns := fake.createHelmReleaseHelmRepositoryReturns
-	fake.recordInvocation("CreateHelmReleaseHelmRepository", []interface{}{arg1, arg2, arg3})
+	fake.recordInvocation("CreateHelmReleaseHelmRepository", []interface{}{arg1, arg2, arg3, arg4})
 	fake.createHelmReleaseHelmRepositoryMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3)
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -309,17 +313,17 @@ func (fake *FakeFlux) CreateHelmReleaseHelmRepositoryCallCount() int {
 	return len(fake.createHelmReleaseHelmRepositoryArgsForCall)
 }
 
-func (fake *FakeFlux) CreateHelmReleaseHelmRepositoryCalls(stub func(string, string, string) ([]byte, error)) {
+func (fake *FakeFlux) CreateHelmReleaseHelmRepositoryCalls(stub func(string, string, string, string) ([]byte, error)) {
 	fake.createHelmReleaseHelmRepositoryMutex.Lock()
 	defer fake.createHelmReleaseHelmRepositoryMutex.Unlock()
 	fake.CreateHelmReleaseHelmRepositoryStub = stub
 }
 
-func (fake *FakeFlux) CreateHelmReleaseHelmRepositoryArgsForCall(i int) (string, string, string) {
+func (fake *FakeFlux) CreateHelmReleaseHelmRepositoryArgsForCall(i int) (string, string, string, string) {
 	fake.createHelmReleaseHelmRepositoryMutex.RLock()
 	defer fake.createHelmReleaseHelmRepositoryMutex.RUnlock()
 	argsForCall := fake.createHelmReleaseHelmRepositoryArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
 }
 
 func (fake *FakeFlux) CreateHelmReleaseHelmRepositoryReturns(result1 []byte, result2 error) {

--- a/pkg/services/app/add.go
+++ b/pkg/services/app/add.go
@@ -61,20 +61,21 @@ const (
 )
 
 type AddParams struct {
-	Dir              string
-	Name             string
-	Url              string
-	Path             string
-	Branch           string
-	PrivateKey       string
-	DeploymentType   string
-	Chart            string
-	SourceType       string
-	AppConfigUrl     string
-	Namespace        string
-	DryRun           bool
-	AutoMerge        bool
-	GitProviderToken string
+	Dir                        string
+	Name                       string
+	Url                        string
+	Path                       string
+	Branch                     string
+	PrivateKey                 string
+	DeploymentType             string
+	Chart                      string
+	SourceType                 string
+	AppConfigUrl               string
+	Namespace                  string
+	DryRun                     bool
+	AutoMerge                  bool
+	GitProviderToken           string
+	HelmReleaseTargetNamespace string
 }
 
 // Three models:
@@ -235,8 +236,6 @@ func (a *App) updateParametersIfNecessary(gitProvider gitproviders.GitProvider, 
 		if params.Name == "" {
 			params.Name = params.Chart
 		}
-
-		return params, nil
 	}
 
 	// Identifying repo url if not set by the user
@@ -270,6 +269,13 @@ func (a *App) updateParametersIfNecessary(gitProvider gitproviders.GitProvider, 
 			} else {
 				params.Branch = branch
 			}
+		}
+	}
+
+	// Validate namespace argument for helm
+	if params.HelmReleaseTargetNamespace != "" {
+		if nserr := utils.ValidateNamespace(params.HelmReleaseTargetNamespace); nserr != nil {
+			return params, nserr
 		}
 	}
 
@@ -604,9 +610,9 @@ func (a *App) generateApplicationGoat(info *AppResourceInfo) ([]byte, error) {
 	case wego.DeploymentTypeHelm:
 		switch info.Spec.SourceType {
 		case wego.SourceTypeHelm:
-			return a.flux.CreateHelmReleaseHelmRepository(info.Name, info.Spec.Path, info.Namespace)
+			return a.flux.CreateHelmReleaseHelmRepository(info.Name, info.Spec.Path, info.Namespace, info.Spec.HelmTargetNamespace)
 		case wego.SourceTypeGit:
-			return a.flux.CreateHelmReleaseGitRepository(info.Name, info.Name, info.Spec.Path, info.Namespace)
+			return a.flux.CreateHelmReleaseGitRepository(info.Name, info.Name, info.Spec.Path, info.Namespace, info.Spec.HelmTargetNamespace)
 		default:
 			return nil, fmt.Errorf("invalid source type: %v", info.Spec.SourceType)
 		}
@@ -678,12 +684,13 @@ func makeWegoApplication(params AddParams) wego.Application {
 			Namespace: params.Namespace,
 		},
 		Spec: wego.ApplicationSpec{
-			ConfigURL:      params.AppConfigUrl,
-			Branch:         params.Branch,
-			URL:            params.Url,
-			Path:           params.Path,
-			DeploymentType: wego.DeploymentType(params.DeploymentType),
-			SourceType:     wego.SourceType(params.SourceType),
+			ConfigURL:           params.AppConfigUrl,
+			Branch:              params.Branch,
+			URL:                 params.Url,
+			Path:                params.Path,
+			DeploymentType:      wego.DeploymentType(params.DeploymentType),
+			SourceType:          wego.SourceType(params.SourceType),
+			HelmTargetNamespace: params.HelmReleaseTargetNamespace,
 		},
 	}
 

--- a/pkg/services/app/add.go
+++ b/pkg/services/app/add.go
@@ -229,17 +229,19 @@ func (a *App) updateParametersIfNecessary(gitProvider gitproviders.GitProvider, 
 		params.AppConfigUrl = sanitizeRepoUrl(params.AppConfigUrl)
 	}
 
-	if params.Chart != "" {
+	switch {
+	case params.Chart != "":
 		params.SourceType = string(wego.SourceTypeHelm)
 		params.DeploymentType = string(wego.DeploymentTypeHelm)
 		params.Path = params.Chart
 		if params.Name == "" {
 			params.Name = params.Chart
 		}
-	}
-
-	// Identifying repo url if not set by the user
-	if params.Url == "" {
+		if params.Url == "" {
+			return params, fmt.Errorf("--url must be specified for helm repositories")
+		}
+	case params.Url == "":
+		// Git repository -- identifying repo url if not set by the user
 		url, err := a.getGitRemoteUrl(params)
 
 		if err != nil {
@@ -247,7 +249,7 @@ func (a *App) updateParametersIfNecessary(gitProvider gitproviders.GitProvider, 
 		}
 
 		params.Url = url
-	} else {
+	default:
 		// making sure url is in the correct format
 		params.Url = sanitizeRepoUrl(params.Url)
 

--- a/pkg/services/app/add_test.go
+++ b/pkg/services/app/add_test.go
@@ -226,7 +226,7 @@ stringData:
 
 				name, url, namespace := fluxClient.CreateSourceHelmArgsForCall(0)
 				Expect(name).To(Equal("loki"))
-				Expect(url).To(Equal("https://charts.kube-ops.io"))
+				Expect(url).To(Equal("https://charts.kube-ops.io.git"))
 				Expect(namespace).To(Equal("wego-system"))
 			})
 		})
@@ -253,10 +253,11 @@ stringData:
 
 				Expect(fluxClient.CreateHelmReleaseHelmRepositoryCallCount()).To(Equal(1))
 
-				name, chart, namespace := fluxClient.CreateHelmReleaseHelmRepositoryArgsForCall(0)
+				name, chart, namespace, targetNamespace := fluxClient.CreateHelmReleaseHelmRepositoryArgsForCall(0)
 				Expect(name).To(Equal("loki"))
 				Expect(chart).To(Equal("loki"))
 				Expect(namespace).To(Equal("wego-system"))
+				Expect(targetNamespace).To(Equal(""))
 			})
 
 			It("creates a helm release using a git source if source type is git", func() {
@@ -268,11 +269,46 @@ stringData:
 
 				Expect(fluxClient.CreateHelmReleaseGitRepositoryCallCount()).To(Equal(1))
 
-				name, source, path, namespace := fluxClient.CreateHelmReleaseGitRepositoryArgsForCall(0)
+				name, source, path, namespace, targetNamespace := fluxClient.CreateHelmReleaseGitRepositoryArgsForCall(0)
 				Expect(name).To(Equal("bar"))
 				Expect(source).To(Equal("bar"))
 				Expect(path).To(Equal("./charts/my-chart"))
 				Expect(namespace).To(Equal("wego-system"))
+				Expect(targetNamespace).To(Equal(""))
+			})
+
+			It("creates helm release for helm repository with target namespace if source type is helm", func() {
+				addParams.Chart = "loki"
+				addParams.HelmReleaseTargetNamespace = "sock-shop"
+
+				err := appSrv.Add(addParams)
+				Expect(err).ShouldNot(HaveOccurred())
+
+				Expect(fluxClient.CreateHelmReleaseHelmRepositoryCallCount()).To(Equal(1))
+
+				name, chart, namespace, targetNamespace := fluxClient.CreateHelmReleaseHelmRepositoryArgsForCall(0)
+				Expect(name).To(Equal("loki"))
+				Expect(chart).To(Equal("loki"))
+				Expect(namespace).To(Equal("wego-system"))
+				Expect(targetNamespace).To(Equal("sock-shop"))
+			})
+
+			It("creates a helm release for git repository with target namespace if source type is git", func() {
+				addParams.Path = "./charts/my-chart"
+				addParams.DeploymentType = string(wego.DeploymentTypeHelm)
+				addParams.HelmReleaseTargetNamespace = "sock-shop"
+
+				err := appSrv.Add(addParams)
+				Expect(err).ShouldNot(HaveOccurred())
+
+				Expect(fluxClient.CreateHelmReleaseGitRepositoryCallCount()).To(Equal(1))
+
+				name, source, path, namespace, targetNamespace := fluxClient.CreateHelmReleaseGitRepositoryArgsForCall(0)
+				Expect(name).To(Equal("bar"))
+				Expect(source).To(Equal("bar"))
+				Expect(path).To(Equal("./charts/my-chart"))
+				Expect(namespace).To(Equal("wego-system"))
+				Expect(targetNamespace).To(Equal("sock-shop"))
 			})
 
 			It("fails if deployment type is invalid", func() {
@@ -370,7 +406,7 @@ stringData:
 
 				name, url, namespace := fluxClient.CreateSourceHelmArgsForCall(0)
 				Expect(name).To(Equal("loki"))
-				Expect(url).To(Equal("https://charts.kube-ops.io"))
+				Expect(url).To(Equal("https://charts.kube-ops.io.git"))
 				Expect(namespace).To(Equal("wego-system"))
 			})
 		})
@@ -409,10 +445,11 @@ stringData:
 
 				Expect(fluxClient.CreateHelmReleaseHelmRepositoryCallCount()).To(Equal(1))
 
-				name, chart, namespace := fluxClient.CreateHelmReleaseHelmRepositoryArgsForCall(0)
+				name, chart, namespace, targetNamespace := fluxClient.CreateHelmReleaseHelmRepositoryArgsForCall(0)
 				Expect(name).To(Equal("loki"))
 				Expect(chart).To(Equal("loki"))
 				Expect(namespace).To(Equal("wego-system"))
+				Expect(targetNamespace).To(Equal(""))
 			})
 
 			It("creates a helm release using a git source if source type is git", func() {
@@ -424,11 +461,59 @@ stringData:
 
 				Expect(fluxClient.CreateHelmReleaseGitRepositoryCallCount()).To(Equal(1))
 
-				name, source, path, namespace := fluxClient.CreateHelmReleaseGitRepositoryArgsForCall(0)
+				name, source, path, namespace, targetNamespace := fluxClient.CreateHelmReleaseGitRepositoryArgsForCall(0)
 				Expect(name).To(Equal("bar"))
 				Expect(source).To(Equal("bar"))
 				Expect(path).To(Equal("./charts/my-chart"))
 				Expect(namespace).To(Equal("wego-system"))
+				Expect(targetNamespace).To(Equal(""))
+			})
+
+			It("creates helm release for helm repository with target namespace if source type is helm", func() {
+				addParams.Chart = "loki"
+				addParams.HelmReleaseTargetNamespace = "sock-shop"
+
+				err := appSrv.Add(addParams)
+				Expect(err).ShouldNot(HaveOccurred())
+
+				Expect(fluxClient.CreateHelmReleaseHelmRepositoryCallCount()).To(Equal(1))
+
+				name, chart, namespace, targetNamespace := fluxClient.CreateHelmReleaseHelmRepositoryArgsForCall(0)
+				Expect(name).To(Equal("loki"))
+				Expect(chart).To(Equal("loki"))
+				Expect(namespace).To(Equal("wego-system"))
+				Expect(targetNamespace).To(Equal("sock-shop"))
+			})
+
+			It("creates a helm release for git repository with target namespace if source type is git", func() {
+				addParams.Path = "./charts/my-chart"
+				addParams.DeploymentType = string(wego.DeploymentTypeHelm)
+				addParams.HelmReleaseTargetNamespace = "sock-shop"
+
+				err := appSrv.Add(addParams)
+				Expect(err).ShouldNot(HaveOccurred())
+
+				Expect(fluxClient.CreateHelmReleaseGitRepositoryCallCount()).To(Equal(1))
+
+				name, source, path, namespace, targetNamespace := fluxClient.CreateHelmReleaseGitRepositoryArgsForCall(0)
+				Expect(name).To(Equal("bar"))
+				Expect(source).To(Equal("bar"))
+				Expect(path).To(Equal("./charts/my-chart"))
+				Expect(namespace).To(Equal("wego-system"))
+				Expect(targetNamespace).To(Equal("sock-shop"))
+			})
+
+			It("validates namespace passed as target namespace", func() {
+				addParams.Chart = "loki"
+				addParams.HelmReleaseTargetNamespace = "sock-shop"
+
+				goodNamespaceErr := appSrv.Add(addParams)
+				Expect(goodNamespaceErr).ShouldNot(HaveOccurred())
+
+				addParams.HelmReleaseTargetNamespace = "sock-shop&*&*&*&"
+
+				badNamespaceErr := appSrv.Add(addParams)
+				Expect(badNamespaceErr).To(HaveOccurred())
 			})
 
 			It("fails if deployment type is invalid", func() {
@@ -563,7 +648,7 @@ stringData:
 
 				name, url, namespace := fluxClient.CreateSourceHelmArgsForCall(0)
 				Expect(name).To(Equal("loki"))
-				Expect(url).To(Equal("https://charts.kube-ops.io"))
+				Expect(url).To(Equal("https://charts.kube-ops.io.git"))
 				Expect(namespace).To(Equal("wego-system"))
 			})
 		})
@@ -636,10 +721,11 @@ stringData:
 
 				Expect(fluxClient.CreateHelmReleaseHelmRepositoryCallCount()).To(Equal(1))
 
-				name, chart, namespace := fluxClient.CreateHelmReleaseHelmRepositoryArgsForCall(0)
+				name, chart, namespace, targetNamespace := fluxClient.CreateHelmReleaseHelmRepositoryArgsForCall(0)
 				Expect(name).To(Equal("loki"))
 				Expect(chart).To(Equal("loki"))
 				Expect(namespace).To(Equal("wego-system"))
+				Expect(targetNamespace).To(Equal(""))
 			})
 
 			It("creates a helm release using a git source if source type is git", func() {
@@ -651,11 +737,46 @@ stringData:
 
 				Expect(fluxClient.CreateHelmReleaseGitRepositoryCallCount()).To(Equal(1))
 
-				name, source, path, namespace := fluxClient.CreateHelmReleaseGitRepositoryArgsForCall(0)
+				name, source, path, namespace, targetNamespace := fluxClient.CreateHelmReleaseGitRepositoryArgsForCall(0)
 				Expect(name).To(Equal("repo"))
 				Expect(source).To(Equal("repo"))
 				Expect(path).To(Equal("./charts/my-chart"))
 				Expect(namespace).To(Equal("wego-system"))
+				Expect(targetNamespace).To(Equal(""))
+			})
+
+			It("creates helm release for helm repository with target namespace if source type is helm", func() {
+				addParams.Chart = "loki"
+				addParams.HelmReleaseTargetNamespace = "sock-shop"
+
+				err := appSrv.Add(addParams)
+				Expect(err).ShouldNot(HaveOccurred())
+
+				Expect(fluxClient.CreateHelmReleaseHelmRepositoryCallCount()).To(Equal(1))
+
+				name, chart, namespace, targetNamespace := fluxClient.CreateHelmReleaseHelmRepositoryArgsForCall(0)
+				Expect(name).To(Equal("loki"))
+				Expect(chart).To(Equal("loki"))
+				Expect(namespace).To(Equal("wego-system"))
+				Expect(targetNamespace).To(Equal("sock-shop"))
+			})
+
+			It("creates a helm release for git repository with target namespace if source type is git", func() {
+				addParams.Path = "./charts/my-chart"
+				addParams.DeploymentType = string(wego.DeploymentTypeHelm)
+				addParams.HelmReleaseTargetNamespace = "sock-shop"
+
+				err := appSrv.Add(addParams)
+				Expect(err).ShouldNot(HaveOccurred())
+
+				Expect(fluxClient.CreateHelmReleaseGitRepositoryCallCount()).To(Equal(1))
+
+				name, source, path, namespace, targetNamespace := fluxClient.CreateHelmReleaseGitRepositoryArgsForCall(0)
+				Expect(name).To(Equal("repo"))
+				Expect(source).To(Equal("repo"))
+				Expect(path).To(Equal("./charts/my-chart"))
+				Expect(namespace).To(Equal("wego-system"))
+				Expect(targetNamespace).To(Equal("sock-shop"))
 			})
 
 			It("fails if deployment type is invalid", func() {

--- a/pkg/services/app/add_test.go
+++ b/pkg/services/app/add_test.go
@@ -513,7 +513,7 @@ stringData:
 				addParams.HelmReleaseTargetNamespace = "sock-shop&*&*&*&"
 
 				badNamespaceErr := appSrv.Add(addParams)
-				Expect(badNamespaceErr).To(HaveOccurred())
+				Expect(badNamespaceErr.Error()).To(HavePrefix("could not update parameters: invalid namespace"))
 			})
 
 			It("fails if deployment type is invalid", func() {

--- a/pkg/services/app/add_test.go
+++ b/pkg/services/app/add_test.go
@@ -226,7 +226,7 @@ stringData:
 
 				name, url, namespace := fluxClient.CreateSourceHelmArgsForCall(0)
 				Expect(name).To(Equal("loki"))
-				Expect(url).To(Equal("https://charts.kube-ops.io.git"))
+				Expect(url).To(Equal("https://charts.kube-ops.io"))
 				Expect(namespace).To(Equal("wego-system"))
 			})
 		})
@@ -406,7 +406,7 @@ stringData:
 
 				name, url, namespace := fluxClient.CreateSourceHelmArgsForCall(0)
 				Expect(name).To(Equal("loki"))
-				Expect(url).To(Equal("https://charts.kube-ops.io.git"))
+				Expect(url).To(Equal("https://charts.kube-ops.io"))
 				Expect(namespace).To(Equal("wego-system"))
 			})
 		})
@@ -438,6 +438,7 @@ stringData:
 			})
 
 			It("creates helm release using a helm repository if source type is helm", func() {
+				addParams.Url = "https://charts.kube-ops.io"
 				addParams.Chart = "loki"
 
 				err := appSrv.Add(addParams)
@@ -470,6 +471,7 @@ stringData:
 			})
 
 			It("creates helm release for helm repository with target namespace if source type is helm", func() {
+				addParams.Url = "https://charts.kube-ops.io"
 				addParams.Chart = "loki"
 				addParams.HelmReleaseTargetNamespace = "sock-shop"
 
@@ -504,6 +506,7 @@ stringData:
 			})
 
 			It("validates namespace passed as target namespace", func() {
+				addParams.Url = "https://charts.kube-ops.io"
 				addParams.Chart = "loki"
 				addParams.HelmReleaseTargetNamespace = "sock-shop"
 
@@ -648,7 +651,7 @@ stringData:
 
 				name, url, namespace := fluxClient.CreateSourceHelmArgsForCall(0)
 				Expect(name).To(Equal("loki"))
-				Expect(url).To(Equal("https://charts.kube-ops.io.git"))
+				Expect(url).To(Equal("https://charts.kube-ops.io"))
 				Expect(namespace).To(Equal("wego-system"))
 			})
 		})

--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	validation "k8s.io/apimachinery/pkg/api/validation"
 )
 
 var commitMessage string
@@ -71,4 +73,12 @@ func GetOwnerFromUrl(url string) (string, error) {
 		return "", fmt.Errorf("could not get owner from url %s", url)
 	}
 	return parts[len(parts)-2], nil
+}
+
+func ValidateNamespace(ns string) error {
+	if errList := validation.ValidateNamespaceName(ns, false); len(errList) != 0 {
+		return fmt.Errorf("invalid namespace: %s", strings.Join(errList, ", "))
+	}
+
+	return nil
 }


### PR DESCRIPTION
Resolves #472 
<!-- Describe what has changed in this PR -->
**What changed?**
We now support passing `--helm-release-target-namespace <ns>` to specify the namespace in which to deploy a helm chart. We also apply standard Kubernetes validation to all namespace arguments.

<!-- Tell your future self why have you made these changes -->
**Why?**
It's unreasonable to ask users to edit their generated `HelmRelease` resources to add a target namespace and that isn't even possible in the `config=NONE` case.

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**
Unit tests and installed `sock-shop` from a helm chart; prior to the fix, all the pods were in the `wego-system` namespace.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
**Release notes**
No changes to user environments are required.

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
The new argument should be documented in the CLI reference.
