### PR TITLE
Disambiguate dagred3 graph creation

### DIFF
--- a/ui/components/DirectedGraph.tsx
+++ b/ui/components/DirectedGraph.tsx
@@ -37,7 +37,10 @@ function DirectedGraph<T>({
       return;
     }
 
-    const graph = new dagreD3.graphlib.Graph()
+    const dagreD3LibRef = dagreD3;
+    const graph = new dagreD3LibRef.graphlib.Graph();
+
+    graph
       .setGraph({
         nodesep: 70,
         ranksep: 50,


### PR DESCRIPTION
Fixes a problematic `new` statement that was giving `parcel` issues parsing and bundling the file.