### PR TITLE
Add dockerized library integration tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -259,3 +259,17 @@ jobs:
         name: acceptance-test-artifacts
         path: ${{ env.ARTIFACTS_BASE_DIR }}
         retention-days: 1
+        ginkgo --randomizeSuites --reportFile=$(pwd)/test-results/smoke-test-results.xml -v ./test/acceptance/test/...
+  library-integration-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@94ab11c41e45d028884a99163086648e898eed25
+      - name: Run Library Integration Test
+        env:
+          GITHUB_TOKEN: "${{ secrets.github_token }}"
+        run: make lib-test
+
+        

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -259,7 +259,6 @@ jobs:
         name: acceptance-test-artifacts
         path: ${{ env.ARTIFACTS_BASE_DIR }}
         retention-days: 1
-        ginkgo --randomizeSuites --reportFile=$(pwd)/test-results/smoke-test-results.xml -v ./test/acceptance/test/...
   library-integration-test:
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ coverage
 *.lcov
 ginkgo.report
 .deps
+test/library/wego-library-test

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,7 @@ clean: ## Clean up images and binaries
 	rm -rf coverage
 	rm -rf node_modules
 	rm -f .deps
+	rm -rf dist
 
 fmt: ## Run go fmt against code
 	go fmt ./...
@@ -127,7 +128,16 @@ cmd/wego/ui/run/dist/index.html: cmd/wego/ui/run/dist
 cmd/wego/ui/run/dist/main.js:
 	npm run build
 
-dist/index.js:
+# Runs a test to raise errors if the integration between WeGO Core and EE is 
+# in danger of breaking due to package API changes.
+# See the test/library dockerfile and test.sh script for more info.
+lib-test: dependencies
+	docker build -t wego-library-test -f test/library/libtest.dockerfile $(CURRENT_DIR)/test/library
+	docker run -e GITHUB_TOKEN=$$GITHUB_TOKEN -i --rm \
+		-v $(CURRENT_DIR):/go/src/github.com/weaveworks/weave-gitops \
+		 wego-library-test
+
+dist/index.js: ui/index.ts
 	npm run build:lib && cp package.json dist
 
 dist/index.d.ts:

--- a/test/library/libtest.dockerfile
+++ b/test/library/libtest.dockerfile
@@ -1,0 +1,9 @@
+FROM golang:1.16
+RUN apt-get update
+RUN apt-get -y install curl gnupg
+RUN curl -sL https://deb.nodesource.com/setup_14.x  | bash -
+RUN apt-get -y install nodejs
+COPY test.sh /test/test.sh
+WORKDIR /test
+CMD ./test.sh
+

--- a/test/library/test.sh
+++ b/test/library/test.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+set -x
+
+git clone https://github.com/weaveworks-gitops-test/wego-library-test.git test/library/wego-library-test
+cd test/library/wego-library-test
+npm ci
+npm run build
+go mod tidy
+go build main.go

--- a/ui/index.ts
+++ b/ui/index.ts
@@ -1,10 +1,10 @@
+import _LoadingPage from "./components/LoadingPage";
 import _AppContextProvider from "./contexts/AppContext";
+import _useApplications from "./hooks/applications";
 import { Applications as appsClient } from "./lib/api/applications/applications.pb";
 import _Theme from "./lib/theme";
 import _ApplicationDetail from "./pages/ApplicationDetail";
 import _Applications from "./pages/Applications";
-import _useApplications from "./hooks/applications";
-import _LoadingPage from "./components/LoadingPage";
 
 export const theme = _Theme;
 export const AppContextProvider = _AppContextProvider;


### PR DESCRIPTION
Closes #691

Adds a test that will report when the "public" API for `wego` go libraries break consuming implementations.

To test, rename something like the `server.DefaultConfig()` function and see the `make lib-test` target fail with an exit code of 2.

Uses this repo as a reference implementation: https://github.com/weaveworks-gitops-test/wego-library-test

Output looks like this when something breaks the API contract:
![Screenshot from 2021-09-07 17-37-23](https://user-images.githubusercontent.com/2802257/132427212-58c66822-996a-4a6e-bc31-99dd654af8ab.png)
