### PR TITLE
Adds multiple build targets and configurations to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,10 +2,25 @@
   "name": "@weaveworks/weave-gitops",
   "version": "0.2.4",
   "description": "Weave GitOps core",
+  "targets": {
+    "default": {
+      "distDir": "cmd/wego/ui/run/dist",
+      "source": "ui/index.html",
+      "sourceMap": false
+    },
+    "lib": {
+      "includeNodeModules": false,
+      "isLibrary": true,
+      "outputFormat": "commonjs",
+      "distDir": "dist",
+      "source": "ui/index.ts",
+      "sourceMap": false
+    }
+  },
   "scripts": {
     "preinstall": "npm install --package-lock-only --ignore-scripts && npx npm-force-resolutions",
-    "build": "parcel build --no-source-maps ui/index.html --dist-dir cmd/wego/ui/run/dist",
-    "build:lib": "parcel build --no-source-maps ui/index.ts --dist-dir dist",
+    "build": "parcel build --target default",
+    "build:lib": "parcel build --target lib",
     "typedefs": "npx -p typescript tsc ui/**/*.ts ui/**/*.tsx --skipLibCheck --esModuleInterop --jsx react-jsx --declaration --allowJs --emitDeclarationOnly --outDir dist",
     "start": "parcel serve --port 4567 ui/index.html",
     "lint": "eslint ui",


### PR DESCRIPTION
<!-- Use # to add the issue this pull request is related to -->
Closes: #690 

<!-- Describe what has changed in this PR -->
**What changed?**

Splits parcel build into multiple build targets, the library one now exposes commonjs and doesn't bundle react and node_modules.

<!-- Tell your future self why have you made these changes -->
**Why?**

As far as I understand it `parcel` infers how you want to build something based on what package.json looks like.
- If `main` is declared in `package.json` then it flips into "library mode" https://v2.parceljs.org/features/targets/#library-targets and builds commonjs artifacts
- However if `main` is declared then you get funny build errors when trying to build the wego UI..

I'm not sure if you can have a single package.json that builds for ui _and_ library. (?) There are build flags that you can pass to `parcel build` to customize things, but some required options are missing like `outputFormat: commonjs`.

Using `targets` seems to be a way to escape a single `package.json` inferred build config and specify things serparately.

**Other things we could try**

- **esm** (?), maybe we could build something that works for both.

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**

```
./make
./bin/wego run ui
open localhost:9001
```

seems to work

```
npm start
open localhost:4567
```

seems to work

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
**Release notes**

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**