### PR TITLE
Update "wego gitops uninstall" to run to completion even if original install failed

### DIFF
--- a/pkg/apputils/utils.go
+++ b/pkg/apputils/utils.go
@@ -46,7 +46,7 @@ func GetLogger() logger.Logger {
 	return logger.NewCLILogger(osysClient.Stdout())
 }
 
-func getBaseClients() (osys.Osys, flux.Flux, kube.Kube, logger.Logger, error) {
+func GetBaseClients() (osys.Osys, flux.Flux, kube.Kube, logger.Logger, error) {
 	osysClient := osys.New()
 	cliRunner := &runner.CLIRunner{}
 	fluxClient := flux.New(osysClient, cliRunner)
@@ -76,7 +76,7 @@ func IsClusterReady() error {
 }
 
 func GetAppService(ctx context.Context, appName, namespace string) (app.AppService, error) {
-	osysClient, fluxClient, kubeClient, logger, baseClientErr := getBaseClients()
+	osysClient, fluxClient, kubeClient, logger, baseClientErr := GetBaseClients()
 	if baseClientErr != nil {
 		return nil, fmt.Errorf("error initializing clients: %w", baseClientErr)
 	}
@@ -90,7 +90,7 @@ func GetAppService(ctx context.Context, appName, namespace string) (app.AppServi
 }
 
 func GetAppServiceForAdd(ctx context.Context, url, configUrl, namespace string, isHelmRepository bool) (app.AppService, error) {
-	osysClient, fluxClient, kubeClient, logger, baseClientErr := getBaseClients()
+	osysClient, fluxClient, kubeClient, logger, baseClientErr := GetBaseClients()
 	if baseClientErr != nil {
 		return nil, fmt.Errorf("error initializing clients: %w", baseClientErr)
 	}

--- a/pkg/kube/kubehttp.go
+++ b/pkg/kube/kubehttp.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -134,12 +133,10 @@ func (k *KubeHTTP) GetClusterStatus(ctx context.Context) ClusterStatus {
 		Namespace: "kube-system",
 	}
 
-	notFoundErr := `deployments.apps "coredns" not found`
-
 	if err := k.Client.Get(ctx, coreDnsName, &dep); err != nil {
 		// Some clusters don't have 'coredns'; if we get a "not found" error, we know we
 		// can talk to the cluster
-		if strings.Contains(err.Error(), notFoundErr) {
+		if apierrors.IsNotFound(err) {
 			return Unmodified
 		}
 

--- a/pkg/services/gitops/gitops_suite_test.go
+++ b/pkg/services/gitops/gitops_suite_test.go
@@ -7,12 +7,14 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/weaveworks/weave-gitops/pkg/flux/fluxfakes"
 	"github.com/weaveworks/weave-gitops/pkg/kube/kubefakes"
+	"github.com/weaveworks/weave-gitops/pkg/logger/loggerfakes"
 	"github.com/weaveworks/weave-gitops/pkg/services/gitops"
 )
 
 var (
 	fluxClient *fluxfakes.FakeFlux
 	kubeClient *kubefakes.FakeKube
+	logger     *loggerfakes.FakeLogger
 
 	gitopsSrv gitops.GitopsService
 )

--- a/pkg/services/gitops/install_test.go
+++ b/pkg/services/gitops/install_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/weaveworks/weave-gitops/pkg/flux/fluxfakes"
 	"github.com/weaveworks/weave-gitops/pkg/kube"
 	"github.com/weaveworks/weave-gitops/pkg/kube/kubefakes"
-	"github.com/weaveworks/weave-gitops/pkg/logger"
+	log "github.com/weaveworks/weave-gitops/pkg/logger"
 	"github.com/weaveworks/weave-gitops/pkg/services/gitops"
 )
 
@@ -23,7 +23,7 @@ var _ = Describe("Install", func() {
 				return kube.Unmodified
 			},
 		}
-		gitopsSrv = gitops.New(logger.NewCLILogger(os.Stderr), fluxClient, kubeClient)
+		gitopsSrv = gitops.New(log.NewCLILogger(os.Stderr), fluxClient, kubeClient)
 
 		installParams = gitops.InstallParams{
 			Namespace: "wego-system",

--- a/pkg/services/gitops/uninstall.go
+++ b/pkg/services/gitops/uninstall.go
@@ -2,11 +2,10 @@ package gitops
 
 import (
 	"context"
-	"errors"
-	"strings"
 
 	"github.com/weaveworks/weave-gitops/manifests"
 	"github.com/weaveworks/weave-gitops/pkg/kube"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 type UinstallParams struct {
@@ -14,7 +13,11 @@ type UinstallParams struct {
 	DryRun    bool
 }
 
-const notFound = "not found"
+type UninstallError struct{}
+
+func (e UninstallError) Error() string {
+	return "errors occurred during uninstall; the original state of the cluster may not be completely restored"
+}
 
 func (g *Gitops) Uninstall(params UinstallParams) error {
 	ctx := context.Background()
@@ -34,7 +37,7 @@ func (g *Gitops) Uninstall(params UinstallParams) error {
 		g.logger.Actionf("Deleting App CRD")
 	} else {
 		if crdErr := g.kube.Delete(ctx, manifests.AppCRD); crdErr != nil {
-			if !strings.HasSuffix(crdErr.Error(), notFound) {
+			if !apierrors.IsNotFound(crdErr) {
 				g.logger.Printf("received error uninstalling app CRD: %q", crdErr)
 				errorOccurred = true
 			}
@@ -42,7 +45,7 @@ func (g *Gitops) Uninstall(params UinstallParams) error {
 	}
 
 	if errorOccurred {
-		return errors.New("errors occurred during uninstall; the original state of the cluster may not be completely restored")
+		return UninstallError{}
 	}
 
 	return nil

--- a/pkg/services/gitops/uninstall.go
+++ b/pkg/services/gitops/uninstall.go
@@ -3,7 +3,7 @@ package gitops
 import (
 	"context"
 	"errors"
-	"fmt"
+	"strings"
 
 	"github.com/weaveworks/weave-gitops/manifests"
 	"github.com/weaveworks/weave-gitops/pkg/kube"
@@ -14,23 +14,35 @@ type UinstallParams struct {
 	DryRun    bool
 }
 
+const notFound = "not found"
+
 func (g *Gitops) Uninstall(params UinstallParams) error {
 	ctx := context.Background()
 	if g.kube.GetClusterStatus(ctx) != kube.WeGOInstalled {
-		return errors.New("wego is not installed... exiting")
+		g.logger.Println("wego is not fully installed... removing any partial installation\n")
 	}
 
-	err := g.flux.Uninstall(params.Namespace, params.DryRun)
-	if err != nil {
-		return fmt.Errorf("error on flux install %s", err)
+	errorOccurred := false
+
+	fluxErr := g.flux.Uninstall(params.Namespace, params.DryRun)
+	if fluxErr != nil {
+		g.logger.Printf("received error uninstalling flux: %q, continuing with uninstall", fluxErr)
+		errorOccurred = true
 	}
 
 	if params.DryRun {
 		g.logger.Actionf("Deleting App CRD")
 	} else {
-		if err := g.kube.Delete(ctx, manifests.AppCRD); err != nil {
-			return fmt.Errorf("failed to delete App CRD: %w", err)
+		if crdErr := g.kube.Delete(ctx, manifests.AppCRD); crdErr != nil {
+			if !strings.HasSuffix(crdErr.Error(), notFound) {
+				g.logger.Printf("received error uninstalling app CRD: %q", crdErr)
+				errorOccurred = true
+			}
 		}
+	}
+
+	if errorOccurred {
+		return errors.New("errors occurred during uninstall; the original state of the cluster may not be completely restored")
 	}
 
 	return nil

--- a/pkg/services/gitops/uninstall_test.go
+++ b/pkg/services/gitops/uninstall_test.go
@@ -2,6 +2,8 @@ package gitops_test
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -14,6 +16,55 @@ import (
 
 var uninstallParams gitops.UinstallParams
 
+func checkFluxUninstallFailure() {
+	fluxErrMsg := "flux uninstall failed"
+	globalErrMsg := "errors occurred during uninstall; the original state of the cluster may not be completely restored"
+
+	loggedMsg := ""
+	logger.PrintfStub = func(str string, args ...interface{}) {
+		loggedMsg = fmt.Sprintf(str, args...)
+	}
+
+	fluxClient.UninstallStub = func(namespace string, dryRun bool) error {
+		return errors.New(fluxErrMsg)
+	}
+
+	err := gitopsSrv.Uninstall(uninstallParams)
+
+	Expect(loggedMsg).To(Equal(fmt.Sprintf("received error uninstalling flux: %q, continuing with uninstall", fluxErrMsg)))
+	Expect(err.Error()).To(Equal(globalErrMsg))
+	Expect(kubeClient.GetClusterStatusCallCount()).To(Equal(1))
+	Expect(fluxClient.UninstallCallCount()).To(Equal(1))
+	namespace, dryRun := fluxClient.UninstallArgsForCall(0)
+	Expect(namespace).To(Equal("wego-system"))
+	Expect(dryRun).To(Equal(false))
+}
+
+func checkAppCRDUninstallFailure() {
+	crdErrMsg := "CRD uninstall failed"
+	globalErrMsg := "errors occurred during uninstall; the original state of the cluster may not be completely restored"
+
+	loggedMsg := ""
+	logger.PrintfStub = func(str string, args ...interface{}) {
+		loggedMsg = fmt.Sprintf(str, args...)
+	}
+
+	kubeClient.DeleteStub = func(ctx context.Context, manifest []byte) error {
+		return errors.New(crdErrMsg)
+	}
+
+	err := gitopsSrv.Uninstall(uninstallParams)
+
+	Expect(loggedMsg).To(Equal(fmt.Sprintf("received error uninstalling app CRD: %q", crdErrMsg)))
+	Expect(err.Error()).To(Equal(globalErrMsg))
+	Expect(kubeClient.GetClusterStatusCallCount()).To(Equal(1))
+	Expect(fluxClient.UninstallCallCount()).To(Equal(1))
+	Expect(kubeClient.DeleteCallCount()).To(Equal(1))
+	namespace, dryRun := fluxClient.UninstallArgsForCall(0)
+	Expect(namespace).To(Equal("wego-system"))
+	Expect(dryRun).To(Equal(false))
+}
+
 var _ = Describe("Uninstall", func() {
 	BeforeEach(func() {
 		fluxClient = &fluxfakes.FakeFlux{}
@@ -22,7 +73,8 @@ var _ = Describe("Uninstall", func() {
 				return kube.WeGOInstalled
 			},
 		}
-		gitopsSrv = gitops.New(&loggerfakes.FakeLogger{}, fluxClient, kubeClient)
+		logger = &loggerfakes.FakeLogger{}
+		gitopsSrv = gitops.New(logger, fluxClient, kubeClient)
 
 		uninstallParams = gitops.UinstallParams{
 			Namespace: "wego-system",
@@ -30,30 +82,82 @@ var _ = Describe("Uninstall", func() {
 		}
 	})
 
-	It("checks if wego is installed before proceeding", func() {
+	It("logs warning information if wego is not installed before proceeding", func() {
 		err := gitopsSrv.Uninstall(uninstallParams)
 		Expect(err).ShouldNot(HaveOccurred())
 
 		Expect(kubeClient.GetClusterStatusCallCount()).To(Equal(1))
 		Expect(fluxClient.UninstallCallCount()).To(Equal(1))
 
+		loggedMsg := ""
+		logger.PrintlnStub = func(str string, args ...interface{}) {
+			loggedMsg = str
+		}
+
+		kubeClient.GetClusterStatusStub = func(ctx context.Context) kube.ClusterStatus {
+			return kube.FluxInstalled
+		}
+
+		Expect(gitopsSrv.Uninstall(uninstallParams)).Should(Succeed())
+		Expect(loggedMsg).To(Equal("wego is not fully installed... removing any partial installation\n"))
+
+		kubeClient.GetClusterStatusStub = func(ctx context.Context) kube.ClusterStatus {
+			return kube.Unmodified
+		}
+		loggedMsg = ""
+
+		Expect(gitopsSrv.Uninstall(uninstallParams)).Should(Succeed())
+		Expect(loggedMsg).To(Equal("wego is not fully installed... removing any partial installation\n"))
+	})
+
+	It("Does not log warning information if wego is installed", func() {
+		loggedMsg := ""
+		logger.PrintlnStub = func(str string, args ...interface{}) {
+			loggedMsg = str
+		}
+
+		Expect(gitopsSrv.Uninstall(uninstallParams)).Should(Succeed())
+		Expect(loggedMsg).To(Equal(""))
+	})
+
+	It("Generates an error if flux uninstall fails with wego installed", func() {
+		checkFluxUninstallFailure()
+	})
+
+	It("Generates an error if flux uninstall fails with only flux installed", func() {
+		kubeClient.GetClusterStatusStub = func(ctx context.Context) kube.ClusterStatus {
+			return kube.FluxInstalled
+		}
+
+		checkFluxUninstallFailure()
+	})
+
+	It("Generates an error if flux uninstall fails with partial or no flux installed", func() {
 		kubeClient.GetClusterStatusStub = func(ctx context.Context) kube.ClusterStatus {
 			return kube.Unmodified
 		}
 
-		err = gitopsSrv.Uninstall(uninstallParams)
-		Expect(err).Should(MatchError("wego is not installed... exiting"))
+		checkFluxUninstallFailure()
 	})
 
-	It("calls flux uninstall", func() {
-		err := gitopsSrv.Uninstall(uninstallParams)
-		Expect(err).ShouldNot(HaveOccurred())
+	It("Generates an error if CRD uninstall fails with wego installed", func() {
+		checkAppCRDUninstallFailure()
+	})
 
-		Expect(fluxClient.UninstallCallCount()).To(Equal(1))
+	It("Generates an error if CRD uninstall fails with only flux installed", func() {
+		kubeClient.GetClusterStatusStub = func(ctx context.Context) kube.ClusterStatus {
+			return kube.FluxInstalled
+		}
 
-		namespace, dryRun := fluxClient.UninstallArgsForCall(0)
-		Expect(namespace).To(Equal("wego-system"))
-		Expect(dryRun).To(Equal(false))
+		checkAppCRDUninstallFailure()
+	})
+
+	It("Generates an error if CRD uninstall fails with partial or no flux installed", func() {
+		kubeClient.GetClusterStatusStub = func(ctx context.Context) kube.ClusterStatus {
+			return kube.Unmodified
+		}
+
+		checkAppCRDUninstallFailure()
 	})
 
 	It("deletes app crd", func() {

--- a/test/acceptance/test/install_tests.go
+++ b/test/acceptance/test/install_tests.go
@@ -134,21 +134,12 @@ var _ = Describe("Weave GitOps Install Tests", func() {
 
 	It("Verify that wego can: install wego components, uninstall wego components, and work in dry-run mode", func() {
 
-		var errorOutput string
 		var installDryRunOutput string
 		var uninstallDryRunOutput string
 
 		By("And I have a brand new cluster", func() {
 			_, err := ResetOrCreateCluster(WEGO_DEFAULT_NAMESPACE, true)
 			Expect(err).ShouldNot(HaveOccurred())
-		})
-
-		By("When I try to uninstall wego in dry-run mode without installing components first", func() {
-			_, errorOutput = runCommandAndReturnStringOutput(WEGO_BIN_PATH + " gitops uninstall --dry-run")
-		})
-
-		By("Then I should see an error output", func() {
-			Eventually(errorOutput).Should(ContainSubstring("Error: wego is not installed... exiting"))
 		})
 
 		By("When I try to install wego in dry-run mode", func() {

--- a/test/acceptance/test/install_tests.go
+++ b/test/acceptance/test/install_tests.go
@@ -100,7 +100,7 @@ var _ = Describe("Weave GitOps Install Tests", func() {
 		})
 	})
 
-	FIt("Verify that wego can uninstall flux if wego was not fully installed", func() {
+	It("Verify that wego can uninstall flux if wego was not fully installed", func() {
 
 		namespace := "test-namespace"
 


### PR DESCRIPTION
<!-- Use # to add the issue this pull request is related to -->
Closes: #677 

<!-- Describe what has changed in this PR -->
**What changed?**
`wego gitops uninstall` used to check for a complete wego installation before continuing. This prevented removing a partial installation.

<!-- Tell your future self why have you made these changes -->
**Why?**
So a failed installation can be undone

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**
Unit and integration tests

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
**Release notes**
No

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
No