### PR TITLE
Removing visibility validation

### DIFF
--- a/pkg/services/auth/auth.go
+++ b/pkg/services/auth/auth.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/fluxcd/go-git-providers/gitprovider"
 	"github.com/go-git/go-git/v5/plumbing/transport/ssh"
 	"github.com/weaveworks/weave-gitops/pkg/flux"
 	"github.com/weaveworks/weave-gitops/pkg/git"
@@ -155,20 +154,6 @@ func (a *authSvc) CreateGitClient(ctx context.Context, targetName, namespace, re
 func (a *authSvc) setupDeployKey(ctx context.Context, name SecretName, targetName string, repo gitproviders.NormalizedRepoURL) (*ssh.PublicKeys, error) {
 	owner := repo.Owner()
 	repoName := repo.RepositoryName()
-	accountType, err := a.gitProvider.GetAccountType(repo.Owner())
-	if err != nil {
-		return nil, fmt.Errorf("error getting account type: %w", err)
-	}
-
-	repoInfo, err := a.gitProvider.GetRepoInfo(accountType, repo.Owner(), repo.RepositoryName())
-	if err != nil {
-		return nil, fmt.Errorf("error getting repo info: %w", err)
-	}
-
-	if repoInfo.Visibility != nil && *repoInfo.Visibility == gitprovider.RepositoryVisibilityPublic {
-		// This is a public repo. We don't need to add deploy keys to it.
-		return nil, nil
-	}
 
 	deployKeyExists, err := a.gitProvider.DeployKeyExists(owner, repoName)
 	if err != nil {

--- a/pkg/services/auth/auth_test.go
+++ b/pkg/services/auth/auth_test.go
@@ -111,7 +111,6 @@ var _ = Describe("auth", func() {
 
 			newSecret := &corev1.Secret{}
 			Expect(k8sClient.Get(ctx, sn.NamespacedName(), newSecret)).To(Succeed())
-			// Expect(gp.RemoveDeployKeyCallCount()).To(Equal(1))
 			Expect(gp.UploadDeployKeyCallCount()).To(Equal(1))
 		})
 	})


### PR DESCRIPTION
<!-- Use # to add the issue this pull request is related to -->
Closes: #758 

<!-- Describe what has changed in this PR -->
**What changed?**
- Removing visibility validation when creating deploy keys


<!-- Tell your future self why have you made these changes -->
**Why?**
we were not able to clone via ssh without an ssh key, which only works in public repositories if using the HTTP endpoint.

To overcome that I removed the repository visibility check that avoids uploading the deploy key to the repo, so it doesn't fail, and even if cloning worked we would have hit another issue when using the auto-merge flag since it would be required anyway to have an ssh key to push code. 

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
**Release notes**

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**