### PR TITLE
Allow flux binary to be overridden via an environment variable at setup time

### DIFF
--- a/pkg/flux/flux.go
+++ b/pkg/flux/flux.go
@@ -32,7 +32,7 @@ type Flux interface {
 	GetLatestStatusAllNamespaces() ([]string, error)
 }
 
-const fluxBinaryPathEnvVar = "FLUX_BIN_PATH"
+const fluxBinaryPathEnvVar = "WEAVE_GITOPS_FLUX_BIN_PATH"
 
 type FluxClient struct {
 	osys   osys.Osys

--- a/pkg/flux/flux.go
+++ b/pkg/flux/flux.go
@@ -32,6 +32,8 @@ type Flux interface {
 	GetLatestStatusAllNamespaces() ([]string, error)
 }
 
+const fluxBinaryPathEnvVar = "FLUX_BIN_PATH"
+
 type FluxClient struct {
 	osys   osys.Osys
 	runner runner.Runner

--- a/pkg/flux/logs_test.go
+++ b/pkg/flux/logs_test.go
@@ -48,15 +48,18 @@ var testFluxLogResponse = []byte(`2021-04-12T19:53:58.545Z info Alert - Starting
 
 // Test Setup
 
-var fluxClient *FluxClient
+const defaultTestFluxVersion = "0.12.0"
 
-var cliRunner *runnerfakes.FakeRunner
-
-var homeDir string
+var (
+	fluxClient *FluxClient
+	cliRunner  *runnerfakes.FakeRunner
+	osysClient *osysfakes.FakeOsys
+	homeDir    string
+)
 
 func init() {
 	cliRunner = &runnerfakes.FakeRunner{}
-	osysClient := &osysfakes.FakeOsys{}
+	osysClient = &osysfakes.FakeOsys{}
 	osysClient.UserHomeDirStub = func() (string, error) {
 		return homeDir, nil
 	}
@@ -117,21 +120,77 @@ func TestSetup(t *testing.T) {
 	require.Equal(t, exePath, filepath.Join(homeDir, ".wego", "bin", "flux-"+version.FluxVersion))
 }
 
-func TestSetupFluxBin(t *testing.T) {
-	dir, err := ioutil.TempDir(t.TempDir(), "a-home-dir")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
-	homeDir = dir
-	version.FluxVersion = "0.11.0"
-	fluxClient.SetupBin()
-	fluxPath := fmt.Sprintf("%v/.wego/bin", homeDir)
-	require.DirExists(t, fluxPath)
-	binPath := fmt.Sprintf("%v/flux-%v", fluxPath, version.FluxVersion)
-	require.FileExists(t, binPath)
+var _ = Describe("Set up flux bin", func() {
+	BeforeEach(func() {
+		dir, err := ioutil.TempDir("", "a-home-dir")
+		Expect(err).ShouldNot(HaveOccurred())
+		homeDir = dir
+	})
 
-	version.FluxVersion = "0.12.0"
-	fluxClient.SetupBin()
-	require.NoFileExists(t, binPath)
-	binPath = fmt.Sprintf("%v/flux-%v", fluxPath, version.FluxVersion)
-	require.FileExists(t, binPath)
-}
+	AfterEach(func() {
+		Expect(os.RemoveAll(homeDir)).To(Succeed())
+		version.FluxVersion = defaultTestFluxVersion
+	})
+
+	Context("Set up flux from embedded binary", func() {
+		It("Sets up flux from binary embedded during build", func() {
+			Expect(osysClient.Getenv(fluxBinaryPathEnvVar)).Should(Equal(""))
+
+			version.FluxVersion = "0.11.0"
+			fluxPath := filepath.Join(homeDir, ".wego", "bin")
+			exe11Path := filepath.Join(fluxPath, "flux-"+version.FluxVersion)
+			Expect(exe11Path).ShouldNot(BeAnExistingFile())
+			Expect(fluxPath).ShouldNot(BeADirectory())
+			fluxClient.SetupBin()
+			Expect(fluxPath).Should(BeADirectory())
+			Expect(exe11Path).Should(BeAnExistingFile())
+
+			version.FluxVersion = defaultTestFluxVersion
+			exe12Path := filepath.Join(fluxPath, "flux-"+version.FluxVersion)
+			Expect(exe12Path).ShouldNot(BeAnExistingFile())
+			fluxClient.SetupBin()
+			Expect(exe12Path).Should(BeAnExistingFile())
+		})
+	})
+
+	Context("Set up flux from binary referenced by env var", func() {
+		var envVal string
+
+		BeforeEach(func() {
+			osysClient = &osysfakes.FakeOsys{}
+			osysClient.UserHomeDirStub = func() (string, error) {
+				return homeDir, nil
+			}
+			osysClient.SetenvStub = func(_, val string) error {
+				envVal = val
+				return nil
+			}
+			osysClient.GetenvStub = func(envVar string) string {
+				return envVal
+			}
+			osysClient.ExitStub = func(code int) {}
+			fluxClient = New(osysClient, cliRunner)
+		})
+
+		It("Fails if passed a bad binary path", func() {
+			osysClient.Setenv(fluxBinaryPathEnvVar, "a-path-pointing-nowhere")
+			fluxClient.SetupBin()
+			Expect(osysClient.ExitCallCount()).Should(Equal(1))
+		})
+
+		It("Copies a referenced binary into the flux executable location", func() {
+			dummyBinary := []byte("dummy")
+			dummyPath := filepath.Join(homeDir, ".dummyBinary")
+			Expect(os.WriteFile(dummyPath, dummyBinary, 0555)).Should(Succeed())
+			Expect(osysClient.Setenv(fluxBinaryPathEnvVar, dummyPath)).Should(Succeed())
+
+			fluxClient.SetupBin()
+			exePath := filepath.Join(homeDir, ".wego", "bin", "flux-"+version.FluxVersion)
+			Expect(osysClient.ExitCallCount()).Should(Equal(0))
+
+			bin, err := os.ReadFile(exePath)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(bin).Should(Equal(dummyBinary))
+		})
+	})
+})

--- a/pkg/flux/logs_test.go
+++ b/pkg/flux/logs_test.go
@@ -173,7 +173,7 @@ var _ = Describe("Set up flux bin", func() {
 		})
 
 		It("Fails if passed a bad binary path", func() {
-			osysClient.Setenv(fluxBinaryPathEnvVar, "a-path-pointing-nowhere")
+			Expect(osysClient.Setenv(fluxBinaryPathEnvVar, "a-path-pointing-nowhere")).Should(Succeed())
 			fluxClient.SetupBin()
 			Expect(osysClient.ExitCallCount()).Should(Equal(1))
 		})

--- a/pkg/flux/setup.go
+++ b/pkg/flux/setup.go
@@ -18,11 +18,20 @@ func (f *FluxClient) SetupBin() {
 	binPath, err := f.GetBinPath()
 	f.checkError(err)
 
+	fluxBinary := fluxExe
+
+	fluxBinaryOverride := f.osys.Getenv(fluxBinaryPathEnvVar)
+	if fluxBinaryOverride != "" {
+		bin, err := os.ReadFile(fluxBinaryOverride)
+		f.checkError(err)
+		fluxBinary = bin
+	}
+
 	if _, err := os.Stat(exePath); os.IsNotExist(err) {
 		// Clean bin if file doesnt exist
 		f.checkError(os.RemoveAll(binPath))
 		f.checkError(os.MkdirAll(binPath, 0755))
-		f.checkError(os.WriteFile(exePath, fluxExe, 0755))
+		f.checkError(os.WriteFile(exePath, fluxBinary, 0755))
 	}
 }
 

--- a/pkg/osys/osys.go
+++ b/pkg/osys/osys.go
@@ -14,6 +14,7 @@ type Osys interface {
 	Getenv(envVar string) string
 	LookupEnv(envVar string) (string, bool)
 	Setenv(envVar, value string) error
+	Unsetenv(envVar string) error
 	Exit(code int)
 	Stdin() *os.File
 	Stdout() *os.File
@@ -42,6 +43,10 @@ func (o *OsysClient) LookupEnv(envVar string) (string, bool) {
 
 func (o *OsysClient) Setenv(envVar, value string) error {
 	return os.Setenv(envVar, value)
+}
+
+func (o *OsysClient) Unsetenv(envVar string) error {
+	return os.Unsetenv(envVar)
 }
 
 // The following three functions are used by both "app add" and "app remove".

--- a/pkg/osys/osysfakes/fake_osys.go
+++ b/pkg/osys/osysfakes/fake_osys.go
@@ -92,6 +92,17 @@ type FakeOsys struct {
 	stdoutReturnsOnCall map[int]struct {
 		result1 *os.File
 	}
+	UnsetenvStub        func(string) error
+	unsetenvMutex       sync.RWMutex
+	unsetenvArgsForCall []struct {
+		arg1 string
+	}
+	unsetenvReturns struct {
+		result1 error
+	}
+	unsetenvReturnsOnCall map[int]struct {
+		result1 error
+	}
 	UserHomeDirStub        func() (string, error)
 	userHomeDirMutex       sync.RWMutex
 	userHomeDirArgsForCall []struct {
@@ -542,6 +553,67 @@ func (fake *FakeOsys) StdoutReturnsOnCall(i int, result1 *os.File) {
 	}{result1}
 }
 
+func (fake *FakeOsys) Unsetenv(arg1 string) error {
+	fake.unsetenvMutex.Lock()
+	ret, specificReturn := fake.unsetenvReturnsOnCall[len(fake.unsetenvArgsForCall)]
+	fake.unsetenvArgsForCall = append(fake.unsetenvArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	stub := fake.UnsetenvStub
+	fakeReturns := fake.unsetenvReturns
+	fake.recordInvocation("Unsetenv", []interface{}{arg1})
+	fake.unsetenvMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeOsys) UnsetenvCallCount() int {
+	fake.unsetenvMutex.RLock()
+	defer fake.unsetenvMutex.RUnlock()
+	return len(fake.unsetenvArgsForCall)
+}
+
+func (fake *FakeOsys) UnsetenvCalls(stub func(string) error) {
+	fake.unsetenvMutex.Lock()
+	defer fake.unsetenvMutex.Unlock()
+	fake.UnsetenvStub = stub
+}
+
+func (fake *FakeOsys) UnsetenvArgsForCall(i int) string {
+	fake.unsetenvMutex.RLock()
+	defer fake.unsetenvMutex.RUnlock()
+	argsForCall := fake.unsetenvArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeOsys) UnsetenvReturns(result1 error) {
+	fake.unsetenvMutex.Lock()
+	defer fake.unsetenvMutex.Unlock()
+	fake.UnsetenvStub = nil
+	fake.unsetenvReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeOsys) UnsetenvReturnsOnCall(i int, result1 error) {
+	fake.unsetenvMutex.Lock()
+	defer fake.unsetenvMutex.Unlock()
+	fake.UnsetenvStub = nil
+	if fake.unsetenvReturnsOnCall == nil {
+		fake.unsetenvReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.unsetenvReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *FakeOsys) UserHomeDir() (string, error) {
 	fake.userHomeDirMutex.Lock()
 	ret, specificReturn := fake.userHomeDirReturnsOnCall[len(fake.userHomeDirArgsForCall)]
@@ -617,6 +689,8 @@ func (fake *FakeOsys) Invocations() map[string][][]interface{} {
 	defer fake.stdinMutex.RUnlock()
 	fake.stdoutMutex.RLock()
 	defer fake.stdoutMutex.RUnlock()
+	fake.unsetenvMutex.RLock()
+	defer fake.unsetenvMutex.RUnlock()
 	fake.userHomeDirMutex.RLock()
 	defer fake.userHomeDirMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}


### PR DESCRIPTION
<!-- Use # to add the issue this pull request is related to -->
Closes: #757 

<!-- Describe what has changed in this PR -->
**What changed?**
We now allow the flux binary used during `weave-gitops` setup to be specified via an environment variable so that the `weave-gitops` code can be used as a library. The flux binary is currently stored as an embedded binary which does not propagate when pulled via `go.mod`. After pulling the code as a module, setting `WEAVE_GITOPS_FLUX_BIN_PATH` to point at a flux binary will cause the referenced binary to be installed for use by weave-gitops.

<!-- Tell your future self why have you made these changes -->
**Why?**
To allow the code to be used as a library

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**
Unit tests

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
**Release notes**
No

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
No