### PR TITLE
Remove --name flag from app remove command

### DIFF
--- a/cmd/wego/app/remove/cmd.go
+++ b/cmd/wego/app/remove/cmd.go
@@ -38,7 +38,6 @@ var Cmd = &cobra.Command{
 }
 
 func init() {
-	Cmd.Flags().StringVar(&params.Name, "name", "", "Name of application")
 	Cmd.Flags().StringVar(&params.PrivateKey, "private-key", "", "Private key to access git repository over ssh")
 	Cmd.Flags().BoolVar(&params.DryRun, "dry-run", false, "If set, 'wego remove' will not make any changes to the system; it will just display the actions that would have been taken")
 }


### PR DESCRIPTION
<!-- Use # to add the issue this pull request is related to -->
Closes: #717

<!-- Describe what has changed in this PR -->
**What changed?**
The flag --name has been removed from the command "wego app remove "


<!-- Tell your future self why have you made these changes -->
**Why?**
No need for this flag as the name of the application can be written as the first command argument without the need for the flag.

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**
The output after the fix:
```
 ./wego app remove --help
Removes an application from a wego cluster so it will no longer be managed via GitOps

Usage:
  wego app remove [--private-key <keyfile>] <app name> [flags]

Examples:

  \# Remove application from wego control via immediate commit
  wego app remove podinfo


Flags:
      --dry-run              If set, 'wego remove' will not make any changes to the system; it will just display the actions that would have been taken
  -h, --help                 help for remove
      --private-key string   Private key to access git repository over ssh

Global Flags:
      --namespace string   gitops runtime namespace (default "wego-system")
  -v, --verbose            Enable verbose output


>> ./wego app remove --name
Error: unknown flag: --name
```



<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
**Release notes**

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**