### PR TITLE
Remove check to differentiate between /private or /tmp

### DIFF
--- a/test/acceptance/test/utils.go
+++ b/test/acceptance/test/utils.go
@@ -214,11 +214,7 @@ func initAndCreateEmptyRepo(appRepoName string, IsPrivateRepo bool) string {
 	session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 	Expect(err).ShouldNot(HaveOccurred())
 	Eventually(session, 10, 1).Should(gexec.Exit())
-	if os.Getenv("CI") == "true" {
-		Expect(session.Out).Should(gbytes.Say(fmt.Sprintf(`Initialized empty Git repository in /tmp/%s/.git/`, appRepoName)))
-	} else {
-		Expect(session.Out).Should(gbytes.Say(fmt.Sprintf(`Initialized empty Git repository in /private/tmp/%s/.git/`, appRepoName)))
-	}
+	Expect(session.Out).Should(MatchRegexp(fmt.Sprintf(`Initialized empty Git repository in /[private|tmp]/%s/.git/`, appRepoName)))
 
 	randStr := RandString(10)
 	fmt.Println("RANDOM-STR", randStr)

--- a/test/acceptance/test/utils.go
+++ b/test/acceptance/test/utils.go
@@ -214,7 +214,7 @@ func initAndCreateEmptyRepo(appRepoName string, IsPrivateRepo bool) string {
 	session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 	Expect(err).ShouldNot(HaveOccurred())
 	Eventually(session, 10, 1).Should(gexec.Exit())
-	Expect(session.Out).Should(MatchRegexp(fmt.Sprintf(`Initialized empty Git repository in /[private|tmp]/%s/.git/`, appRepoName)))
+	Expect(string(session.Out.Contents())).Should(MatchRegexp(fmt.Sprintf(`Initialized empty Git repository in (/private)?/tmp/%s/.git/`, appRepoName)))
 
 	randStr := RandString(10)
 	fmt.Println("RANDOM-STR", randStr)


### PR DESCRIPTION
<!-- Use # to add the issue this pull request is related to -->
Closes: 

<!-- Describe what has changed in this PR -->
**What changed?**
Using a regular expression to ignore the differences on default paths when using `git init`

<!-- Tell your future self why have you made these changes -->
**Why?**
When initializing folders using `git init`, it returns different paths for different scenarios:
- Running tests locally returns `Initialized empty Git repository in /private/tmp/wego-test-app-l0obud5k/.git/`, notice `/private`
- Running tests on PRs returns `Initialized empty Git repository in /tmp/wego-test-app-l0obud5k/.git/`, notice `/temp`
- Running tests on Nightly returns `Initialized empty Git repository in /tmp/wego-test-app-l0obud5k/.git/`, notice `/private`

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**
Manually locally and using tests suites triggered by CI.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
**Release notes**

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**