### PR TITLE
Update README to v0.2.4 - fix parse error

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ _Weave GitOps is in early stages and iterating. Not all capabilities are availab
 Mac / Linux
 
 ```console
-curl -L https://github.com/weaveworks/weave-gitops/releases/download/v0.2.2/wego-$(uname)-$(uname -m) -o wego
+curl -L "https://github.com/weaveworks/weave-gitops/releases/download/v0.2.4/wego-$(uname)-$(uname -m)" -o wego
 chmod +x wego
 sudo mv ./wego /usr/local/bin/wego
 wego version


### PR DESCRIPTION
Updated to new release and mirrored change to the [docs](https://github.com/weaveworks/weave-gitops-docs/pull/60) to avoid parse error

<!-- Use # to add the issue this pull request is related to -->
Closes: 

<!-- Describe what has changed in this PR -->
**What changed?**
Updates install instructions from v0.2.2 to v0.2.4
Mirrors change we made in the [docs](https://github.com/weaveworks/weave-gitops-docs/pull/60) to avoid `zsh: parse error near `)'`

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**
Local test on mac

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
**Release notes**

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**