### PR TITLE
Deleting last manifest causes sync failure

### DIFF
--- a/cmd/wego/ui/run/cmd.go
+++ b/cmd/wego/ui/run/cmd.go
@@ -105,6 +105,7 @@ func runCmd(cmd *cobra.Command, args []string) error {
 	<-quit
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+
 	defer func() {
 		cancel()
 	}()

--- a/pkg/services/app/add.go
+++ b/pkg/services/app/add.go
@@ -743,7 +743,7 @@ func (a *App) createKeepFilePullRequest(info *AppResourceInfo, cloneNeeded bool)
 	defer remover()
 
 	if accountType == gitproviders.AccountTypeOrg {
-		orgRepoRef := gitproviders.NewOrgRepositoryRef(github.DefaultDomain, owner, repoName)
+		orgRepoRef := gitproviders.NewOrgRepositoryRef(a.GitProvider.GetProviderDomain(), owner, repoName)
 
 		prLink, err := a.GitProvider.CreatePullRequestToOrgRepo(orgRepoRef, info.Spec.Branch, pullRequestBranchName, files, utils.GetCommitMessage(), fmt.Sprintf("wego add %s", info.Name), fmt.Sprintf("Added sentinel file for %s", info.Name))
 		if err != nil {
@@ -753,7 +753,7 @@ func (a *App) createKeepFilePullRequest(info *AppResourceInfo, cloneNeeded bool)
 		return nil
 	}
 
-	userRepoRef := gitproviders.NewUserRepositoryRef(github.DefaultDomain, owner, repoName)
+	userRepoRef := gitproviders.NewUserRepositoryRef(a.GitProvider.GetProviderDomain(), owner, repoName)
 
 	prLink, err := a.GitProvider.CreatePullRequestToUserRepo(userRepoRef, info.Spec.Branch, pullRequestBranchName, files, utils.GetCommitMessage(), fmt.Sprintf("wego add %s", info.Name), fmt.Sprintf("Added sentinel file for %s", info.Name))
 	if err != nil {

--- a/pkg/services/app/add.go
+++ b/pkg/services/app/add.go
@@ -302,6 +302,7 @@ func (a *App) addAppWithNoConfigRepo(info *AppResourceInfo, params AddParams, se
 	if info.Spec.SourceType != wego.SourceTypeHelm && !params.DryRun {
 		if !params.AutoMerge {
 			a.Logger.Actionf("Creating pull request for .keep file in application repository")
+
 			if err := a.createKeepFilePullRequest(info, cloneNeeded(params)); err != nil {
 				return err
 			}
@@ -416,6 +417,7 @@ func (a *App) addAppWithConfigInExternalRepo(info *AppResourceInfo, params AddPa
 
 			if info.Spec.SourceType != wego.SourceTypeHelm {
 				a.Logger.Actionf("Creating pull request for .keep file in application repository")
+
 				if err := a.createKeepFilePullRequest(info, cloneNeeded(params)); err != nil {
 					return err
 				}
@@ -516,6 +518,7 @@ func (a *App) generateExternalRepoManifests(info *AppResourceInfo, branch string
 	}
 
 	targetSource, err := a.Flux.CreateSourceGit(repoName, info.Spec.ConfigURL, branch, secretRef, info.Namespace)
+
 	if err != nil {
 		return nil, fmt.Errorf("could not generate target source manifests: %w", err)
 	}
@@ -649,6 +652,7 @@ func (a *App) writeAppKeepFile(info *AppResourceInfo, cloneNeeded bool) error {
 	if err != nil {
 		return fmt.Errorf("failed to clone configuration repo: %w", err)
 	}
+
 	defer remover()
 
 	return a.AppGit.Write(info.appKeepFilePath(), []byte(keepFileContents))
@@ -740,6 +744,7 @@ func (a *App) createKeepFilePullRequest(info *AppResourceInfo, cloneNeeded bool)
 	if err != nil {
 		return fmt.Errorf("failed to clone app repo: %w", err)
 	}
+
 	defer remover()
 
 	if accountType == gitproviders.AccountTypeOrg {
@@ -749,7 +754,9 @@ func (a *App) createKeepFilePullRequest(info *AppResourceInfo, cloneNeeded bool)
 		if err != nil {
 			return fmt.Errorf("unable to create sentinel file pull request: %w", err)
 		}
+
 		a.Logger.Println("Pull Request created: %s\n", prLink.Get().WebURL)
+
 		return nil
 	}
 
@@ -759,7 +766,9 @@ func (a *App) createKeepFilePullRequest(info *AppResourceInfo, cloneNeeded bool)
 	if err != nil {
 		return fmt.Errorf("unable to create sentinel file pull request: %w", err)
 	}
+
 	a.Logger.Println("Sentinel Pull Request created: %s\n", prLink.Get().WebURL)
+
 	return nil
 }
 

--- a/pkg/services/app/add_test.go
+++ b/pkg/services/app/add_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-git/go-git/v5/storage/memory"
 	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	wego "github.com/weaveworks/weave-gitops/api/v1alpha1"
 	"github.com/weaveworks/weave-gitops/pkg/git"
@@ -268,7 +269,7 @@ var _ = Describe("Add", func() {
 			addParams.Url = "ssh://git@github.com/foo/bar.git"
 			addParams.AppConfigUrl = ""
 
-			gitClient.OpenStub = func(s string) (*gogit.Repository, error) {
+			configGitClient.OpenStub = func(s string) (*gogit.Repository, error) {
 				r, err := gogit.Init(memory.NewStorage(), memfs.New())
 				Expect(err).ShouldNot(HaveOccurred())
 
@@ -460,8 +461,8 @@ var _ = Describe("Add", func() {
 				err := appSrv.Add(addParams)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				Expect(gitClient.CloneCallCount()).To(Equal(1))
-				_, repoDir, url, branch := gitClient.CloneArgsForCall(0)
+				Expect(configGitClient.CloneCallCount()).To(Equal(1))
+				_, repoDir, url, branch := configGitClient.CloneArgsForCall(0)
 
 				Expect(repoDir).To(ContainSubstring("user-repo-"))
 				Expect(url).To(Equal("ssh://git@github.com/foo/bar.git"))
@@ -480,17 +481,17 @@ var _ = Describe("Add", func() {
 				err := appSrv.Add(addParams)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				Expect(gitClient.WriteCallCount()).To(Equal(3))
+				Expect(configGitClient.WriteCallCount()).To(Equal(3))
 
-				path, content := gitClient.WriteArgsForCall(0)
+				path, content := configGitClient.WriteArgsForCall(0)
 				Expect(path).To(Equal(".wego/apps/bar/app.yaml"))
 				Expect(string(content)).To(ContainSubstring("kind: Application"))
 
-				path, content = gitClient.WriteArgsForCall(1)
+				path, content = configGitClient.WriteArgsForCall(1)
 				Expect(path).To(Equal(".wego/targets/test-cluster/bar/bar-gitops-source.yaml"))
 				Expect(content).To(Equal([]byte("git")))
 
-				path, content = gitClient.WriteArgsForCall(2)
+				path, content = configGitClient.WriteArgsForCall(2)
 				Expect(path).To(Equal(".wego/targets/test-cluster/bar/bar-gitops-deploy.yaml"))
 				Expect(content).To(Equal([]byte("kustomization")))
 			})
@@ -500,9 +501,9 @@ var _ = Describe("Add", func() {
 			err := appSrv.Add(addParams)
 			Expect(err).ShouldNot(HaveOccurred())
 
-			Expect(gitClient.CommitCallCount()).To(Equal(1))
+			Expect(configGitClient.CommitCallCount()).To(Equal(1))
 
-			msg, filters := gitClient.CommitArgsForCall(0)
+			msg, filters := configGitClient.CommitArgsForCall(0)
 			Expect(msg).To(Equal(git.Commit{
 				Author:  git.Author{Name: "Weave Gitops", Email: "weave-gitops@weave.works"},
 				Message: "Add App manifests",
@@ -716,8 +717,8 @@ var _ = Describe("Add", func() {
 			err := appSrv.Add(addParams)
 			Expect(err).ShouldNot(HaveOccurred())
 
-			Expect(gitClient.CloneCallCount()).To(Equal(1))
-			_, repoDir, url, branch := gitClient.CloneArgsForCall(0)
+			Expect(configGitClient.CloneCallCount()).To(Equal(1))
+			_, repoDir, url, branch := configGitClient.CloneArgsForCall(0)
 
 			Expect(repoDir).To(ContainSubstring("user-repo-"))
 			Expect(url).To(Equal("ssh://git@github.com/foo/bar.git"))
@@ -735,17 +736,17 @@ var _ = Describe("Add", func() {
 			err := appSrv.Add(addParams)
 			Expect(err).ShouldNot(HaveOccurred())
 
-			Expect(gitClient.WriteCallCount()).To(Equal(3))
+			Expect(configGitClient.WriteCallCount()).To(Equal(3))
 
-			path, content := gitClient.WriteArgsForCall(0)
+			path, content := configGitClient.WriteArgsForCall(0)
 			Expect(path).To(Equal("apps/repo/app.yaml"))
 			Expect(string(content)).To(ContainSubstring("kind: Application"))
 
-			path, content = gitClient.WriteArgsForCall(1)
+			path, content = configGitClient.WriteArgsForCall(1)
 			Expect(path).To(Equal("targets/test-cluster/repo/repo-gitops-source.yaml"))
 			Expect(content).To(Equal([]byte("git")))
 
-			path, content = gitClient.WriteArgsForCall(2)
+			path, content = configGitClient.WriteArgsForCall(2)
 			Expect(path).To(Equal("targets/test-cluster/repo/repo-gitops-deploy.yaml"))
 			Expect(content).To(Equal([]byte("kustomization")))
 		})
@@ -754,9 +755,9 @@ var _ = Describe("Add", func() {
 			err := appSrv.Add(addParams)
 			Expect(err).ShouldNot(HaveOccurred())
 
-			Expect(gitClient.CommitCallCount()).To(Equal(1))
+			Expect(configGitClient.CommitCallCount()).To(Equal(1))
 
-			msg, filters := gitClient.CommitArgsForCall(0)
+			msg, filters := configGitClient.CommitArgsForCall(0)
 			Expect(msg).To(Equal(git.Commit{
 				Author:  git.Author{Name: "Weave Gitops", Email: "weave-gitops@weave.works"},
 				Message: "Add App manifests",
@@ -865,8 +866,8 @@ var _ = Describe("Add", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 
 			Expect(fluxClient.CreateSecretGitCallCount()).To(Equal(0))
-			Expect(gitClient.CloneCallCount()).To(Equal(0))
-			Expect(gitClient.WriteCallCount()).To(Equal(0))
+			Expect(configGitClient.CloneCallCount()).To(Equal(0))
+			Expect(configGitClient.WriteCallCount()).To(Equal(0))
 			Expect(kubeClient.ApplyCallCount()).To(Equal(0))
 		})
 	})
@@ -949,6 +950,125 @@ var _ = Describe("Add", func() {
 			Expect(kustName).To(Equal("wego-" + getHash(fmt.Sprintf("%s-%s", clusterName, addParams.Name))))
 			Expect(secretName).To(Equal("wego-" + getHash(fmt.Sprintf("wego-%s-%s", clusterName, repoName))))
 		})
+	})
+
+	Context("ensure that a .keep file is created during 'wego app add' so that deletion of all app manifests will work correctly", func() {
+		type testConfig struct {
+			autoMerge            bool
+			accountType          gitproviders.ProviderAccountType
+			chartName, configURL string
+		}
+
+		type testResults struct {
+			writeCallCount, orgPullRequestCallCount, userPullRequestCallCount int
+		}
+
+		BeforeEach(func() {
+			addParams.Branch = "non-default-branch"
+			appGitClient.WriteStub = func(path string, content []byte) error {
+				Expect(path).To(Equal(".keep"))
+				Expect(content).To(Equal([]byte(keepFileContents)))
+
+				return nil
+			}
+
+			gitProviders.CreatePullRequestToOrgRepoStub = func(orgRepRef gitprovider.OrgRepositoryRef, targetBranch string, newBranch string, files []gitprovider.CommitFile, commitMessage string, prTitle string, prDescription string) (gitprovider.PullRequest, error) {
+				if targetBranch == addParams.Branch {
+					Expect(len(files)).To(Equal(1))
+					Expect(*(files[0].Path)).To(Equal(".keep"))
+					Expect(*(files[0].Content)).To(Equal(keepFileContents))
+				}
+
+				return dummyPullRequest{}, nil
+			}
+
+			gitProviders.CreatePullRequestToUserRepoStub = func(userRepRef gitprovider.UserRepositoryRef, targetBranch string, newBranch string, files []gitprovider.CommitFile, commitMessage string, prTitle string, prDescription string) (gitprovider.PullRequest, error) {
+				if targetBranch == addParams.Branch {
+					Expect(len(files)).To(Equal(1))
+					Expect(*(files[0].Path)).To(Equal(".keep"))
+					Expect(*(files[0].Content)).To(Equal(keepFileContents))
+				}
+
+				return dummyPullRequest{}, nil
+			}
+		})
+
+		DescribeTable("creates an empty '.keep' file for non-helm repos unless config is stored in app repo", func(conf testConfig, expected testResults) {
+			addParams.Chart = conf.chartName
+			addParams.AppConfigUrl = conf.configURL
+			addParams.AutoMerge = conf.autoMerge
+
+			gitProviders.GetAccountTypeStub = func(s string) (gitproviders.ProviderAccountType, error) {
+				return conf.accountType, nil
+			}
+
+			Expect(appSrv.Add(addParams)).To(Succeed())
+			Expect(appGitClient.WriteCallCount()).To(Equal(expected.writeCallCount))
+			Expect(gitProviders.CreatePullRequestToOrgRepoCallCount()).To(Equal(expected.orgPullRequestCallCount))
+			Expect(gitProviders.CreatePullRequestToUserRepoCallCount()).To(Equal(expected.userPullRequestCallCount))
+		},
+			Entry("helm, no stored config, org account",
+				testConfig{chartName: "loki", configURL: "NONE", accountType: gitproviders.AccountTypeOrg, autoMerge: true},
+				testResults{}),
+			Entry("helm, no stored config, user account",
+				testConfig{chartName: "loki", configURL: "NONE", accountType: gitproviders.AccountTypeUser, autoMerge: true},
+				testResults{}),
+			Entry("helm, external config, org account",
+				testConfig{chartName: "loki", configURL: "https://github.com/foo/bar", accountType: gitproviders.AccountTypeOrg, autoMerge: true},
+				testResults{}),
+			Entry("helm, external config, user account",
+				testConfig{chartName: "loki", configURL: "https://github.com/foo/bar", accountType: gitproviders.AccountTypeUser, autoMerge: true},
+				testResults{}),
+			Entry("kustomize, no stored config, org account",
+				testConfig{configURL: "NONE", accountType: gitproviders.AccountTypeOrg, autoMerge: true},
+				testResults{writeCallCount: 1}),
+			Entry("kustomize, no stored config, user account",
+				testConfig{configURL: "NONE", accountType: gitproviders.AccountTypeUser, autoMerge: true},
+				testResults{writeCallCount: 1}),
+			Entry("kustomize, config stored in app repo, org account",
+				testConfig{accountType: gitproviders.AccountTypeOrg, autoMerge: true},
+				testResults{}),
+			Entry("kustomize, config stored in app repo, user account",
+				testConfig{accountType: gitproviders.AccountTypeUser, autoMerge: true},
+				testResults{}),
+			Entry("kustomize, external config, org account",
+				testConfig{configURL: "https://github.com/foo/bar", accountType: gitproviders.AccountTypeOrg, autoMerge: true},
+				testResults{writeCallCount: 1}),
+			Entry("kustomize, external config, user account",
+				testConfig{configURL: "https://github.com/foo/bar", accountType: gitproviders.AccountTypeUser, autoMerge: true},
+				testResults{writeCallCount: 1}),
+
+			// pull requests
+			Entry("helm, no stored config, org account",
+				testConfig{chartName: "loki", configURL: "NONE", accountType: gitproviders.AccountTypeOrg},
+				testResults{}),
+			Entry("helm, no stored config, user account",
+				testConfig{chartName: "loki", configURL: "NONE", accountType: gitproviders.AccountTypeUser},
+				testResults{}),
+			Entry("helm, external config, org account",
+				testConfig{chartName: "loki", configURL: "https://github.com/foo/bar", accountType: gitproviders.AccountTypeOrg},
+				testResults{orgPullRequestCallCount: 1}),
+			Entry("helm, external config, user account",
+				testConfig{chartName: "loki", configURL: "https://github.com/foo/bar", accountType: gitproviders.AccountTypeUser},
+				testResults{userPullRequestCallCount: 1}),
+			Entry("kustomize, no stored config, org account",
+				testConfig{configURL: "NONE", accountType: gitproviders.AccountTypeOrg},
+				testResults{orgPullRequestCallCount: 1}),
+			Entry("kustomize, no stored config, user account",
+				testConfig{configURL: "NONE", accountType: gitproviders.AccountTypeUser},
+				testResults{userPullRequestCallCount: 1}),
+			Entry("kustomize, config stored in app repo, org account",
+				testConfig{accountType: gitproviders.AccountTypeOrg},
+				testResults{orgPullRequestCallCount: 1}),
+			Entry("kustomize, config stored in app repo, user account",
+				testConfig{accountType: gitproviders.AccountTypeUser},
+				testResults{userPullRequestCallCount: 1}),
+			Entry("kustomize, external config, org account",
+				testConfig{configURL: "https://github.com/foo/bar", accountType: gitproviders.AccountTypeOrg},
+				testResults{orgPullRequestCallCount: 2}),
+			Entry("kustomize, external config, user account",
+				testConfig{configURL: "https://github.com/foo/bar", accountType: gitproviders.AccountTypeUser},
+				testResults{userPullRequestCallCount: 2}))
 	})
 })
 

--- a/pkg/services/app/app_suite_test.go
+++ b/pkg/services/app/app_suite_test.go
@@ -18,17 +18,19 @@ import (
 )
 
 var (
-	gitClient    *gitfakes.FakeGit
-	fluxClient   *fluxfakes.FakeFlux
-	kubeClient   *kubefakes.FakeKube
-	osysClient   *osysfakes.FakeOsys
-	gitProviders *gitprovidersfakes.FakeGitProvider
+	appGitClient    *gitfakes.FakeGit
+	configGitClient *gitfakes.FakeGit
+	fluxClient      *fluxfakes.FakeFlux
+	kubeClient      *kubefakes.FakeKube
+	osysClient      *osysfakes.FakeOsys
+	gitProviders    *gitprovidersfakes.FakeGitProvider
 
 	appSrv AppService
 )
 
 var _ = BeforeEach(func() {
-	gitClient = &gitfakes.FakeGit{}
+	appGitClient = &gitfakes.FakeGit{}
+	configGitClient = &gitfakes.FakeGit{}
 	fluxClient = &fluxfakes.FakeFlux{}
 	osysClient = &osysfakes.FakeOsys{}
 	kubeClient = &kubefakes.FakeKube{
@@ -51,7 +53,7 @@ var _ = BeforeEach(func() {
 		},
 	}
 
-	appSrv = New(context.Background(), &loggerfakes.FakeLogger{}, gitClient, gitClient, gitProviders, fluxClient, kubeClient, osysClient)
+	appSrv = New(context.Background(), &loggerfakes.FakeLogger{}, appGitClient, configGitClient, gitProviders, fluxClient, kubeClient, osysClient)
 })
 
 func TestApp(t *testing.T) {

--- a/pkg/services/app/remove_test.go
+++ b/pkg/services/app/remove_test.go
@@ -246,6 +246,7 @@ func checkAddResults() error {
 	}
 
 	if len(goatPaths) != len(info.clusterResourcePaths()) {
+		fmt.Printf("GP: %#+v\n", goatPaths)
 		return fmt.Errorf("expected %d goat paths, found: %d", len(info.clusterResourcePaths()), len(goatPaths))
 	}
 
@@ -346,7 +347,7 @@ var _ = Describe("Remove", func() {
 			Expect(setupFlux()).To(Succeed())
 
 			// Track the resources added to the cluster via files added to the repository
-			gitClient.WriteStub = func(path string, manifest []byte) error {
+			configGitClient.WriteStub = func(path string, manifest []byte) error {
 				storeGOATPath(path, manifest)
 				return storeCreatedResource(manifest)
 			}
@@ -453,12 +454,12 @@ var _ = Describe("Remove", func() {
 		var _ = BeforeEach(func() {
 			Expect(setupFlux()).To(Succeed())
 
-			gitClient.WriteStub = func(path string, manifest []byte) error {
+			configGitClient.WriteStub = func(path string, manifest []byte) error {
 				storeGOATPath(path, manifest)
 				return storeCreatedResource(manifest)
 			}
 
-			gitClient.RemoveStub = func(path string) error {
+			configGitClient.RemoveStub = func(path string) error {
 				if err := removeGOATPath(path); err != nil {
 					return err
 				}

--- a/test/acceptance/test/utils.go
+++ b/test/acceptance/test/utils.go
@@ -138,9 +138,9 @@ func getUniqueWorkload(placeHolderSuffix string, uniqueSuffix string) string {
 func setupSSHKey(sshKeyPath string) {
 	if _, err := os.Stat(sshKeyPath); os.IsNotExist(err) {
 		command := exec.Command("sh", "-c", fmt.Sprintf(`
-	                       echo "%s" >> %s &&
-	                       chmod 0600 %s &&
-	                       ls -la %s`, os.Getenv("GITHUB_KEY"), sshKeyPath, sshKeyPath, sshKeyPath))
+                           echo "%s" >> %s &&
+                           chmod 0600 %s &&
+                           ls -la %s`, os.Getenv("GITHUB_KEY"), sshKeyPath, sshKeyPath, sshKeyPath))
 		session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 		Expect(err).ShouldNot(HaveOccurred())
 		Eventually(session).Should(gexec.Exit())
@@ -630,6 +630,7 @@ func mergePR(repoAbsolutePath, prLink string) {
 
 func setArtifactsDir() string {
 	path := "/tmp/wego-test"
+
 	if os.Getenv("ARTIFACTS_BASE_DIR") == "" {
 		return path
 	}


### PR DESCRIPTION
<!-- Use # to add the issue this pull request is related to -->
Closes: #616 

<!-- Describe what has changed in this PR -->
**What changed?**
We now add a `.keep` file to the app repository for the `--app-config-url=NONE` and `--app-config-url=<url>` cases so that removing the last app manifest does not break flux synchronization. We don't do this for `--app-config-url=""` (the config in app repo case) because the `.wego` directory performs the same function.

<!-- Tell your future self why have you made these changes -->
**Why?**
To prevent confusing failures for users that believe they are undoing an app by removing all manifests.

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**
Unit tests and manual tests

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
**Release notes**
No

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
Yes, we will need to talk about the extra pull request being made in the app repository (or extra commit in the auto-merge case)