### PR TITLE
Add GH Workflow for github-repo-stats

### DIFF
--- a/.github/workflows/repostats.yaml
+++ b/.github/workflows/repostats.yaml
@@ -1,0 +1,23 @@
+on:
+  schedule:
+    # Run this once per day, towards the end of the day for keeping the most
+    # recent data point most meaningful (hours are interpreted in UTC).
+    - cron: "0 23 * * *"
+  workflow_dispatch: # Allow for running this manually.
+
+jobs:
+  j1:
+    name: repostats-for-weave-gitops
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        statsRepo:
+        - weaveworks/weave-gitops
+      fail-fast: false
+      max-parallel: 1
+    steps:
+      - name: run-ghrs
+        uses: jgehrcke/github-repo-stats@dab4a915b37a7521cd54033a3147daaeb868ec5c
+        with:
+          repository: ${{ matrix.statsRepo }}
+          ghtoken: ${{ secrets.BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
	Fixes: #534

	Following largely fluxcd/community#109 to allow us to track
	information of how many clones/stars/etc weave-gitops sees.

	If we want additional repos to be tracked, this can be done
	easily.

	We need to add an empty branch called 'github-repo-stats'
	to get this set up.

Signed-off-by: Daniel Holbach <daniel@weave.works>

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
**Release notes**

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**