### PR TITLE
Use cobra to require at least one argument for remove

### DIFF
--- a/cmd/wego/app/remove/cmd.go
+++ b/cmd/wego/app/remove/cmd.go
@@ -38,6 +38,7 @@ var Cmd = &cobra.Command{
   # Remove application from wego control via immediate commit
   wego app remove podinfo
 `,
+	Args:          cobra.MinimumNArgs(1),
 	RunE:          runCmd,
 	SilenceUsage:  true,
 	SilenceErrors: true,
@@ -55,10 +56,6 @@ func init() {
 func runCmd(cmd *cobra.Command, args []string) error {
 	params.Name = args[0]
 	params.Namespace, _ = cmd.Parent().Flags().GetString("namespace")
-
-	if len(args) == 0 {
-		return fmt.Errorf("you must specify an application name")
-	}
 
 	osysClient := osys.New()
 

--- a/cmd/wego/app/remove/cmd.go
+++ b/cmd/wego/app/remove/cmd.go
@@ -27,14 +27,11 @@ var params app.RemoveParams
 
 var Cmd = &cobra.Command{
 	Use:   "remove [--private-key <keyfile>] <app name>",
-	Short: "Add a workload repository to a wego cluster",
+	Short: "Remove an app from a wego cluster",
 	Long: strings.TrimSpace(dedent.Dedent(`
-        Associates an additional application in a git repository with a wego cluster so that its contents may be managed via GitOps
+        Removes an application from a wego cluster so it will no longer be managed via GitOps
     `)),
 	Example: `
-  # Remove application from wego control via pull request
-  wego app remove podinfo
-
   # Remove application from wego control via immediate commit
   wego app remove podinfo
 `,


### PR DESCRIPTION
Resolves #641 

<!-- Describe what has changed in this PR -->
**What changed?**
We no longer panic if `wego app remove` is called with no arguments

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**
Tested by hand as we don't have unit tests for the cobra command wrappers; in this case, we now use cobra facilities to require that at least one argument is present.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
**Release notes**
No

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
No