### PR TITLE
Aligns material-ui versions in lock/package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "styled-components": "^5.3.0"
   },
   "dependencies": {
-    "@material-ui/core": "^4.11.4",
+    "@material-ui/core": "^4.12.3",
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.58",
     "history": "^5.0.0",


### PR DESCRIPTION
- package.json specified ^4.11
- package-lock.json specifies 4.12
- 4.12 introduced new stuff we're now using (`createTheme` instead of `createMuiTheme`)

<!-- Use # to add the issue this pull request is related to -->
Closes: #689 

<!-- Describe what has changed in this PR -->
**What changed?**

Material-ui version in package.json now better reflects the code dependencies.

<!-- Tell your future self why have you made these changes -->
**Why?**

So we can consume the npm package more easily in other projects without them having to override things.

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**

`npm install` and check `package-lock.json` hasn't changed