### PR TITLE
Switch `go:embed` to use a file-system to check flux binary at runtime rather than build time

### DIFF
--- a/pkg/flux/bin/flux
+++ b/pkg/flux/bin/flux
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
 
-echo -e "Flux binary not available
+echo -e "Flux binary not available"
 exit 1
 

--- a/pkg/flux/bin/flux
+++ b/pkg/flux/bin/flux
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+
+echo -e "Flux binary not available
+exit 1
+

--- a/pkg/flux/bin/flux
+++ b/pkg/flux/bin/flux
@@ -1,5 +1,0 @@
-#!/usr/bin/env sh
-
-echo -e "Flux binary not available"
-exit 1
-

--- a/pkg/flux/bin/go_embed_fs_cannot_be_empty.txt
+++ b/pkg/flux/bin/go_embed_fs_cannot_be_empty.txt
@@ -1,0 +1,2 @@
+This file is here to stop `go:embed` complaining there aren't any files at `go build` time.
+


### PR DESCRIPTION
<!-- Use # to add the issue this pull request is related to -->
Closes: #757 

<!-- Describe what has changed in this PR -->
**What changed?**

Switch `go:embed` from `[]byte` to file-system.

- So we can deal w/ flux being missing at runtime instead of build time
- This allows us to build weave-gitops as a dep as flux will always be missing in that context.

<!-- Tell your future self why have you made these changes -->
**Why?**

Before this change we see this error:

```bash
git clone https://github.com/weaveworks-gitops-test/wego-library-test.git
vim go.mod # remove replace directive
go get -d github.com/weaveworks/weave-gitops@a92de7749f97e36ca52784b7480e59820b988fba
go build main.go

../../go/pkg/mod/github.com/weaveworks/weave-gitops@v0.2.6-0.20210914212909-a92de7749f97/pkg/flux/setup.go:11:12: pattern bin/flux: no matching files found
```

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**

If the filesystem is completely empty we still get:
```bash
go get -d github.com/weaveworks/weave-gitops@36715fe2f412007da76f64ec5046978472c120f2
go build main.go

../../go/pkg/mod/github.com/weaveworks/weave-gitops@v0.2.6-0.20210915071017-36715fe2f412/pkg/flux/setup.go:11:12: pattern bin/*: no matching files found
```

After adding the dummy file:
```
go get -d github.com/weaveworks/weave-gitops@3126831b9a52e14d6ece6716e4da53cebef56b70
go build main.go
```
🎉 .

In `weave-gitops`:
```
ewq:~/weave/weave-gitops(adds-dummy-bin-flux *+%=)$ go build cmd/wego/main.go
ewq:~/weave/weave-gitops(adds-dummy-bin-flux *+%=)$ ./main flux --help

Command line utility for assembling Kubernetes CD pipelines the GitOps way.

Usage:
  flux [command]

<...SNIP...>

ewq:~/weave/weave-gitops(adds-dummy-bin-flux *+%=)$ rm pkg/flux/bin/flux
ewq:~/weave/weave-gitops(adds-dummy-bin-flux *+%=)$ go build cmd/wego/main.go
ewq:~/weave/weave-gitops(adds-dummy-bin-flux *+%=)$ ./main flux --help
Error: error reading embedded flux binary: open bin/flux: file does not exist
ewq:~/weave/weave-gitops(adds-dummy-bin-flux *+%=)$
```