### PR TITLE
Add useApplications to the UI exports

### DIFF
--- a/ui/components/LoadingPage.tsx
+++ b/ui/components/LoadingPage.tsx
@@ -2,6 +2,7 @@ import { CircularProgress } from "@material-ui/core";
 import * as React from "react";
 import styled from "styled-components";
 import Flex from "./Flex";
+import theme from "./../lib/theme";
 
 type Props = {
   className?: string;
@@ -11,7 +12,7 @@ function LoadingPage({ className }: Props) {
   return (
     <div>
       <Flex className={className} center wide align>
-        <CircularProgress />
+        <CircularProgress style={{ color: theme.colors.primary }} />
       </Flex>
     </div>
   );

--- a/ui/components/Page.tsx
+++ b/ui/components/Page.tsx
@@ -2,7 +2,7 @@ import { Breadcrumbs } from "@material-ui/core";
 import { Alert, AlertTitle } from "@material-ui/lab";
 import _ from "lodash";
 import React from "react";
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 import useCommon from "../hooks/common";
 import { PageRoute } from "../lib/types";
 import { formatURL } from "../lib/utils";
@@ -53,7 +53,11 @@ function Page({ className, children, title, breadcrumbs, loading }: Props) {
   const { appState } = useCommon();
 
   if (loading) {
-    return <LoadingPage />;
+    return (
+      <Content>
+        <LoadingPage />
+      </Content>
+    );
   }
 
   return (

--- a/ui/components/Page.tsx
+++ b/ui/components/Page.tsx
@@ -2,7 +2,7 @@ import { Breadcrumbs } from "@material-ui/core";
 import { Alert, AlertTitle } from "@material-ui/lab";
 import _ from "lodash";
 import React from "react";
-import styled, { css } from "styled-components";
+import styled from "styled-components";
 import useCommon from "../hooks/common";
 import { PageRoute } from "../lib/types";
 import { formatURL } from "../lib/utils";

--- a/ui/index.ts
+++ b/ui/index.ts
@@ -4,6 +4,7 @@ import _Theme from "./lib/theme";
 import _ApplicationDetail from "./pages/ApplicationDetail";
 import _Applications from "./pages/Applications";
 import _useApplications from "./hooks/applications";
+import _LoadingPage from "./components/LoadingPage";
 
 export const theme = _Theme;
 export const AppContextProvider = _AppContextProvider;
@@ -11,3 +12,4 @@ export const Applications = _Applications;
 export const ApplicationDetail = _ApplicationDetail;
 export const applicationsClient = appsClient;
 export const useApplications = _useApplications;
+export const LoadingPage = _LoadingPage;

--- a/ui/index.ts
+++ b/ui/index.ts
@@ -3,9 +3,11 @@ import { Applications as appsClient } from "./lib/api/applications/applications.
 import _Theme from "./lib/theme";
 import _ApplicationDetail from "./pages/ApplicationDetail";
 import _Applications from "./pages/Applications";
+import _useApplications from "./hooks/applications";
 
 export const theme = _Theme;
 export const AppContextProvider = _AppContextProvider;
 export const Applications = _Applications;
 export const ApplicationDetail = _ApplicationDetail;
 export const applicationsClient = appsClient;
+export const useApplications = _useApplications;


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
The UI is also exporting the `useApplications` hook and `LoadingPage` now. 
Updated Loader style to match what we do in WE in terms of wrapping content. 

<!-- Tell your future self why have you made these changes -->
**Why?**
The export is needed in WE to have access to the number of applications.
The LoadingPage will be used in WE instead of what we have atm to ensure consistency. 