### PR TITLE
Skip auth and key validation on dry-run

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/go-logr/zapr v0.4.0
 	github.com/google/go-cmp v0.5.6
 	github.com/google/uuid v1.2.0 // indirect
-	github.com/google/go-github v17.0.0+incompatible
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.5.0
 	github.com/grpc-ecosystem/protoc-gen-grpc-gateway-ts v1.1.1
 	github.com/jandelgado/gcov2lcov v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -336,8 +336,6 @@ github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
-github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-github/v32 v32.1.0 h1:GWkQOdXqviCPx7Q7Fj+KyPoGm4SwHRh8rheoPhd27II=
 github.com/google/go-github/v32 v32.1.0/go.mod h1:rIEpZD9CTDQwDK9GDrtMTycQNA4JU3qBsCizh3q2WCI=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=

--- a/pkg/gitproviders/factory.go
+++ b/pkg/gitproviders/factory.go
@@ -1,6 +1,7 @@
 package gitproviders
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/fluxcd/go-git-providers/github"
@@ -30,9 +31,11 @@ type Config struct {
 	Token string
 }
 
+var ErrInvalidGitProviderToken = errors.New("invalid git provider token")
+
 func buildGitProvider(config Config) (gitprovider.Client, error) {
 	if config.Token == "" {
-		return nil, fmt.Errorf("no git provider token present")
+		return nil, ErrInvalidGitProviderToken
 	}
 
 	var client gitprovider.Client

--- a/pkg/gitproviders/provider_test.go
+++ b/pkg/gitproviders/provider_test.go
@@ -227,7 +227,7 @@ var gitProvider defaultGitProvider
 var _ = Describe("Initialization", func() {
 	It("it validates token presence", func() {
 		_, err := New(Config{})
-		Expect(err).Should(MatchError("failed to build git provider: no git provider token present"))
+		Expect(err).Should(HaveOccurred())
 	})
 
 	It("builds a github client", func() {

--- a/pkg/services/app/add_test.go
+++ b/pkg/services/app/add_test.go
@@ -516,6 +516,7 @@ stringData:
 				addParams.HelmReleaseTargetNamespace = "sock-shop&*&*&*&"
 
 				badNamespaceErr := appSrv.Add(addParams)
+				Expect(badNamespaceErr).NotTo(BeNil())
 				Expect(badNamespaceErr.Error()).To(HavePrefix("could not update parameters: invalid namespace"))
 			})
 


### PR DESCRIPTION
Closes #601 

Skips doing authentication stuff when `--dry-run` is specified. A warning message will be displayed when no token is specified:

```
◎ Checking cluster status
✔ Wego installed
⚠️ No Git Provider token found. Skipping authentication for dry run.
Adding application:

Name: stringly
URL: ssh://git@github.com/jpellizzari/stringly.git
Path: ./
Branch: main
Type: kustomize

---
apiVersion: source.toolkit.fluxcd.io/v1beta1
kind: GitRepository
metadata:
  name: stringly
  namespace: wego-system
spec:
  interval: 30s
  ref:
    branch: main
  secretRef:
    name: wego-kind-kind-788gy0-stringly
  url: ssh://git@github.com/jpellizzari/stringly.git

...
```