### PR TITLE
Remove token arg

### DIFF
--- a/.github/workflows/upgrade-flux.yaml
+++ b/.github/workflows/upgrade-flux.yaml
@@ -29,7 +29,7 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@9825ae65b1cb54b543b938503728b432a0176d29 # v3
         with:
-          token: ${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_TOKEN }}
+#           token: ${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_TOKEN }}
           commit-message: |
             ${{ steps.update.outputs.pr_title }}
             ${{ steps.update.outputs.pr_body }}


### PR DESCRIPTION
Closes #377 

Uses the `GITHUB_TOKEN` default to create a PR on a cron job.