### PR TITLE
Connect Stdout and Stderr to "wego flux" commands

### DIFF
--- a/cmd/wego/flux/cmd.go
+++ b/cmd/wego/flux/cmd.go
@@ -40,10 +40,10 @@ func runCmd(cmd *cobra.Command, args []string) {
 	}
 
 	c := exec.Command(exePath, args...)
-
+	c.Stdin = osysClient.Stdin()
+	c.Stdout = osysClient.Stdout()
 	// run command
-	output, _ := c.CombinedOutput()
-	fmt.Print(string(output))
+	_ = c.Run()
 }
 
 func runStatusCmd(cmd *cobra.Command, args []string) {

--- a/cmd/wego/flux/cmd.go
+++ b/cmd/wego/flux/cmd.go
@@ -42,6 +42,7 @@ func runCmd(cmd *cobra.Command, args []string) {
 	c := exec.Command(exePath, args...)
 	c.Stdin = osysClient.Stdin()
 	c.Stdout = osysClient.Stdout()
+	c.Stderr = osysClient.Stderr()
 	// run command
 	_ = c.Run()
 }

--- a/test/acceptance/test/flux_tests.go
+++ b/test/acceptance/test/flux_tests.go
@@ -28,7 +28,7 @@ var _ = Describe("WEGO Flux Tests", func() {
 		})
 
 		By("Then I should see wego error message", func() {
-			Eventually(sessionOutput.Wait().Out.Contents()).Should(ContainSubstring("✗ unknown command \"foo\" for \"flux\""))
+			Eventually(sessionOutput.Wait().Err.Contents()).Should(ContainSubstring("✗ unknown command \"foo\" for \"flux\""))
 		})
 	})
 


### PR DESCRIPTION
Resolves #615 

<!-- Describe what has changed in this PR -->
**What changed?**
The `wego flux` command wasn't reading Stdin so flux commands that prompted the user failed. Now the command has Stdin, Stdout, and Stderr attached.

<!-- Tell your future self why have you made these changes -->
**Why?**
So that interactive flux commands will work correctly

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**
I ran the bug scenario by hand before and after

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
**Release notes**
No

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
No