### PR TITLE
Make wait tests reliable by abstracting out the time update

### DIFF
--- a/pkg/utils/common_test.go
+++ b/pkg/utils/common_test.go
@@ -39,52 +39,74 @@ func TestExists(t *testing.T) {
 
 var _ = Describe("Test common utils", func() {
 
-	It("Verify WaitUntil succeeds at first attempt in less than 1 millisecond", func() {
+	It("Verify timedRepeat succeeds at first attempt without updating the current time", func() {
 
 		var output bytes.Buffer
 		start := time.Now()
-
-		err := WaitUntil(&output, time.Millisecond, time.Millisecond, func() error {
-			return nil
-		})
-		Expect(time.Since(start)).Should(BeNumerically("<=", time.Millisecond))
+		resultTime, err := timedRepeat(
+			&output,
+			start,
+			time.Millisecond,
+			time.Millisecond,
+			func(currentTime time.Time) time.Time {
+				return currentTime.Add(time.Millisecond)
+			},
+			func() error {
+				return nil
+			})
+		Expect(resultTime.Sub(start)).Should(BeNumerically("==", 0))
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(output.String()).To(BeEmpty())
 
 	})
 
-	It("Verify WaitUntil prints out proper messages after succeeding at second attempt in less than 1 millisecond", func() {
+	It("Verify timedRepeat prints out proper messages after succeeding at second attempt", func() {
 
 		counter := 0
 
 		var output bytes.Buffer
 		start := time.Now()
-		err := WaitUntil(&output, time.Millisecond, time.Millisecond*10, func() error {
-			if counter == 0 {
-				counter++
-				return fmt.Errorf("some error")
-			}
-			return nil
-		})
-		Expect(time.Since(start)).Should(BeNumerically("<=", time.Millisecond*3))
+		resultTime, err := timedRepeat(
+			&output,
+			start,
+			time.Millisecond,
+			time.Millisecond*10,
+			func(currentTime time.Time) time.Time {
+				return currentTime.Add(time.Millisecond)
+			},
+			func() error {
+				if counter == 0 {
+					counter++
+					return fmt.Errorf("some error")
+				}
+				return nil
+			})
+		Expect(resultTime.Sub(start)).Should(BeNumerically("==", time.Millisecond))
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(output.String()).To(Equal("error occurred some error, retrying in 1ms\n"))
 
 	})
 
-	It("Verify WaitUntil prints out proper messages after reaching timeout", func() {
+	It("Verify timedRepeat prints out proper messages after reaching limit", func() {
 
 		var output bytes.Buffer
 		start := time.Now()
-		err := WaitUntil(&output, time.Second, time.Second*2, func() error {
-			return fmt.Errorf("some error")
-		})
-		Expect(time.Since(start)).Should(BeNumerically(">=", time.Second*2))
+		resultTime, err := timedRepeat(
+			&output,
+			start,
+			time.Second,
+			time.Second*2,
+			func(currentTime time.Time) time.Time {
+				return currentTime.Add(time.Second)
+			},
+			func() error {
+				return fmt.Errorf("some error")
+			})
+		Expect(resultTime.Sub(start)).Should(BeNumerically("==", time.Second*2))
 		Expect(err).Should(MatchError("timeout reached 2s"))
 		Expect(output.String()).Should(Equal(`error occurred some error, retrying in 1s
 error occurred some error, retrying in 1s
 `))
-
 	})
 
 	It("Verify CaptureStdout captures whatever is printed out to stdout in the callback", func() {


### PR DESCRIPTION
Resolves #576 

<!-- Describe what has changed in this PR -->
**What changed?**
`utils.WaitUntil` is now a wrapper around a `timedRepeat` function that accepts a time updater. The tests use reliable addition-based updaters while `utils.WaitUntil` passes in:

```
func(currentTime time.Time) time.Time {
	time.Sleep(poll)
	return time.Now()
},
```

<!-- Tell your future self why have you made these changes -->
**Why?**
So that unit tests won't fail due to an unusual timing delay

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**
The unit tests were updated to test the actual repeat and check functionality with reliable updaters.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
**Release notes**
No

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
No