### PR TITLE
Fix non-deterministic behavior between `npm i` and `npm ci`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,7 @@ proto: ## Generate protobuf files
 
 node_modules: ## Install node modules
 	npm ci
+	npx npm-force-resolutions
 
 ui-lint: ## Run linter against the UI
 	npm run lint

--- a/package-lock.json
+++ b/package-lock.json
@@ -2358,7 +2358,7 @@
         "@parcel/plugin": "2.0.0-rc.0",
         "@parcel/source-map": "2.0.0-rc.6",
         "cssnano": "^5.0.5",
-        "postcss": "^8.3.0"
+        "postcss": "8.3.6"
       },
       "dependencies": {
         "postcss": {
@@ -2450,7 +2450,7 @@
         "@parcel/source-map": "2.0.0-rc.6",
         "@parcel/utils": "2.0.0-rc.0",
         "nullthrows": "^1.1.1",
-        "postcss": "^8.3.0"
+        "postcss": "8.3.6"
       },
       "dependencies": {
         "postcss": {
@@ -2613,26 +2613,22 @@
         "@parcel/plugin": "2.0.0-rc.0",
         "@parcel/utils": "2.0.0-rc.0",
         "connect": "^3.7.0",
-        "ejs": "^2.6.1",
+        "ejs": "^3.1.6",
         "http-proxy-middleware": "^1.0.0",
         "nullthrows": "^1.1.1",
         "serve-handler": "^6.0.0",
-        "ws": "^7.0.0"
+        "ws": "^7.4.6"
       },
       "dependencies": {
         "ejs": {
-          "version": "3.1.6",
-          "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.6.tgz",
-          "integrity": "sha512-9lt9Zse4hPucPkoP7FHDF0LQAlGyF9JVpnClFLFH3aSSbxmyoqINRpp/9wePWJTUl4KOQwRL72Iw3InHPDkoGw==",
+          "version": "^3.1.6",
           "dev": true,
           "requires": {
             "jake": "^10.6.1"
           }
         },
         "ws": {
-          "version": "7.5.5",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.5.tgz",
-          "integrity": "sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w==",
+          "version": "^7.4.6",
           "dev": true
         }
       }
@@ -2728,7 +2724,7 @@
         "@parcel/source-map": "2.0.0-rc.6",
         "@parcel/utils": "2.0.0-rc.0",
         "nullthrows": "^1.1.1",
-        "postcss": "^8.3.0",
+        "postcss": "8.3.6",
         "postcss-value-parser": "^4.1.0",
         "semver": "^5.4.1"
       },
@@ -4938,7 +4934,7 @@
       "dev": true,
       "requires": {
         "icss-replace-symbols": "1.1.0",
-        "postcss": "6.0.1",
+        "postcss": "8.3.6",
         "postcss-modules-extract-imports": "1.1.0",
         "postcss-modules-local-by-default": "1.2.0",
         "postcss-modules-scope": "1.1.0",
@@ -5014,16 +5010,14 @@
       "dev": true,
       "requires": {
         "boolbase": "^1.0.0",
-        "css-what": "^5.0.0",
+        "css-what": "^5.0.1",
         "domhandler": "^4.2.0",
         "domutils": "^2.6.0",
         "nth-check": "^2.0.0"
       },
       "dependencies": {
         "css-what": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.0.1.tgz",
-          "integrity": "sha512-FYDTSHb/7KXsWICVsxdmiExPjCfRC4qRFBdVwv7Ax9hMnvMmEjP9RfxTEZ3qPZGmADDn2vAKSo9UcN1jKVYscg==",
+          "version": "^5.0.1",
           "dev": true
         }
       }
@@ -7601,7 +7595,7 @@
       "dev": true,
       "requires": {
         "cssnano": "^5.0.0",
-        "postcss": "^8.2.9",
+        "postcss": "8.3.6",
         "posthtml": "^0.15.2",
         "purgecss": "^4.0.0",
         "relateurl": "^0.2.7",
@@ -7752,7 +7746,7 @@
       "integrity": "sha512-4aFq7wvWyMHKgxsH8QQtGpvbASCf+eM3wPRLI6R+MgAnTCZ6STYsRvttLvRWK0Nfif5piF394St3HeJDaljGPA==",
       "dev": true,
       "requires": {
-        "postcss": "^7.0.14"
+        "postcss": "8.3.6"
       },
       "dependencies": {
         "postcss": {
@@ -8921,9 +8915,7 @@
           },
           "dependencies": {
             "ws": {
-              "version": "7.5.5",
-              "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.5.tgz",
-              "integrity": "sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w==",
+              "version": "^7.4.6",
               "dev": true
             }
           }
@@ -8997,9 +8989,7 @@
           }
         },
         "ws": {
-          "version": "7.5.5",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.5.tgz",
-          "integrity": "sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w=="
+          "version": "^7.4.6"
         }
       }
     },
@@ -9999,14 +9989,12 @@
         "whatwg-encoding": "^1.0.5",
         "whatwg-mimetype": "^2.3.0",
         "whatwg-url": "^7.0.0",
-        "ws": "^6.1.2",
+        "ws": "^7.4.6",
         "xml-name-validator": "^3.0.0"
       },
       "dependencies": {
         "ws": {
-          "version": "7.5.5",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.5.tgz",
-          "integrity": "sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w==",
+          "version": "^7.4.6",
           "dev": true
         }
       }
@@ -11668,7 +11656,7 @@
         "generic-names": "^2.0.1",
         "icss-replace-symbols": "^1.1.0",
         "lodash.camelcase": "^4.3.0",
-        "postcss": "^7.0.32",
+        "postcss": "8.3.6",
         "postcss-modules-extract-imports": "^2.0.0",
         "postcss-modules-local-by-default": "^3.0.2",
         "postcss-modules-scope": "^2.2.0",
@@ -11693,7 +11681,7 @@
           "integrity": "sha512-LaYLDNS4SG8Q5WAWqIJgdHPJrDDr/Lv775rMBFUbgjTz6j34lUznACHcdRWroPvXANP2Vj7yNK57vp9eFqzLWQ==",
           "dev": true,
           "requires": {
-            "postcss": "^7.0.5"
+            "postcss": "8.3.6"
           },
           "dependencies": {
             "postcss": {
@@ -11716,7 +11704,7 @@
           "dev": true,
           "requires": {
             "icss-utils": "^4.1.1",
-            "postcss": "^7.0.32",
+            "postcss": "8.3.6",
             "postcss-selector-parser": "^6.0.2",
             "postcss-value-parser": "^4.1.0"
           },
@@ -11740,7 +11728,7 @@
           "integrity": "sha512-YyEgsTMRpNd+HmyC7H/mh3y+MeFWevy7V1evVhJWewmMbjDHIbZbOXICC2y+m1xI1UVfIT1HMW/O04Hxyu9oXQ==",
           "dev": true,
           "requires": {
-            "postcss": "^7.0.6",
+            "postcss": "8.3.6",
             "postcss-selector-parser": "^6.0.0"
           },
           "dependencies": {
@@ -11764,7 +11752,7 @@
           "dev": true,
           "requires": {
             "icss-utils": "^4.0.0",
-            "postcss": "^7.0.6"
+            "postcss": "8.3.6"
           },
           "dependencies": {
             "postcss": {
@@ -11801,7 +11789,7 @@
       "integrity": "sha1-thTJcgvmgW6u41+zpfqh26agXds=",
       "dev": true,
       "requires": {
-        "postcss": "^6.0.1"
+        "postcss": "8.3.6"
       },
       "dependencies": {
         "postcss": {
@@ -11829,7 +11817,7 @@
       "dev": true,
       "requires": {
         "css-selector-tokenizer": "^0.7.0",
-        "postcss": "^6.0.1"
+        "postcss": "8.3.6"
       },
       "dependencies": {
         "postcss": {
@@ -11857,7 +11845,7 @@
       "dev": true,
       "requires": {
         "css-selector-tokenizer": "^0.7.0",
-        "postcss": "^6.0.1"
+        "postcss": "8.3.6"
       },
       "dependencies": {
         "postcss": {
@@ -11885,7 +11873,7 @@
       "dev": true,
       "requires": {
         "icss-replace-symbols": "^1.1.0",
-        "postcss": "^6.0.1"
+        "postcss": "8.3.6"
       },
       "dependencies": {
         "postcss": {
@@ -11977,14 +11965,12 @@
       "dev": true,
       "requires": {
         "is-absolute-url": "^3.0.3",
-        "normalize-url": "^6.0.1",
+        "normalize-url": "^5.3.1",
         "postcss-value-parser": "^4.1.0"
       },
       "dependencies": {
         "normalize-url": {
-          "version": "5.3.1",
-          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-5.3.1.tgz",
-          "integrity": "sha512-K1c7+vaAP+Yh5bOGmA10PGPpp+6h7WZrl7GwqKhUflBc9flU9pzG27DDeB9+iuhZkE3BJZOcgN1P/2sS5pqrWw==",
+          "version": "^5.3.1",
           "dev": true
         }
       }
@@ -12250,7 +12236,7 @@
       "requires": {
         "commander": "^6.0.0",
         "glob": "^7.0.0",
-        "postcss": "^8.2.1",
+        "postcss": "8.3.6",
         "postcss-selector-parser": "^6.0.2"
       },
       "dependencies": {
@@ -14018,7 +14004,7 @@
         "is-html": "^1.1.0",
         "jsdom": "^14.1.0",
         "lodash": "^4.17.15",
-        "postcss": "^7.0.17",
+        "postcss": "8.3.6",
         "postcss-selector-parser": "6.0.2",
         "request": "^2.88.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -2358,7 +2358,7 @@
         "@parcel/plugin": "2.0.0-rc.0",
         "@parcel/source-map": "2.0.0-rc.6",
         "cssnano": "^5.0.5",
-        "postcss": "8.3.6"
+        "postcss": "^8.3.0"
       },
       "dependencies": {
         "postcss": {
@@ -2450,7 +2450,7 @@
         "@parcel/source-map": "2.0.0-rc.6",
         "@parcel/utils": "2.0.0-rc.0",
         "nullthrows": "^1.1.1",
-        "postcss": "8.3.6"
+        "postcss": "^8.3.0"
       },
       "dependencies": {
         "postcss": {
@@ -2613,18 +2613,26 @@
         "@parcel/plugin": "2.0.0-rc.0",
         "@parcel/utils": "2.0.0-rc.0",
         "connect": "^3.7.0",
-        "ejs": "^3.1.6",
+        "ejs": "^2.6.1",
         "http-proxy-middleware": "^1.0.0",
         "nullthrows": "^1.1.1",
         "serve-handler": "^6.0.0",
-        "ws": "^7.4.6"
+        "ws": "^7.0.0"
       },
       "dependencies": {
         "ejs": {
-          "version": "^3.1.6"
+          "version": "3.1.6",
+          "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.6.tgz",
+          "integrity": "sha512-9lt9Zse4hPucPkoP7FHDF0LQAlGyF9JVpnClFLFH3aSSbxmyoqINRpp/9wePWJTUl4KOQwRL72Iw3InHPDkoGw==",
+          "dev": true,
+          "requires": {
+            "jake": "^10.6.1"
+          }
         },
         "ws": {
-          "version": "^7.4.6",
+          "version": "7.5.5",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.5.tgz",
+          "integrity": "sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w==",
           "dev": true
         }
       }
@@ -2720,7 +2728,7 @@
         "@parcel/source-map": "2.0.0-rc.6",
         "@parcel/utils": "2.0.0-rc.0",
         "nullthrows": "^1.1.1",
-        "postcss": "8.3.6",
+        "postcss": "^8.3.0",
         "postcss-value-parser": "^4.1.0",
         "semver": "^5.4.1"
       },
@@ -3903,10 +3911,10 @@
       "integrity": "sha512-lobf6RWXb8c4uZ7Mdq0U12efYmpD1UFnyOWVJPTa3ukqZrMopav+2hdNu0hgBF0JIBFK9QgrBDfwYvh3DFJDAA==",
       "dev": true
     },
-    "async-limiter": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
-      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
+    "async": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+      "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
       "dev": true
     },
     "asynckit": {
@@ -4930,7 +4938,7 @@
       "dev": true,
       "requires": {
         "icss-replace-symbols": "1.1.0",
-        "postcss": "8.3.6",
+        "postcss": "6.0.1",
         "postcss-modules-extract-imports": "1.1.0",
         "postcss-modules-local-by-default": "1.2.0",
         "postcss-modules-scope": "1.1.0",
@@ -4940,20 +4948,17 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "ansi-styles": {
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
         },
         "chalk": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
           "requires": {
             "ansi-styles": "^2.2.1",
             "escape-string-regexp": "^1.0.2",
@@ -4964,16 +4969,14 @@
             "supports-color": {
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-              "dev": true
+              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
             }
           }
         },
         "has-flag": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-          "dev": true
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
         },
         "postcss": {
           "version": "8.3.6",
@@ -4981,16 +4984,15 @@
           "integrity": "sha512-wG1cc/JhRgdqB6WHEuyLTedf3KIRuD0hG6ldkFEZNCjRxiC+3i6kkWUUbiJQayP28iwG35cEmAbe98585BYV0A==",
           "dev": true,
           "requires": {
-            "chalk": "^1.1.3",
-            "source-map": "^0.5.6",
-            "supports-color": "^3.2.3"
+            "colorette": "^1.2.2",
+            "nanoid": "^3.1.23",
+            "source-map-js": "^0.6.2"
           }
         },
         "strip-ansi": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4999,7 +5001,6 @@
           "version": "3.2.3",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-          "dev": true,
           "requires": {
             "has-flag": "^1.0.0"
           }
@@ -5013,14 +5014,16 @@
       "dev": true,
       "requires": {
         "boolbase": "^1.0.0",
-        "css-what": "^5.0.1",
+        "css-what": "^5.0.0",
         "domhandler": "^4.2.0",
         "domutils": "^2.6.0",
         "nth-check": "^2.0.0"
       },
       "dependencies": {
         "css-what": {
-          "version": "^5.0.1",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.0.1.tgz",
+          "integrity": "sha512-FYDTSHb/7KXsWICVsxdmiExPjCfRC4qRFBdVwv7Ax9hMnvMmEjP9RfxTEZ3qPZGmADDn2vAKSo9UcN1jKVYscg==",
           "dev": true
         }
       }
@@ -6029,10 +6032,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
-      "dev": true
-    },
-    "ejs": {
-      "version": "^3.1.6",
       "dev": true
     },
     "electron-to-chromium": {
@@ -7086,6 +7085,15 @@
         "flat-cache": "^3.0.4"
       }
     },
+    "filelist": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.2.tgz",
+      "integrity": "sha512-z7O0IS8Plc39rTCq6i6iHxk43duYOn8uFJiWSewIq0Bww1RNybVHSCjahmcC87ZqAm4OTvFzlzeGu3XAzG1ctQ==",
+      "dev": true,
+      "requires": {
+        "minimatch": "^3.0.4"
+      }
+    },
     "filesize": {
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/filesize/-/filesize-6.4.0.tgz",
@@ -7593,7 +7601,7 @@
       "dev": true,
       "requires": {
         "cssnano": "^5.0.0",
-        "postcss": "8.3.6",
+        "postcss": "^8.2.9",
         "posthtml": "^0.15.2",
         "purgecss": "^4.0.0",
         "relateurl": "^0.2.7",
@@ -7744,7 +7752,7 @@
       "integrity": "sha512-4aFq7wvWyMHKgxsH8QQtGpvbASCf+eM3wPRLI6R+MgAnTCZ6STYsRvttLvRWK0Nfif5piF394St3HeJDaljGPA==",
       "dev": true,
       "requires": {
-        "postcss": "8.3.6"
+        "postcss": "^7.0.14"
       },
       "dependencies": {
         "postcss": {
@@ -7753,22 +7761,20 @@
           "integrity": "sha512-wG1cc/JhRgdqB6WHEuyLTedf3KIRuD0hG6ldkFEZNCjRxiC+3i6kkWUUbiJQayP28iwG35cEmAbe98585BYV0A==",
           "dev": true,
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "colorette": "^1.2.2",
+            "nanoid": "^3.1.23",
+            "source-map-js": "^0.6.2"
           }
         },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "supports-color": {
           "version": "6.1.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-          "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -8329,6 +8335,18 @@
       "requires": {
         "html-escaper": "^2.0.0",
         "istanbul-lib-report": "^3.0.0"
+      }
+    },
+    "jake": {
+      "version": "10.8.2",
+      "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.2.tgz",
+      "integrity": "sha512-eLpKyrfG3mzvGE2Du8VoPbeSkRry093+tyNjdYaBbJS9v17knImYGNXQCUV0gLxQtF82m3E8iRb/wdSQZLoq7A==",
+      "dev": true,
+      "requires": {
+        "async": "0.9.x",
+        "chalk": "^2.4.2",
+        "filelist": "^1.0.1",
+        "minimatch": "^3.0.4"
       }
     },
     "jest": {
@@ -8903,7 +8921,9 @@
           },
           "dependencies": {
             "ws": {
-              "version": "^7.4.6",
+              "version": "7.5.5",
+              "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.5.tgz",
+              "integrity": "sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w==",
               "dev": true
             }
           }
@@ -8977,7 +8997,9 @@
           }
         },
         "ws": {
-          "version": "^7.4.6"
+          "version": "7.5.5",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.5.tgz",
+          "integrity": "sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w=="
         }
       }
     },
@@ -9977,12 +9999,15 @@
         "whatwg-encoding": "^1.0.5",
         "whatwg-mimetype": "^2.3.0",
         "whatwg-url": "^7.0.0",
-        "ws": "^7.4.6",
+        "ws": "^6.1.2",
         "xml-name-validator": "^3.0.0"
       },
       "dependencies": {
         "ws": {
-          "version": "^7.4.6"
+          "version": "7.5.5",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.5.tgz",
+          "integrity": "sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w==",
+          "dev": true
         }
       }
     },
@@ -10844,10 +10869,6 @@
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true
     },
-    "normalize-url": {
-      "version": "^5.3.1",
-      "dev": true
-    },
     "npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
@@ -11647,7 +11668,7 @@
         "generic-names": "^2.0.1",
         "icss-replace-symbols": "^1.1.0",
         "lodash.camelcase": "^4.3.0",
-        "postcss": "8.3.6",
+        "postcss": "^7.0.32",
         "postcss-modules-extract-imports": "^2.0.0",
         "postcss-modules-local-by-default": "^3.0.2",
         "postcss-modules-scope": "^2.2.0",
@@ -11661,9 +11682,9 @@
           "integrity": "sha512-wG1cc/JhRgdqB6WHEuyLTedf3KIRuD0hG6ldkFEZNCjRxiC+3i6kkWUUbiJQayP28iwG35cEmAbe98585BYV0A==",
           "dev": true,
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "colorette": "^1.2.2",
+            "nanoid": "^3.1.23",
+            "source-map-js": "^0.6.2"
           }
         },
         "postcss-modules-extract-imports": {
@@ -11672,7 +11693,7 @@
           "integrity": "sha512-LaYLDNS4SG8Q5WAWqIJgdHPJrDDr/Lv775rMBFUbgjTz6j34lUznACHcdRWroPvXANP2Vj7yNK57vp9eFqzLWQ==",
           "dev": true,
           "requires": {
-            "postcss": "8.3.6"
+            "postcss": "^7.0.5"
           },
           "dependencies": {
             "postcss": {
@@ -11681,9 +11702,9 @@
               "integrity": "sha512-wG1cc/JhRgdqB6WHEuyLTedf3KIRuD0hG6ldkFEZNCjRxiC+3i6kkWUUbiJQayP28iwG35cEmAbe98585BYV0A==",
               "dev": true,
               "requires": {
-                "chalk": "^2.4.2",
-                "source-map": "^0.6.1",
-                "supports-color": "^6.1.0"
+                "colorette": "^1.2.2",
+                "nanoid": "^3.1.23",
+                "source-map-js": "^0.6.2"
               }
             }
           }
@@ -11695,7 +11716,7 @@
           "dev": true,
           "requires": {
             "icss-utils": "^4.1.1",
-            "postcss": "8.3.6",
+            "postcss": "^7.0.32",
             "postcss-selector-parser": "^6.0.2",
             "postcss-value-parser": "^4.1.0"
           },
@@ -11706,9 +11727,9 @@
               "integrity": "sha512-wG1cc/JhRgdqB6WHEuyLTedf3KIRuD0hG6ldkFEZNCjRxiC+3i6kkWUUbiJQayP28iwG35cEmAbe98585BYV0A==",
               "dev": true,
               "requires": {
-                "chalk": "^2.4.2",
-                "source-map": "^0.6.1",
-                "supports-color": "^6.1.0"
+                "colorette": "^1.2.2",
+                "nanoid": "^3.1.23",
+                "source-map-js": "^0.6.2"
               }
             }
           }
@@ -11719,7 +11740,7 @@
           "integrity": "sha512-YyEgsTMRpNd+HmyC7H/mh3y+MeFWevy7V1evVhJWewmMbjDHIbZbOXICC2y+m1xI1UVfIT1HMW/O04Hxyu9oXQ==",
           "dev": true,
           "requires": {
-            "postcss": "8.3.6",
+            "postcss": "^7.0.6",
             "postcss-selector-parser": "^6.0.0"
           },
           "dependencies": {
@@ -11729,9 +11750,9 @@
               "integrity": "sha512-wG1cc/JhRgdqB6WHEuyLTedf3KIRuD0hG6ldkFEZNCjRxiC+3i6kkWUUbiJQayP28iwG35cEmAbe98585BYV0A==",
               "dev": true,
               "requires": {
-                "chalk": "^2.4.2",
-                "source-map": "^0.6.1",
-                "supports-color": "^6.1.0"
+                "colorette": "^1.2.2",
+                "nanoid": "^3.1.23",
+                "source-map-js": "^0.6.2"
               }
             }
           }
@@ -11743,7 +11764,7 @@
           "dev": true,
           "requires": {
             "icss-utils": "^4.0.0",
-            "postcss": "8.3.6"
+            "postcss": "^7.0.6"
           },
           "dependencies": {
             "postcss": {
@@ -11752,9 +11773,9 @@
               "integrity": "sha512-wG1cc/JhRgdqB6WHEuyLTedf3KIRuD0hG6ldkFEZNCjRxiC+3i6kkWUUbiJQayP28iwG35cEmAbe98585BYV0A==",
               "dev": true,
               "requires": {
-                "chalk": "^2.4.2",
-                "source-map": "^0.6.1",
-                "supports-color": "^6.1.0"
+                "colorette": "^1.2.2",
+                "nanoid": "^3.1.23",
+                "source-map-js": "^0.6.2"
               }
             }
           }
@@ -11762,14 +11783,12 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "supports-color": {
           "version": "6.1.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-          "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -11782,7 +11801,7 @@
       "integrity": "sha1-thTJcgvmgW6u41+zpfqh26agXds=",
       "dev": true,
       "requires": {
-        "postcss": "8.3.6"
+        "postcss": "^6.0.1"
       },
       "dependencies": {
         "postcss": {
@@ -11791,16 +11810,15 @@
           "integrity": "sha512-wG1cc/JhRgdqB6WHEuyLTedf3KIRuD0hG6ldkFEZNCjRxiC+3i6kkWUUbiJQayP28iwG35cEmAbe98585BYV0A==",
           "dev": true,
           "requires": {
-            "chalk": "^2.4.1",
-            "source-map": "^0.6.1",
-            "supports-color": "^5.4.0"
+            "colorette": "^1.2.2",
+            "nanoid": "^3.1.23",
+            "source-map-js": "^0.6.2"
           }
         },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         }
       }
     },
@@ -11811,7 +11829,7 @@
       "dev": true,
       "requires": {
         "css-selector-tokenizer": "^0.7.0",
-        "postcss": "8.3.6"
+        "postcss": "^6.0.1"
       },
       "dependencies": {
         "postcss": {
@@ -11820,16 +11838,15 @@
           "integrity": "sha512-wG1cc/JhRgdqB6WHEuyLTedf3KIRuD0hG6ldkFEZNCjRxiC+3i6kkWUUbiJQayP28iwG35cEmAbe98585BYV0A==",
           "dev": true,
           "requires": {
-            "chalk": "^2.4.1",
-            "source-map": "^0.6.1",
-            "supports-color": "^5.4.0"
+            "colorette": "^1.2.2",
+            "nanoid": "^3.1.23",
+            "source-map-js": "^0.6.2"
           }
         },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         }
       }
     },
@@ -11840,7 +11857,7 @@
       "dev": true,
       "requires": {
         "css-selector-tokenizer": "^0.7.0",
-        "postcss": "8.3.6"
+        "postcss": "^6.0.1"
       },
       "dependencies": {
         "postcss": {
@@ -11849,16 +11866,15 @@
           "integrity": "sha512-wG1cc/JhRgdqB6WHEuyLTedf3KIRuD0hG6ldkFEZNCjRxiC+3i6kkWUUbiJQayP28iwG35cEmAbe98585BYV0A==",
           "dev": true,
           "requires": {
-            "chalk": "^2.4.1",
-            "source-map": "^0.6.1",
-            "supports-color": "^5.4.0"
+            "colorette": "^1.2.2",
+            "nanoid": "^3.1.23",
+            "source-map-js": "^0.6.2"
           }
         },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         }
       }
     },
@@ -11869,7 +11885,7 @@
       "dev": true,
       "requires": {
         "icss-replace-symbols": "^1.1.0",
-        "postcss": "8.3.6"
+        "postcss": "^6.0.1"
       },
       "dependencies": {
         "postcss": {
@@ -11878,16 +11894,15 @@
           "integrity": "sha512-wG1cc/JhRgdqB6WHEuyLTedf3KIRuD0hG6ldkFEZNCjRxiC+3i6kkWUUbiJQayP28iwG35cEmAbe98585BYV0A==",
           "dev": true,
           "requires": {
-            "chalk": "^2.4.1",
-            "source-map": "^0.6.1",
-            "supports-color": "^5.4.0"
+            "colorette": "^1.2.2",
+            "nanoid": "^3.1.23",
+            "source-map-js": "^0.6.2"
           }
         },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         }
       }
     },
@@ -11962,12 +11977,15 @@
       "dev": true,
       "requires": {
         "is-absolute-url": "^3.0.3",
-        "normalize-url": "^5.3.1",
+        "normalize-url": "^6.0.1",
         "postcss-value-parser": "^4.1.0"
       },
       "dependencies": {
         "normalize-url": {
-          "version": "^5.3.1"
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-5.3.1.tgz",
+          "integrity": "sha512-K1c7+vaAP+Yh5bOGmA10PGPpp+6h7WZrl7GwqKhUflBc9flU9pzG27DDeB9+iuhZkE3BJZOcgN1P/2sS5pqrWw==",
+          "dev": true
         }
       }
     },
@@ -12232,7 +12250,7 @@
       "requires": {
         "commander": "^6.0.0",
         "glob": "^7.0.0",
-        "postcss": "8.3.6",
+        "postcss": "^8.2.1",
         "postcss-selector-parser": "^6.0.2"
       },
       "dependencies": {
@@ -14000,7 +14018,7 @@
         "is-html": "^1.1.0",
         "jsdom": "^14.1.0",
         "lodash": "^4.17.15",
-        "postcss": "8.3.6",
+        "postcss": "^7.0.17",
         "postcss-selector-parser": "6.0.2",
         "request": "^2.88.0"
       },
@@ -14017,9 +14035,9 @@
           "integrity": "sha512-wG1cc/JhRgdqB6WHEuyLTedf3KIRuD0hG6ldkFEZNCjRxiC+3i6kkWUUbiJQayP28iwG35cEmAbe98585BYV0A==",
           "dev": true,
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "colorette": "^1.2.2",
+            "nanoid": "^3.1.23",
+            "source-map-js": "^0.6.2"
           }
         },
         "postcss-selector-parser": {
@@ -14036,14 +14054,12 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "supports-color": {
           "version": "6.1.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-          "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -14483,13 +14499,6 @@
         "is-typedarray": "^1.0.0",
         "signal-exit": "^3.0.2",
         "typedarray-to-buffer": "^3.1.5"
-      }
-    },
-    "ws": {
-      "version": "^7.4.6",
-      "dev": true,
-      "requires": {
-        "async-limiter": "~1.0.0"
       }
     },
     "xml-name-validator": {


### PR DESCRIPTION
There was an issue where `npm ci` seemed to not run `force-resolutions` as expected. This change makes it explicitly called in the `make all` target.

`force-resolutions` is used to avoid security vulnerabilities in our JS third-party packages.