### PR TITLE
add/remove/git commits to gitlab using a gitlab token

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -113,6 +113,9 @@ jobs:
         GITHUB_ORG: weaveworks-gitops-test
         GITHUB_TOKEN: "${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_TOKEN }}"
         GITHUB_KEY: "${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_SSH_KEY }}"
+        GITLAB_ORG: weave-gitops
+        GITLAB_SUBGROUP: weabe-gitops-sub
+        GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
       run: |
         export WEGO_BIN_PATH=$(pwd)/bin/gitops
         go get github.com/onsi/ginkgo/ginkgo

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -104,9 +104,6 @@ jobs:
         ssh-private-key: |
               ${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_SSH_KEY }}
               ${{ secrets.GITLAB_KEY }}
-    - name: Setup Gitlab SSH host
-      run: |
-        ssh-keyscan gitlab.com >> ~/.ssh/known_hosts
     - name: Configure git settings
       run: |
         git config --global init.defaultBranch main

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -101,8 +101,9 @@ jobs:
     - name: Set up ssh agent
       uses: webfactory/ssh-agent@v0.5.2
       with:
-        ssh-private-key: ${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_SSH_KEY }}
-        ssh-private-key: ${{ secrets.GITLAB_KEY }}
+        ssh-private-key: |
+        ${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_SSH_KEY }}
+        ${{ secrets.GITLAB_KEY }}
     - name: Configure git settings
       run: |
         git config --global init.defaultBranch main

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -103,7 +103,6 @@ jobs:
       with:
         ssh-private-key: |
               ${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_SSH_KEY }}
-              ${{ secrets.GITLAB_KEY }}
     - name: Configure git settings
       run: |
         git config --global init.defaultBranch main

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -116,6 +116,7 @@ jobs:
         GITLAB_ORG: weave-gitops
         GITLAB_SUBGROUP: weave-gitops-sub
         GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
+        GITLAB_KEY: ${{ secrets.GITLAB_KEY }}
       run: |
         export WEGO_BIN_PATH=$(pwd)/bin/gitops
         go get github.com/onsi/ginkgo/ginkgo

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -113,8 +113,8 @@ jobs:
         GITHUB_ORG: weaveworks-gitops-test
         GITHUB_TOKEN: "${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_TOKEN }}"
         GITHUB_KEY: "${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_SSH_KEY }}"
-        GITLAB_ORG: weaveworks
-        GITLAB_SUBGROUP: weabe-gitops
+        GITLAB_ORG: gogittest
+        GITLAB_SUBGROUP: sub-group
         GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
       run: |
         export WEGO_BIN_PATH=$(pwd)/bin/gitops

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -104,6 +104,9 @@ jobs:
         ssh-private-key: |
               ${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_SSH_KEY }}
               ${{ secrets.GITLAB_KEY }}
+    - name: Setup Gitlab SSH Key
+      run: |
+        ssh-add ${{secrets.GITLAB_KEY}}
     - name: Configure git settings
       run: |
         git config --global init.defaultBranch main

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -113,8 +113,8 @@ jobs:
         GITHUB_ORG: weaveworks-gitops-test
         GITHUB_TOKEN: "${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_TOKEN }}"
         GITHUB_KEY: "${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_SSH_KEY }}"
-        GITLAB_ORG: weave-gitops
-        GITLAB_SUBGROUP: weabe-gitops-sub
+        GITLAB_ORG: weaveworks
+        GITLAB_SUBGROUP: weabe-gitops
         GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
       run: |
         export WEGO_BIN_PATH=$(pwd)/bin/gitops

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -113,8 +113,8 @@ jobs:
         GITHUB_ORG: weaveworks-gitops-test
         GITHUB_TOKEN: "${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_TOKEN }}"
         GITHUB_KEY: "${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_SSH_KEY }}"
-        GITLAB_ORG: gogittest
-        GITLAB_SUBGROUP: sub-group
+        GITLAB_ORG: weave-gitops
+        GITLAB_SUBGROUP: weave-gitops-sub
         GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
       run: |
         export WEGO_BIN_PATH=$(pwd)/bin/gitops

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -104,6 +104,9 @@ jobs:
         ssh-private-key: |
               ${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_SSH_KEY }}
               ${{ secrets.GITLAB_KEY }}
+    - name: Setup Gitlab SSH host
+      run: |
+        ssh-keyscan gitlab.com >> ~/.ssh/known_hosts
     - name: Configure git settings
       run: |
         git config --global init.defaultBranch main

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -102,6 +102,7 @@ jobs:
       uses: webfactory/ssh-agent@v0.5.2
       with:
         ssh-private-key: ${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_SSH_KEY }}
+        ssh-private-key: ${{ secrets.GITLAB_KEY }}
     - name: Configure git settings
       run: |
         git config --global init.defaultBranch main

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -104,9 +104,6 @@ jobs:
         ssh-private-key: |
               ${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_SSH_KEY }}
               ${{ secrets.GITLAB_KEY }}
-    - name: Setup Gitlab SSH Key
-      run: |
-        ssh-add ${{secrets.GITLAB_KEY}}
     - name: Configure git settings
       run: |
         git config --global init.defaultBranch main

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -99,11 +99,11 @@ jobs:
       run: |
         make dependencies
     - name: Set up ssh agent
-      uses: webfactory/ssh-agent@v0.5.2
+      uses: webfactory/ssh-agent@v0.5.3
       with:
         ssh-private-key: |
-        ${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_SSH_KEY }}
-        ${{ secrets.GITLAB_KEY }}
+              ${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_SSH_KEY }}
+              ${{ secrets.GITLAB_KEY }}
     - name: Configure git settings
       run: |
         git config --global init.defaultBranch main

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -100,8 +100,8 @@ jobs:
         GITHUB_ORG: weaveworks-gitops-test
         GITHUB_TOKEN: "${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_TOKEN }}"
         GITHUB_KEY: "${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_SSH_KEY }}"
-        GITLAB_ORG: weaveworks
-        GITLAB_SUBGROUP: weabe-gitops
+        GITLAB_ORG: gogittest
+        GITLAB_SUBGROUP: sub-group
         GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
       run: |
         export WEGO_BIN_PATH=$(pwd)/bin/gitops-${{matrix.os}}-nightly
@@ -186,8 +186,8 @@ jobs:
         GITHUB_ORG: weaveworks-gitops-test
         GITHUB_TOKEN: "${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_TOKEN }}"
         GITHUB_KEY: "${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_SSH_KEY }}"
-        GITLAB_ORG: weaveworks
-        GITLAB_SUBGROUP: weabe-gitops
+        GITLAB_ORG: gogittest
+        GITLAB_SUBGROUP: sub-group
         GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
       run: |
         export WEGO_BIN_PATH=$(pwd)/bin/gitops-${{matrix.os}}-nightly

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -87,6 +87,7 @@ jobs:
       uses: webfactory/ssh-agent@v0.5.2
       with:
         ssh-private-key: ${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_SSH_KEY }}
+        ssh-private-key: ${{ secrets.GITLAB_KEY }}
     - name: Configure git settings
       run: |
         git config --global init.defaultBranch main
@@ -174,6 +175,7 @@ jobs:
       uses: webfactory/ssh-agent@v0.5.2
       with:
         ssh-private-key: ${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_SSH_KEY }}
+        ssh-private-key: ${{ secrets.GITLAB_KEY }}
     - name: Configure git settings
       run: |
         git config --global init.defaultBranch main

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -86,8 +86,9 @@ jobs:
     - name: Set up ssh agent
       uses: webfactory/ssh-agent@v0.5.2
       with:
-        ssh-private-key: ${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_SSH_KEY }}
-        ssh-private-key: ${{ secrets.GITLAB_KEY }}
+        ssh-private-key: |
+        ${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_SSH_KEY }}
+        ${{ secrets.GITLAB_KEY }}
     - name: Configure git settings
       run: |
         git config --global init.defaultBranch main
@@ -174,8 +175,9 @@ jobs:
     - name: Set up ssh agent
       uses: webfactory/ssh-agent@v0.5.2
       with:
-        ssh-private-key: ${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_SSH_KEY }}
-        ssh-private-key: ${{ secrets.GITLAB_KEY }}
+        ssh-private-key: |
+        ${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_SSH_KEY }}
+        ${{ secrets.GITLAB_KEY }}
     - name: Configure git settings
       run: |
         git config --global init.defaultBranch main

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -89,9 +89,6 @@ jobs:
         ssh-private-key: |
               ${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_SSH_KEY }}
               ${{ secrets.GITLAB_KEY }}
-    - name: Setup Gitlab SSH host
-      run: |
-        ssh-keyscan gitlab.com >> ~/.ssh/known_hosts
     - name: Configure git settings
       run: |
         git config --global init.defaultBranch main
@@ -181,9 +178,6 @@ jobs:
         ssh-private-key: |
               ${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_SSH_KEY }}
               ${{ secrets.GITLAB_KEY }}
-    - name: Setup Gitlab SSH host
-      run: |
-        ssh-keyscan gitlab.com >> ~/.ssh/known_hosts
     - name: Configure git settings
       run: |
         git config --global init.defaultBranch main

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -89,6 +89,9 @@ jobs:
         ssh-private-key: |
               ${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_SSH_KEY }}
               ${{ secrets.GITLAB_KEY }}
+    - name: Setup Gitlab SSH Key
+      run: |
+        ssh-add ${{secrets.GITLAB_KEY}}
     - name: Configure git settings
       run: |
         git config --global init.defaultBranch main
@@ -178,6 +181,9 @@ jobs:
         ssh-private-key: |
               ${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_SSH_KEY }}
               ${{ secrets.GITLAB_KEY }}
+    - name: Setup Gitlab SSH Key
+      run: |
+        ssh-add ${{secrets.GITLAB_KEY}}
     - name: Configure git settings
       run: |
         git config --global init.defaultBranch main

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -100,8 +100,8 @@ jobs:
         GITHUB_ORG: weaveworks-gitops-test
         GITHUB_TOKEN: "${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_TOKEN }}"
         GITHUB_KEY: "${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_SSH_KEY }}"
-        GITLAB_ORG: gogittest
-        GITLAB_SUBGROUP: sub-group
+        GITLAB_ORG: weave-gitops
+        GITLAB_SUBGROUP: weave-gitops-sub
         GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
       run: |
         export WEGO_BIN_PATH=$(pwd)/bin/gitops-${{matrix.os}}-nightly
@@ -186,8 +186,8 @@ jobs:
         GITHUB_ORG: weaveworks-gitops-test
         GITHUB_TOKEN: "${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_TOKEN }}"
         GITHUB_KEY: "${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_SSH_KEY }}"
-        GITLAB_ORG: gogittest
-        GITLAB_SUBGROUP: sub-group
+        GITLAB_ORG: weave-gitops
+        GITLAB_SUBGROUP: weave-gitops-sub
         GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
       run: |
         export WEGO_BIN_PATH=$(pwd)/bin/gitops-${{matrix.os}}-nightly

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -89,9 +89,6 @@ jobs:
         ssh-private-key: |
               ${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_SSH_KEY }}
               ${{ secrets.GITLAB_KEY }}
-    - name: Setup Gitlab SSH Key
-      run: |
-        ssh-add ${{secrets.GITLAB_KEY}}
     - name: Configure git settings
       run: |
         git config --global init.defaultBranch main
@@ -181,9 +178,6 @@ jobs:
         ssh-private-key: |
               ${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_SSH_KEY }}
               ${{ secrets.GITLAB_KEY }}
-    - name: Setup Gitlab SSH Key
-      run: |
-        ssh-add ${{secrets.GITLAB_KEY}}
     - name: Configure git settings
       run: |
         git config --global init.defaultBranch main

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -103,6 +103,7 @@ jobs:
         GITLAB_ORG: weave-gitops
         GITLAB_SUBGROUP: weave-gitops-sub
         GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
+        GITLAB_KEY: ${{ secrets.GITLAB_KEY }}
       run: |
         export WEGO_BIN_PATH=$(pwd)/bin/gitops-${{matrix.os}}-nightly
         export CLUSTER_PROVIDER=kubectl
@@ -189,6 +190,7 @@ jobs:
         GITLAB_ORG: weave-gitops
         GITLAB_SUBGROUP: weave-gitops-sub
         GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
+        GITLAB_KEY: ${{ secrets.GITLAB_KEY }}
       run: |
         export WEGO_BIN_PATH=$(pwd)/bin/gitops-${{matrix.os}}-nightly
         export CLUSTER_PROVIDER=kubectl

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -100,8 +100,8 @@ jobs:
         GITHUB_ORG: weaveworks-gitops-test
         GITHUB_TOKEN: "${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_TOKEN }}"
         GITHUB_KEY: "${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_SSH_KEY }}"
-        GITLAB_ORG: weave-gitops
-        GITLAB_SUBGROUP: weabe-gitops-sub
+        GITLAB_ORG: weaveworks
+        GITLAB_SUBGROUP: weabe-gitops
         GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
       run: |
         export WEGO_BIN_PATH=$(pwd)/bin/gitops-${{matrix.os}}-nightly
@@ -186,8 +186,8 @@ jobs:
         GITHUB_ORG: weaveworks-gitops-test
         GITHUB_TOKEN: "${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_TOKEN }}"
         GITHUB_KEY: "${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_SSH_KEY }}"
-        GITLAB_ORG: weave-gitops
-        GITLAB_SUBGROUP: weabe-gitops-sub
+        GITLAB_ORG: weaveworks
+        GITLAB_SUBGROUP: weabe-gitops
         GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
       run: |
         export WEGO_BIN_PATH=$(pwd)/bin/gitops-${{matrix.os}}-nightly

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -89,6 +89,9 @@ jobs:
         ssh-private-key: |
               ${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_SSH_KEY }}
               ${{ secrets.GITLAB_KEY }}
+    - name: Setup Gitlab SSH host
+      run: |
+        ssh-keyscan gitlab.com >> ~/.ssh/known_hosts
     - name: Configure git settings
       run: |
         git config --global init.defaultBranch main
@@ -178,6 +181,9 @@ jobs:
         ssh-private-key: |
               ${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_SSH_KEY }}
               ${{ secrets.GITLAB_KEY }}
+    - name: Setup Gitlab SSH host
+      run: |
+        ssh-keyscan gitlab.com >> ~/.ssh/known_hosts
     - name: Configure git settings
       run: |
         git config --global init.defaultBranch main

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -84,11 +84,11 @@ jobs:
         chmod +x bin/gitops-${{matrix.os}}-nightly
         ls -la bin
     - name: Set up ssh agent
-      uses: webfactory/ssh-agent@v0.5.2
+      uses: webfactory/ssh-agent@v0.5.3
       with:
         ssh-private-key: |
-        ${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_SSH_KEY }}
-        ${{ secrets.GITLAB_KEY }}
+              ${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_SSH_KEY }}
+              ${{ secrets.GITLAB_KEY }}
     - name: Configure git settings
       run: |
         git config --global init.defaultBranch main
@@ -173,11 +173,11 @@ jobs:
         chmod +x bin/gitops-${{matrix.os}}-nightly
         ls -la bin
     - name: Set up ssh agent
-      uses: webfactory/ssh-agent@v0.5.2
+      uses: webfactory/ssh-agent@v0.5.3
       with:
         ssh-private-key: |
-        ${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_SSH_KEY }}
-        ${{ secrets.GITLAB_KEY }}
+              ${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_SSH_KEY }}
+              ${{ secrets.GITLAB_KEY }}
     - name: Configure git settings
       run: |
         git config --global init.defaultBranch main

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -88,7 +88,6 @@ jobs:
       with:
         ssh-private-key: |
               ${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_SSH_KEY }}
-              ${{ secrets.GITLAB_KEY }}
     - name: Configure git settings
       run: |
         git config --global init.defaultBranch main
@@ -177,7 +176,6 @@ jobs:
       with:
         ssh-private-key: |
               ${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_SSH_KEY }}
-              ${{ secrets.GITLAB_KEY }}
     - name: Configure git settings
       run: |
         git config --global init.defaultBranch main

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -100,6 +100,9 @@ jobs:
         GITHUB_ORG: weaveworks-gitops-test
         GITHUB_TOKEN: "${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_TOKEN }}"
         GITHUB_KEY: "${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_SSH_KEY }}"
+        GITLAB_ORG: weave-gitops
+        GITLAB_SUBGROUP: weabe-gitops-sub
+        GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
       run: |
         export WEGO_BIN_PATH=$(pwd)/bin/gitops-${{matrix.os}}-nightly
         export CLUSTER_PROVIDER=kubectl
@@ -183,6 +186,9 @@ jobs:
         GITHUB_ORG: weaveworks-gitops-test
         GITHUB_TOKEN: "${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_TOKEN }}"
         GITHUB_KEY: "${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_SSH_KEY }}"
+        GITLAB_ORG: weave-gitops
+        GITLAB_SUBGROUP: weabe-gitops-sub
+        GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
       run: |
         export WEGO_BIN_PATH=$(pwd)/bin/gitops-${{matrix.os}}-nightly
         export CLUSTER_PROVIDER=kubectl

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -164,9 +164,6 @@ jobs:
         ssh-private-key: |
               ${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_SSH_KEY }}
               ${{ secrets.GITLAB_KEY }}
-    - name: Setup Gitlab SSH host
-      run: |
-        ssh-keyscan gitlab.com >> ~/.ssh/known_hosts
     - name: Configure git settings
       run: |
         git config --global init.defaultBranch main
@@ -255,9 +252,6 @@ jobs:
         ssh-private-key: |
               ${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_SSH_KEY }}
               ${{ secrets.GITLAB_KEY }}
-    - name: Setup Gitlab SSH host
-      run: |
-        ssh-keyscan gitlab.com >> ~/.ssh/known_hosts
     - name: Configure git settings
       run: |
         git config --global init.defaultBranch main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -164,6 +164,9 @@ jobs:
         ssh-private-key: |
               ${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_SSH_KEY }}
               ${{ secrets.GITLAB_KEY }}
+    - name: Setup Gitlab SSH Key
+      run: |
+        ssh-add ${{secrets.GITLAB_KEY}}
     - name: Configure git settings
       run: |
         git config --global init.defaultBranch main
@@ -252,6 +255,9 @@ jobs:
         ssh-private-key: |
               ${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_SSH_KEY }}
               ${{ secrets.GITLAB_KEY }}
+    - name: Setup Gitlab SSH Key
+      run: |
+        ssh-add ${{secrets.GITLAB_KEY}}
     - name: Configure git settings
       run: |
         git config --global init.defaultBranch main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -159,11 +159,11 @@ jobs:
       run: |
         make dependencies
     - name: Set up ssh agent
-      uses: webfactory/ssh-agent@v0.5.2
+      uses: webfactory/ssh-agent@v0.5.3
       with:
         ssh-private-key: |
-        ${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_SSH_KEY }}
-        ${{ secrets.GITLAB_KEY }}
+              ${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_SSH_KEY }}
+              ${{ secrets.GITLAB_KEY }}
     - name: Configure git settings
       run: |
         git config --global init.defaultBranch main
@@ -247,11 +247,11 @@ jobs:
       run: |
         make dependencies
     - name: Set up ssh agent
-      uses: webfactory/ssh-agent@v0.5.2
+      uses: webfactory/ssh-agent@v0.5.3
       with:
         ssh-private-key: |
-        ${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_SSH_KEY }}
-        ${{ secrets.GITLAB_KEY }}
+              ${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_SSH_KEY }}
+              ${{ secrets.GITLAB_KEY }}
     - name: Configure git settings
       run: |
         git config --global init.defaultBranch main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,6 +111,7 @@ jobs:
         GITLAB_ORG: weave-gitops
         GITLAB_SUBGROUP: weave-gitops-sub
         GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
+        GITLAB_KEY: ${{ secrets.GITLAB_KEY }}
     steps:
     - name: Install Go
       uses: actions/setup-go@v2
@@ -196,6 +197,7 @@ jobs:
         GITLAB_ORG: weave-gitops
         GITLAB_SUBGROUP: weave-gitops-sub
         GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
+        GITLAB_KEY: ${{ secrets.GITLAB_KEY }}
     steps:
     - name: Install Go
       uses: actions/setup-go@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -164,6 +164,9 @@ jobs:
         ssh-private-key: |
               ${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_SSH_KEY }}
               ${{ secrets.GITLAB_KEY }}
+    - name: Setup Gitlab SSH host
+      run: |
+        ssh-keyscan gitlab.com >> ~/.ssh/known_hosts
     - name: Configure git settings
       run: |
         git config --global init.defaultBranch main
@@ -252,6 +255,9 @@ jobs:
         ssh-private-key: |
               ${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_SSH_KEY }}
               ${{ secrets.GITLAB_KEY }}
+    - name: Setup Gitlab SSH host
+      run: |
+        ssh-keyscan gitlab.com >> ~/.ssh/known_hosts
     - name: Configure git settings
       run: |
         git config --global init.defaultBranch main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -162,6 +162,7 @@ jobs:
       uses: webfactory/ssh-agent@v0.5.2
       with:
         ssh-private-key: ${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_SSH_KEY }}
+        ssh-private-key: ${{ secrets.GITLAB_KEY }}
     - name: Configure git settings
       run: |
         git config --global init.defaultBranch main
@@ -248,6 +249,7 @@ jobs:
       uses: webfactory/ssh-agent@v0.5.2
       with:
         ssh-private-key: ${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_SSH_KEY }}
+        ssh-private-key: ${{ secrets.GITLAB_KEY }}
     - name: Configure git settings
       run: |
         git config --global init.defaultBranch main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -164,9 +164,6 @@ jobs:
         ssh-private-key: |
               ${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_SSH_KEY }}
               ${{ secrets.GITLAB_KEY }}
-    - name: Setup Gitlab SSH Key
-      run: |
-        ssh-add ${{secrets.GITLAB_KEY}}
     - name: Configure git settings
       run: |
         git config --global init.defaultBranch main
@@ -255,9 +252,6 @@ jobs:
         ssh-private-key: |
               ${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_SSH_KEY }}
               ${{ secrets.GITLAB_KEY }}
-    - name: Setup Gitlab SSH Key
-      run: |
-        ssh-add ${{secrets.GITLAB_KEY}}
     - name: Configure git settings
       run: |
         git config --global init.defaultBranch main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,8 +108,8 @@ jobs:
         GITHUB_KEY: "${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_SSH_KEY }}"
         ARTIFACTS_BASE_DIR: "/tmp/wego-test"
         IS_TEST_ENV: "true"
-        GITLAB_ORG: weaveworks
-        GITLAB_SUBGROUP: weabe-gitops
+        GITLAB_ORG: gogittest
+        GITLAB_SUBGROUP: sub-group
         GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
     steps:
     - name: Install Go
@@ -193,8 +193,8 @@ jobs:
         GITHUB_KEY: "${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_SSH_KEY }}"
         ARTIFACTS_BASE_DIR: "/tmp/wego-test"
         IS_TEST_ENV: "true"
-        GITLAB_ORG: weaveworks
-        GITLAB_SUBGROUP: weabe-gitops
+        GITLAB_ORG: gogittest
+        GITLAB_SUBGROUP: sub-group
         GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
     steps:
     - name: Install Go

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -161,8 +161,9 @@ jobs:
     - name: Set up ssh agent
       uses: webfactory/ssh-agent@v0.5.2
       with:
-        ssh-private-key: ${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_SSH_KEY }}
-        ssh-private-key: ${{ secrets.GITLAB_KEY }}
+        ssh-private-key: |
+        ${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_SSH_KEY }}
+        ${{ secrets.GITLAB_KEY }}
     - name: Configure git settings
       run: |
         git config --global init.defaultBranch main
@@ -248,8 +249,9 @@ jobs:
     - name: Set up ssh agent
       uses: webfactory/ssh-agent@v0.5.2
       with:
-        ssh-private-key: ${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_SSH_KEY }}
-        ssh-private-key: ${{ secrets.GITLAB_KEY }}
+        ssh-private-key: |
+        ${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_SSH_KEY }}
+        ${{ secrets.GITLAB_KEY }}
     - name: Configure git settings
       run: |
         git config --global init.defaultBranch main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,6 +108,9 @@ jobs:
         GITHUB_KEY: "${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_SSH_KEY }}"
         ARTIFACTS_BASE_DIR: "/tmp/wego-test"
         IS_TEST_ENV: "true"
+        GITLAB_ORG: weave-gitops
+        GITLAB_SUBGROUP: weabe-gitops-sub
+        GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
     steps:
     - name: Install Go
       uses: actions/setup-go@v2
@@ -190,6 +193,9 @@ jobs:
         GITHUB_KEY: "${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_SSH_KEY }}"
         ARTIFACTS_BASE_DIR: "/tmp/wego-test"
         IS_TEST_ENV: "true"
+        GITLAB_ORG: weave-gitops
+        GITLAB_SUBGROUP: weabe-gitops-sub
+        GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
     steps:
     - name: Install Go
       uses: actions/setup-go@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -163,7 +163,6 @@ jobs:
       with:
         ssh-private-key: |
               ${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_SSH_KEY }}
-              ${{ secrets.GITLAB_KEY }}
     - name: Configure git settings
       run: |
         git config --global init.defaultBranch main
@@ -251,7 +250,6 @@ jobs:
       with:
         ssh-private-key: |
               ${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_SSH_KEY }}
-              ${{ secrets.GITLAB_KEY }}
     - name: Configure git settings
       run: |
         git config --global init.defaultBranch main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,8 +108,8 @@ jobs:
         GITHUB_KEY: "${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_SSH_KEY }}"
         ARTIFACTS_BASE_DIR: "/tmp/wego-test"
         IS_TEST_ENV: "true"
-        GITLAB_ORG: gogittest
-        GITLAB_SUBGROUP: sub-group
+        GITLAB_ORG: weave-gitops
+        GITLAB_SUBGROUP: weave-gitops-sub
         GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
     steps:
     - name: Install Go
@@ -193,8 +193,8 @@ jobs:
         GITHUB_KEY: "${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_SSH_KEY }}"
         ARTIFACTS_BASE_DIR: "/tmp/wego-test"
         IS_TEST_ENV: "true"
-        GITLAB_ORG: gogittest
-        GITLAB_SUBGROUP: sub-group
+        GITLAB_ORG: weave-gitops
+        GITLAB_SUBGROUP: weave-gitops-sub
         GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
     steps:
     - name: Install Go

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,8 +108,8 @@ jobs:
         GITHUB_KEY: "${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_SSH_KEY }}"
         ARTIFACTS_BASE_DIR: "/tmp/wego-test"
         IS_TEST_ENV: "true"
-        GITLAB_ORG: weave-gitops
-        GITLAB_SUBGROUP: weabe-gitops-sub
+        GITLAB_ORG: weaveworks
+        GITLAB_SUBGROUP: weabe-gitops
         GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
     steps:
     - name: Install Go
@@ -193,8 +193,8 @@ jobs:
         GITHUB_KEY: "${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_SSH_KEY }}"
         ARTIFACTS_BASE_DIR: "/tmp/wego-test"
         IS_TEST_ENV: "true"
-        GITLAB_ORG: weave-gitops
-        GITLAB_SUBGROUP: weabe-gitops-sub
+        GITLAB_ORG: weaveworks
+        GITLAB_SUBGROUP: weabe-gitops
         GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
     steps:
     - name: Install Go

--- a/cmd/gitops/app/add/cmd.go
+++ b/cmd/gitops/app/add/cmd.go
@@ -72,7 +72,7 @@ func ensureUrlIsValid() error {
 			return fmt.Errorf("could not get remote url for directory %s: %w", params.Dir, repoUrlErr)
 		}
 
-		params.Url = utils.SanitizeRepoUrl(repoUrlString)
+		params.Url = repoUrlString
 	}
 
 	return nil

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/deepmap/oapi-codegen v1.8.1
 	github.com/dnaeon/go-vcr v1.2.0
-	github.com/fluxcd/go-git-providers v0.2.1-0.20210908163615-833963032787
+	github.com/fluxcd/go-git-providers v0.2.1-0.20210920141513-ddc36f3d5f60
 	github.com/fluxcd/helm-controller/api v0.11.1
 	github.com/fluxcd/kustomize-controller/api v0.13.2
 	github.com/fluxcd/pkg/apis/meta v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -181,8 +181,8 @@ github.com/evanphx/json-patch v4.11.0+incompatible h1:glyUF9yIYtMHzn8xaKw5rMhdWc
 github.com/evanphx/json-patch v4.11.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
-github.com/fluxcd/go-git-providers v0.2.1-0.20210908163615-833963032787 h1:/Zj0v51h0Rrblhpy4opWGeB7Yhwe1lK44QBzLJciDsY=
-github.com/fluxcd/go-git-providers v0.2.1-0.20210908163615-833963032787/go.mod h1:kByvCO8EATmdOqHne60f0NsJUjsbOwcfADTj7RHGjcs=
+github.com/fluxcd/go-git-providers v0.2.1-0.20210920141513-ddc36f3d5f60 h1:OuJ+swDiof5XLWNNsSKqSQpIcdpS+QYBZJ3lr/B+5U4=
+github.com/fluxcd/go-git-providers v0.2.1-0.20210920141513-ddc36f3d5f60/go.mod h1:kByvCO8EATmdOqHne60f0NsJUjsbOwcfADTj7RHGjcs=
 github.com/fluxcd/helm-controller/api v0.11.1 h1:7oanAnhcRdqrnALDGpZcg5iuDqwCv+jNTmGvSrgDyCo=
 github.com/fluxcd/helm-controller/api v0.11.1/go.mod h1:nt5YdVS+jWXDSbP3gAX3HII6oX+8ahrHD6og2ZVsnN4=
 github.com/fluxcd/kustomize-controller/api v0.13.2 h1:Dd+gryMtV1J6TuFvbHj50VFauUNOtC3Uowa5yxgZ+l0=

--- a/pkg/apputils/utils.go
+++ b/pkg/apputils/utils.go
@@ -144,7 +144,7 @@ func getGitClients(ctx context.Context, url, configUrl, namespace string, isHelm
 		return nil, nil, nil, fmt.Errorf("error getting target name: %w", err)
 	}
 
-	authsvc, err := getAuthService(ctx, providerUrl, dryRun)
+	authsvc, err := getAuthService(ctx, normalizedUrl, dryRun)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("error creating auth service: %w", err)
 	}
@@ -180,7 +180,7 @@ func getGitClients(ctx context.Context, url, configUrl, namespace string, isHelm
 	return appClient, configClient, authsvc.GetGitProvider(), nil
 }
 
-func getAuthService(ctx context.Context, providerUrl string, dryRun bool) (auth.AuthService, error) {
+func getAuthService(ctx context.Context, normalizedUrl gitproviders.NormalizedRepoURL, dryRun bool) (auth.AuthService, error) {
 	var (
 		gitProvider gitproviders.GitProvider
 		err         error
@@ -191,7 +191,7 @@ func getAuthService(ctx context.Context, providerUrl string, dryRun bool) (auth.
 			return nil, fmt.Errorf("error creating git provider client: %w", err)
 		}
 	} else {
-		if gitProvider, err = auth.GetGitProvider(ctx, providerUrl); err != nil {
+		if gitProvider, err = auth.GetGitProvider(ctx, normalizedUrl); err != nil {
 			return nil, fmt.Errorf("error obtaining git provider token: %w", err)
 		}
 	}

--- a/pkg/apputils/utils.go
+++ b/pkg/apputils/utils.go
@@ -162,7 +162,11 @@ func getGitClients(ctx context.Context, url, configUrl, namespace string, isHelm
 	}
 
 	if isExternalConfig {
-		configRepoClient, configRepoErr := authsvc.CreateGitClient(ctx, normalizedUrl, targetName, namespace)
+		normalizedConfigUrl, err := gitproviders.NewNormalizedRepoURL(configUrl)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("error normalizing url: %w", err)
+		}
+		configRepoClient, configRepoErr := authsvc.CreateGitClient(ctx, normalizedConfigUrl, targetName, namespace)
 		if configRepoErr != nil {
 			return nil, nil, nil, configRepoErr
 		}

--- a/pkg/apputils/utils.go
+++ b/pkg/apputils/utils.go
@@ -14,7 +14,6 @@ import (
 	"github.com/weaveworks/weave-gitops/pkg/runner"
 	"github.com/weaveworks/weave-gitops/pkg/services/app"
 	"github.com/weaveworks/weave-gitops/pkg/services/auth"
-	"github.com/weaveworks/weave-gitops/pkg/utils"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -163,9 +162,9 @@ func getGitClients(ctx context.Context, url, configUrl, namespace string, isHelm
 	}
 
 	if isExternalConfig {
-		configRepoClient, err := authsvc.CreateGitClient(ctx, targetName, namespace, utils.SanitizeRepoUrl(configUrl))
-		if err != nil {
-			return nil, nil, nil, err
+		configRepoClient, configRepoErr := authsvc.CreateGitClient(ctx, targetName, namespace, configUrl)
+		if configRepoErr != nil {
+			return nil, nil, nil, configRepoErr
 		}
 
 		configClient = configRepoClient

--- a/pkg/apputils/utils.go
+++ b/pkg/apputils/utils.go
@@ -153,16 +153,16 @@ func getGitClients(ctx context.Context, url, configUrl, namespace string, isHelm
 
 	if !isHelmRepository {
 		// We need to do this even if we have an external config to set up the deploy key for the app repo
-		appRepoClient, err := authsvc.CreateGitClient(ctx, targetName, namespace, utils.SanitizeRepoUrl(url))
-		if err != nil {
-			return nil, nil, nil, err
+		appRepoClient, appRepoErr := authsvc.CreateGitClient(ctx, normalizedUrl, targetName, namespace)
+		if appRepoErr != nil {
+			return nil, nil, nil, appRepoErr
 		}
 
 		appClient = appRepoClient
 	}
 
 	if isExternalConfig {
-		configRepoClient, configRepoErr := authsvc.CreateGitClient(ctx, targetName, namespace, configUrl)
+		configRepoClient, configRepoErr := authsvc.CreateGitClient(ctx, normalizedUrl, targetName, namespace)
 		if configRepoErr != nil {
 			return nil, nil, nil, configRepoErr
 		}

--- a/pkg/apputils/utils.go
+++ b/pkg/apputils/utils.go
@@ -166,6 +166,7 @@ func getGitClients(ctx context.Context, url, configUrl, namespace string, isHelm
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("error normalizing url: %w", err)
 		}
+
 		configRepoClient, configRepoErr := authsvc.CreateGitClient(ctx, normalizedConfigUrl, targetName, namespace)
 		if configRepoErr != nil {
 			return nil, nil, nil, configRepoErr

--- a/pkg/apputils/utils.go
+++ b/pkg/apputils/utils.go
@@ -130,6 +130,11 @@ func getGitClients(ctx context.Context, url, configUrl, namespace string, isHelm
 		return nil, nil, nil, nil
 	}
 
+	normalizedUrl, err := gitproviders.NewNormalizedRepoURL(providerUrl)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("error normalizing url: %w", err)
+	}
+
 	kube, _, err := kube.NewKubeHTTPClient()
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("error creating k8s http client: %w", err)

--- a/pkg/git/gogit.go
+++ b/pkg/git/gogit.go
@@ -34,7 +34,6 @@ import (
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/go-git/go-git/v5/plumbing/transport"
-	"github.com/weaveworks/weave-gitops/pkg/utils"
 )
 
 type GoGit struct {
@@ -335,7 +334,7 @@ func (g *GoGit) GetRemoteUrl(dir string, remoteName string) (string, error) {
 		return "", fmt.Errorf("remote config in %s does not have an url", dir)
 	}
 
-	return utils.SanitizeRepoUrl(urls[0]), nil
+	return urls[0], nil
 }
 
 func (g *GoGit) ValidateAccess(ctx context.Context, url string, branch string) error {

--- a/pkg/gitproviders/README.md
+++ b/pkg/gitproviders/README.md
@@ -20,7 +20,7 @@ Note: Only GITHUB_TOKEN is a must, the other can be set as needed.
 
 To initialize the recorder, use the function `getTestClientWithCassette`:
 ```go
-client, recorder, err := getTestClientWithCassette("CASSETTE_NAME")
+client, recorder, err := getTestClientWithCassette("CASSETTE_NAME", "provider name")
 ```
 
 - `client` is the object from `fluxcd/go-git-providers` that was injected with the recorder and makes the api calls.

--- a/pkg/gitproviders/README.md
+++ b/pkg/gitproviders/README.md
@@ -38,7 +38,7 @@ var _ = Describe("create github repo", func() {
 	var err error
 	BeforeEach(func() {
 	    var client gitprovider.Client
-		client, recorder, err = getTestClientWithCassette("CASSETTE_ID")
+		client, recorder, err = getTestClientWithCassette("CASSETTE_ID", "provider name")
 		Expect(err).NotTo(HaveOccurred())
 		gitProvider = defaultGitProvider{
 			provider: client,

--- a/pkg/gitproviders/cache/gitlab_repo_group_exists.yaml
+++ b/pkg/gitproviders/cache/gitlab_repo_group_exists.yaml
@@ -1,0 +1,600 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers: {}
+    url: https://gitlab.com/api/v4/
+    method: GET
+  response:
+    body: '{"error":"404 Not Found"}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Ray:
+      - 68fcbf7dea992806-SLC
+      Content-Length:
+      - "25"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Sep 2021 20:12:10 GMT
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Gitlab-Lb:
+      - fe-15-lb-gprd
+      Gitlab-Sv:
+      - localhost
+      Ratelimit-Limit:
+      - "2000"
+      Ratelimit-Observed:
+      - "1"
+      Ratelimit-Remaining:
+      - "1999"
+      Ratelimit-Reset:
+      - "1631823190"
+      Ratelimit-Resettime:
+      - Thu, 16 Sep 2021 20:13:10 GMT
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Request-Id:
+      - 01FFR3STQFGP736199XTVMCM87
+      X-Runtime:
+      - "1.368908"
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Authorization:
+      - Bearer 3QcwbqArcVLJsJX1hCGa
+      User-Agent:
+      - go-gitlab
+    url: https://gitlab.com/api/v4/groups/weaveworks
+    method: GET
+  response:
+    body: '{"id":12950108,"web_url":"https://gitlab.com/groups/weaveworks","name":"weaveworks","path":"weaveworks","description":"","visibility":"private","share_with_group_lock":false,"require_two_factor_authentication":false,"two_factor_grace_period":48,"project_creation_level":"developer","auto_devops_enabled":null,"subgroup_creation_level":"maintainer","emails_disabled":null,"mentions_disabled":null,"lfs_enabled":true,"default_branch_protection":2,"avatar_url":null,"request_access_enabled":true,"full_name":"weaveworks","full_path":"weaveworks","created_at":"2021-08-06T15:46:38.421Z","parent_id":null,"ldap_cn":null,"ldap_access":null,"shared_with_groups":[],"runners_token":"h2iQ2g78zxhBARVnydwH","prevent_sharing_groups_outside_hierarchy":false,"projects":[{"id":29674239,"description":"Weave
+      Gitops test repo","name":"wego-test-app-fhyw7gy8","name_with_namespace":"weaveworks
+      / wego-test-app-fhyw7gy8","path":"wego-test-app-fhyw7gy8","path_with_namespace":"weaveworks/wego-test-app-fhyw7gy8","created_at":"2021-09-16T19:32:01.189Z","default_branch":"main","tag_list":[],"topics":[],"ssh_url_to_repo":"git@gitlab.com:weaveworks/wego-test-app-fhyw7gy8.git","http_url_to_repo":"https://gitlab.com/weaveworks/wego-test-app-fhyw7gy8.git","web_url":"https://gitlab.com/weaveworks/wego-test-app-fhyw7gy8","readme_url":"https://gitlab.com/weaveworks/wego-test-app-fhyw7gy8/-/blob/main/README.md","avatar_url":null,"forks_count":0,"star_count":0,"last_activity_at":"2021-09-16T19:32:01.189Z","namespace":{"id":12950108,"name":"weaveworks","path":"weaveworks","kind":"group","full_path":"weaveworks","parent_id":null,"avatar_url":null,"web_url":"https://gitlab.com/groups/weaveworks"},"container_registry_image_prefix":"registry.gitlab.com/weaveworks/wego-test-app-fhyw7gy8","_links":{"self":"https://gitlab.com/api/v4/projects/29674239","issues":"https://gitlab.com/api/v4/projects/29674239/issues","merge_requests":"https://gitlab.com/api/v4/projects/29674239/merge_requests","repo_branches":"https://gitlab.com/api/v4/projects/29674239/repository/branches","labels":"https://gitlab.com/api/v4/projects/29674239/labels","events":"https://gitlab.com/api/v4/projects/29674239/events","members":"https://gitlab.com/api/v4/projects/29674239/members"},"packages_enabled":true,"empty_repo":false,"archived":false,"visibility":"private","resolve_outdated_diff_discussions":false,"container_expiration_policy":{"cadence":"1d","enabled":false,"keep_n":10,"older_than":"90d","name_regex":".*","name_regex_keep":null,"next_run_at":"2021-09-17T19:32:01.224Z"},"issues_enabled":true,"merge_requests_enabled":true,"wiki_enabled":true,"jobs_enabled":true,"snippets_enabled":true,"container_registry_enabled":true,"service_desk_enabled":true,"service_desk_address":"incoming+weaveworks-wego-test-app-fhyw7gy8-29674239-issue-@incoming.gitlab.com","can_create_merge_request_in":true,"issues_access_level":"enabled","repository_access_level":"enabled","merge_requests_access_level":"enabled","forking_access_level":"enabled","wiki_access_level":"enabled","builds_access_level":"enabled","snippets_access_level":"enabled","pages_access_level":"private","operations_access_level":"enabled","analytics_access_level":"enabled","container_registry_access_level":"enabled","emails_disabled":null,"shared_runners_enabled":true,"lfs_enabled":true,"creator_id":9448734,"import_status":"none","open_issues_count":0,"ci_default_git_depth":50,"ci_forward_deployment_enabled":true,"ci_job_token_scope_enabled":false,"public_jobs":true,"build_timeout":3600,"auto_cancel_pending_pipelines":"enabled","build_coverage_regex":null,"ci_config_path":"","shared_with_groups":[],"only_allow_merge_if_pipeline_succeeds":false,"allow_merge_on_skipped_pipeline":null,"restrict_user_defined_variables":false,"request_access_enabled":true,"only_allow_merge_if_all_discussions_are_resolved":false,"remove_source_branch_after_merge":true,"printing_merge_request_link_enabled":true,"merge_method":"merge","squash_option":"default_off","suggestion_commit_message":null,"auto_devops_enabled":false,"auto_devops_deploy_strategy":"continuous","autoclose_referenced_issues":true,"keep_latest_artifact":true,"external_authorization_classification_label":"","requirements_enabled":false,"security_and_compliance_enabled":true,"compliance_frameworks":[]},{"id":29672490,"description":"Weave
+      Gitops test repo","name":"wego-test-app-e638ymz4","name_with_namespace":"weaveworks
+      / wego-test-app-e638ymz4","path":"wego-test-app-e638ymz4","path_with_namespace":"weaveworks/wego-test-app-e638ymz4","created_at":"2021-09-16T18:04:06.216Z","default_branch":"main","tag_list":[],"topics":[],"ssh_url_to_repo":"git@gitlab.com:weaveworks/wego-test-app-e638ymz4.git","http_url_to_repo":"https://gitlab.com/weaveworks/wego-test-app-e638ymz4.git","web_url":"https://gitlab.com/weaveworks/wego-test-app-e638ymz4","readme_url":"https://gitlab.com/weaveworks/wego-test-app-e638ymz4/-/blob/main/README.md","avatar_url":null,"forks_count":0,"star_count":0,"last_activity_at":"2021-09-16T18:04:06.216Z","namespace":{"id":12950108,"name":"weaveworks","path":"weaveworks","kind":"group","full_path":"weaveworks","parent_id":null,"avatar_url":null,"web_url":"https://gitlab.com/groups/weaveworks"},"container_registry_image_prefix":"registry.gitlab.com/weaveworks/wego-test-app-e638ymz4","_links":{"self":"https://gitlab.com/api/v4/projects/29672490","issues":"https://gitlab.com/api/v4/projects/29672490/issues","merge_requests":"https://gitlab.com/api/v4/projects/29672490/merge_requests","repo_branches":"https://gitlab.com/api/v4/projects/29672490/repository/branches","labels":"https://gitlab.com/api/v4/projects/29672490/labels","events":"https://gitlab.com/api/v4/projects/29672490/events","members":"https://gitlab.com/api/v4/projects/29672490/members"},"packages_enabled":true,"empty_repo":false,"archived":false,"visibility":"private","resolve_outdated_diff_discussions":false,"container_expiration_policy":{"cadence":"1d","enabled":false,"keep_n":10,"older_than":"90d","name_regex":".*","name_regex_keep":null,"next_run_at":"2021-09-17T18:04:06.265Z"},"issues_enabled":true,"merge_requests_enabled":true,"wiki_enabled":true,"jobs_enabled":true,"snippets_enabled":true,"container_registry_enabled":true,"service_desk_enabled":true,"service_desk_address":"incoming+weaveworks-wego-test-app-e638ymz4-29672490-issue-@incoming.gitlab.com","can_create_merge_request_in":true,"issues_access_level":"enabled","repository_access_level":"enabled","merge_requests_access_level":"enabled","forking_access_level":"enabled","wiki_access_level":"enabled","builds_access_level":"enabled","snippets_access_level":"enabled","pages_access_level":"private","operations_access_level":"enabled","analytics_access_level":"enabled","container_registry_access_level":"enabled","emails_disabled":null,"shared_runners_enabled":true,"lfs_enabled":true,"creator_id":9448734,"import_status":"none","open_issues_count":0,"ci_default_git_depth":50,"ci_forward_deployment_enabled":true,"ci_job_token_scope_enabled":false,"public_jobs":true,"build_timeout":3600,"auto_cancel_pending_pipelines":"enabled","build_coverage_regex":null,"ci_config_path":"","shared_with_groups":[],"only_allow_merge_if_pipeline_succeeds":false,"allow_merge_on_skipped_pipeline":null,"restrict_user_defined_variables":false,"request_access_enabled":true,"only_allow_merge_if_all_discussions_are_resolved":false,"remove_source_branch_after_merge":true,"printing_merge_request_link_enabled":true,"merge_method":"merge","squash_option":"default_off","suggestion_commit_message":null,"auto_devops_enabled":false,"auto_devops_deploy_strategy":"continuous","autoclose_referenced_issues":true,"keep_latest_artifact":true,"external_authorization_classification_label":"","requirements_enabled":false,"security_and_compliance_enabled":true,"compliance_frameworks":[]},{"id":29671793,"description":"Weave
+      Gitops test repo","name":"wego-test-app-o7pawhqu","name_with_namespace":"weaveworks
+      / wego-test-app-o7pawhqu","path":"wego-test-app-o7pawhqu","path_with_namespace":"weaveworks/wego-test-app-o7pawhqu","created_at":"2021-09-16T17:19:38.589Z","default_branch":"main","tag_list":[],"topics":[],"ssh_url_to_repo":"git@gitlab.com:weaveworks/wego-test-app-o7pawhqu.git","http_url_to_repo":"https://gitlab.com/weaveworks/wego-test-app-o7pawhqu.git","web_url":"https://gitlab.com/weaveworks/wego-test-app-o7pawhqu","readme_url":"https://gitlab.com/weaveworks/wego-test-app-o7pawhqu/-/blob/main/README.md","avatar_url":null,"forks_count":0,"star_count":0,"last_activity_at":"2021-09-16T17:19:38.589Z","namespace":{"id":12950108,"name":"weaveworks","path":"weaveworks","kind":"group","full_path":"weaveworks","parent_id":null,"avatar_url":null,"web_url":"https://gitlab.com/groups/weaveworks"},"container_registry_image_prefix":"registry.gitlab.com/weaveworks/wego-test-app-o7pawhqu","_links":{"self":"https://gitlab.com/api/v4/projects/29671793","issues":"https://gitlab.com/api/v4/projects/29671793/issues","merge_requests":"https://gitlab.com/api/v4/projects/29671793/merge_requests","repo_branches":"https://gitlab.com/api/v4/projects/29671793/repository/branches","labels":"https://gitlab.com/api/v4/projects/29671793/labels","events":"https://gitlab.com/api/v4/projects/29671793/events","members":"https://gitlab.com/api/v4/projects/29671793/members"},"packages_enabled":true,"empty_repo":false,"archived":false,"visibility":"private","resolve_outdated_diff_discussions":false,"container_expiration_policy":{"cadence":"1d","enabled":false,"keep_n":10,"older_than":"90d","name_regex":".*","name_regex_keep":null,"next_run_at":"2021-09-17T17:19:38.611Z"},"issues_enabled":true,"merge_requests_enabled":true,"wiki_enabled":true,"jobs_enabled":true,"snippets_enabled":true,"container_registry_enabled":true,"service_desk_enabled":true,"service_desk_address":"incoming+weaveworks-wego-test-app-o7pawhqu-29671793-issue-@incoming.gitlab.com","can_create_merge_request_in":true,"issues_access_level":"enabled","repository_access_level":"enabled","merge_requests_access_level":"enabled","forking_access_level":"enabled","wiki_access_level":"enabled","builds_access_level":"enabled","snippets_access_level":"enabled","pages_access_level":"private","operations_access_level":"enabled","analytics_access_level":"enabled","container_registry_access_level":"enabled","emails_disabled":null,"shared_runners_enabled":true,"lfs_enabled":true,"creator_id":9448734,"import_status":"none","open_issues_count":0,"ci_default_git_depth":50,"ci_forward_deployment_enabled":true,"ci_job_token_scope_enabled":false,"public_jobs":true,"build_timeout":3600,"auto_cancel_pending_pipelines":"enabled","build_coverage_regex":null,"ci_config_path":"","shared_with_groups":[],"only_allow_merge_if_pipeline_succeeds":false,"allow_merge_on_skipped_pipeline":null,"restrict_user_defined_variables":false,"request_access_enabled":true,"only_allow_merge_if_all_discussions_are_resolved":false,"remove_source_branch_after_merge":true,"printing_merge_request_link_enabled":true,"merge_method":"merge","squash_option":"default_off","suggestion_commit_message":null,"auto_devops_enabled":false,"auto_devops_deploy_strategy":"continuous","autoclose_referenced_issues":true,"keep_latest_artifact":true,"external_authorization_classification_label":"","requirements_enabled":false,"security_and_compliance_enabled":true,"compliance_frameworks":[]},{"id":29671435,"description":"Weave
+      Gitops test repo","name":"wego-test-app-0crtft9p","name_with_namespace":"weaveworks
+      / wego-test-app-0crtft9p","path":"wego-test-app-0crtft9p","path_with_namespace":"weaveworks/wego-test-app-0crtft9p","created_at":"2021-09-16T17:01:19.553Z","default_branch":"main","tag_list":[],"topics":[],"ssh_url_to_repo":"git@gitlab.com:weaveworks/wego-test-app-0crtft9p.git","http_url_to_repo":"https://gitlab.com/weaveworks/wego-test-app-0crtft9p.git","web_url":"https://gitlab.com/weaveworks/wego-test-app-0crtft9p","readme_url":"https://gitlab.com/weaveworks/wego-test-app-0crtft9p/-/blob/main/README.md","avatar_url":null,"forks_count":0,"star_count":0,"last_activity_at":"2021-09-16T17:01:19.553Z","namespace":{"id":12950108,"name":"weaveworks","path":"weaveworks","kind":"group","full_path":"weaveworks","parent_id":null,"avatar_url":null,"web_url":"https://gitlab.com/groups/weaveworks"},"container_registry_image_prefix":"registry.gitlab.com/weaveworks/wego-test-app-0crtft9p","_links":{"self":"https://gitlab.com/api/v4/projects/29671435","issues":"https://gitlab.com/api/v4/projects/29671435/issues","merge_requests":"https://gitlab.com/api/v4/projects/29671435/merge_requests","repo_branches":"https://gitlab.com/api/v4/projects/29671435/repository/branches","labels":"https://gitlab.com/api/v4/projects/29671435/labels","events":"https://gitlab.com/api/v4/projects/29671435/events","members":"https://gitlab.com/api/v4/projects/29671435/members"},"packages_enabled":true,"empty_repo":false,"archived":false,"visibility":"private","resolve_outdated_diff_discussions":false,"container_expiration_policy":{"cadence":"1d","enabled":false,"keep_n":10,"older_than":"90d","name_regex":".*","name_regex_keep":null,"next_run_at":"2021-09-17T17:01:19.595Z"},"issues_enabled":true,"merge_requests_enabled":true,"wiki_enabled":true,"jobs_enabled":true,"snippets_enabled":true,"container_registry_enabled":true,"service_desk_enabled":true,"service_desk_address":"incoming+weaveworks-wego-test-app-0crtft9p-29671435-issue-@incoming.gitlab.com","can_create_merge_request_in":true,"issues_access_level":"enabled","repository_access_level":"enabled","merge_requests_access_level":"enabled","forking_access_level":"enabled","wiki_access_level":"enabled","builds_access_level":"enabled","snippets_access_level":"enabled","pages_access_level":"private","operations_access_level":"enabled","analytics_access_level":"enabled","container_registry_access_level":"enabled","emails_disabled":null,"shared_runners_enabled":true,"lfs_enabled":true,"creator_id":9448734,"import_status":"none","open_issues_count":0,"ci_default_git_depth":50,"ci_forward_deployment_enabled":true,"ci_job_token_scope_enabled":false,"public_jobs":true,"build_timeout":3600,"auto_cancel_pending_pipelines":"enabled","build_coverage_regex":null,"ci_config_path":"","shared_with_groups":[],"only_allow_merge_if_pipeline_succeeds":false,"allow_merge_on_skipped_pipeline":null,"restrict_user_defined_variables":false,"request_access_enabled":true,"only_allow_merge_if_all_discussions_are_resolved":false,"remove_source_branch_after_merge":true,"printing_merge_request_link_enabled":true,"merge_method":"merge","squash_option":"default_off","suggestion_commit_message":null,"auto_devops_enabled":false,"auto_devops_deploy_strategy":"continuous","autoclose_referenced_issues":true,"keep_latest_artifact":true,"external_authorization_classification_label":"","requirements_enabled":false,"security_and_compliance_enabled":true,"compliance_frameworks":[]},{"id":29671183,"description":"Weave
+      Gitops test repo","name":"wego-test-app-0l8jm1or","name_with_namespace":"weaveworks
+      / wego-test-app-0l8jm1or","path":"wego-test-app-0l8jm1or","path_with_namespace":"weaveworks/wego-test-app-0l8jm1or","created_at":"2021-09-16T16:47:11.202Z","default_branch":"main","tag_list":[],"topics":[],"ssh_url_to_repo":"git@gitlab.com:weaveworks/wego-test-app-0l8jm1or.git","http_url_to_repo":"https://gitlab.com/weaveworks/wego-test-app-0l8jm1or.git","web_url":"https://gitlab.com/weaveworks/wego-test-app-0l8jm1or","readme_url":"https://gitlab.com/weaveworks/wego-test-app-0l8jm1or/-/blob/main/README.md","avatar_url":null,"forks_count":0,"star_count":0,"last_activity_at":"2021-09-16T16:47:11.202Z","namespace":{"id":12950108,"name":"weaveworks","path":"weaveworks","kind":"group","full_path":"weaveworks","parent_id":null,"avatar_url":null,"web_url":"https://gitlab.com/groups/weaveworks"},"container_registry_image_prefix":"registry.gitlab.com/weaveworks/wego-test-app-0l8jm1or","_links":{"self":"https://gitlab.com/api/v4/projects/29671183","issues":"https://gitlab.com/api/v4/projects/29671183/issues","merge_requests":"https://gitlab.com/api/v4/projects/29671183/merge_requests","repo_branches":"https://gitlab.com/api/v4/projects/29671183/repository/branches","labels":"https://gitlab.com/api/v4/projects/29671183/labels","events":"https://gitlab.com/api/v4/projects/29671183/events","members":"https://gitlab.com/api/v4/projects/29671183/members"},"packages_enabled":true,"empty_repo":false,"archived":false,"visibility":"private","resolve_outdated_diff_discussions":false,"container_expiration_policy":{"cadence":"1d","enabled":false,"keep_n":10,"older_than":"90d","name_regex":".*","name_regex_keep":null,"next_run_at":"2021-09-17T16:47:11.233Z"},"issues_enabled":true,"merge_requests_enabled":true,"wiki_enabled":true,"jobs_enabled":true,"snippets_enabled":true,"container_registry_enabled":true,"service_desk_enabled":true,"service_desk_address":"incoming+weaveworks-wego-test-app-0l8jm1or-29671183-issue-@incoming.gitlab.com","can_create_merge_request_in":true,"issues_access_level":"enabled","repository_access_level":"enabled","merge_requests_access_level":"enabled","forking_access_level":"enabled","wiki_access_level":"enabled","builds_access_level":"enabled","snippets_access_level":"enabled","pages_access_level":"private","operations_access_level":"enabled","analytics_access_level":"enabled","container_registry_access_level":"enabled","emails_disabled":null,"shared_runners_enabled":true,"lfs_enabled":true,"creator_id":9448734,"import_status":"none","open_issues_count":0,"ci_default_git_depth":50,"ci_forward_deployment_enabled":true,"ci_job_token_scope_enabled":false,"public_jobs":true,"build_timeout":3600,"auto_cancel_pending_pipelines":"enabled","build_coverage_regex":null,"ci_config_path":"","shared_with_groups":[],"only_allow_merge_if_pipeline_succeeds":false,"allow_merge_on_skipped_pipeline":null,"restrict_user_defined_variables":false,"request_access_enabled":true,"only_allow_merge_if_all_discussions_are_resolved":false,"remove_source_branch_after_merge":true,"printing_merge_request_link_enabled":true,"merge_method":"merge","squash_option":"default_off","suggestion_commit_message":null,"auto_devops_enabled":false,"auto_devops_deploy_strategy":"continuous","autoclose_referenced_issues":true,"keep_latest_artifact":true,"external_authorization_classification_label":"","requirements_enabled":false,"security_and_compliance_enabled":true,"compliance_frameworks":[]},{"id":29437553,"description":"","name":"nginxgroup","name_with_namespace":"weaveworks
+      / nginxgroup","path":"nginxgroup","path_with_namespace":"weaveworks/nginxgroup","created_at":"2021-09-07T19:44:23.068Z","default_branch":"main","tag_list":[],"topics":[],"ssh_url_to_repo":"git@gitlab.com:weaveworks/nginxgroup.git","http_url_to_repo":"https://gitlab.com/weaveworks/nginxgroup.git","web_url":"https://gitlab.com/weaveworks/nginxgroup","readme_url":null,"avatar_url":null,"forks_count":0,"star_count":0,"last_activity_at":"2021-09-14T20:40:53.551Z","namespace":{"id":12950108,"name":"weaveworks","path":"weaveworks","kind":"group","full_path":"weaveworks","parent_id":null,"avatar_url":null,"web_url":"https://gitlab.com/groups/weaveworks"},"container_registry_image_prefix":"registry.gitlab.com/weaveworks/nginxgroup","_links":{"self":"https://gitlab.com/api/v4/projects/29437553","issues":"https://gitlab.com/api/v4/projects/29437553/issues","merge_requests":"https://gitlab.com/api/v4/projects/29437553/merge_requests","repo_branches":"https://gitlab.com/api/v4/projects/29437553/repository/branches","labels":"https://gitlab.com/api/v4/projects/29437553/labels","events":"https://gitlab.com/api/v4/projects/29437553/events","members":"https://gitlab.com/api/v4/projects/29437553/members"},"packages_enabled":true,"empty_repo":false,"archived":false,"visibility":"private","resolve_outdated_diff_discussions":false,"container_expiration_policy":{"cadence":"1d","enabled":false,"keep_n":10,"older_than":"90d","name_regex":".*","name_regex_keep":null,"next_run_at":"2021-09-08T19:44:23.091Z"},"issues_enabled":true,"merge_requests_enabled":true,"wiki_enabled":true,"jobs_enabled":true,"snippets_enabled":true,"container_registry_enabled":true,"service_desk_enabled":true,"service_desk_address":"incoming+weaveworks-nginxgroup-29437553-issue-@incoming.gitlab.com","can_create_merge_request_in":true,"issues_access_level":"enabled","repository_access_level":"enabled","merge_requests_access_level":"enabled","forking_access_level":"enabled","wiki_access_level":"enabled","builds_access_level":"enabled","snippets_access_level":"enabled","pages_access_level":"private","operations_access_level":"enabled","analytics_access_level":"enabled","container_registry_access_level":"enabled","emails_disabled":null,"shared_runners_enabled":true,"lfs_enabled":true,"creator_id":9448734,"import_status":"none","open_issues_count":0,"ci_default_git_depth":50,"ci_forward_deployment_enabled":true,"ci_job_token_scope_enabled":false,"public_jobs":true,"build_timeout":3600,"auto_cancel_pending_pipelines":"enabled","build_coverage_regex":null,"ci_config_path":"","shared_with_groups":[],"only_allow_merge_if_pipeline_succeeds":false,"allow_merge_on_skipped_pipeline":null,"restrict_user_defined_variables":false,"request_access_enabled":true,"only_allow_merge_if_all_discussions_are_resolved":false,"remove_source_branch_after_merge":true,"printing_merge_request_link_enabled":true,"merge_method":"merge","squash_option":"default_off","suggestion_commit_message":null,"auto_devops_enabled":false,"auto_devops_deploy_strategy":"continuous","autoclose_referenced_issues":true,"keep_latest_artifact":true,"external_authorization_classification_label":"","requirements_enabled":false,"security_and_compliance_enabled":true,"compliance_frameworks":[]},{"id":28692370,"description":"test","name":"mre","name_with_namespace":"weaveworks
+      / mre","path":"mre","path_with_namespace":"weaveworks/mre","created_at":"2021-08-06T21:42:06.180Z","default_branch":"main","tag_list":[],"topics":[],"ssh_url_to_repo":"git@gitlab.com:weaveworks/mre.git","http_url_to_repo":"https://gitlab.com/weaveworks/mre.git","web_url":"https://gitlab.com/weaveworks/mre","readme_url":"https://gitlab.com/weaveworks/mre/-/blob/main/README.md","avatar_url":null,"forks_count":0,"star_count":0,"last_activity_at":"2021-08-06T21:42:06.180Z","namespace":{"id":12950108,"name":"weaveworks","path":"weaveworks","kind":"group","full_path":"weaveworks","parent_id":null,"avatar_url":null,"web_url":"https://gitlab.com/groups/weaveworks"},"container_registry_image_prefix":"registry.gitlab.com/weaveworks/mre","_links":{"self":"https://gitlab.com/api/v4/projects/28692370","issues":"https://gitlab.com/api/v4/projects/28692370/issues","merge_requests":"https://gitlab.com/api/v4/projects/28692370/merge_requests","repo_branches":"https://gitlab.com/api/v4/projects/28692370/repository/branches","labels":"https://gitlab.com/api/v4/projects/28692370/labels","events":"https://gitlab.com/api/v4/projects/28692370/events","members":"https://gitlab.com/api/v4/projects/28692370/members"},"packages_enabled":true,"empty_repo":false,"archived":false,"visibility":"private","resolve_outdated_diff_discussions":false,"container_expiration_policy":{"cadence":"1d","enabled":false,"keep_n":10,"older_than":"90d","name_regex":".*","name_regex_keep":null,"next_run_at":"2021-08-07T21:42:06.209Z"},"issues_enabled":true,"merge_requests_enabled":true,"wiki_enabled":true,"jobs_enabled":true,"snippets_enabled":true,"container_registry_enabled":true,"service_desk_enabled":true,"service_desk_address":"incoming+weaveworks-mre-28692370-issue-@incoming.gitlab.com","can_create_merge_request_in":true,"issues_access_level":"enabled","repository_access_level":"enabled","merge_requests_access_level":"enabled","forking_access_level":"enabled","wiki_access_level":"enabled","builds_access_level":"enabled","snippets_access_level":"enabled","pages_access_level":"private","operations_access_level":"enabled","analytics_access_level":"enabled","container_registry_access_level":"enabled","emails_disabled":null,"shared_runners_enabled":true,"lfs_enabled":true,"creator_id":9463163,"import_status":"none","open_issues_count":0,"ci_default_git_depth":50,"ci_forward_deployment_enabled":true,"ci_job_token_scope_enabled":false,"public_jobs":true,"build_timeout":3600,"auto_cancel_pending_pipelines":"enabled","build_coverage_regex":null,"ci_config_path":"","shared_with_groups":[],"only_allow_merge_if_pipeline_succeeds":false,"allow_merge_on_skipped_pipeline":null,"restrict_user_defined_variables":false,"request_access_enabled":true,"only_allow_merge_if_all_discussions_are_resolved":false,"remove_source_branch_after_merge":true,"printing_merge_request_link_enabled":true,"merge_method":"merge","squash_option":"default_off","suggestion_commit_message":null,"auto_devops_enabled":false,"auto_devops_deploy_strategy":"continuous","autoclose_referenced_issues":true,"keep_latest_artifact":true,"external_authorization_classification_label":"","requirements_enabled":false,"security_and_compliance_enabled":true,"compliance_frameworks":[]}],"shared_projects":[],"shared_runners_minutes_limit":null,"extra_shared_runners_minutes_limit":null,"prevent_forking_outside_group":null}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Ray:
+      - 68fcbf87bdd82806-SLC
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Sep 2021 20:12:11 GMT
+      Etag:
+      - W/"8f85c1468c3b835d6fe7eb7072e105e3"
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Gitlab-Lb:
+      - fe-16-lb-gprd
+      Gitlab-Sv:
+      - localhost
+      Ratelimit-Limit:
+      - "2000"
+      Ratelimit-Observed:
+      - "2"
+      Ratelimit-Remaining:
+      - "1998"
+      Ratelimit-Reset:
+      - "1631823191"
+      Ratelimit-Resettime:
+      - Thu, 16 Sep 2021 20:13:11 GMT
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Request-Id:
+      - 01FFR3SW8RJ576QJ1FQ8BT2S1X
+      X-Runtime:
+      - "0.320516"
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Authorization:
+      - Bearer 3QcwbqArcVLJsJX1hCGa
+      User-Agent:
+      - go-gitlab
+    url: https://gitlab.com/api/v4/groups/weaveworks
+    method: GET
+  response:
+    body: '{"id":12950108,"web_url":"https://gitlab.com/groups/weaveworks","name":"weaveworks","path":"weaveworks","description":"","visibility":"private","share_with_group_lock":false,"require_two_factor_authentication":false,"two_factor_grace_period":48,"project_creation_level":"developer","auto_devops_enabled":null,"subgroup_creation_level":"maintainer","emails_disabled":null,"mentions_disabled":null,"lfs_enabled":true,"default_branch_protection":2,"avatar_url":null,"request_access_enabled":true,"full_name":"weaveworks","full_path":"weaveworks","created_at":"2021-08-06T15:46:38.421Z","parent_id":null,"ldap_cn":null,"ldap_access":null,"shared_with_groups":[],"runners_token":"h2iQ2g78zxhBARVnydwH","prevent_sharing_groups_outside_hierarchy":false,"projects":[{"id":29674239,"description":"Weave
+      Gitops test repo","name":"wego-test-app-fhyw7gy8","name_with_namespace":"weaveworks
+      / wego-test-app-fhyw7gy8","path":"wego-test-app-fhyw7gy8","path_with_namespace":"weaveworks/wego-test-app-fhyw7gy8","created_at":"2021-09-16T19:32:01.189Z","default_branch":"main","tag_list":[],"topics":[],"ssh_url_to_repo":"git@gitlab.com:weaveworks/wego-test-app-fhyw7gy8.git","http_url_to_repo":"https://gitlab.com/weaveworks/wego-test-app-fhyw7gy8.git","web_url":"https://gitlab.com/weaveworks/wego-test-app-fhyw7gy8","readme_url":"https://gitlab.com/weaveworks/wego-test-app-fhyw7gy8/-/blob/main/README.md","avatar_url":null,"forks_count":0,"star_count":0,"last_activity_at":"2021-09-16T19:32:01.189Z","namespace":{"id":12950108,"name":"weaveworks","path":"weaveworks","kind":"group","full_path":"weaveworks","parent_id":null,"avatar_url":null,"web_url":"https://gitlab.com/groups/weaveworks"},"container_registry_image_prefix":"registry.gitlab.com/weaveworks/wego-test-app-fhyw7gy8","_links":{"self":"https://gitlab.com/api/v4/projects/29674239","issues":"https://gitlab.com/api/v4/projects/29674239/issues","merge_requests":"https://gitlab.com/api/v4/projects/29674239/merge_requests","repo_branches":"https://gitlab.com/api/v4/projects/29674239/repository/branches","labels":"https://gitlab.com/api/v4/projects/29674239/labels","events":"https://gitlab.com/api/v4/projects/29674239/events","members":"https://gitlab.com/api/v4/projects/29674239/members"},"packages_enabled":true,"empty_repo":false,"archived":false,"visibility":"private","resolve_outdated_diff_discussions":false,"container_expiration_policy":{"cadence":"1d","enabled":false,"keep_n":10,"older_than":"90d","name_regex":".*","name_regex_keep":null,"next_run_at":"2021-09-17T19:32:01.224Z"},"issues_enabled":true,"merge_requests_enabled":true,"wiki_enabled":true,"jobs_enabled":true,"snippets_enabled":true,"container_registry_enabled":true,"service_desk_enabled":true,"service_desk_address":"incoming+weaveworks-wego-test-app-fhyw7gy8-29674239-issue-@incoming.gitlab.com","can_create_merge_request_in":true,"issues_access_level":"enabled","repository_access_level":"enabled","merge_requests_access_level":"enabled","forking_access_level":"enabled","wiki_access_level":"enabled","builds_access_level":"enabled","snippets_access_level":"enabled","pages_access_level":"private","operations_access_level":"enabled","analytics_access_level":"enabled","container_registry_access_level":"enabled","emails_disabled":null,"shared_runners_enabled":true,"lfs_enabled":true,"creator_id":9448734,"import_status":"none","open_issues_count":0,"ci_default_git_depth":50,"ci_forward_deployment_enabled":true,"ci_job_token_scope_enabled":false,"public_jobs":true,"build_timeout":3600,"auto_cancel_pending_pipelines":"enabled","build_coverage_regex":null,"ci_config_path":"","shared_with_groups":[],"only_allow_merge_if_pipeline_succeeds":false,"allow_merge_on_skipped_pipeline":null,"restrict_user_defined_variables":false,"request_access_enabled":true,"only_allow_merge_if_all_discussions_are_resolved":false,"remove_source_branch_after_merge":true,"printing_merge_request_link_enabled":true,"merge_method":"merge","squash_option":"default_off","suggestion_commit_message":null,"auto_devops_enabled":false,"auto_devops_deploy_strategy":"continuous","autoclose_referenced_issues":true,"keep_latest_artifact":true,"external_authorization_classification_label":"","requirements_enabled":false,"security_and_compliance_enabled":true,"compliance_frameworks":[]},{"id":29672490,"description":"Weave
+      Gitops test repo","name":"wego-test-app-e638ymz4","name_with_namespace":"weaveworks
+      / wego-test-app-e638ymz4","path":"wego-test-app-e638ymz4","path_with_namespace":"weaveworks/wego-test-app-e638ymz4","created_at":"2021-09-16T18:04:06.216Z","default_branch":"main","tag_list":[],"topics":[],"ssh_url_to_repo":"git@gitlab.com:weaveworks/wego-test-app-e638ymz4.git","http_url_to_repo":"https://gitlab.com/weaveworks/wego-test-app-e638ymz4.git","web_url":"https://gitlab.com/weaveworks/wego-test-app-e638ymz4","readme_url":"https://gitlab.com/weaveworks/wego-test-app-e638ymz4/-/blob/main/README.md","avatar_url":null,"forks_count":0,"star_count":0,"last_activity_at":"2021-09-16T18:04:06.216Z","namespace":{"id":12950108,"name":"weaveworks","path":"weaveworks","kind":"group","full_path":"weaveworks","parent_id":null,"avatar_url":null,"web_url":"https://gitlab.com/groups/weaveworks"},"container_registry_image_prefix":"registry.gitlab.com/weaveworks/wego-test-app-e638ymz4","_links":{"self":"https://gitlab.com/api/v4/projects/29672490","issues":"https://gitlab.com/api/v4/projects/29672490/issues","merge_requests":"https://gitlab.com/api/v4/projects/29672490/merge_requests","repo_branches":"https://gitlab.com/api/v4/projects/29672490/repository/branches","labels":"https://gitlab.com/api/v4/projects/29672490/labels","events":"https://gitlab.com/api/v4/projects/29672490/events","members":"https://gitlab.com/api/v4/projects/29672490/members"},"packages_enabled":true,"empty_repo":false,"archived":false,"visibility":"private","resolve_outdated_diff_discussions":false,"container_expiration_policy":{"cadence":"1d","enabled":false,"keep_n":10,"older_than":"90d","name_regex":".*","name_regex_keep":null,"next_run_at":"2021-09-17T18:04:06.265Z"},"issues_enabled":true,"merge_requests_enabled":true,"wiki_enabled":true,"jobs_enabled":true,"snippets_enabled":true,"container_registry_enabled":true,"service_desk_enabled":true,"service_desk_address":"incoming+weaveworks-wego-test-app-e638ymz4-29672490-issue-@incoming.gitlab.com","can_create_merge_request_in":true,"issues_access_level":"enabled","repository_access_level":"enabled","merge_requests_access_level":"enabled","forking_access_level":"enabled","wiki_access_level":"enabled","builds_access_level":"enabled","snippets_access_level":"enabled","pages_access_level":"private","operations_access_level":"enabled","analytics_access_level":"enabled","container_registry_access_level":"enabled","emails_disabled":null,"shared_runners_enabled":true,"lfs_enabled":true,"creator_id":9448734,"import_status":"none","open_issues_count":0,"ci_default_git_depth":50,"ci_forward_deployment_enabled":true,"ci_job_token_scope_enabled":false,"public_jobs":true,"build_timeout":3600,"auto_cancel_pending_pipelines":"enabled","build_coverage_regex":null,"ci_config_path":"","shared_with_groups":[],"only_allow_merge_if_pipeline_succeeds":false,"allow_merge_on_skipped_pipeline":null,"restrict_user_defined_variables":false,"request_access_enabled":true,"only_allow_merge_if_all_discussions_are_resolved":false,"remove_source_branch_after_merge":true,"printing_merge_request_link_enabled":true,"merge_method":"merge","squash_option":"default_off","suggestion_commit_message":null,"auto_devops_enabled":false,"auto_devops_deploy_strategy":"continuous","autoclose_referenced_issues":true,"keep_latest_artifact":true,"external_authorization_classification_label":"","requirements_enabled":false,"security_and_compliance_enabled":true,"compliance_frameworks":[]},{"id":29671793,"description":"Weave
+      Gitops test repo","name":"wego-test-app-o7pawhqu","name_with_namespace":"weaveworks
+      / wego-test-app-o7pawhqu","path":"wego-test-app-o7pawhqu","path_with_namespace":"weaveworks/wego-test-app-o7pawhqu","created_at":"2021-09-16T17:19:38.589Z","default_branch":"main","tag_list":[],"topics":[],"ssh_url_to_repo":"git@gitlab.com:weaveworks/wego-test-app-o7pawhqu.git","http_url_to_repo":"https://gitlab.com/weaveworks/wego-test-app-o7pawhqu.git","web_url":"https://gitlab.com/weaveworks/wego-test-app-o7pawhqu","readme_url":"https://gitlab.com/weaveworks/wego-test-app-o7pawhqu/-/blob/main/README.md","avatar_url":null,"forks_count":0,"star_count":0,"last_activity_at":"2021-09-16T17:19:38.589Z","namespace":{"id":12950108,"name":"weaveworks","path":"weaveworks","kind":"group","full_path":"weaveworks","parent_id":null,"avatar_url":null,"web_url":"https://gitlab.com/groups/weaveworks"},"container_registry_image_prefix":"registry.gitlab.com/weaveworks/wego-test-app-o7pawhqu","_links":{"self":"https://gitlab.com/api/v4/projects/29671793","issues":"https://gitlab.com/api/v4/projects/29671793/issues","merge_requests":"https://gitlab.com/api/v4/projects/29671793/merge_requests","repo_branches":"https://gitlab.com/api/v4/projects/29671793/repository/branches","labels":"https://gitlab.com/api/v4/projects/29671793/labels","events":"https://gitlab.com/api/v4/projects/29671793/events","members":"https://gitlab.com/api/v4/projects/29671793/members"},"packages_enabled":true,"empty_repo":false,"archived":false,"visibility":"private","resolve_outdated_diff_discussions":false,"container_expiration_policy":{"cadence":"1d","enabled":false,"keep_n":10,"older_than":"90d","name_regex":".*","name_regex_keep":null,"next_run_at":"2021-09-17T17:19:38.611Z"},"issues_enabled":true,"merge_requests_enabled":true,"wiki_enabled":true,"jobs_enabled":true,"snippets_enabled":true,"container_registry_enabled":true,"service_desk_enabled":true,"service_desk_address":"incoming+weaveworks-wego-test-app-o7pawhqu-29671793-issue-@incoming.gitlab.com","can_create_merge_request_in":true,"issues_access_level":"enabled","repository_access_level":"enabled","merge_requests_access_level":"enabled","forking_access_level":"enabled","wiki_access_level":"enabled","builds_access_level":"enabled","snippets_access_level":"enabled","pages_access_level":"private","operations_access_level":"enabled","analytics_access_level":"enabled","container_registry_access_level":"enabled","emails_disabled":null,"shared_runners_enabled":true,"lfs_enabled":true,"creator_id":9448734,"import_status":"none","open_issues_count":0,"ci_default_git_depth":50,"ci_forward_deployment_enabled":true,"ci_job_token_scope_enabled":false,"public_jobs":true,"build_timeout":3600,"auto_cancel_pending_pipelines":"enabled","build_coverage_regex":null,"ci_config_path":"","shared_with_groups":[],"only_allow_merge_if_pipeline_succeeds":false,"allow_merge_on_skipped_pipeline":null,"restrict_user_defined_variables":false,"request_access_enabled":true,"only_allow_merge_if_all_discussions_are_resolved":false,"remove_source_branch_after_merge":true,"printing_merge_request_link_enabled":true,"merge_method":"merge","squash_option":"default_off","suggestion_commit_message":null,"auto_devops_enabled":false,"auto_devops_deploy_strategy":"continuous","autoclose_referenced_issues":true,"keep_latest_artifact":true,"external_authorization_classification_label":"","requirements_enabled":false,"security_and_compliance_enabled":true,"compliance_frameworks":[]},{"id":29671435,"description":"Weave
+      Gitops test repo","name":"wego-test-app-0crtft9p","name_with_namespace":"weaveworks
+      / wego-test-app-0crtft9p","path":"wego-test-app-0crtft9p","path_with_namespace":"weaveworks/wego-test-app-0crtft9p","created_at":"2021-09-16T17:01:19.553Z","default_branch":"main","tag_list":[],"topics":[],"ssh_url_to_repo":"git@gitlab.com:weaveworks/wego-test-app-0crtft9p.git","http_url_to_repo":"https://gitlab.com/weaveworks/wego-test-app-0crtft9p.git","web_url":"https://gitlab.com/weaveworks/wego-test-app-0crtft9p","readme_url":"https://gitlab.com/weaveworks/wego-test-app-0crtft9p/-/blob/main/README.md","avatar_url":null,"forks_count":0,"star_count":0,"last_activity_at":"2021-09-16T17:01:19.553Z","namespace":{"id":12950108,"name":"weaveworks","path":"weaveworks","kind":"group","full_path":"weaveworks","parent_id":null,"avatar_url":null,"web_url":"https://gitlab.com/groups/weaveworks"},"container_registry_image_prefix":"registry.gitlab.com/weaveworks/wego-test-app-0crtft9p","_links":{"self":"https://gitlab.com/api/v4/projects/29671435","issues":"https://gitlab.com/api/v4/projects/29671435/issues","merge_requests":"https://gitlab.com/api/v4/projects/29671435/merge_requests","repo_branches":"https://gitlab.com/api/v4/projects/29671435/repository/branches","labels":"https://gitlab.com/api/v4/projects/29671435/labels","events":"https://gitlab.com/api/v4/projects/29671435/events","members":"https://gitlab.com/api/v4/projects/29671435/members"},"packages_enabled":true,"empty_repo":false,"archived":false,"visibility":"private","resolve_outdated_diff_discussions":false,"container_expiration_policy":{"cadence":"1d","enabled":false,"keep_n":10,"older_than":"90d","name_regex":".*","name_regex_keep":null,"next_run_at":"2021-09-17T17:01:19.595Z"},"issues_enabled":true,"merge_requests_enabled":true,"wiki_enabled":true,"jobs_enabled":true,"snippets_enabled":true,"container_registry_enabled":true,"service_desk_enabled":true,"service_desk_address":"incoming+weaveworks-wego-test-app-0crtft9p-29671435-issue-@incoming.gitlab.com","can_create_merge_request_in":true,"issues_access_level":"enabled","repository_access_level":"enabled","merge_requests_access_level":"enabled","forking_access_level":"enabled","wiki_access_level":"enabled","builds_access_level":"enabled","snippets_access_level":"enabled","pages_access_level":"private","operations_access_level":"enabled","analytics_access_level":"enabled","container_registry_access_level":"enabled","emails_disabled":null,"shared_runners_enabled":true,"lfs_enabled":true,"creator_id":9448734,"import_status":"none","open_issues_count":0,"ci_default_git_depth":50,"ci_forward_deployment_enabled":true,"ci_job_token_scope_enabled":false,"public_jobs":true,"build_timeout":3600,"auto_cancel_pending_pipelines":"enabled","build_coverage_regex":null,"ci_config_path":"","shared_with_groups":[],"only_allow_merge_if_pipeline_succeeds":false,"allow_merge_on_skipped_pipeline":null,"restrict_user_defined_variables":false,"request_access_enabled":true,"only_allow_merge_if_all_discussions_are_resolved":false,"remove_source_branch_after_merge":true,"printing_merge_request_link_enabled":true,"merge_method":"merge","squash_option":"default_off","suggestion_commit_message":null,"auto_devops_enabled":false,"auto_devops_deploy_strategy":"continuous","autoclose_referenced_issues":true,"keep_latest_artifact":true,"external_authorization_classification_label":"","requirements_enabled":false,"security_and_compliance_enabled":true,"compliance_frameworks":[]},{"id":29671183,"description":"Weave
+      Gitops test repo","name":"wego-test-app-0l8jm1or","name_with_namespace":"weaveworks
+      / wego-test-app-0l8jm1or","path":"wego-test-app-0l8jm1or","path_with_namespace":"weaveworks/wego-test-app-0l8jm1or","created_at":"2021-09-16T16:47:11.202Z","default_branch":"main","tag_list":[],"topics":[],"ssh_url_to_repo":"git@gitlab.com:weaveworks/wego-test-app-0l8jm1or.git","http_url_to_repo":"https://gitlab.com/weaveworks/wego-test-app-0l8jm1or.git","web_url":"https://gitlab.com/weaveworks/wego-test-app-0l8jm1or","readme_url":"https://gitlab.com/weaveworks/wego-test-app-0l8jm1or/-/blob/main/README.md","avatar_url":null,"forks_count":0,"star_count":0,"last_activity_at":"2021-09-16T16:47:11.202Z","namespace":{"id":12950108,"name":"weaveworks","path":"weaveworks","kind":"group","full_path":"weaveworks","parent_id":null,"avatar_url":null,"web_url":"https://gitlab.com/groups/weaveworks"},"container_registry_image_prefix":"registry.gitlab.com/weaveworks/wego-test-app-0l8jm1or","_links":{"self":"https://gitlab.com/api/v4/projects/29671183","issues":"https://gitlab.com/api/v4/projects/29671183/issues","merge_requests":"https://gitlab.com/api/v4/projects/29671183/merge_requests","repo_branches":"https://gitlab.com/api/v4/projects/29671183/repository/branches","labels":"https://gitlab.com/api/v4/projects/29671183/labels","events":"https://gitlab.com/api/v4/projects/29671183/events","members":"https://gitlab.com/api/v4/projects/29671183/members"},"packages_enabled":true,"empty_repo":false,"archived":false,"visibility":"private","resolve_outdated_diff_discussions":false,"container_expiration_policy":{"cadence":"1d","enabled":false,"keep_n":10,"older_than":"90d","name_regex":".*","name_regex_keep":null,"next_run_at":"2021-09-17T16:47:11.233Z"},"issues_enabled":true,"merge_requests_enabled":true,"wiki_enabled":true,"jobs_enabled":true,"snippets_enabled":true,"container_registry_enabled":true,"service_desk_enabled":true,"service_desk_address":"incoming+weaveworks-wego-test-app-0l8jm1or-29671183-issue-@incoming.gitlab.com","can_create_merge_request_in":true,"issues_access_level":"enabled","repository_access_level":"enabled","merge_requests_access_level":"enabled","forking_access_level":"enabled","wiki_access_level":"enabled","builds_access_level":"enabled","snippets_access_level":"enabled","pages_access_level":"private","operations_access_level":"enabled","analytics_access_level":"enabled","container_registry_access_level":"enabled","emails_disabled":null,"shared_runners_enabled":true,"lfs_enabled":true,"creator_id":9448734,"import_status":"none","open_issues_count":0,"ci_default_git_depth":50,"ci_forward_deployment_enabled":true,"ci_job_token_scope_enabled":false,"public_jobs":true,"build_timeout":3600,"auto_cancel_pending_pipelines":"enabled","build_coverage_regex":null,"ci_config_path":"","shared_with_groups":[],"only_allow_merge_if_pipeline_succeeds":false,"allow_merge_on_skipped_pipeline":null,"restrict_user_defined_variables":false,"request_access_enabled":true,"only_allow_merge_if_all_discussions_are_resolved":false,"remove_source_branch_after_merge":true,"printing_merge_request_link_enabled":true,"merge_method":"merge","squash_option":"default_off","suggestion_commit_message":null,"auto_devops_enabled":false,"auto_devops_deploy_strategy":"continuous","autoclose_referenced_issues":true,"keep_latest_artifact":true,"external_authorization_classification_label":"","requirements_enabled":false,"security_and_compliance_enabled":true,"compliance_frameworks":[]},{"id":29437553,"description":"","name":"nginxgroup","name_with_namespace":"weaveworks
+      / nginxgroup","path":"nginxgroup","path_with_namespace":"weaveworks/nginxgroup","created_at":"2021-09-07T19:44:23.068Z","default_branch":"main","tag_list":[],"topics":[],"ssh_url_to_repo":"git@gitlab.com:weaveworks/nginxgroup.git","http_url_to_repo":"https://gitlab.com/weaveworks/nginxgroup.git","web_url":"https://gitlab.com/weaveworks/nginxgroup","readme_url":null,"avatar_url":null,"forks_count":0,"star_count":0,"last_activity_at":"2021-09-14T20:40:53.551Z","namespace":{"id":12950108,"name":"weaveworks","path":"weaveworks","kind":"group","full_path":"weaveworks","parent_id":null,"avatar_url":null,"web_url":"https://gitlab.com/groups/weaveworks"},"container_registry_image_prefix":"registry.gitlab.com/weaveworks/nginxgroup","_links":{"self":"https://gitlab.com/api/v4/projects/29437553","issues":"https://gitlab.com/api/v4/projects/29437553/issues","merge_requests":"https://gitlab.com/api/v4/projects/29437553/merge_requests","repo_branches":"https://gitlab.com/api/v4/projects/29437553/repository/branches","labels":"https://gitlab.com/api/v4/projects/29437553/labels","events":"https://gitlab.com/api/v4/projects/29437553/events","members":"https://gitlab.com/api/v4/projects/29437553/members"},"packages_enabled":true,"empty_repo":false,"archived":false,"visibility":"private","resolve_outdated_diff_discussions":false,"container_expiration_policy":{"cadence":"1d","enabled":false,"keep_n":10,"older_than":"90d","name_regex":".*","name_regex_keep":null,"next_run_at":"2021-09-08T19:44:23.091Z"},"issues_enabled":true,"merge_requests_enabled":true,"wiki_enabled":true,"jobs_enabled":true,"snippets_enabled":true,"container_registry_enabled":true,"service_desk_enabled":true,"service_desk_address":"incoming+weaveworks-nginxgroup-29437553-issue-@incoming.gitlab.com","can_create_merge_request_in":true,"issues_access_level":"enabled","repository_access_level":"enabled","merge_requests_access_level":"enabled","forking_access_level":"enabled","wiki_access_level":"enabled","builds_access_level":"enabled","snippets_access_level":"enabled","pages_access_level":"private","operations_access_level":"enabled","analytics_access_level":"enabled","container_registry_access_level":"enabled","emails_disabled":null,"shared_runners_enabled":true,"lfs_enabled":true,"creator_id":9448734,"import_status":"none","open_issues_count":0,"ci_default_git_depth":50,"ci_forward_deployment_enabled":true,"ci_job_token_scope_enabled":false,"public_jobs":true,"build_timeout":3600,"auto_cancel_pending_pipelines":"enabled","build_coverage_regex":null,"ci_config_path":"","shared_with_groups":[],"only_allow_merge_if_pipeline_succeeds":false,"allow_merge_on_skipped_pipeline":null,"restrict_user_defined_variables":false,"request_access_enabled":true,"only_allow_merge_if_all_discussions_are_resolved":false,"remove_source_branch_after_merge":true,"printing_merge_request_link_enabled":true,"merge_method":"merge","squash_option":"default_off","suggestion_commit_message":null,"auto_devops_enabled":false,"auto_devops_deploy_strategy":"continuous","autoclose_referenced_issues":true,"keep_latest_artifact":true,"external_authorization_classification_label":"","requirements_enabled":false,"security_and_compliance_enabled":true,"compliance_frameworks":[]},{"id":28692370,"description":"test","name":"mre","name_with_namespace":"weaveworks
+      / mre","path":"mre","path_with_namespace":"weaveworks/mre","created_at":"2021-08-06T21:42:06.180Z","default_branch":"main","tag_list":[],"topics":[],"ssh_url_to_repo":"git@gitlab.com:weaveworks/mre.git","http_url_to_repo":"https://gitlab.com/weaveworks/mre.git","web_url":"https://gitlab.com/weaveworks/mre","readme_url":"https://gitlab.com/weaveworks/mre/-/blob/main/README.md","avatar_url":null,"forks_count":0,"star_count":0,"last_activity_at":"2021-08-06T21:42:06.180Z","namespace":{"id":12950108,"name":"weaveworks","path":"weaveworks","kind":"group","full_path":"weaveworks","parent_id":null,"avatar_url":null,"web_url":"https://gitlab.com/groups/weaveworks"},"container_registry_image_prefix":"registry.gitlab.com/weaveworks/mre","_links":{"self":"https://gitlab.com/api/v4/projects/28692370","issues":"https://gitlab.com/api/v4/projects/28692370/issues","merge_requests":"https://gitlab.com/api/v4/projects/28692370/merge_requests","repo_branches":"https://gitlab.com/api/v4/projects/28692370/repository/branches","labels":"https://gitlab.com/api/v4/projects/28692370/labels","events":"https://gitlab.com/api/v4/projects/28692370/events","members":"https://gitlab.com/api/v4/projects/28692370/members"},"packages_enabled":true,"empty_repo":false,"archived":false,"visibility":"private","resolve_outdated_diff_discussions":false,"container_expiration_policy":{"cadence":"1d","enabled":false,"keep_n":10,"older_than":"90d","name_regex":".*","name_regex_keep":null,"next_run_at":"2021-08-07T21:42:06.209Z"},"issues_enabled":true,"merge_requests_enabled":true,"wiki_enabled":true,"jobs_enabled":true,"snippets_enabled":true,"container_registry_enabled":true,"service_desk_enabled":true,"service_desk_address":"incoming+weaveworks-mre-28692370-issue-@incoming.gitlab.com","can_create_merge_request_in":true,"issues_access_level":"enabled","repository_access_level":"enabled","merge_requests_access_level":"enabled","forking_access_level":"enabled","wiki_access_level":"enabled","builds_access_level":"enabled","snippets_access_level":"enabled","pages_access_level":"private","operations_access_level":"enabled","analytics_access_level":"enabled","container_registry_access_level":"enabled","emails_disabled":null,"shared_runners_enabled":true,"lfs_enabled":true,"creator_id":9463163,"import_status":"none","open_issues_count":0,"ci_default_git_depth":50,"ci_forward_deployment_enabled":true,"ci_job_token_scope_enabled":false,"public_jobs":true,"build_timeout":3600,"auto_cancel_pending_pipelines":"enabled","build_coverage_regex":null,"ci_config_path":"","shared_with_groups":[],"only_allow_merge_if_pipeline_succeeds":false,"allow_merge_on_skipped_pipeline":null,"restrict_user_defined_variables":false,"request_access_enabled":true,"only_allow_merge_if_all_discussions_are_resolved":false,"remove_source_branch_after_merge":true,"printing_merge_request_link_enabled":true,"merge_method":"merge","squash_option":"default_off","suggestion_commit_message":null,"auto_devops_enabled":false,"auto_devops_deploy_strategy":"continuous","autoclose_referenced_issues":true,"keep_latest_artifact":true,"external_authorization_classification_label":"","requirements_enabled":false,"security_and_compliance_enabled":true,"compliance_frameworks":[]}],"shared_projects":[],"shared_runners_minutes_limit":null,"extra_shared_runners_minutes_limit":null,"prevent_forking_outside_group":null}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Ray:
+      - 68fcbf8a894d2806-SLC
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Sep 2021 20:12:11 GMT
+      Etag:
+      - W/"8f85c1468c3b835d6fe7eb7072e105e3"
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Gitlab-Lb:
+      - fe-17-lb-gprd
+      Gitlab-Sv:
+      - localhost
+      Ratelimit-Limit:
+      - "2000"
+      Ratelimit-Observed:
+      - "3"
+      Ratelimit-Remaining:
+      - "1997"
+      Ratelimit-Reset:
+      - "1631823191"
+      Ratelimit-Resettime:
+      - Thu, 16 Sep 2021 20:13:11 GMT
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Request-Id:
+      - 01FFR3SWPRZCJV9R4PA96E9AWV
+      X-Runtime:
+      - "0.217188"
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"name":"repo-exists-group","namespace_id":12950108,"default_branch":"main","description":"Weave
+      Gitops repo","visibility":"private","initialize_with_readme":true}'
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Authorization:
+      - Bearer 3QcwbqArcVLJsJX1hCGa
+      Content-Type:
+      - application/json
+      User-Agent:
+      - go-gitlab
+    url: https://gitlab.com/api/v4/projects
+    method: POST
+  response:
+    body: '{"id":29675264,"description":"Weave Gitops repo","name":"repo-exists-group","name_with_namespace":"weaveworks
+      / repo-exists-group","path":"repo-exists-group","path_with_namespace":"weaveworks/repo-exists-group","created_at":"2021-09-16T20:12:11.794Z","default_branch":"main","tag_list":[],"topics":[],"ssh_url_to_repo":"git@gitlab.com:weaveworks/repo-exists-group.git","http_url_to_repo":"https://gitlab.com/weaveworks/repo-exists-group.git","web_url":"https://gitlab.com/weaveworks/repo-exists-group","readme_url":"https://gitlab.com/weaveworks/repo-exists-group/-/blob/main/README.md","avatar_url":null,"forks_count":0,"star_count":0,"last_activity_at":"2021-09-16T20:12:11.794Z","namespace":{"id":12950108,"name":"weaveworks","path":"weaveworks","kind":"group","full_path":"weaveworks","parent_id":null,"avatar_url":null,"web_url":"https://gitlab.com/groups/weaveworks"},"container_registry_image_prefix":"registry.gitlab.com/weaveworks/repo-exists-group","_links":{"self":"https://gitlab.com/api/v4/projects/29675264","issues":"https://gitlab.com/api/v4/projects/29675264/issues","merge_requests":"https://gitlab.com/api/v4/projects/29675264/merge_requests","repo_branches":"https://gitlab.com/api/v4/projects/29675264/repository/branches","labels":"https://gitlab.com/api/v4/projects/29675264/labels","events":"https://gitlab.com/api/v4/projects/29675264/events","members":"https://gitlab.com/api/v4/projects/29675264/members"},"packages_enabled":true,"empty_repo":false,"archived":false,"visibility":"private","resolve_outdated_diff_discussions":false,"container_expiration_policy":{"cadence":"1d","enabled":false,"keep_n":10,"older_than":"90d","name_regex":".*","name_regex_keep":null,"next_run_at":"2021-09-17T20:12:11.816Z"},"issues_enabled":true,"merge_requests_enabled":true,"wiki_enabled":true,"jobs_enabled":true,"snippets_enabled":true,"container_registry_enabled":true,"service_desk_enabled":true,"service_desk_address":"incoming+weaveworks-repo-exists-group-29675264-issue-@incoming.gitlab.com","can_create_merge_request_in":true,"issues_access_level":"enabled","repository_access_level":"enabled","merge_requests_access_level":"enabled","forking_access_level":"enabled","wiki_access_level":"enabled","builds_access_level":"enabled","snippets_access_level":"enabled","pages_access_level":"private","operations_access_level":"enabled","analytics_access_level":"enabled","container_registry_access_level":"enabled","emails_disabled":null,"shared_runners_enabled":true,"lfs_enabled":true,"creator_id":9448734,"import_status":"none","import_error":null,"open_issues_count":0,"runners_token":"3exXWy_U_KziYYW-UjJo","ci_default_git_depth":50,"ci_forward_deployment_enabled":true,"ci_job_token_scope_enabled":false,"public_jobs":true,"build_git_strategy":"fetch","build_timeout":3600,"auto_cancel_pending_pipelines":"enabled","build_coverage_regex":null,"ci_config_path":"","shared_with_groups":[],"only_allow_merge_if_pipeline_succeeds":false,"allow_merge_on_skipped_pipeline":null,"restrict_user_defined_variables":false,"request_access_enabled":true,"only_allow_merge_if_all_discussions_are_resolved":false,"remove_source_branch_after_merge":true,"printing_merge_request_link_enabled":true,"merge_method":"merge","squash_option":"default_off","suggestion_commit_message":null,"auto_devops_enabled":false,"auto_devops_deploy_strategy":"continuous","autoclose_referenced_issues":true,"keep_latest_artifact":true,"external_authorization_classification_label":"","requirements_enabled":false,"security_and_compliance_enabled":true,"compliance_frameworks":[]}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Ray:
+      - 68fcbf8cdc2d2806-SLC
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Sep 2021 20:12:12 GMT
+      Etag:
+      - W/"77dc7dae9d497c145c2ac4ffb37435a2"
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Gitlab-Lb:
+      - fe-02-lb-gprd
+      Gitlab-Sv:
+      - localhost
+      Ratelimit-Limit:
+      - "2000"
+      Ratelimit-Observed:
+      - "4"
+      Ratelimit-Remaining:
+      - "1996"
+      Ratelimit-Reset:
+      - "1631823192"
+      Ratelimit-Resettime:
+      - Thu, 16 Sep 2021 20:13:12 GMT
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Request-Id:
+      - 01FFR3SX24MFSJ518ZMXFR1S5H
+      X-Runtime:
+      - "0.984434"
+    status: 201 Created
+    code: 201
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Authorization:
+      - Bearer 3QcwbqArcVLJsJX1hCGa
+      User-Agent:
+      - go-gitlab
+    url: https://gitlab.com/api/v4/projects/weaveworks%2Frepo-exists-group
+    method: GET
+  response:
+    body: '{"id":29675264,"description":"Weave Gitops repo","name":"repo-exists-group","name_with_namespace":"weaveworks
+      / repo-exists-group","path":"repo-exists-group","path_with_namespace":"weaveworks/repo-exists-group","created_at":"2021-09-16T20:12:11.794Z","default_branch":"main","tag_list":[],"topics":[],"ssh_url_to_repo":"git@gitlab.com:weaveworks/repo-exists-group.git","http_url_to_repo":"https://gitlab.com/weaveworks/repo-exists-group.git","web_url":"https://gitlab.com/weaveworks/repo-exists-group","readme_url":"https://gitlab.com/weaveworks/repo-exists-group/-/blob/main/README.md","avatar_url":null,"forks_count":0,"star_count":0,"last_activity_at":"2021-09-16T20:12:11.794Z","namespace":{"id":12950108,"name":"weaveworks","path":"weaveworks","kind":"group","full_path":"weaveworks","parent_id":null,"avatar_url":null,"web_url":"https://gitlab.com/groups/weaveworks"},"container_registry_image_prefix":"registry.gitlab.com/weaveworks/repo-exists-group","_links":{"self":"https://gitlab.com/api/v4/projects/29675264","issues":"https://gitlab.com/api/v4/projects/29675264/issues","merge_requests":"https://gitlab.com/api/v4/projects/29675264/merge_requests","repo_branches":"https://gitlab.com/api/v4/projects/29675264/repository/branches","labels":"https://gitlab.com/api/v4/projects/29675264/labels","events":"https://gitlab.com/api/v4/projects/29675264/events","members":"https://gitlab.com/api/v4/projects/29675264/members"},"packages_enabled":true,"empty_repo":false,"archived":false,"visibility":"private","resolve_outdated_diff_discussions":false,"container_expiration_policy":{"cadence":"1d","enabled":false,"keep_n":10,"older_than":"90d","name_regex":".*","name_regex_keep":null,"next_run_at":"2021-09-17T20:12:11.816Z"},"issues_enabled":true,"merge_requests_enabled":true,"wiki_enabled":true,"jobs_enabled":true,"snippets_enabled":true,"container_registry_enabled":true,"service_desk_enabled":true,"service_desk_address":"incoming+weaveworks-repo-exists-group-29675264-issue-@incoming.gitlab.com","can_create_merge_request_in":true,"issues_access_level":"enabled","repository_access_level":"enabled","merge_requests_access_level":"enabled","forking_access_level":"enabled","wiki_access_level":"enabled","builds_access_level":"enabled","snippets_access_level":"enabled","pages_access_level":"private","operations_access_level":"enabled","analytics_access_level":"enabled","container_registry_access_level":"enabled","emails_disabled":null,"shared_runners_enabled":true,"lfs_enabled":true,"creator_id":9448734,"import_status":"none","import_error":null,"open_issues_count":0,"runners_token":"3exXWy_U_KziYYW-UjJo","ci_default_git_depth":50,"ci_forward_deployment_enabled":true,"ci_job_token_scope_enabled":false,"public_jobs":true,"build_git_strategy":"fetch","build_timeout":3600,"auto_cancel_pending_pipelines":"enabled","build_coverage_regex":null,"ci_config_path":"","shared_with_groups":[],"only_allow_merge_if_pipeline_succeeds":false,"allow_merge_on_skipped_pipeline":null,"restrict_user_defined_variables":false,"request_access_enabled":true,"only_allow_merge_if_all_discussions_are_resolved":false,"remove_source_branch_after_merge":true,"printing_merge_request_link_enabled":true,"merge_method":"merge","squash_option":"default_off","suggestion_commit_message":null,"auto_devops_enabled":false,"auto_devops_deploy_strategy":"continuous","autoclose_referenced_issues":true,"keep_latest_artifact":true,"external_authorization_classification_label":"","requirements_enabled":false,"security_and_compliance_enabled":true,"compliance_frameworks":[],"permissions":{"project_access":null,"group_access":{"access_level":50,"notification_level":3}}}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Ray:
+      - 68fcbf93deb62806-SLC
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Sep 2021 20:12:13 GMT
+      Etag:
+      - W/"1493feb5ee24e0ee72a8d3dc8fe0d77c"
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Gitlab-Lb:
+      - fe-14-lb-gprd
+      Gitlab-Sv:
+      - localhost
+      Ratelimit-Limit:
+      - "2000"
+      Ratelimit-Observed:
+      - "5"
+      Ratelimit-Remaining:
+      - "1995"
+      Ratelimit-Reset:
+      - "1631823193"
+      Ratelimit-Resettime:
+      - Thu, 16 Sep 2021 20:13:13 GMT
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Request-Id:
+      - 01FFR3SY5KWKTPV0R43J999XTM
+      X-Runtime:
+      - "0.221088"
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Authorization:
+      - Bearer 3QcwbqArcVLJsJX1hCGa
+      User-Agent:
+      - go-gitlab
+    url: https://gitlab.com/api/v4/groups/weaveworks
+    method: GET
+  response:
+    body: '{"id":12950108,"web_url":"https://gitlab.com/groups/weaveworks","name":"weaveworks","path":"weaveworks","description":"","visibility":"private","share_with_group_lock":false,"require_two_factor_authentication":false,"two_factor_grace_period":48,"project_creation_level":"developer","auto_devops_enabled":null,"subgroup_creation_level":"maintainer","emails_disabled":null,"mentions_disabled":null,"lfs_enabled":true,"default_branch_protection":2,"avatar_url":null,"request_access_enabled":true,"full_name":"weaveworks","full_path":"weaveworks","created_at":"2021-08-06T15:46:38.421Z","parent_id":null,"ldap_cn":null,"ldap_access":null,"shared_with_groups":[],"runners_token":"h2iQ2g78zxhBARVnydwH","prevent_sharing_groups_outside_hierarchy":false,"projects":[{"id":29675264,"description":"Weave
+      Gitops repo","name":"repo-exists-group","name_with_namespace":"weaveworks /
+      repo-exists-group","path":"repo-exists-group","path_with_namespace":"weaveworks/repo-exists-group","created_at":"2021-09-16T20:12:11.794Z","default_branch":"main","tag_list":[],"topics":[],"ssh_url_to_repo":"git@gitlab.com:weaveworks/repo-exists-group.git","http_url_to_repo":"https://gitlab.com/weaveworks/repo-exists-group.git","web_url":"https://gitlab.com/weaveworks/repo-exists-group","readme_url":"https://gitlab.com/weaveworks/repo-exists-group/-/blob/main/README.md","avatar_url":null,"forks_count":0,"star_count":0,"last_activity_at":"2021-09-16T20:12:11.794Z","namespace":{"id":12950108,"name":"weaveworks","path":"weaveworks","kind":"group","full_path":"weaveworks","parent_id":null,"avatar_url":null,"web_url":"https://gitlab.com/groups/weaveworks"},"container_registry_image_prefix":"registry.gitlab.com/weaveworks/repo-exists-group","_links":{"self":"https://gitlab.com/api/v4/projects/29675264","issues":"https://gitlab.com/api/v4/projects/29675264/issues","merge_requests":"https://gitlab.com/api/v4/projects/29675264/merge_requests","repo_branches":"https://gitlab.com/api/v4/projects/29675264/repository/branches","labels":"https://gitlab.com/api/v4/projects/29675264/labels","events":"https://gitlab.com/api/v4/projects/29675264/events","members":"https://gitlab.com/api/v4/projects/29675264/members"},"packages_enabled":true,"empty_repo":false,"archived":false,"visibility":"private","resolve_outdated_diff_discussions":false,"container_expiration_policy":{"cadence":"1d","enabled":false,"keep_n":10,"older_than":"90d","name_regex":".*","name_regex_keep":null,"next_run_at":"2021-09-17T20:12:11.816Z"},"issues_enabled":true,"merge_requests_enabled":true,"wiki_enabled":true,"jobs_enabled":true,"snippets_enabled":true,"container_registry_enabled":true,"service_desk_enabled":true,"service_desk_address":"incoming+weaveworks-repo-exists-group-29675264-issue-@incoming.gitlab.com","can_create_merge_request_in":true,"issues_access_level":"enabled","repository_access_level":"enabled","merge_requests_access_level":"enabled","forking_access_level":"enabled","wiki_access_level":"enabled","builds_access_level":"enabled","snippets_access_level":"enabled","pages_access_level":"private","operations_access_level":"enabled","analytics_access_level":"enabled","container_registry_access_level":"enabled","emails_disabled":null,"shared_runners_enabled":true,"lfs_enabled":true,"creator_id":9448734,"import_status":"none","open_issues_count":0,"ci_default_git_depth":50,"ci_forward_deployment_enabled":true,"ci_job_token_scope_enabled":false,"public_jobs":true,"build_timeout":3600,"auto_cancel_pending_pipelines":"enabled","build_coverage_regex":null,"ci_config_path":"","shared_with_groups":[],"only_allow_merge_if_pipeline_succeeds":false,"allow_merge_on_skipped_pipeline":null,"restrict_user_defined_variables":false,"request_access_enabled":true,"only_allow_merge_if_all_discussions_are_resolved":false,"remove_source_branch_after_merge":true,"printing_merge_request_link_enabled":true,"merge_method":"merge","squash_option":"default_off","suggestion_commit_message":null,"auto_devops_enabled":false,"auto_devops_deploy_strategy":"continuous","autoclose_referenced_issues":true,"keep_latest_artifact":true,"external_authorization_classification_label":"","requirements_enabled":false,"security_and_compliance_enabled":true,"compliance_frameworks":[]},{"id":29674239,"description":"Weave
+      Gitops test repo","name":"wego-test-app-fhyw7gy8","name_with_namespace":"weaveworks
+      / wego-test-app-fhyw7gy8","path":"wego-test-app-fhyw7gy8","path_with_namespace":"weaveworks/wego-test-app-fhyw7gy8","created_at":"2021-09-16T19:32:01.189Z","default_branch":"main","tag_list":[],"topics":[],"ssh_url_to_repo":"git@gitlab.com:weaveworks/wego-test-app-fhyw7gy8.git","http_url_to_repo":"https://gitlab.com/weaveworks/wego-test-app-fhyw7gy8.git","web_url":"https://gitlab.com/weaveworks/wego-test-app-fhyw7gy8","readme_url":"https://gitlab.com/weaveworks/wego-test-app-fhyw7gy8/-/blob/main/README.md","avatar_url":null,"forks_count":0,"star_count":0,"last_activity_at":"2021-09-16T19:32:01.189Z","namespace":{"id":12950108,"name":"weaveworks","path":"weaveworks","kind":"group","full_path":"weaveworks","parent_id":null,"avatar_url":null,"web_url":"https://gitlab.com/groups/weaveworks"},"container_registry_image_prefix":"registry.gitlab.com/weaveworks/wego-test-app-fhyw7gy8","_links":{"self":"https://gitlab.com/api/v4/projects/29674239","issues":"https://gitlab.com/api/v4/projects/29674239/issues","merge_requests":"https://gitlab.com/api/v4/projects/29674239/merge_requests","repo_branches":"https://gitlab.com/api/v4/projects/29674239/repository/branches","labels":"https://gitlab.com/api/v4/projects/29674239/labels","events":"https://gitlab.com/api/v4/projects/29674239/events","members":"https://gitlab.com/api/v4/projects/29674239/members"},"packages_enabled":true,"empty_repo":false,"archived":false,"visibility":"private","resolve_outdated_diff_discussions":false,"container_expiration_policy":{"cadence":"1d","enabled":false,"keep_n":10,"older_than":"90d","name_regex":".*","name_regex_keep":null,"next_run_at":"2021-09-17T19:32:01.224Z"},"issues_enabled":true,"merge_requests_enabled":true,"wiki_enabled":true,"jobs_enabled":true,"snippets_enabled":true,"container_registry_enabled":true,"service_desk_enabled":true,"service_desk_address":"incoming+weaveworks-wego-test-app-fhyw7gy8-29674239-issue-@incoming.gitlab.com","can_create_merge_request_in":true,"issues_access_level":"enabled","repository_access_level":"enabled","merge_requests_access_level":"enabled","forking_access_level":"enabled","wiki_access_level":"enabled","builds_access_level":"enabled","snippets_access_level":"enabled","pages_access_level":"private","operations_access_level":"enabled","analytics_access_level":"enabled","container_registry_access_level":"enabled","emails_disabled":null,"shared_runners_enabled":true,"lfs_enabled":true,"creator_id":9448734,"import_status":"none","open_issues_count":0,"ci_default_git_depth":50,"ci_forward_deployment_enabled":true,"ci_job_token_scope_enabled":false,"public_jobs":true,"build_timeout":3600,"auto_cancel_pending_pipelines":"enabled","build_coverage_regex":null,"ci_config_path":"","shared_with_groups":[],"only_allow_merge_if_pipeline_succeeds":false,"allow_merge_on_skipped_pipeline":null,"restrict_user_defined_variables":false,"request_access_enabled":true,"only_allow_merge_if_all_discussions_are_resolved":false,"remove_source_branch_after_merge":true,"printing_merge_request_link_enabled":true,"merge_method":"merge","squash_option":"default_off","suggestion_commit_message":null,"auto_devops_enabled":false,"auto_devops_deploy_strategy":"continuous","autoclose_referenced_issues":true,"keep_latest_artifact":true,"external_authorization_classification_label":"","requirements_enabled":false,"security_and_compliance_enabled":true,"compliance_frameworks":[]},{"id":29672490,"description":"Weave
+      Gitops test repo","name":"wego-test-app-e638ymz4","name_with_namespace":"weaveworks
+      / wego-test-app-e638ymz4","path":"wego-test-app-e638ymz4","path_with_namespace":"weaveworks/wego-test-app-e638ymz4","created_at":"2021-09-16T18:04:06.216Z","default_branch":"main","tag_list":[],"topics":[],"ssh_url_to_repo":"git@gitlab.com:weaveworks/wego-test-app-e638ymz4.git","http_url_to_repo":"https://gitlab.com/weaveworks/wego-test-app-e638ymz4.git","web_url":"https://gitlab.com/weaveworks/wego-test-app-e638ymz4","readme_url":"https://gitlab.com/weaveworks/wego-test-app-e638ymz4/-/blob/main/README.md","avatar_url":null,"forks_count":0,"star_count":0,"last_activity_at":"2021-09-16T18:04:06.216Z","namespace":{"id":12950108,"name":"weaveworks","path":"weaveworks","kind":"group","full_path":"weaveworks","parent_id":null,"avatar_url":null,"web_url":"https://gitlab.com/groups/weaveworks"},"container_registry_image_prefix":"registry.gitlab.com/weaveworks/wego-test-app-e638ymz4","_links":{"self":"https://gitlab.com/api/v4/projects/29672490","issues":"https://gitlab.com/api/v4/projects/29672490/issues","merge_requests":"https://gitlab.com/api/v4/projects/29672490/merge_requests","repo_branches":"https://gitlab.com/api/v4/projects/29672490/repository/branches","labels":"https://gitlab.com/api/v4/projects/29672490/labels","events":"https://gitlab.com/api/v4/projects/29672490/events","members":"https://gitlab.com/api/v4/projects/29672490/members"},"packages_enabled":true,"empty_repo":false,"archived":false,"visibility":"private","resolve_outdated_diff_discussions":false,"container_expiration_policy":{"cadence":"1d","enabled":false,"keep_n":10,"older_than":"90d","name_regex":".*","name_regex_keep":null,"next_run_at":"2021-09-17T18:04:06.265Z"},"issues_enabled":true,"merge_requests_enabled":true,"wiki_enabled":true,"jobs_enabled":true,"snippets_enabled":true,"container_registry_enabled":true,"service_desk_enabled":true,"service_desk_address":"incoming+weaveworks-wego-test-app-e638ymz4-29672490-issue-@incoming.gitlab.com","can_create_merge_request_in":true,"issues_access_level":"enabled","repository_access_level":"enabled","merge_requests_access_level":"enabled","forking_access_level":"enabled","wiki_access_level":"enabled","builds_access_level":"enabled","snippets_access_level":"enabled","pages_access_level":"private","operations_access_level":"enabled","analytics_access_level":"enabled","container_registry_access_level":"enabled","emails_disabled":null,"shared_runners_enabled":true,"lfs_enabled":true,"creator_id":9448734,"import_status":"none","open_issues_count":0,"ci_default_git_depth":50,"ci_forward_deployment_enabled":true,"ci_job_token_scope_enabled":false,"public_jobs":true,"build_timeout":3600,"auto_cancel_pending_pipelines":"enabled","build_coverage_regex":null,"ci_config_path":"","shared_with_groups":[],"only_allow_merge_if_pipeline_succeeds":false,"allow_merge_on_skipped_pipeline":null,"restrict_user_defined_variables":false,"request_access_enabled":true,"only_allow_merge_if_all_discussions_are_resolved":false,"remove_source_branch_after_merge":true,"printing_merge_request_link_enabled":true,"merge_method":"merge","squash_option":"default_off","suggestion_commit_message":null,"auto_devops_enabled":false,"auto_devops_deploy_strategy":"continuous","autoclose_referenced_issues":true,"keep_latest_artifact":true,"external_authorization_classification_label":"","requirements_enabled":false,"security_and_compliance_enabled":true,"compliance_frameworks":[]},{"id":29671793,"description":"Weave
+      Gitops test repo","name":"wego-test-app-o7pawhqu","name_with_namespace":"weaveworks
+      / wego-test-app-o7pawhqu","path":"wego-test-app-o7pawhqu","path_with_namespace":"weaveworks/wego-test-app-o7pawhqu","created_at":"2021-09-16T17:19:38.589Z","default_branch":"main","tag_list":[],"topics":[],"ssh_url_to_repo":"git@gitlab.com:weaveworks/wego-test-app-o7pawhqu.git","http_url_to_repo":"https://gitlab.com/weaveworks/wego-test-app-o7pawhqu.git","web_url":"https://gitlab.com/weaveworks/wego-test-app-o7pawhqu","readme_url":"https://gitlab.com/weaveworks/wego-test-app-o7pawhqu/-/blob/main/README.md","avatar_url":null,"forks_count":0,"star_count":0,"last_activity_at":"2021-09-16T17:19:38.589Z","namespace":{"id":12950108,"name":"weaveworks","path":"weaveworks","kind":"group","full_path":"weaveworks","parent_id":null,"avatar_url":null,"web_url":"https://gitlab.com/groups/weaveworks"},"container_registry_image_prefix":"registry.gitlab.com/weaveworks/wego-test-app-o7pawhqu","_links":{"self":"https://gitlab.com/api/v4/projects/29671793","issues":"https://gitlab.com/api/v4/projects/29671793/issues","merge_requests":"https://gitlab.com/api/v4/projects/29671793/merge_requests","repo_branches":"https://gitlab.com/api/v4/projects/29671793/repository/branches","labels":"https://gitlab.com/api/v4/projects/29671793/labels","events":"https://gitlab.com/api/v4/projects/29671793/events","members":"https://gitlab.com/api/v4/projects/29671793/members"},"packages_enabled":true,"empty_repo":false,"archived":false,"visibility":"private","resolve_outdated_diff_discussions":false,"container_expiration_policy":{"cadence":"1d","enabled":false,"keep_n":10,"older_than":"90d","name_regex":".*","name_regex_keep":null,"next_run_at":"2021-09-17T17:19:38.611Z"},"issues_enabled":true,"merge_requests_enabled":true,"wiki_enabled":true,"jobs_enabled":true,"snippets_enabled":true,"container_registry_enabled":true,"service_desk_enabled":true,"service_desk_address":"incoming+weaveworks-wego-test-app-o7pawhqu-29671793-issue-@incoming.gitlab.com","can_create_merge_request_in":true,"issues_access_level":"enabled","repository_access_level":"enabled","merge_requests_access_level":"enabled","forking_access_level":"enabled","wiki_access_level":"enabled","builds_access_level":"enabled","snippets_access_level":"enabled","pages_access_level":"private","operations_access_level":"enabled","analytics_access_level":"enabled","container_registry_access_level":"enabled","emails_disabled":null,"shared_runners_enabled":true,"lfs_enabled":true,"creator_id":9448734,"import_status":"none","open_issues_count":0,"ci_default_git_depth":50,"ci_forward_deployment_enabled":true,"ci_job_token_scope_enabled":false,"public_jobs":true,"build_timeout":3600,"auto_cancel_pending_pipelines":"enabled","build_coverage_regex":null,"ci_config_path":"","shared_with_groups":[],"only_allow_merge_if_pipeline_succeeds":false,"allow_merge_on_skipped_pipeline":null,"restrict_user_defined_variables":false,"request_access_enabled":true,"only_allow_merge_if_all_discussions_are_resolved":false,"remove_source_branch_after_merge":true,"printing_merge_request_link_enabled":true,"merge_method":"merge","squash_option":"default_off","suggestion_commit_message":null,"auto_devops_enabled":false,"auto_devops_deploy_strategy":"continuous","autoclose_referenced_issues":true,"keep_latest_artifact":true,"external_authorization_classification_label":"","requirements_enabled":false,"security_and_compliance_enabled":true,"compliance_frameworks":[]},{"id":29671435,"description":"Weave
+      Gitops test repo","name":"wego-test-app-0crtft9p","name_with_namespace":"weaveworks
+      / wego-test-app-0crtft9p","path":"wego-test-app-0crtft9p","path_with_namespace":"weaveworks/wego-test-app-0crtft9p","created_at":"2021-09-16T17:01:19.553Z","default_branch":"main","tag_list":[],"topics":[],"ssh_url_to_repo":"git@gitlab.com:weaveworks/wego-test-app-0crtft9p.git","http_url_to_repo":"https://gitlab.com/weaveworks/wego-test-app-0crtft9p.git","web_url":"https://gitlab.com/weaveworks/wego-test-app-0crtft9p","readme_url":"https://gitlab.com/weaveworks/wego-test-app-0crtft9p/-/blob/main/README.md","avatar_url":null,"forks_count":0,"star_count":0,"last_activity_at":"2021-09-16T17:01:19.553Z","namespace":{"id":12950108,"name":"weaveworks","path":"weaveworks","kind":"group","full_path":"weaveworks","parent_id":null,"avatar_url":null,"web_url":"https://gitlab.com/groups/weaveworks"},"container_registry_image_prefix":"registry.gitlab.com/weaveworks/wego-test-app-0crtft9p","_links":{"self":"https://gitlab.com/api/v4/projects/29671435","issues":"https://gitlab.com/api/v4/projects/29671435/issues","merge_requests":"https://gitlab.com/api/v4/projects/29671435/merge_requests","repo_branches":"https://gitlab.com/api/v4/projects/29671435/repository/branches","labels":"https://gitlab.com/api/v4/projects/29671435/labels","events":"https://gitlab.com/api/v4/projects/29671435/events","members":"https://gitlab.com/api/v4/projects/29671435/members"},"packages_enabled":true,"empty_repo":false,"archived":false,"visibility":"private","resolve_outdated_diff_discussions":false,"container_expiration_policy":{"cadence":"1d","enabled":false,"keep_n":10,"older_than":"90d","name_regex":".*","name_regex_keep":null,"next_run_at":"2021-09-17T17:01:19.595Z"},"issues_enabled":true,"merge_requests_enabled":true,"wiki_enabled":true,"jobs_enabled":true,"snippets_enabled":true,"container_registry_enabled":true,"service_desk_enabled":true,"service_desk_address":"incoming+weaveworks-wego-test-app-0crtft9p-29671435-issue-@incoming.gitlab.com","can_create_merge_request_in":true,"issues_access_level":"enabled","repository_access_level":"enabled","merge_requests_access_level":"enabled","forking_access_level":"enabled","wiki_access_level":"enabled","builds_access_level":"enabled","snippets_access_level":"enabled","pages_access_level":"private","operations_access_level":"enabled","analytics_access_level":"enabled","container_registry_access_level":"enabled","emails_disabled":null,"shared_runners_enabled":true,"lfs_enabled":true,"creator_id":9448734,"import_status":"none","open_issues_count":0,"ci_default_git_depth":50,"ci_forward_deployment_enabled":true,"ci_job_token_scope_enabled":false,"public_jobs":true,"build_timeout":3600,"auto_cancel_pending_pipelines":"enabled","build_coverage_regex":null,"ci_config_path":"","shared_with_groups":[],"only_allow_merge_if_pipeline_succeeds":false,"allow_merge_on_skipped_pipeline":null,"restrict_user_defined_variables":false,"request_access_enabled":true,"only_allow_merge_if_all_discussions_are_resolved":false,"remove_source_branch_after_merge":true,"printing_merge_request_link_enabled":true,"merge_method":"merge","squash_option":"default_off","suggestion_commit_message":null,"auto_devops_enabled":false,"auto_devops_deploy_strategy":"continuous","autoclose_referenced_issues":true,"keep_latest_artifact":true,"external_authorization_classification_label":"","requirements_enabled":false,"security_and_compliance_enabled":true,"compliance_frameworks":[]},{"id":29671183,"description":"Weave
+      Gitops test repo","name":"wego-test-app-0l8jm1or","name_with_namespace":"weaveworks
+      / wego-test-app-0l8jm1or","path":"wego-test-app-0l8jm1or","path_with_namespace":"weaveworks/wego-test-app-0l8jm1or","created_at":"2021-09-16T16:47:11.202Z","default_branch":"main","tag_list":[],"topics":[],"ssh_url_to_repo":"git@gitlab.com:weaveworks/wego-test-app-0l8jm1or.git","http_url_to_repo":"https://gitlab.com/weaveworks/wego-test-app-0l8jm1or.git","web_url":"https://gitlab.com/weaveworks/wego-test-app-0l8jm1or","readme_url":"https://gitlab.com/weaveworks/wego-test-app-0l8jm1or/-/blob/main/README.md","avatar_url":null,"forks_count":0,"star_count":0,"last_activity_at":"2021-09-16T16:47:11.202Z","namespace":{"id":12950108,"name":"weaveworks","path":"weaveworks","kind":"group","full_path":"weaveworks","parent_id":null,"avatar_url":null,"web_url":"https://gitlab.com/groups/weaveworks"},"container_registry_image_prefix":"registry.gitlab.com/weaveworks/wego-test-app-0l8jm1or","_links":{"self":"https://gitlab.com/api/v4/projects/29671183","issues":"https://gitlab.com/api/v4/projects/29671183/issues","merge_requests":"https://gitlab.com/api/v4/projects/29671183/merge_requests","repo_branches":"https://gitlab.com/api/v4/projects/29671183/repository/branches","labels":"https://gitlab.com/api/v4/projects/29671183/labels","events":"https://gitlab.com/api/v4/projects/29671183/events","members":"https://gitlab.com/api/v4/projects/29671183/members"},"packages_enabled":true,"empty_repo":false,"archived":false,"visibility":"private","resolve_outdated_diff_discussions":false,"container_expiration_policy":{"cadence":"1d","enabled":false,"keep_n":10,"older_than":"90d","name_regex":".*","name_regex_keep":null,"next_run_at":"2021-09-17T16:47:11.233Z"},"issues_enabled":true,"merge_requests_enabled":true,"wiki_enabled":true,"jobs_enabled":true,"snippets_enabled":true,"container_registry_enabled":true,"service_desk_enabled":true,"service_desk_address":"incoming+weaveworks-wego-test-app-0l8jm1or-29671183-issue-@incoming.gitlab.com","can_create_merge_request_in":true,"issues_access_level":"enabled","repository_access_level":"enabled","merge_requests_access_level":"enabled","forking_access_level":"enabled","wiki_access_level":"enabled","builds_access_level":"enabled","snippets_access_level":"enabled","pages_access_level":"private","operations_access_level":"enabled","analytics_access_level":"enabled","container_registry_access_level":"enabled","emails_disabled":null,"shared_runners_enabled":true,"lfs_enabled":true,"creator_id":9448734,"import_status":"none","open_issues_count":0,"ci_default_git_depth":50,"ci_forward_deployment_enabled":true,"ci_job_token_scope_enabled":false,"public_jobs":true,"build_timeout":3600,"auto_cancel_pending_pipelines":"enabled","build_coverage_regex":null,"ci_config_path":"","shared_with_groups":[],"only_allow_merge_if_pipeline_succeeds":false,"allow_merge_on_skipped_pipeline":null,"restrict_user_defined_variables":false,"request_access_enabled":true,"only_allow_merge_if_all_discussions_are_resolved":false,"remove_source_branch_after_merge":true,"printing_merge_request_link_enabled":true,"merge_method":"merge","squash_option":"default_off","suggestion_commit_message":null,"auto_devops_enabled":false,"auto_devops_deploy_strategy":"continuous","autoclose_referenced_issues":true,"keep_latest_artifact":true,"external_authorization_classification_label":"","requirements_enabled":false,"security_and_compliance_enabled":true,"compliance_frameworks":[]},{"id":29437553,"description":"","name":"nginxgroup","name_with_namespace":"weaveworks
+      / nginxgroup","path":"nginxgroup","path_with_namespace":"weaveworks/nginxgroup","created_at":"2021-09-07T19:44:23.068Z","default_branch":"main","tag_list":[],"topics":[],"ssh_url_to_repo":"git@gitlab.com:weaveworks/nginxgroup.git","http_url_to_repo":"https://gitlab.com/weaveworks/nginxgroup.git","web_url":"https://gitlab.com/weaveworks/nginxgroup","readme_url":null,"avatar_url":null,"forks_count":0,"star_count":0,"last_activity_at":"2021-09-14T20:40:53.551Z","namespace":{"id":12950108,"name":"weaveworks","path":"weaveworks","kind":"group","full_path":"weaveworks","parent_id":null,"avatar_url":null,"web_url":"https://gitlab.com/groups/weaveworks"},"container_registry_image_prefix":"registry.gitlab.com/weaveworks/nginxgroup","_links":{"self":"https://gitlab.com/api/v4/projects/29437553","issues":"https://gitlab.com/api/v4/projects/29437553/issues","merge_requests":"https://gitlab.com/api/v4/projects/29437553/merge_requests","repo_branches":"https://gitlab.com/api/v4/projects/29437553/repository/branches","labels":"https://gitlab.com/api/v4/projects/29437553/labels","events":"https://gitlab.com/api/v4/projects/29437553/events","members":"https://gitlab.com/api/v4/projects/29437553/members"},"packages_enabled":true,"empty_repo":false,"archived":false,"visibility":"private","resolve_outdated_diff_discussions":false,"container_expiration_policy":{"cadence":"1d","enabled":false,"keep_n":10,"older_than":"90d","name_regex":".*","name_regex_keep":null,"next_run_at":"2021-09-08T19:44:23.091Z"},"issues_enabled":true,"merge_requests_enabled":true,"wiki_enabled":true,"jobs_enabled":true,"snippets_enabled":true,"container_registry_enabled":true,"service_desk_enabled":true,"service_desk_address":"incoming+weaveworks-nginxgroup-29437553-issue-@incoming.gitlab.com","can_create_merge_request_in":true,"issues_access_level":"enabled","repository_access_level":"enabled","merge_requests_access_level":"enabled","forking_access_level":"enabled","wiki_access_level":"enabled","builds_access_level":"enabled","snippets_access_level":"enabled","pages_access_level":"private","operations_access_level":"enabled","analytics_access_level":"enabled","container_registry_access_level":"enabled","emails_disabled":null,"shared_runners_enabled":true,"lfs_enabled":true,"creator_id":9448734,"import_status":"none","open_issues_count":0,"ci_default_git_depth":50,"ci_forward_deployment_enabled":true,"ci_job_token_scope_enabled":false,"public_jobs":true,"build_timeout":3600,"auto_cancel_pending_pipelines":"enabled","build_coverage_regex":null,"ci_config_path":"","shared_with_groups":[],"only_allow_merge_if_pipeline_succeeds":false,"allow_merge_on_skipped_pipeline":null,"restrict_user_defined_variables":false,"request_access_enabled":true,"only_allow_merge_if_all_discussions_are_resolved":false,"remove_source_branch_after_merge":true,"printing_merge_request_link_enabled":true,"merge_method":"merge","squash_option":"default_off","suggestion_commit_message":null,"auto_devops_enabled":false,"auto_devops_deploy_strategy":"continuous","autoclose_referenced_issues":true,"keep_latest_artifact":true,"external_authorization_classification_label":"","requirements_enabled":false,"security_and_compliance_enabled":true,"compliance_frameworks":[]},{"id":28692370,"description":"test","name":"mre","name_with_namespace":"weaveworks
+      / mre","path":"mre","path_with_namespace":"weaveworks/mre","created_at":"2021-08-06T21:42:06.180Z","default_branch":"main","tag_list":[],"topics":[],"ssh_url_to_repo":"git@gitlab.com:weaveworks/mre.git","http_url_to_repo":"https://gitlab.com/weaveworks/mre.git","web_url":"https://gitlab.com/weaveworks/mre","readme_url":"https://gitlab.com/weaveworks/mre/-/blob/main/README.md","avatar_url":null,"forks_count":0,"star_count":0,"last_activity_at":"2021-08-06T21:42:06.180Z","namespace":{"id":12950108,"name":"weaveworks","path":"weaveworks","kind":"group","full_path":"weaveworks","parent_id":null,"avatar_url":null,"web_url":"https://gitlab.com/groups/weaveworks"},"container_registry_image_prefix":"registry.gitlab.com/weaveworks/mre","_links":{"self":"https://gitlab.com/api/v4/projects/28692370","issues":"https://gitlab.com/api/v4/projects/28692370/issues","merge_requests":"https://gitlab.com/api/v4/projects/28692370/merge_requests","repo_branches":"https://gitlab.com/api/v4/projects/28692370/repository/branches","labels":"https://gitlab.com/api/v4/projects/28692370/labels","events":"https://gitlab.com/api/v4/projects/28692370/events","members":"https://gitlab.com/api/v4/projects/28692370/members"},"packages_enabled":true,"empty_repo":false,"archived":false,"visibility":"private","resolve_outdated_diff_discussions":false,"container_expiration_policy":{"cadence":"1d","enabled":false,"keep_n":10,"older_than":"90d","name_regex":".*","name_regex_keep":null,"next_run_at":"2021-08-07T21:42:06.209Z"},"issues_enabled":true,"merge_requests_enabled":true,"wiki_enabled":true,"jobs_enabled":true,"snippets_enabled":true,"container_registry_enabled":true,"service_desk_enabled":true,"service_desk_address":"incoming+weaveworks-mre-28692370-issue-@incoming.gitlab.com","can_create_merge_request_in":true,"issues_access_level":"enabled","repository_access_level":"enabled","merge_requests_access_level":"enabled","forking_access_level":"enabled","wiki_access_level":"enabled","builds_access_level":"enabled","snippets_access_level":"enabled","pages_access_level":"private","operations_access_level":"enabled","analytics_access_level":"enabled","container_registry_access_level":"enabled","emails_disabled":null,"shared_runners_enabled":true,"lfs_enabled":true,"creator_id":9463163,"import_status":"none","open_issues_count":0,"ci_default_git_depth":50,"ci_forward_deployment_enabled":true,"ci_job_token_scope_enabled":false,"public_jobs":true,"build_timeout":3600,"auto_cancel_pending_pipelines":"enabled","build_coverage_regex":null,"ci_config_path":"","shared_with_groups":[],"only_allow_merge_if_pipeline_succeeds":false,"allow_merge_on_skipped_pipeline":null,"restrict_user_defined_variables":false,"request_access_enabled":true,"only_allow_merge_if_all_discussions_are_resolved":false,"remove_source_branch_after_merge":true,"printing_merge_request_link_enabled":true,"merge_method":"merge","squash_option":"default_off","suggestion_commit_message":null,"auto_devops_enabled":false,"auto_devops_deploy_strategy":"continuous","autoclose_referenced_issues":true,"keep_latest_artifact":true,"external_authorization_classification_label":"","requirements_enabled":false,"security_and_compliance_enabled":true,"compliance_frameworks":[]}],"shared_projects":[],"shared_runners_minutes_limit":null,"extra_shared_runners_minutes_limit":null,"prevent_forking_outside_group":null}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Ray:
+      - 68fcbf95fa062806-SLC
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Sep 2021 20:12:13 GMT
+      Etag:
+      - W/"85235ed85e5ed1ed96119a725732936c"
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Gitlab-Lb:
+      - fe-12-lb-gprd
+      Gitlab-Sv:
+      - localhost
+      Ratelimit-Limit:
+      - "2000"
+      Ratelimit-Observed:
+      - "6"
+      Ratelimit-Remaining:
+      - "1994"
+      Ratelimit-Reset:
+      - "1631823193"
+      Ratelimit-Resettime:
+      - Thu, 16 Sep 2021 20:13:13 GMT
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Request-Id:
+      - 01FFR3SYFNZKJJEE7TRP53C1HJ
+      X-Runtime:
+      - "0.354244"
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Authorization:
+      - Bearer 3QcwbqArcVLJsJX1hCGa
+      User-Agent:
+      - go-gitlab
+    url: https://gitlab.com/api/v4/projects/weaveworks%2Frepo-exists-group
+    method: GET
+  response:
+    body: '{"id":29675264,"description":"Weave Gitops repo","name":"repo-exists-group","name_with_namespace":"weaveworks
+      / repo-exists-group","path":"repo-exists-group","path_with_namespace":"weaveworks/repo-exists-group","created_at":"2021-09-16T20:12:11.794Z","default_branch":"main","tag_list":[],"topics":[],"ssh_url_to_repo":"git@gitlab.com:weaveworks/repo-exists-group.git","http_url_to_repo":"https://gitlab.com/weaveworks/repo-exists-group.git","web_url":"https://gitlab.com/weaveworks/repo-exists-group","readme_url":"https://gitlab.com/weaveworks/repo-exists-group/-/blob/main/README.md","avatar_url":null,"forks_count":0,"star_count":0,"last_activity_at":"2021-09-16T20:12:11.794Z","namespace":{"id":12950108,"name":"weaveworks","path":"weaveworks","kind":"group","full_path":"weaveworks","parent_id":null,"avatar_url":null,"web_url":"https://gitlab.com/groups/weaveworks"},"container_registry_image_prefix":"registry.gitlab.com/weaveworks/repo-exists-group","_links":{"self":"https://gitlab.com/api/v4/projects/29675264","issues":"https://gitlab.com/api/v4/projects/29675264/issues","merge_requests":"https://gitlab.com/api/v4/projects/29675264/merge_requests","repo_branches":"https://gitlab.com/api/v4/projects/29675264/repository/branches","labels":"https://gitlab.com/api/v4/projects/29675264/labels","events":"https://gitlab.com/api/v4/projects/29675264/events","members":"https://gitlab.com/api/v4/projects/29675264/members"},"packages_enabled":true,"empty_repo":false,"archived":false,"visibility":"private","resolve_outdated_diff_discussions":false,"container_expiration_policy":{"cadence":"1d","enabled":false,"keep_n":10,"older_than":"90d","name_regex":".*","name_regex_keep":null,"next_run_at":"2021-09-17T20:12:11.816Z"},"issues_enabled":true,"merge_requests_enabled":true,"wiki_enabled":true,"jobs_enabled":true,"snippets_enabled":true,"container_registry_enabled":true,"service_desk_enabled":true,"service_desk_address":"incoming+weaveworks-repo-exists-group-29675264-issue-@incoming.gitlab.com","can_create_merge_request_in":true,"issues_access_level":"enabled","repository_access_level":"enabled","merge_requests_access_level":"enabled","forking_access_level":"enabled","wiki_access_level":"enabled","builds_access_level":"enabled","snippets_access_level":"enabled","pages_access_level":"private","operations_access_level":"enabled","analytics_access_level":"enabled","container_registry_access_level":"enabled","emails_disabled":null,"shared_runners_enabled":true,"lfs_enabled":true,"creator_id":9448734,"import_status":"none","import_error":null,"open_issues_count":0,"runners_token":"3exXWy_U_KziYYW-UjJo","ci_default_git_depth":50,"ci_forward_deployment_enabled":true,"ci_job_token_scope_enabled":false,"public_jobs":true,"build_git_strategy":"fetch","build_timeout":3600,"auto_cancel_pending_pipelines":"enabled","build_coverage_regex":null,"ci_config_path":"","shared_with_groups":[],"only_allow_merge_if_pipeline_succeeds":false,"allow_merge_on_skipped_pipeline":null,"restrict_user_defined_variables":false,"request_access_enabled":true,"only_allow_merge_if_all_discussions_are_resolved":false,"remove_source_branch_after_merge":true,"printing_merge_request_link_enabled":true,"merge_method":"merge","squash_option":"default_off","suggestion_commit_message":null,"auto_devops_enabled":false,"auto_devops_deploy_strategy":"continuous","autoclose_referenced_issues":true,"keep_latest_artifact":true,"external_authorization_classification_label":"","requirements_enabled":false,"security_and_compliance_enabled":true,"compliance_frameworks":[],"permissions":{"project_access":null,"group_access":{"access_level":50,"notification_level":3}}}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Ray:
+      - 68fcbf98fd1d2806-SLC
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Sep 2021 20:12:13 GMT
+      Etag:
+      - W/"1493feb5ee24e0ee72a8d3dc8fe0d77c"
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Gitlab-Lb:
+      - fe-12-lb-gprd
+      Gitlab-Sv:
+      - localhost
+      Ratelimit-Limit:
+      - "2000"
+      Ratelimit-Observed:
+      - "7"
+      Ratelimit-Remaining:
+      - "1993"
+      Ratelimit-Reset:
+      - "1631823193"
+      Ratelimit-Resettime:
+      - Thu, 16 Sep 2021 20:13:13 GMT
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Request-Id:
+      - 01FFR3SYYS3SP2T43E8PBS0THX
+      X-Runtime:
+      - "0.095171"
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Authorization:
+      - Bearer 3QcwbqArcVLJsJX1hCGa
+      User-Agent:
+      - go-gitlab
+    url: https://gitlab.com/api/v4/projects/weaveworks%2Frepo-exists-group
+    method: GET
+  response:
+    body: '{"id":29675264,"description":"Weave Gitops repo","name":"repo-exists-group","name_with_namespace":"weaveworks
+      / repo-exists-group","path":"repo-exists-group","path_with_namespace":"weaveworks/repo-exists-group","created_at":"2021-09-16T20:12:11.794Z","default_branch":"main","tag_list":[],"topics":[],"ssh_url_to_repo":"git@gitlab.com:weaveworks/repo-exists-group.git","http_url_to_repo":"https://gitlab.com/weaveworks/repo-exists-group.git","web_url":"https://gitlab.com/weaveworks/repo-exists-group","readme_url":"https://gitlab.com/weaveworks/repo-exists-group/-/blob/main/README.md","avatar_url":null,"forks_count":0,"star_count":0,"last_activity_at":"2021-09-16T20:12:11.794Z","namespace":{"id":12950108,"name":"weaveworks","path":"weaveworks","kind":"group","full_path":"weaveworks","parent_id":null,"avatar_url":null,"web_url":"https://gitlab.com/groups/weaveworks"},"container_registry_image_prefix":"registry.gitlab.com/weaveworks/repo-exists-group","_links":{"self":"https://gitlab.com/api/v4/projects/29675264","issues":"https://gitlab.com/api/v4/projects/29675264/issues","merge_requests":"https://gitlab.com/api/v4/projects/29675264/merge_requests","repo_branches":"https://gitlab.com/api/v4/projects/29675264/repository/branches","labels":"https://gitlab.com/api/v4/projects/29675264/labels","events":"https://gitlab.com/api/v4/projects/29675264/events","members":"https://gitlab.com/api/v4/projects/29675264/members"},"packages_enabled":true,"empty_repo":false,"archived":false,"visibility":"private","resolve_outdated_diff_discussions":false,"container_expiration_policy":{"cadence":"1d","enabled":false,"keep_n":10,"older_than":"90d","name_regex":".*","name_regex_keep":null,"next_run_at":"2021-09-17T20:12:11.816Z"},"issues_enabled":true,"merge_requests_enabled":true,"wiki_enabled":true,"jobs_enabled":true,"snippets_enabled":true,"container_registry_enabled":true,"service_desk_enabled":true,"service_desk_address":"incoming+weaveworks-repo-exists-group-29675264-issue-@incoming.gitlab.com","can_create_merge_request_in":true,"issues_access_level":"enabled","repository_access_level":"enabled","merge_requests_access_level":"enabled","forking_access_level":"enabled","wiki_access_level":"enabled","builds_access_level":"enabled","snippets_access_level":"enabled","pages_access_level":"private","operations_access_level":"enabled","analytics_access_level":"enabled","container_registry_access_level":"enabled","emails_disabled":null,"shared_runners_enabled":true,"lfs_enabled":true,"creator_id":9448734,"import_status":"none","import_error":null,"open_issues_count":0,"runners_token":"3exXWy_U_KziYYW-UjJo","ci_default_git_depth":50,"ci_forward_deployment_enabled":true,"ci_job_token_scope_enabled":false,"public_jobs":true,"build_git_strategy":"fetch","build_timeout":3600,"auto_cancel_pending_pipelines":"enabled","build_coverage_regex":null,"ci_config_path":"","shared_with_groups":[],"only_allow_merge_if_pipeline_succeeds":false,"allow_merge_on_skipped_pipeline":null,"restrict_user_defined_variables":false,"request_access_enabled":true,"only_allow_merge_if_all_discussions_are_resolved":false,"remove_source_branch_after_merge":true,"printing_merge_request_link_enabled":true,"merge_method":"merge","squash_option":"default_off","suggestion_commit_message":null,"auto_devops_enabled":false,"auto_devops_deploy_strategy":"continuous","autoclose_referenced_issues":true,"keep_latest_artifact":true,"external_authorization_classification_label":"","requirements_enabled":false,"security_and_compliance_enabled":true,"compliance_frameworks":[],"permissions":{"project_access":null,"group_access":{"access_level":50,"notification_level":3}}}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Ray:
+      - 68fcbf9a3e7e2806-SLC
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Sep 2021 20:12:14 GMT
+      Etag:
+      - W/"1493feb5ee24e0ee72a8d3dc8fe0d77c"
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Gitlab-Lb:
+      - fe-04-lb-gprd
+      Gitlab-Sv:
+      - localhost
+      Ratelimit-Limit:
+      - "2000"
+      Ratelimit-Observed:
+      - "8"
+      Ratelimit-Remaining:
+      - "1992"
+      Ratelimit-Reset:
+      - "1631823194"
+      Ratelimit-Resettime:
+      - Thu, 16 Sep 2021 20:13:14 GMT
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Request-Id:
+      - 01FFR3SZ512EYQKSA1FM9HWNYH
+      X-Runtime:
+      - "0.165555"
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Authorization:
+      - Bearer 3QcwbqArcVLJsJX1hCGa
+      User-Agent:
+      - go-gitlab
+    url: https://gitlab.com/api/v4/projects/weaveworks%2Frepo-exists-group
+    method: DELETE
+  response:
+    body: '{"message":"202 Accepted"}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Ray:
+      - 68fcbf9c38512806-SLC
+      Content-Length:
+      - "26"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Sep 2021 20:12:14 GMT
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Gitlab-Lb:
+      - fe-15-lb-gprd
+      Gitlab-Sv:
+      - localhost
+      Ratelimit-Limit:
+      - "2000"
+      Ratelimit-Observed:
+      - "9"
+      Ratelimit-Remaining:
+      - "1991"
+      Ratelimit-Reset:
+      - "1631823194"
+      Ratelimit-Resettime:
+      - Thu, 16 Sep 2021 20:13:14 GMT
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Request-Id:
+      - 01FFR3SZETDP02HXGSKYH60ES2
+      X-Runtime:
+      - "0.083193"
+    status: 202 Accepted
+    code: 202
+    duration: ""

--- a/pkg/gitproviders/cache/gitlab_repo_personal_exists.yaml
+++ b/pkg/gitproviders/cache/gitlab_repo_personal_exists.yaml
@@ -1,0 +1,508 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers: {}
+    url: https://gitlab.com/api/v4/
+    method: GET
+  response:
+    body: '{"error":"404 Not Found"}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Ray:
+      - 68fcad69ac1527c8-SLC
+      Content-Length:
+      - "25"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Sep 2021 19:59:48 GMT
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Gitlab-Lb:
+      - fe-09-lb-gprd
+      Gitlab-Sv:
+      - localhost
+      Ratelimit-Limit:
+      - "2000"
+      Ratelimit-Observed:
+      - "1"
+      Ratelimit-Remaining:
+      - "1999"
+      Ratelimit-Reset:
+      - "1631822448"
+      Ratelimit-Resettime:
+      - Thu, 16 Sep 2021 20:00:48 GMT
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Request-Id:
+      - 01FFR337J559F8FA6C0DHBD9Z0
+      X-Runtime:
+      - "0.028862"
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Authorization:
+      - Bearer 3QcwbqArcVLJsJX1hCGa
+      User-Agent:
+      - go-gitlab
+    url: https://gitlab.com/api/v4/groups/bot
+    method: GET
+  response:
+    body: '{"message":"404 Group Not Found"}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Ray:
+      - 68fcad6b3dc127c8-SLC
+      Content-Length:
+      - "33"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Sep 2021 19:59:49 GMT
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Gitlab-Lb:
+      - fe-15-lb-gprd
+      Gitlab-Sv:
+      - localhost
+      Ratelimit-Limit:
+      - "2000"
+      Ratelimit-Observed:
+      - "2"
+      Ratelimit-Remaining:
+      - "1998"
+      Ratelimit-Reset:
+      - "1631822449"
+      Ratelimit-Resettime:
+      - Thu, 16 Sep 2021 20:00:49 GMT
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Request-Id:
+      - 01FFR337T0ZFRHNZHKJZM7RCJ9
+      X-Runtime:
+      - "0.083138"
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: '{"name":"repo-exists-personal","default_branch":"main","description":"Weave
+      Gitops repo","visibility":"private","initialize_with_readme":true}'
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Authorization:
+      - Bearer 3QcwbqArcVLJsJX1hCGa
+      Content-Type:
+      - application/json
+      User-Agent:
+      - go-gitlab
+    url: https://gitlab.com/api/v4/projects
+    method: POST
+  response:
+    body: '{"id":29674943,"description":"Weave Gitops repo","name":"repo-exists-personal","name_with_namespace":"Justin
+      Thompson / repo-exists-personal","path":"repo-exists-personal","path_with_namespace":"bot/repo-exists-personal","created_at":"2021-09-16T19:59:49.728Z","default_branch":"main","tag_list":[],"topics":[],"ssh_url_to_repo":"git@gitlab.com:bot/repo-exists-personal.git","http_url_to_repo":"https://gitlab.com/bot/repo-exists-personal.git","web_url":"https://gitlab.com/bot/repo-exists-personal","readme_url":"https://gitlab.com/bot/repo-exists-personal/-/blob/main/README.md","avatar_url":null,"forks_count":0,"star_count":0,"last_activity_at":"2021-09-16T19:59:49.728Z","namespace":{"id":12928988,"name":"Justin
+      Thompson","path":"bot","kind":"user","full_path":"bot","parent_id":null,"avatar_url":"https://secure.gravatar.com/avatar/62dfcd7af41091ec077a9f91aa3e5bb7?s=80\u0026d=identicon","web_url":"https://gitlab.com/bot"},"container_registry_image_prefix":"registry.gitlab.com/j-thompson12/repo-exists-personal","_links":{"self":"https://gitlab.com/api/v4/projects/29674943","issues":"https://gitlab.com/api/v4/projects/29674943/issues","merge_requests":"https://gitlab.com/api/v4/projects/29674943/merge_requests","repo_branches":"https://gitlab.com/api/v4/projects/29674943/repository/branches","labels":"https://gitlab.com/api/v4/projects/29674943/labels","events":"https://gitlab.com/api/v4/projects/29674943/events","members":"https://gitlab.com/api/v4/projects/29674943/members"},"packages_enabled":true,"empty_repo":false,"archived":false,"visibility":"private","owner":{"id":9448734,"name":"Justin
+      Thompson","username":"bot","state":"active","avatar_url":"https://secure.gravatar.com/avatar/62dfcd7af41091ec077a9f91aa3e5bb7?s=80\u0026d=identicon","web_url":"https://gitlab.com/bot"},"resolve_outdated_diff_discussions":false,"container_expiration_policy":{"cadence":"1d","enabled":false,"keep_n":10,"older_than":"90d","name_regex":".*","name_regex_keep":null,"next_run_at":"2021-09-17T19:59:49.802Z"},"issues_enabled":true,"merge_requests_enabled":true,"wiki_enabled":true,"jobs_enabled":true,"snippets_enabled":true,"container_registry_enabled":true,"service_desk_enabled":true,"service_desk_address":"incoming+j-thompson12-repo-exists-personal-29674943-issue-@incoming.gitlab.com","can_create_merge_request_in":true,"issues_access_level":"enabled","repository_access_level":"enabled","merge_requests_access_level":"enabled","forking_access_level":"enabled","wiki_access_level":"enabled","builds_access_level":"enabled","snippets_access_level":"enabled","pages_access_level":"private","operations_access_level":"enabled","analytics_access_level":"enabled","container_registry_access_level":"enabled","emails_disabled":null,"shared_runners_enabled":true,"lfs_enabled":true,"creator_id":9448734,"import_status":"none","import_error":null,"open_issues_count":0,"runners_token":"MLxfukHs6ykumK-cjysj","ci_default_git_depth":50,"ci_forward_deployment_enabled":true,"ci_job_token_scope_enabled":false,"public_jobs":true,"build_git_strategy":"fetch","build_timeout":3600,"auto_cancel_pending_pipelines":"enabled","build_coverage_regex":null,"ci_config_path":"","shared_with_groups":[],"only_allow_merge_if_pipeline_succeeds":false,"allow_merge_on_skipped_pipeline":null,"restrict_user_defined_variables":false,"request_access_enabled":true,"only_allow_merge_if_all_discussions_are_resolved":false,"remove_source_branch_after_merge":true,"printing_merge_request_link_enabled":true,"merge_method":"merge","squash_option":"default_off","suggestion_commit_message":null,"auto_devops_enabled":false,"auto_devops_deploy_strategy":"continuous","autoclose_referenced_issues":true,"keep_latest_artifact":true,"external_authorization_classification_label":"","requirements_enabled":false,"security_and_compliance_enabled":true,"compliance_frameworks":[]}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Ray:
+      - 68fcad6c582627c8-SLC
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Sep 2021 19:59:51 GMT
+      Etag:
+      - W/"3081a02f534c6098a77150c6bf5f6f3f"
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Gitlab-Lb:
+      - fe-02-lb-gprd
+      Gitlab-Sv:
+      - localhost
+      Ratelimit-Limit:
+      - "2000"
+      Ratelimit-Observed:
+      - "3"
+      Ratelimit-Remaining:
+      - "1997"
+      Ratelimit-Reset:
+      - "1631822451"
+      Ratelimit-Resettime:
+      - Thu, 16 Sep 2021 20:00:51 GMT
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Request-Id:
+      - 01FFR337ZWTZJSP343APJ9VMWM
+      X-Runtime:
+      - "2.020445"
+    status: 201 Created
+    code: 201
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Authorization:
+      - Bearer 3QcwbqArcVLJsJX1hCGa
+      User-Agent:
+      - go-gitlab
+    url: https://gitlab.com/api/v4/projects/bot%2Frepo-exists-personal
+    method: GET
+  response:
+    body: '{"id":29674943,"description":"Weave Gitops repo","name":"repo-exists-personal","name_with_namespace":"Justin
+      Thompson / repo-exists-personal","path":"repo-exists-personal","path_with_namespace":"bot/repo-exists-personal","created_at":"2021-09-16T19:59:49.728Z","default_branch":"main","tag_list":[],"topics":[],"ssh_url_to_repo":"git@gitlab.com:bot/repo-exists-personal.git","http_url_to_repo":"https://gitlab.com/bot/repo-exists-personal.git","web_url":"https://gitlab.com/bot/repo-exists-personal","readme_url":"https://gitlab.com/bot/repo-exists-personal/-/blob/main/README.md","avatar_url":null,"forks_count":0,"star_count":0,"last_activity_at":"2021-09-16T19:59:49.728Z","namespace":{"id":12928988,"name":"Justin
+      Thompson","path":"bot","kind":"user","full_path":"bot","parent_id":null,"avatar_url":"https://secure.gravatar.com/avatar/62dfcd7af41091ec077a9f91aa3e5bb7?s=80\u0026d=identicon","web_url":"https://gitlab.com/bot"},"container_registry_image_prefix":"registry.gitlab.com/j-thompson12/repo-exists-personal","_links":{"self":"https://gitlab.com/api/v4/projects/29674943","issues":"https://gitlab.com/api/v4/projects/29674943/issues","merge_requests":"https://gitlab.com/api/v4/projects/29674943/merge_requests","repo_branches":"https://gitlab.com/api/v4/projects/29674943/repository/branches","labels":"https://gitlab.com/api/v4/projects/29674943/labels","events":"https://gitlab.com/api/v4/projects/29674943/events","members":"https://gitlab.com/api/v4/projects/29674943/members"},"packages_enabled":true,"empty_repo":false,"archived":false,"visibility":"private","owner":{"id":9448734,"name":"Justin
+      Thompson","username":"bot","state":"active","avatar_url":"https://secure.gravatar.com/avatar/62dfcd7af41091ec077a9f91aa3e5bb7?s=80\u0026d=identicon","web_url":"https://gitlab.com/bot"},"resolve_outdated_diff_discussions":false,"container_expiration_policy":{"cadence":"1d","enabled":false,"keep_n":10,"older_than":"90d","name_regex":".*","name_regex_keep":null,"next_run_at":"2021-09-17T19:59:49.802Z"},"issues_enabled":true,"merge_requests_enabled":true,"wiki_enabled":true,"jobs_enabled":true,"snippets_enabled":true,"container_registry_enabled":true,"service_desk_enabled":true,"service_desk_address":"incoming+j-thompson12-repo-exists-personal-29674943-issue-@incoming.gitlab.com","can_create_merge_request_in":true,"issues_access_level":"enabled","repository_access_level":"enabled","merge_requests_access_level":"enabled","forking_access_level":"enabled","wiki_access_level":"enabled","builds_access_level":"enabled","snippets_access_level":"enabled","pages_access_level":"private","operations_access_level":"enabled","analytics_access_level":"enabled","container_registry_access_level":"enabled","emails_disabled":null,"shared_runners_enabled":true,"lfs_enabled":true,"creator_id":9448734,"import_status":"none","import_error":null,"open_issues_count":0,"runners_token":"MLxfukHs6ykumK-cjysj","ci_default_git_depth":50,"ci_forward_deployment_enabled":true,"ci_job_token_scope_enabled":false,"public_jobs":true,"build_git_strategy":"fetch","build_timeout":3600,"auto_cancel_pending_pipelines":"enabled","build_coverage_regex":null,"ci_config_path":"","shared_with_groups":[],"only_allow_merge_if_pipeline_succeeds":false,"allow_merge_on_skipped_pipeline":null,"restrict_user_defined_variables":false,"request_access_enabled":true,"only_allow_merge_if_all_discussions_are_resolved":false,"remove_source_branch_after_merge":true,"printing_merge_request_link_enabled":true,"merge_method":"merge","squash_option":"default_off","suggestion_commit_message":null,"auto_devops_enabled":false,"auto_devops_deploy_strategy":"continuous","autoclose_referenced_issues":true,"keep_latest_artifact":true,"external_authorization_classification_label":"","requirements_enabled":false,"security_and_compliance_enabled":true,"compliance_frameworks":[],"permissions":{"project_access":{"access_level":40,"notification_level":3},"group_access":null}}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Ray:
+      - 68fcad79a81027c8-SLC
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Sep 2021 19:59:51 GMT
+      Etag:
+      - W/"584a9805a056ce7fd69cc4703c33886e"
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Gitlab-Lb:
+      - fe-06-lb-gprd
+      Gitlab-Sv:
+      - localhost
+      Ratelimit-Limit:
+      - "2000"
+      Ratelimit-Observed:
+      - "4"
+      Ratelimit-Remaining:
+      - "1996"
+      Ratelimit-Reset:
+      - "1631822451"
+      Ratelimit-Resettime:
+      - Thu, 16 Sep 2021 20:00:51 GMT
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Request-Id:
+      - 01FFR33A2D5EZ4B03MWM9AWPZF
+      X-Runtime:
+      - "0.081998"
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Authorization:
+      - Bearer 3QcwbqArcVLJsJX1hCGa
+      User-Agent:
+      - go-gitlab
+    url: https://gitlab.com/api/v4/groups/bot
+    method: GET
+  response:
+    body: '{"message":"404 Group Not Found"}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Ray:
+      - 68fcad7ad9a027c8-SLC
+      Content-Length:
+      - "33"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Sep 2021 19:59:51 GMT
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Gitlab-Lb:
+      - fe-06-lb-gprd
+      Gitlab-Sv:
+      - localhost
+      Ratelimit-Limit:
+      - "2000"
+      Ratelimit-Observed:
+      - "5"
+      Ratelimit-Remaining:
+      - "1995"
+      Ratelimit-Reset:
+      - "1631822451"
+      Ratelimit-Resettime:
+      - Thu, 16 Sep 2021 20:00:51 GMT
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Request-Id:
+      - 01FFR33A8BM235NX2RX8W39Y6G
+      X-Runtime:
+      - "0.028542"
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Authorization:
+      - Bearer 3QcwbqArcVLJsJX1hCGa
+      User-Agent:
+      - go-gitlab
+    url: https://gitlab.com/api/v4/projects/bot%2Frepo-exists-personal
+    method: GET
+  response:
+    body: '{"id":29674943,"description":"Weave Gitops repo","name":"repo-exists-personal","name_with_namespace":"Justin
+      Thompson / repo-exists-personal","path":"repo-exists-personal","path_with_namespace":"bot/repo-exists-personal","created_at":"2021-09-16T19:59:49.728Z","default_branch":"main","tag_list":[],"topics":[],"ssh_url_to_repo":"git@gitlab.com:bot/repo-exists-personal.git","http_url_to_repo":"https://gitlab.com/bot/repo-exists-personal.git","web_url":"https://gitlab.com/bot/repo-exists-personal","readme_url":"https://gitlab.com/bot/repo-exists-personal/-/blob/main/README.md","avatar_url":null,"forks_count":0,"star_count":0,"last_activity_at":"2021-09-16T19:59:49.728Z","namespace":{"id":12928988,"name":"Justin
+      Thompson","path":"bot","kind":"user","full_path":"bot","parent_id":null,"avatar_url":"https://secure.gravatar.com/avatar/62dfcd7af41091ec077a9f91aa3e5bb7?s=80\u0026d=identicon","web_url":"https://gitlab.com/bot"},"container_registry_image_prefix":"registry.gitlab.com/j-thompson12/repo-exists-personal","_links":{"self":"https://gitlab.com/api/v4/projects/29674943","issues":"https://gitlab.com/api/v4/projects/29674943/issues","merge_requests":"https://gitlab.com/api/v4/projects/29674943/merge_requests","repo_branches":"https://gitlab.com/api/v4/projects/29674943/repository/branches","labels":"https://gitlab.com/api/v4/projects/29674943/labels","events":"https://gitlab.com/api/v4/projects/29674943/events","members":"https://gitlab.com/api/v4/projects/29674943/members"},"packages_enabled":true,"empty_repo":false,"archived":false,"visibility":"private","owner":{"id":9448734,"name":"Justin
+      Thompson","username":"bot","state":"active","avatar_url":"https://secure.gravatar.com/avatar/62dfcd7af41091ec077a9f91aa3e5bb7?s=80\u0026d=identicon","web_url":"https://gitlab.com/bot"},"resolve_outdated_diff_discussions":false,"container_expiration_policy":{"cadence":"1d","enabled":false,"keep_n":10,"older_than":"90d","name_regex":".*","name_regex_keep":null,"next_run_at":"2021-09-17T19:59:49.802Z"},"issues_enabled":true,"merge_requests_enabled":true,"wiki_enabled":true,"jobs_enabled":true,"snippets_enabled":true,"container_registry_enabled":true,"service_desk_enabled":true,"service_desk_address":"incoming+j-thompson12-repo-exists-personal-29674943-issue-@incoming.gitlab.com","can_create_merge_request_in":true,"issues_access_level":"enabled","repository_access_level":"enabled","merge_requests_access_level":"enabled","forking_access_level":"enabled","wiki_access_level":"enabled","builds_access_level":"enabled","snippets_access_level":"enabled","pages_access_level":"private","operations_access_level":"enabled","analytics_access_level":"enabled","container_registry_access_level":"enabled","emails_disabled":null,"shared_runners_enabled":true,"lfs_enabled":true,"creator_id":9448734,"import_status":"none","import_error":null,"open_issues_count":0,"runners_token":"MLxfukHs6ykumK-cjysj","ci_default_git_depth":50,"ci_forward_deployment_enabled":true,"ci_job_token_scope_enabled":false,"public_jobs":true,"build_git_strategy":"fetch","build_timeout":3600,"auto_cancel_pending_pipelines":"enabled","build_coverage_regex":null,"ci_config_path":"","shared_with_groups":[],"only_allow_merge_if_pipeline_succeeds":false,"allow_merge_on_skipped_pipeline":null,"restrict_user_defined_variables":false,"request_access_enabled":true,"only_allow_merge_if_all_discussions_are_resolved":false,"remove_source_branch_after_merge":true,"printing_merge_request_link_enabled":true,"merge_method":"merge","squash_option":"default_off","suggestion_commit_message":null,"auto_devops_enabled":false,"auto_devops_deploy_strategy":"continuous","autoclose_referenced_issues":true,"keep_latest_artifact":true,"external_authorization_classification_label":"","requirements_enabled":false,"security_and_compliance_enabled":true,"compliance_frameworks":[],"permissions":{"project_access":{"access_level":40,"notification_level":3},"group_access":null}}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Ray:
+      - 68fcad7bbaa427c8-SLC
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Sep 2021 19:59:51 GMT
+      Etag:
+      - W/"584a9805a056ce7fd69cc4703c33886e"
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Gitlab-Lb:
+      - fe-06-lb-gprd
+      Gitlab-Sv:
+      - localhost
+      Ratelimit-Limit:
+      - "2000"
+      Ratelimit-Observed:
+      - "6"
+      Ratelimit-Remaining:
+      - "1994"
+      Ratelimit-Reset:
+      - "1631822451"
+      Ratelimit-Resettime:
+      - Thu, 16 Sep 2021 20:00:51 GMT
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Request-Id:
+      - 01FFR33AC8PP8JDTEHWKW0FKYD
+      X-Runtime:
+      - "0.078690"
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Authorization:
+      - Bearer 3QcwbqArcVLJsJX1hCGa
+      User-Agent:
+      - go-gitlab
+    url: https://gitlab.com/api/v4/projects/bot%2Frepo-exists-personal
+    method: GET
+  response:
+    body: '{"id":29674943,"description":"Weave Gitops repo","name":"repo-exists-personal","name_with_namespace":"Justin
+      Thompson / repo-exists-personal","path":"repo-exists-personal","path_with_namespace":"bot/repo-exists-personal","created_at":"2021-09-16T19:59:49.728Z","default_branch":"main","tag_list":[],"topics":[],"ssh_url_to_repo":"git@gitlab.com:bot/repo-exists-personal.git","http_url_to_repo":"https://gitlab.com/bot/repo-exists-personal.git","web_url":"https://gitlab.com/bot/repo-exists-personal","readme_url":"https://gitlab.com/bot/repo-exists-personal/-/blob/main/README.md","avatar_url":null,"forks_count":0,"star_count":0,"last_activity_at":"2021-09-16T19:59:49.728Z","namespace":{"id":12928988,"name":"Justin
+      Thompson","path":"bot","kind":"user","full_path":"bot","parent_id":null,"avatar_url":"https://secure.gravatar.com/avatar/62dfcd7af41091ec077a9f91aa3e5bb7?s=80\u0026d=identicon","web_url":"https://gitlab.com/bot"},"container_registry_image_prefix":"registry.gitlab.com/j-thompson12/repo-exists-personal","_links":{"self":"https://gitlab.com/api/v4/projects/29674943","issues":"https://gitlab.com/api/v4/projects/29674943/issues","merge_requests":"https://gitlab.com/api/v4/projects/29674943/merge_requests","repo_branches":"https://gitlab.com/api/v4/projects/29674943/repository/branches","labels":"https://gitlab.com/api/v4/projects/29674943/labels","events":"https://gitlab.com/api/v4/projects/29674943/events","members":"https://gitlab.com/api/v4/projects/29674943/members"},"packages_enabled":true,"empty_repo":false,"archived":false,"visibility":"private","owner":{"id":9448734,"name":"Justin
+      Thompson","username":"bot","state":"active","avatar_url":"https://secure.gravatar.com/avatar/62dfcd7af41091ec077a9f91aa3e5bb7?s=80\u0026d=identicon","web_url":"https://gitlab.com/bot"},"resolve_outdated_diff_discussions":false,"container_expiration_policy":{"cadence":"1d","enabled":false,"keep_n":10,"older_than":"90d","name_regex":".*","name_regex_keep":null,"next_run_at":"2021-09-17T19:59:49.802Z"},"issues_enabled":true,"merge_requests_enabled":true,"wiki_enabled":true,"jobs_enabled":true,"snippets_enabled":true,"container_registry_enabled":true,"service_desk_enabled":true,"service_desk_address":"incoming+j-thompson12-repo-exists-personal-29674943-issue-@incoming.gitlab.com","can_create_merge_request_in":true,"issues_access_level":"enabled","repository_access_level":"enabled","merge_requests_access_level":"enabled","forking_access_level":"enabled","wiki_access_level":"enabled","builds_access_level":"enabled","snippets_access_level":"enabled","pages_access_level":"private","operations_access_level":"enabled","analytics_access_level":"enabled","container_registry_access_level":"enabled","emails_disabled":null,"shared_runners_enabled":true,"lfs_enabled":true,"creator_id":9448734,"import_status":"none","import_error":null,"open_issues_count":0,"runners_token":"MLxfukHs6ykumK-cjysj","ci_default_git_depth":50,"ci_forward_deployment_enabled":true,"ci_job_token_scope_enabled":false,"public_jobs":true,"build_git_strategy":"fetch","build_timeout":3600,"auto_cancel_pending_pipelines":"enabled","build_coverage_regex":null,"ci_config_path":"","shared_with_groups":[],"only_allow_merge_if_pipeline_succeeds":false,"allow_merge_on_skipped_pipeline":null,"restrict_user_defined_variables":false,"request_access_enabled":true,"only_allow_merge_if_all_discussions_are_resolved":false,"remove_source_branch_after_merge":true,"printing_merge_request_link_enabled":true,"merge_method":"merge","squash_option":"default_off","suggestion_commit_message":null,"auto_devops_enabled":false,"auto_devops_deploy_strategy":"continuous","autoclose_referenced_issues":true,"keep_latest_artifact":true,"external_authorization_classification_label":"","requirements_enabled":false,"security_and_compliance_enabled":true,"compliance_frameworks":[],"permissions":{"project_access":{"access_level":40,"notification_level":3},"group_access":null}}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Ray:
+      - 68fcad7ccc5027c8-SLC
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Sep 2021 19:59:51 GMT
+      Etag:
+      - W/"584a9805a056ce7fd69cc4703c33886e"
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Gitlab-Lb:
+      - fe-16-lb-gprd
+      Gitlab-Sv:
+      - localhost
+      Ratelimit-Limit:
+      - "2000"
+      Ratelimit-Observed:
+      - "7"
+      Ratelimit-Remaining:
+      - "1993"
+      Ratelimit-Reset:
+      - "1631822451"
+      Ratelimit-Resettime:
+      - Thu, 16 Sep 2021 20:00:51 GMT
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Request-Id:
+      - 01FFR33AHZMTKYGPYGSTBVNN15
+      X-Runtime:
+      - "0.074861"
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Authorization:
+      - Bearer 3QcwbqArcVLJsJX1hCGa
+      User-Agent:
+      - go-gitlab
+    url: https://gitlab.com/api/v4/projects/bot%2Frepo-exists-personal
+    method: DELETE
+  response:
+    body: '{"message":"202 Accepted"}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Ray:
+      - 68fcad7ded7827c8-SLC
+      Content-Length:
+      - "26"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Sep 2021 19:59:52 GMT
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Gitlab-Lb:
+      - fe-14-lb-gprd
+      Gitlab-Sv:
+      - localhost
+      Ratelimit-Limit:
+      - "2000"
+      Ratelimit-Observed:
+      - "8"
+      Ratelimit-Remaining:
+      - "1992"
+      Ratelimit-Reset:
+      - "1631822452"
+      Ratelimit-Resettime:
+      - Thu, 16 Sep 2021 20:00:52 GMT
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Request-Id:
+      - 01FFR33AQG9NTPE7HNHZJEV741
+      X-Runtime:
+      - "0.072732"
+    status: 202 Accepted
+    code: 202
+    duration: ""

--- a/pkg/gitproviders/factory.go
+++ b/pkg/gitproviders/factory.go
@@ -52,6 +52,7 @@ func buildGitProvider(config Config) (gitprovider.Client, string, error) {
 		}
 	case GitProviderGitLab:
 		opts := []gitprovider.ClientOption{
+			gitprovider.WithOAuth2Token(config.Token),
 			gitprovider.WithConditionalRequests(true),
 		}
 		if config.Hostname != "" {

--- a/pkg/gitproviders/provider.go
+++ b/pkg/gitproviders/provider.go
@@ -561,7 +561,7 @@ func (p defaultGitProvider) waitUntilRepoCreated(ownerType ProviderAccountType, 
 // The raw URL is assumed to be something like ssh://git@github.com/myorg/myrepo.git.
 // The common `git clone` variant of `git@github.com:myorg/myrepo.git` is not supported.
 func DetectGitProviderFromUrl(raw string) (GitProviderName, error) {
-	// Needed for gitlab url parse to work
+	// Needed for url parse to work for some urls
 	if strings.HasPrefix(raw, "git@") {
 		raw = "ssh://" + raw
 		raw = strings.Replace(raw, ".com:", ".com/", 1)

--- a/pkg/gitproviders/provider.go
+++ b/pkg/gitproviders/provider.go
@@ -254,7 +254,7 @@ func (p defaultGitProvider) GetAccountType(owner string) (ProviderAccountType, e
 	})
 
 	if err != nil {
-		if errors.Is(err, gitprovider.ErrNotFound) || strings.Contains(err.Error(), "404 Group Not Found") {
+		if errors.Is(err, gitprovider.ErrNotFound) || errors.Is(err, gitprovider.ErrGroupNotFound) {
 			return AccountTypeUser, nil
 		}
 

--- a/pkg/gitproviders/provider.go
+++ b/pkg/gitproviders/provider.go
@@ -679,6 +679,8 @@ func (n NormalizedRepoURL) Protocol() RepositoryURLProtocol {
 }
 
 func getOwnerFromUrl(url url.URL, providerName GitProviderName) (string, error) {
+	url.Path = strings.TrimPrefix(url.Path, "/")
+
 	parts := strings.Split(url.Path, "/")
 	if len(parts) < 2 {
 		return "", fmt.Errorf("could not get owner from url %v", url)
@@ -686,9 +688,12 @@ func getOwnerFromUrl(url url.URL, providerName GitProviderName) (string, error) 
 
 	if providerName == GitProviderGitLab {
 		if len(parts) > 3 {
-			return parts[1] + "/" + parts[2], nil
+			return "", fmt.Errorf("a subgroup in a subgroup is not currently supported")
+		}
+		if len(parts) > 2 {
+			return parts[0] + "/" + parts[1], nil
 		}
 	}
 
-	return parts[1], nil
+	return parts[0], nil
 }

--- a/pkg/gitproviders/provider.go
+++ b/pkg/gitproviders/provider.go
@@ -683,7 +683,7 @@ func getOwnerFromUrl(url url.URL, providerName GitProviderName) (string, error) 
 
 	parts := strings.Split(url.Path, "/")
 	if len(parts) < 2 {
-		return "", fmt.Errorf("could not get owner from url %v", url)
+		return "", fmt.Errorf("could not get owner from url %v", url.String())
 	}
 
 	if providerName == GitProviderGitLab {

--- a/pkg/gitproviders/provider.go
+++ b/pkg/gitproviders/provider.go
@@ -690,6 +690,7 @@ func getOwnerFromUrl(url url.URL, providerName GitProviderName) (string, error) 
 		if len(parts) > 3 {
 			return "", fmt.Errorf("a subgroup in a subgroup is not currently supported")
 		}
+
 		if len(parts) > 2 {
 			return parts[0] + "/" + parts[1], nil
 		}

--- a/pkg/gitproviders/provider.go
+++ b/pkg/gitproviders/provider.go
@@ -254,7 +254,7 @@ func (p defaultGitProvider) GetAccountType(owner string) (ProviderAccountType, e
 	})
 
 	if err != nil {
-		if errors.Is(err, gitprovider.ErrNotFound) {
+		if errors.Is(err, gitprovider.ErrNotFound) || strings.Contains(err.Error(), "404 Group Not Found") {
 			return AccountTypeUser, nil
 		}
 

--- a/pkg/gitproviders/provider.go
+++ b/pkg/gitproviders/provider.go
@@ -254,7 +254,7 @@ func (p defaultGitProvider) GetAccountType(owner string) (ProviderAccountType, e
 	})
 
 	if err != nil {
-		if errors.Is(err, gitprovider.ErrNotFound) || errors.Is(err, gitprovider.ErrGroupNotFound) {
+		if errors.Is(err, gitprovider.ErrNotFound) || strings.Contains(err.Error(), gitprovider.ErrGroupNotFound.Error()) {
 			return AccountTypeUser, nil
 		}
 

--- a/pkg/gitproviders/provider.go
+++ b/pkg/gitproviders/provider.go
@@ -556,12 +556,9 @@ func (p defaultGitProvider) waitUntilRepoCreated(ownerType ProviderAccountType, 
 	return nil
 }
 
-// DetectGitProviderFromUrl accepts a url related to a git repo and
-// returns the name of the provider associated.
 // The raw URL is assumed to be something like ssh://git@github.com/myorg/myrepo.git.
 // The common `git clone` variant of `git@github.com:myorg/myrepo.git` is not supported.
-func DetectGitProviderFromUrl(raw string) (GitProviderName, error) {
-	// Needed for url parse to work for some urls
+func detectGitProviderFromUrl(raw string) (GitProviderName, error) {
 	if strings.HasPrefix(raw, "git@") {
 		raw = "ssh://" + raw
 		raw = strings.Replace(raw, ".com:", ".com/", 1)
@@ -599,7 +596,7 @@ type NormalizedRepoURL struct {
 // normalizeRepoURLString accepts a url like git@github.com:someuser/podinfo.git and converts it into
 // a string like ssh://git@github.com/someuser/podinfo.git. This helps standardize the different
 // user inputs that might be provided.
-func normalizeRepoURLString(url string, providerName string) string {
+func normalizeRepoURLString(url string, providerName GitProviderName) string {
 	trimmed := ""
 
 	if !strings.HasSuffix(url, ".git") {
@@ -624,12 +621,12 @@ func normalizeRepoURLString(url string, providerName string) string {
 }
 
 func NewNormalizedRepoURL(uri string) (NormalizedRepoURL, error) {
-	providerName, err := DetectGitProviderFromUrl(uri)
+	providerName, err := detectGitProviderFromUrl(uri)
 	if err != nil {
 		return NormalizedRepoURL{}, fmt.Errorf("could get provider name from URL %s: %w", uri, err)
 	}
 
-	normalized := normalizeRepoURLString(uri, string(providerName))
+	normalized := normalizeRepoURLString(uri, providerName)
 
 	u, err := url.Parse(normalized)
 	if err != nil {

--- a/pkg/gitproviders/provider_test.go
+++ b/pkg/gitproviders/provider_test.go
@@ -865,18 +865,18 @@ var _ = Describe("Test org deploy keys creation", func() {
 	})
 })
 
-var _ = Describe("helpers", func() {
-	DescribeTable("detectGitProviderFromUrl", func(input string, expected GitProviderName) {
-		result, err := detectGitProviderFromUrl(input)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(result).To(Equal(expected))
-	},
-		Entry("ssh+github", "ssh://git@github.com/weaveworks/weave-gitops.git", GitProviderGitHub),
-		Entry("ssh+gitlab", "ssh://git@gitlab.com/weaveworks/weave-gitops.git", GitProviderGitLab),
-		Entry("ssh+gitlab with subgroup", "git@gitlab.com:gogittest/sub-group/nginxsub.git", GitProviderGitLab),
-	)
+// var _ = Describe("helpers", func() {
+// 	DescribeTable("detectGitProviderFromUrl", func(input string, expected GitProviderName) {
+// 		result, err := detectGitProviderFromUrl(input)
+// 		Expect(err).NotTo(HaveOccurred())
+// 		Expect(result).To(Equal(expected))
+// 	},
+// 		Entry("ssh+github", "ssh://git@github.com/weaveworks/weave-gitops.git", GitProviderGitHub),
+// 		Entry("ssh+gitlab", "ssh://git@gitlab.com/weaveworks/weave-gitops.git", GitProviderGitLab),
+// 		Entry("ssh+gitlab with subgroup", "git@gitlab.com:gogittest/sub-group/nginxsub.git", GitProviderGitLab),
+// 	)
 
-})
+// })
 
 var _ = Describe("get owner from url", func() {
 	DescribeTable("getOwnerFromUrl", func(normalizedUrl string, providerName GitProviderName, expected string) {
@@ -891,6 +891,16 @@ var _ = Describe("get owner from url", func() {
 		Entry("gitlab with subgroup", "ssh://git@gitlab.com/weaveworks/sub_group/weave-gitops.git", GitProviderGitLab, "weaveworks/sub_group"),
 	)
 
+	DescribeTable("getOwnerFromUrl fail paths", func(normalizedUrl string, providerName GitProviderName, expected string) {
+		u, err := url.Parse(normalizedUrl)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = getOwnerFromUrl(*u, providerName)
+		Expect(err).To(HaveOccurred())
+	},
+		Entry("missing owner", "ssh://git@gitlab.com/weave-gitops.git", GitProviderGitLab, "weaveworks"),
+		Entry("empty path", "", GitProviderGitLab, "weaveworks"),
+		Entry("subgroup in a subgroup", "ssh://git@gitlab.com/weaveworks/sub_group/another_sub_group/weave-gitops.git", GitProviderGitLab, ""),
+	)
 })
 
 type expectedRepoURL struct {
@@ -901,73 +911,73 @@ type expectedRepoURL struct {
 	protocol RepositoryURLProtocol
 }
 
-var _ = DescribeTable("NormalizedRepoURL", func(input string, expected expectedRepoURL) {
-	result, err := NewNormalizedRepoURL(input)
-	Expect(err).NotTo(HaveOccurred())
+// var _ = DescribeTable("NormalizedRepoURL", func(input string, expected expectedRepoURL) {
+// 	result, err := NewNormalizedRepoURL(input)
+// 	Expect(err).NotTo(HaveOccurred())
 
-	Expect(result.String()).To(Equal(expected.s))
-	u, err := url.Parse(expected.s)
-	Expect(err).NotTo(HaveOccurred())
-	Expect(result.URL()).To(Equal(u))
-	Expect(result.Owner()).To(Equal(expected.owner))
-	Expect(result.Provider()).To(Equal(expected.provider))
-	Expect(result.Protocol()).To(Equal(expected.protocol))
-},
-	Entry("github git clone style", "git@github.com:someuser/podinfo.git", expectedRepoURL{
-		s:        "ssh://git@github.com/someuser/podinfo.git",
-		owner:    "someuser",
-		name:     "podinfo",
-		provider: GitProviderGitHub,
-		protocol: RepositoryURLProtocolSSH,
-	}),
-	Entry("github url style", "ssh://git@github.com/someuser/podinfo.git", expectedRepoURL{
-		s:        "ssh://git@github.com/someuser/podinfo.git",
-		owner:    "someuser",
-		name:     "podinfo",
-		provider: GitProviderGitHub,
-		protocol: RepositoryURLProtocolSSH,
-	}),
-	Entry("github https", "https://github.com/someuser/podinfo.git", expectedRepoURL{
-		s:        "ssh://git@github.com/someuser/podinfo.git",
-		owner:    "someuser",
-		name:     "podinfo",
-		provider: GitProviderGitHub,
-		protocol: RepositoryURLProtocolSSH,
-	}),
-	Entry("gitlab git clone style", "git@gitlab.com:someuser/podinfo.git", expectedRepoURL{
-		s:        "ssh://git@gitlab.com/someuser/podinfo.git",
-		owner:    "someuser",
-		name:     "podinfo",
-		provider: GitProviderGitLab,
-		protocol: RepositoryURLProtocolSSH,
-	}),
-	Entry("gitlab https", "https://gitlab.com/someuser/podinfo.git", expectedRepoURL{
-		s:        "ssh://git@gitlab.com/someuser/podinfo.git",
-		owner:    "someuser",
-		name:     "podinfo",
-		provider: GitProviderGitLab,
-		protocol: RepositoryURLProtocolSSH,
-	}),
-)
+// 	Expect(result.String()).To(Equal(expected.s))
+// 	u, err := url.Parse(expected.s)
+// 	Expect(err).NotTo(HaveOccurred())
+// 	Expect(result.URL()).To(Equal(u))
+// 	Expect(result.Owner()).To(Equal(expected.owner))
+// 	Expect(result.Provider()).To(Equal(expected.provider))
+// 	Expect(result.Protocol()).To(Equal(expected.protocol))
+// },
+// 	Entry("github git clone style", "git@github.com:someuser/podinfo.git", expectedRepoURL{
+// 		s:        "ssh://git@github.com/someuser/podinfo.git",
+// 		owner:    "someuser",
+// 		name:     "podinfo",
+// 		provider: GitProviderGitHub,
+// 		protocol: RepositoryURLProtocolSSH,
+// 	}),
+// 	Entry("github url style", "ssh://git@github.com/someuser/podinfo.git", expectedRepoURL{
+// 		s:        "ssh://git@github.com/someuser/podinfo.git",
+// 		owner:    "someuser",
+// 		name:     "podinfo",
+// 		provider: GitProviderGitHub,
+// 		protocol: RepositoryURLProtocolSSH,
+// 	}),
+// 	Entry("github https", "https://github.com/someuser/podinfo.git", expectedRepoURL{
+// 		s:        "ssh://git@github.com/someuser/podinfo.git",
+// 		owner:    "someuser",
+// 		name:     "podinfo",
+// 		provider: GitProviderGitHub,
+// 		protocol: RepositoryURLProtocolSSH,
+// 	}),
+// 	Entry("gitlab git clone style", "git@gitlab.com:someuser/podinfo.git", expectedRepoURL{
+// 		s:        "ssh://git@gitlab.com/someuser/podinfo.git",
+// 		owner:    "someuser",
+// 		name:     "podinfo",
+// 		provider: GitProviderGitLab,
+// 		protocol: RepositoryURLProtocolSSH,
+// 	}),
+// 	Entry("gitlab https", "https://gitlab.com/someuser/podinfo.git", expectedRepoURL{
+// 		s:        "ssh://git@gitlab.com/someuser/podinfo.git",
+// 		owner:    "someuser",
+// 		name:     "podinfo",
+// 		provider: GitProviderGitLab,
+// 		protocol: RepositoryURLProtocolSSH,
+// 	}),
+// )
 
-var _ = Describe("Test GetRepoVisiblity", func() {
-	url := "ssh://git@github.com/foo/bar"
-	It("tests that a nil info generates the appropriate error", func() {
-		result, underlyingError := getVisibilityFromRepoInfo(url, nil)
-		Expect(result).To(BeNil())
-		Expect(underlyingError.Error()).To(Equal(fmt.Sprintf("unable to obtain repository visibility for: %s", url)))
-	})
+// var _ = Describe("Test GetRepoVisiblity", func() {
+// 	url := "ssh://git@github.com/foo/bar"
+// 	It("tests that a nil info generates the appropriate error", func() {
+// 		result, underlyingError := getVisibilityFromRepoInfo(url, nil)
+// 		Expect(result).To(BeNil())
+// 		Expect(underlyingError.Error()).To(Equal(fmt.Sprintf("unable to obtain repository visibility for: %s", url)))
+// 	})
 
-	It("tests that a nil visibility reference generates the appropriate error", func() {
-		result, underlyingError := getVisibilityFromRepoInfo(url, &gitprovider.RepositoryInfo{Visibility: nil})
-		Expect(result).To(BeNil())
-		Expect(underlyingError.Error()).To(Equal(fmt.Sprintf("unable to obtain repository visibility for: %s", url)))
-	})
+// 	It("tests that a nil visibility reference generates the appropriate error", func() {
+// 		result, underlyingError := getVisibilityFromRepoInfo(url, &gitprovider.RepositoryInfo{Visibility: nil})
+// 		Expect(result).To(BeNil())
+// 		Expect(underlyingError.Error()).To(Equal(fmt.Sprintf("unable to obtain repository visibility for: %s", url)))
+// 	})
 
-	It("tests that a non-nil visibility reference is successful", func() {
-		public := gitprovider.RepositoryVisibilityPublic
-		result, underlyingError := getVisibilityFromRepoInfo(url, &gitprovider.RepositoryInfo{Visibility: &public})
-		Expect(underlyingError).To(BeNil())
-		Expect(result).To(Equal(&public))
-	})
-})
+// 	It("tests that a non-nil visibility reference is successful", func() {
+// 		public := gitprovider.RepositoryVisibilityPublic
+// 		result, underlyingError := getVisibilityFromRepoInfo(url, &gitprovider.RepositoryInfo{Visibility: &public})
+// 		Expect(underlyingError).To(BeNil())
+// 		Expect(result).To(Equal(&public))
+// 	})
+// })

--- a/pkg/gitproviders/provider_test.go
+++ b/pkg/gitproviders/provider_test.go
@@ -458,6 +458,7 @@ var _ = Describe("test gitlab project", func() {
 		client, recorder, err = getTestClientWithCassette("gitlab_repo_personal_exists", GitLabProviderName)
 		Expect(err).NotTo(HaveOccurred())
 		gitProvider = defaultGitProvider{
+			domain:   gitlab.DefaultDomain,
 			provider: client,
 		}
 	})
@@ -496,6 +497,7 @@ var _ = Describe("test gitlab group project", func() {
 		client, recorder, err = getTestClientWithCassette("gitlab_repo_group_exists", GitLabProviderName)
 		Expect(err).NotTo(HaveOccurred())
 		gitProvider = defaultGitProvider{
+			domain:   gitlab.DefaultDomain,
 			provider: client,
 		}
 	})

--- a/pkg/gitproviders/provider_test.go
+++ b/pkg/gitproviders/provider_test.go
@@ -865,18 +865,18 @@ var _ = Describe("Test org deploy keys creation", func() {
 	})
 })
 
-// var _ = Describe("helpers", func() {
-// 	DescribeTable("detectGitProviderFromUrl", func(input string, expected GitProviderName) {
-// 		result, err := detectGitProviderFromUrl(input)
-// 		Expect(err).NotTo(HaveOccurred())
-// 		Expect(result).To(Equal(expected))
-// 	},
-// 		Entry("ssh+github", "ssh://git@github.com/weaveworks/weave-gitops.git", GitProviderGitHub),
-// 		Entry("ssh+gitlab", "ssh://git@gitlab.com/weaveworks/weave-gitops.git", GitProviderGitLab),
-// 		Entry("ssh+gitlab with subgroup", "git@gitlab.com:gogittest/sub-group/nginxsub.git", GitProviderGitLab),
-// 	)
+var _ = Describe("helpers", func() {
+	DescribeTable("detectGitProviderFromUrl", func(input string, expected GitProviderName) {
+		result, err := detectGitProviderFromUrl(input)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(expected))
+	},
+		Entry("ssh+github", "ssh://git@github.com/weaveworks/weave-gitops.git", GitProviderGitHub),
+		Entry("ssh+gitlab", "ssh://git@gitlab.com/weaveworks/weave-gitops.git", GitProviderGitLab),
+		Entry("ssh+gitlab with subgroup", "git@gitlab.com:gogittest/sub-group/nginxsub.git", GitProviderGitLab),
+	)
 
-// })
+})
 
 var _ = Describe("get owner from url", func() {
 	DescribeTable("getOwnerFromUrl", func(normalizedUrl string, providerName GitProviderName, expected string) {
@@ -911,73 +911,73 @@ type expectedRepoURL struct {
 	protocol RepositoryURLProtocol
 }
 
-// var _ = DescribeTable("NormalizedRepoURL", func(input string, expected expectedRepoURL) {
-// 	result, err := NewNormalizedRepoURL(input)
-// 	Expect(err).NotTo(HaveOccurred())
+var _ = DescribeTable("NormalizedRepoURL", func(input string, expected expectedRepoURL) {
+	result, err := NewNormalizedRepoURL(input)
+	Expect(err).NotTo(HaveOccurred())
 
-// 	Expect(result.String()).To(Equal(expected.s))
-// 	u, err := url.Parse(expected.s)
-// 	Expect(err).NotTo(HaveOccurred())
-// 	Expect(result.URL()).To(Equal(u))
-// 	Expect(result.Owner()).To(Equal(expected.owner))
-// 	Expect(result.Provider()).To(Equal(expected.provider))
-// 	Expect(result.Protocol()).To(Equal(expected.protocol))
-// },
-// 	Entry("github git clone style", "git@github.com:someuser/podinfo.git", expectedRepoURL{
-// 		s:        "ssh://git@github.com/someuser/podinfo.git",
-// 		owner:    "someuser",
-// 		name:     "podinfo",
-// 		provider: GitProviderGitHub,
-// 		protocol: RepositoryURLProtocolSSH,
-// 	}),
-// 	Entry("github url style", "ssh://git@github.com/someuser/podinfo.git", expectedRepoURL{
-// 		s:        "ssh://git@github.com/someuser/podinfo.git",
-// 		owner:    "someuser",
-// 		name:     "podinfo",
-// 		provider: GitProviderGitHub,
-// 		protocol: RepositoryURLProtocolSSH,
-// 	}),
-// 	Entry("github https", "https://github.com/someuser/podinfo.git", expectedRepoURL{
-// 		s:        "ssh://git@github.com/someuser/podinfo.git",
-// 		owner:    "someuser",
-// 		name:     "podinfo",
-// 		provider: GitProviderGitHub,
-// 		protocol: RepositoryURLProtocolSSH,
-// 	}),
-// 	Entry("gitlab git clone style", "git@gitlab.com:someuser/podinfo.git", expectedRepoURL{
-// 		s:        "ssh://git@gitlab.com/someuser/podinfo.git",
-// 		owner:    "someuser",
-// 		name:     "podinfo",
-// 		provider: GitProviderGitLab,
-// 		protocol: RepositoryURLProtocolSSH,
-// 	}),
-// 	Entry("gitlab https", "https://gitlab.com/someuser/podinfo.git", expectedRepoURL{
-// 		s:        "ssh://git@gitlab.com/someuser/podinfo.git",
-// 		owner:    "someuser",
-// 		name:     "podinfo",
-// 		provider: GitProviderGitLab,
-// 		protocol: RepositoryURLProtocolSSH,
-// 	}),
-// )
+	Expect(result.String()).To(Equal(expected.s))
+	u, err := url.Parse(expected.s)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(result.URL()).To(Equal(u))
+	Expect(result.Owner()).To(Equal(expected.owner))
+	Expect(result.Provider()).To(Equal(expected.provider))
+	Expect(result.Protocol()).To(Equal(expected.protocol))
+},
+	Entry("github git clone style", "git@github.com:someuser/podinfo.git", expectedRepoURL{
+		s:        "ssh://git@github.com/someuser/podinfo.git",
+		owner:    "someuser",
+		name:     "podinfo",
+		provider: GitProviderGitHub,
+		protocol: RepositoryURLProtocolSSH,
+	}),
+	Entry("github url style", "ssh://git@github.com/someuser/podinfo.git", expectedRepoURL{
+		s:        "ssh://git@github.com/someuser/podinfo.git",
+		owner:    "someuser",
+		name:     "podinfo",
+		provider: GitProviderGitHub,
+		protocol: RepositoryURLProtocolSSH,
+	}),
+	Entry("github https", "https://github.com/someuser/podinfo.git", expectedRepoURL{
+		s:        "ssh://git@github.com/someuser/podinfo.git",
+		owner:    "someuser",
+		name:     "podinfo",
+		provider: GitProviderGitHub,
+		protocol: RepositoryURLProtocolSSH,
+	}),
+	Entry("gitlab git clone style", "git@gitlab.com:someuser/podinfo.git", expectedRepoURL{
+		s:        "ssh://git@gitlab.com/someuser/podinfo.git",
+		owner:    "someuser",
+		name:     "podinfo",
+		provider: GitProviderGitLab,
+		protocol: RepositoryURLProtocolSSH,
+	}),
+	Entry("gitlab https", "https://gitlab.com/someuser/podinfo.git", expectedRepoURL{
+		s:        "ssh://git@gitlab.com/someuser/podinfo.git",
+		owner:    "someuser",
+		name:     "podinfo",
+		provider: GitProviderGitLab,
+		protocol: RepositoryURLProtocolSSH,
+	}),
+)
 
-// var _ = Describe("Test GetRepoVisiblity", func() {
-// 	url := "ssh://git@github.com/foo/bar"
-// 	It("tests that a nil info generates the appropriate error", func() {
-// 		result, underlyingError := getVisibilityFromRepoInfo(url, nil)
-// 		Expect(result).To(BeNil())
-// 		Expect(underlyingError.Error()).To(Equal(fmt.Sprintf("unable to obtain repository visibility for: %s", url)))
-// 	})
+var _ = Describe("Test GetRepoVisiblity", func() {
+	url := "ssh://git@github.com/foo/bar"
+	It("tests that a nil info generates the appropriate error", func() {
+		result, underlyingError := getVisibilityFromRepoInfo(url, nil)
+		Expect(result).To(BeNil())
+		Expect(underlyingError.Error()).To(Equal(fmt.Sprintf("unable to obtain repository visibility for: %s", url)))
+	})
 
-// 	It("tests that a nil visibility reference generates the appropriate error", func() {
-// 		result, underlyingError := getVisibilityFromRepoInfo(url, &gitprovider.RepositoryInfo{Visibility: nil})
-// 		Expect(result).To(BeNil())
-// 		Expect(underlyingError.Error()).To(Equal(fmt.Sprintf("unable to obtain repository visibility for: %s", url)))
-// 	})
+	It("tests that a nil visibility reference generates the appropriate error", func() {
+		result, underlyingError := getVisibilityFromRepoInfo(url, &gitprovider.RepositoryInfo{Visibility: nil})
+		Expect(result).To(BeNil())
+		Expect(underlyingError.Error()).To(Equal(fmt.Sprintf("unable to obtain repository visibility for: %s", url)))
+	})
 
-// 	It("tests that a non-nil visibility reference is successful", func() {
-// 		public := gitprovider.RepositoryVisibilityPublic
-// 		result, underlyingError := getVisibilityFromRepoInfo(url, &gitprovider.RepositoryInfo{Visibility: &public})
-// 		Expect(underlyingError).To(BeNil())
-// 		Expect(result).To(Equal(&public))
-// 	})
-// })
+	It("tests that a non-nil visibility reference is successful", func() {
+		public := gitprovider.RepositoryVisibilityPublic
+		result, underlyingError := getVisibilityFromRepoInfo(url, &gitprovider.RepositoryInfo{Visibility: &public})
+		Expect(underlyingError).To(BeNil())
+		Expect(result).To(Equal(&public))
+	})
+})

--- a/pkg/gitproviders/provider_test.go
+++ b/pkg/gitproviders/provider_test.go
@@ -891,16 +891,32 @@ var _ = Describe("get owner from url", func() {
 		Entry("gitlab with subgroup", "ssh://git@gitlab.com/weaveworks/sub_group/weave-gitops.git", GitProviderGitLab, "weaveworks/sub_group"),
 	)
 
-	DescribeTable("getOwnerFromUrl fail paths", func(normalizedUrl string, providerName GitProviderName, expected string) {
+	It("missing owner", func() {
+		normalizedUrl := "ssh://git@gitlab.com/weave-gitops.git"
 		u, err := url.Parse(normalizedUrl)
 		Expect(err).NotTo(HaveOccurred())
-		_, err = getOwnerFromUrl(*u, providerName)
+		_, err = getOwnerFromUrl(*u, GitProviderGitLab)
 		Expect(err).To(HaveOccurred())
-	},
-		Entry("missing owner", "ssh://git@gitlab.com/weave-gitops.git", GitProviderGitLab, "weaveworks"),
-		Entry("empty path", "", GitProviderGitLab, "weaveworks"),
-		Entry("subgroup in a subgroup", "ssh://git@gitlab.com/weaveworks/sub_group/another_sub_group/weave-gitops.git", GitProviderGitLab, ""),
-	)
+		Expect(err.Error()).To(Equal("could not get owner from url ssh://git@gitlab.com/weave-gitops.git"))
+	})
+
+	It("empty url", func() {
+		normalizedUrl := ""
+		u, err := url.Parse(normalizedUrl)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = getOwnerFromUrl(*u, GitProviderGitLab)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(Equal("could not get owner from url "))
+	})
+
+	It("subgroup in a subgroup", func() {
+		normalizedUrl := "ssh://git@gitlab.com/weaveworks/sub_group/another_sub_group/weave-gitops.git"
+		u, err := url.Parse(normalizedUrl)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = getOwnerFromUrl(*u, GitProviderGitLab)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(Equal("a subgroup in a subgroup is not currently supported"))
+	})
 })
 
 type expectedRepoURL struct {

--- a/pkg/gitproviders/provider_test.go
+++ b/pkg/gitproviders/provider_test.go
@@ -385,13 +385,18 @@ var _ = Describe("test org repo exists", func() {
 		}
 	})
 
-	It("succeed on validating repo existence", func() {
+	It("succeed on validating org repo existence", func() {
 		err = gitProvider.CreateRepository(repoName, accounts.GithubOrgName, true)
 		Expect(err).NotTo(HaveOccurred())
 
 		exists, err := gitProvider.RepositoryExists(repoName, accounts.GithubOrgName)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(true).To(Equal(exists))
+	})
+
+	It("fails to validate org repo existence", func() {
+		_, err := gitProvider.RepositoryExists("foo", accounts.GithubOrgName)
+		Expect(err).To(HaveOccurred())
 	})
 
 	AfterEach(func() {
@@ -423,7 +428,7 @@ var _ = Describe("test personal repo exists", func() {
 		}
 	})
 
-	It("succeed on validating repo existence", func() {
+	It("succeed on user repo existence", func() {
 		accounts := getAccounts()
 
 		err := gitProvider.CreateRepository(repoName, accounts.GithubUserName, true)
@@ -432,6 +437,11 @@ var _ = Describe("test personal repo exists", func() {
 		exists, err := gitProvider.RepositoryExists(repoName, accounts.GithubUserName)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(true).To(Equal(exists))
+	})
+
+	It("fails to validate user repo existence", func() {
+		_, err := gitProvider.RepositoryExists("foo", accounts.GithubUserName)
+		Expect(err).To(HaveOccurred())
 	})
 
 	AfterEach(func() {
@@ -856,8 +866,8 @@ var _ = Describe("Test org deploy keys creation", func() {
 })
 
 var _ = Describe("helpers", func() {
-	DescribeTable("DetectGitProviderFromUrl", func(input string, expected GitProviderName) {
-		result, err := DetectGitProviderFromUrl(input)
+	DescribeTable("detectGitProviderFromUrl", func(input string, expected GitProviderName) {
+		result, err := detectGitProviderFromUrl(input)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result).To(Equal(expected))
 	},

--- a/pkg/gitproviders/provider_test.go
+++ b/pkg/gitproviders/provider_test.go
@@ -863,7 +863,7 @@ var _ = Describe("helpers", func() {
 	},
 		Entry("ssh+github", "ssh://git@github.com/weaveworks/weave-gitops.git", GitProviderGitHub),
 		Entry("ssh+gitlab", "ssh://git@gitlab.com/weaveworks/weave-gitops.git", GitProviderGitLab),
-		Entry("ssh+gitlab", "git@gitlab.com:gogittest/sub-group/nginxsub.git", GitProviderGitLab),
+		Entry("ssh+gitlab with subgroups", "git@gitlab.com:gogittest/sub-group/nginxsub.git", GitProviderGitLab),
 	)
 
 })

--- a/pkg/gitproviders/provider_test.go
+++ b/pkg/gitproviders/provider_test.go
@@ -863,6 +863,7 @@ var _ = Describe("helpers", func() {
 	},
 		Entry("ssh+github", "ssh://git@github.com/weaveworks/weave-gitops.git", GitProviderGitHub),
 		Entry("ssh+gitlab", "ssh://git@gitlab.com/weaveworks/weave-gitops.git", GitProviderGitLab),
+		Entry("ssh+gitlab", "git@gitlab.com:gogittest/sub-group/nginxsub.git", GitProviderGitLab),
 	)
 
 })
@@ -902,11 +903,11 @@ var _ = DescribeTable("NormalizedRepoURL", func(input string, expected expectedR
 		protocol: RepositoryURLProtocolSSH,
 	}),
 	Entry("github https", "https://github.com/someuser/podinfo.git", expectedRepoURL{
-		s:        "https://github.com/someuser/podinfo.git",
+		s:        "ssh://git@github.com/someuser/podinfo.git",
 		owner:    "someuser",
 		name:     "podinfo",
 		provider: GitProviderGitHub,
-		protocol: RepositoryURLProtocolHTTPS,
+		protocol: RepositoryURLProtocolSSH,
 	}),
 	Entry("gitlab git clone style", "git@gitlab.com:someuser/podinfo.git", expectedRepoURL{
 		s:        "ssh://git@gitlab.com/someuser/podinfo.git",
@@ -916,11 +917,11 @@ var _ = DescribeTable("NormalizedRepoURL", func(input string, expected expectedR
 		protocol: RepositoryURLProtocolSSH,
 	}),
 	Entry("gitlab https", "https://gitlab.com/someuser/podinfo.git", expectedRepoURL{
-		s:        "https://gitlab.com/someuser/podinfo.git",
+		s:        "ssh://git@gitlab.com/someuser/podinfo.git",
 		owner:    "someuser",
 		name:     "podinfo",
 		provider: GitProviderGitLab,
-		protocol: RepositoryURLProtocolHTTPS,
+		protocol: RepositoryURLProtocolSSH,
 	}),
 )
 

--- a/pkg/gitproviders/provider_test.go
+++ b/pkg/gitproviders/provider_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/fluxcd/go-git-providers/gitlab"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -208,13 +207,13 @@ func getAccounts() *accounts {
 func getTestClientWithCassette(cassetteID string, providerName string) (gitprovider.Client, *recorder.Recorder, error) {
 	t := customTransport{}
 
-	var err error
 	cacheGitRecorder, err := NewRecorder(cassetteID, getAccounts())
 	if err != nil {
 		return nil, nil, err
 	}
 
 	cacheGitRecorder.SetTransport(&t)
+
 	var gitTestClient gitprovider.Client
 	if providerName == GitHubProviderName {
 		gitTestClient, err = newGithubTestClient(SetRecorder(cacheGitRecorder))

--- a/pkg/gitproviders/provider_test.go
+++ b/pkg/gitproviders/provider_test.go
@@ -879,8 +879,8 @@ var _ = Describe("helpers", func() {
 })
 
 var _ = Describe("get owner from url", func() {
-	DescribeTable("getOwnerFromUrl", func(ur string, providerName GitProviderName, expected string) {
-		u, err := url.Parse(ur)
+	DescribeTable("getOwnerFromUrl", func(normalizedUrl string, providerName GitProviderName, expected string) {
+		u, err := url.Parse(normalizedUrl)
 		Expect(err).NotTo(HaveOccurred())
 		result, err := getOwnerFromUrl(*u, providerName)
 		Expect(err).NotTo(HaveOccurred())

--- a/pkg/gitproviders/provider_test.go
+++ b/pkg/gitproviders/provider_test.go
@@ -873,7 +873,22 @@ var _ = Describe("helpers", func() {
 	},
 		Entry("ssh+github", "ssh://git@github.com/weaveworks/weave-gitops.git", GitProviderGitHub),
 		Entry("ssh+gitlab", "ssh://git@gitlab.com/weaveworks/weave-gitops.git", GitProviderGitLab),
-		Entry("ssh+gitlab with subgroups", "git@gitlab.com:gogittest/sub-group/nginxsub.git", GitProviderGitLab),
+		Entry("ssh+gitlab with subgroup", "git@gitlab.com:gogittest/sub-group/nginxsub.git", GitProviderGitLab),
+	)
+
+})
+
+var _ = Describe("get owner from url", func() {
+	DescribeTable("getOwnerFromUrl", func(ur string, providerName GitProviderName, expected string) {
+		u, err := url.Parse(ur)
+		Expect(err).NotTo(HaveOccurred())
+		result, err := getOwnerFromUrl(*u, providerName)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(expected))
+	},
+		Entry("github", "ssh://git@github.com/weaveworks/weave-gitops.git", GitProviderGitHub, "weaveworks"),
+		Entry("gitlab", "ssh://git@gitlab.com/weaveworks/weave-gitops.git", GitProviderGitLab, "weaveworks"),
+		Entry("gitlab with subgroup", "ssh://git@gitlab.com/weaveworks/sub_group/weave-gitops.git", GitProviderGitLab, "weaveworks/sub_group"),
 	)
 
 })

--- a/pkg/osys/osys.go
+++ b/pkg/osys/osys.go
@@ -3,8 +3,6 @@ package osys
 import (
 	"errors"
 	"os"
-
-	"github.com/weaveworks/weave-gitops/pkg/gitproviders"
 )
 
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
@@ -12,7 +10,7 @@ import (
 //counterfeiter:generate . Osys
 type Osys interface {
 	UserHomeDir() (string, error)
-	GetGitProviderToken(providerName gitproviders.GitProviderName) (string, error)
+	GetGitProviderToken(tokenVarName string) (string, error)
 	Getenv(envVar string) string
 	LookupEnv(envVar string) (string, bool)
 	Setenv(envVar, value string) error
@@ -58,19 +56,8 @@ func (o *OsysClient) Unsetenv(envVar string) error {
 
 var ErrNoGitProviderTokenSet = errors.New("no git provider token env variable set")
 
-func (o *OsysClient) GetGitProviderToken(providerName gitproviders.GitProviderName) (string, error) {
-	var providerToken string
-
-	var found bool
-
-	switch providerName {
-	case gitproviders.GitProviderGitHub:
-		providerToken, found = o.LookupEnv("GITHUB_TOKEN")
-	case gitproviders.GitProviderGitLab:
-		providerToken, found = o.LookupEnv("GITLAB_TOKEN")
-	default:
-		return "", ErrNoGitProviderTokenSet
-	}
+func (o *OsysClient) GetGitProviderToken(tokenVarName string) (string, error) {
+	providerToken, found := o.LookupEnv(tokenVarName)
 
 	if !found || providerToken == "" {
 		return "", ErrNoGitProviderTokenSet

--- a/pkg/osys/osys.go
+++ b/pkg/osys/osys.go
@@ -3,6 +3,8 @@ package osys
 import (
 	"errors"
 	"os"
+
+	"github.com/weaveworks/weave-gitops/pkg/gitproviders"
 )
 
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
@@ -10,7 +12,7 @@ import (
 //counterfeiter:generate . Osys
 type Osys interface {
 	UserHomeDir() (string, error)
-	GetGitProviderToken(tokenVarName string) (string, error)
+	GetGitProviderToken(providerName gitproviders.GitProviderName) (string, error)
 	Getenv(envVar string) string
 	LookupEnv(envVar string) (string, bool)
 	Setenv(envVar, value string) error
@@ -56,8 +58,17 @@ func (o *OsysClient) Unsetenv(envVar string) error {
 
 var ErrNoGitProviderTokenSet = errors.New("no git provider token env variable set")
 
-func (o *OsysClient) GetGitProviderToken(tokenVarName string) (string, error) {
-	providerToken, found := o.LookupEnv(tokenVarName)
+func (o *OsysClient) GetGitProviderToken(providerName gitproviders.GitProviderName) (string, error) {
+	var providerToken string
+	var found bool
+	switch providerName {
+	case gitproviders.GitProviderGitHub:
+		providerToken, found = o.LookupEnv("GITHUB_TOKEN")
+	case gitproviders.GitProviderGitLab:
+		providerToken, found = o.LookupEnv("GITLAB_TOKEN")
+	default:
+		return "", ErrNoGitProviderTokenSet
+	}
 
 	if !found || providerToken == "" {
 		return "", ErrNoGitProviderTokenSet

--- a/pkg/osys/osys.go
+++ b/pkg/osys/osys.go
@@ -60,7 +60,9 @@ var ErrNoGitProviderTokenSet = errors.New("no git provider token env variable se
 
 func (o *OsysClient) GetGitProviderToken(providerName gitproviders.GitProviderName) (string, error) {
 	var providerToken string
+
 	var found bool
+
 	switch providerName {
 	case gitproviders.GitProviderGitHub:
 		providerToken, found = o.LookupEnv("GITHUB_TOKEN")

--- a/pkg/osys/osysfakes/fake_osys.go
+++ b/pkg/osys/osysfakes/fake_osys.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"sync"
 
-	"github.com/weaveworks/weave-gitops/pkg/gitproviders"
 	"github.com/weaveworks/weave-gitops/pkg/osys"
 )
 
@@ -15,10 +14,10 @@ type FakeOsys struct {
 	exitArgsForCall []struct {
 		arg1 int
 	}
-	GetGitProviderTokenStub        func(gitproviders.GitProviderName) (string, error)
+	GetGitProviderTokenStub        func(string) (string, error)
 	getGitProviderTokenMutex       sync.RWMutex
 	getGitProviderTokenArgsForCall []struct {
-		arg1 gitproviders.GitProviderName
+		arg1 string
 	}
 	getGitProviderTokenReturns struct {
 		result1 string
@@ -153,11 +152,11 @@ func (fake *FakeOsys) ExitArgsForCall(i int) int {
 	return argsForCall.arg1
 }
 
-func (fake *FakeOsys) GetGitProviderToken(arg1 gitproviders.GitProviderName) (string, error) {
+func (fake *FakeOsys) GetGitProviderToken(arg1 string) (string, error) {
 	fake.getGitProviderTokenMutex.Lock()
 	ret, specificReturn := fake.getGitProviderTokenReturnsOnCall[len(fake.getGitProviderTokenArgsForCall)]
 	fake.getGitProviderTokenArgsForCall = append(fake.getGitProviderTokenArgsForCall, struct {
-		arg1 gitproviders.GitProviderName
+		arg1 string
 	}{arg1})
 	stub := fake.GetGitProviderTokenStub
 	fakeReturns := fake.getGitProviderTokenReturns
@@ -178,13 +177,13 @@ func (fake *FakeOsys) GetGitProviderTokenCallCount() int {
 	return len(fake.getGitProviderTokenArgsForCall)
 }
 
-func (fake *FakeOsys) GetGitProviderTokenCalls(stub func(gitproviders.GitProviderName) (string, error)) {
+func (fake *FakeOsys) GetGitProviderTokenCalls(stub func(string) (string, error)) {
 	fake.getGitProviderTokenMutex.Lock()
 	defer fake.getGitProviderTokenMutex.Unlock()
 	fake.GetGitProviderTokenStub = stub
 }
 
-func (fake *FakeOsys) GetGitProviderTokenArgsForCall(i int) gitproviders.GitProviderName {
+func (fake *FakeOsys) GetGitProviderTokenArgsForCall(i int) string {
 	fake.getGitProviderTokenMutex.RLock()
 	defer fake.getGitProviderTokenMutex.RUnlock()
 	argsForCall := fake.getGitProviderTokenArgsForCall[i]

--- a/pkg/osys/osysfakes/fake_osys.go
+++ b/pkg/osys/osysfakes/fake_osys.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"sync"
 
+	"github.com/weaveworks/weave-gitops/pkg/gitproviders"
 	"github.com/weaveworks/weave-gitops/pkg/osys"
 )
 
@@ -14,10 +15,10 @@ type FakeOsys struct {
 	exitArgsForCall []struct {
 		arg1 int
 	}
-	GetGitProviderTokenStub        func(string) (string, error)
+	GetGitProviderTokenStub        func(gitproviders.GitProviderName) (string, error)
 	getGitProviderTokenMutex       sync.RWMutex
 	getGitProviderTokenArgsForCall []struct {
-		arg1 string
+		arg1 gitproviders.GitProviderName
 	}
 	getGitProviderTokenReturns struct {
 		result1 string
@@ -152,11 +153,11 @@ func (fake *FakeOsys) ExitArgsForCall(i int) int {
 	return argsForCall.arg1
 }
 
-func (fake *FakeOsys) GetGitProviderToken(arg1 string) (string, error) {
+func (fake *FakeOsys) GetGitProviderToken(arg1 gitproviders.GitProviderName) (string, error) {
 	fake.getGitProviderTokenMutex.Lock()
 	ret, specificReturn := fake.getGitProviderTokenReturnsOnCall[len(fake.getGitProviderTokenArgsForCall)]
 	fake.getGitProviderTokenArgsForCall = append(fake.getGitProviderTokenArgsForCall, struct {
-		arg1 string
+		arg1 gitproviders.GitProviderName
 	}{arg1})
 	stub := fake.GetGitProviderTokenStub
 	fakeReturns := fake.getGitProviderTokenReturns
@@ -177,13 +178,13 @@ func (fake *FakeOsys) GetGitProviderTokenCallCount() int {
 	return len(fake.getGitProviderTokenArgsForCall)
 }
 
-func (fake *FakeOsys) GetGitProviderTokenCalls(stub func(string) (string, error)) {
+func (fake *FakeOsys) GetGitProviderTokenCalls(stub func(gitproviders.GitProviderName) (string, error)) {
 	fake.getGitProviderTokenMutex.Lock()
 	defer fake.getGitProviderTokenMutex.Unlock()
 	fake.GetGitProviderTokenStub = stub
 }
 
-func (fake *FakeOsys) GetGitProviderTokenArgsForCall(i int) string {
+func (fake *FakeOsys) GetGitProviderTokenArgsForCall(i int) gitproviders.GitProviderName {
 	fake.getGitProviderTokenMutex.RLock()
 	defer fake.getGitProviderTokenMutex.RUnlock()
 	argsForCall := fake.getGitProviderTokenArgsForCall[i]

--- a/pkg/services/app/add.go
+++ b/pkg/services/app/add.go
@@ -233,17 +233,12 @@ func (a *App) updateParametersIfNecessary(params AddParams) (AddParams, error) {
 			return params, fmt.Errorf("--url must be specified for helm repositories")
 		}
 	default:
-		// making sure url is in the correct format
-		if strings.Contains(params.Url, "git@gitlab.com:") {
-			params.Url = strings.Replace(params.Url, ":", "/", 1)
-		}
+		params.Url = utils.SanitizeRepoUrl(params.Url)
 
 		_, err := url.Parse(params.Url)
 		if err != nil {
 			return params, fmt.Errorf("error validating url %w", err)
 		}
-
-		params.Url = utils.SanitizeRepoUrl(params.Url)
 
 		// resetting Dir param since Url has priority over it
 		params.Dir = ""

--- a/pkg/services/app/add.go
+++ b/pkg/services/app/add.go
@@ -234,6 +234,10 @@ func (a *App) updateParametersIfNecessary(params AddParams) (AddParams, error) {
 		}
 	default:
 		// making sure url is in the correct format
+		if strings.Contains(params.Url, "git@gitlab.com:") {
+			params.Url = strings.Replace(params.Url, ":", "/", 1)
+		}
+
 		_, err := url.Parse(params.Url)
 		if err != nil {
 			return params, fmt.Errorf("error validating url %w", err)

--- a/pkg/services/app/add.go
+++ b/pkg/services/app/add.go
@@ -6,7 +6,6 @@ import (
 	"crypto/md5"
 	"fmt"
 	"io/ioutil"
-	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -212,7 +211,12 @@ func (a *App) updateParametersIfNecessary(params AddParams) (AddParams, error) {
 
 	// making sure the config url is in good format
 	if IsExternalConfigUrl(params.AppConfigUrl) {
-		params.AppConfigUrl = utils.SanitizeRepoUrl(params.AppConfigUrl)
+		normalizedAppConfigUrl, err := gitproviders.NewNormalizedRepoURL(params.AppConfigUrl)
+		if err != nil {
+			return params, fmt.Errorf("error normalizing url: %w", err)
+		}
+
+		params.AppConfigUrl = normalizedAppConfigUrl.String()
 	}
 
 	switch {
@@ -233,13 +237,11 @@ func (a *App) updateParametersIfNecessary(params AddParams) (AddParams, error) {
 			return params, fmt.Errorf("--url must be specified for helm repositories")
 		}
 	default:
-		params.Url = utils.SanitizeRepoUrl(params.Url)
-
-		_, err := url.Parse(params.Url)
+		normalizedUrl, err := gitproviders.NewNormalizedRepoURL(params.Url)
 		if err != nil {
-			return params, fmt.Errorf("error validating url %w", err)
+			return params, fmt.Errorf("error normalizing url: %w", err)
 		}
-
+		params.Url = normalizedUrl.String()
 		// resetting Dir param since Url has priority over it
 		params.Dir = ""
 	}
@@ -580,8 +582,6 @@ func (a *App) cloneRepo(client git.Git, url string, branch string, dryRun bool) 
 		return func() {}, nil
 	}
 
-	url = utils.SanitizeRepoUrl(url)
-
 	repoDir, err := ioutil.TempDir("", "user-repo-")
 	if err != nil {
 		return nil, fmt.Errorf("failed creating temp. directory to clone repo: %w", err)
@@ -653,9 +653,7 @@ func generateResourceName(url string) string {
 	return hashNameIfTooLong(strings.ReplaceAll(utils.UrlToRepoName(url), "_", "-"))
 }
 
-func (a *App) createPullRequestToRepo(info *AppResourceInfo, repo string, appHash string, appYaml []byte, goatSource, goatDeploy []byte) error {
-	repoName := generateResourceName(repo)
-
+func (a *App) createPullRequestToRepo(info *AppResourceInfo, repoURL string, appHash string, appYaml []byte, goatSource, goatDeploy []byte) error {
 	appPath := info.appYamlPath()
 	goatSourcePath := info.appAutomationSourcePath()
 	goatDeployPath := info.appAutomationDeployPath()
@@ -679,23 +677,23 @@ func (a *App) createPullRequestToRepo(info *AppResourceInfo, repo string, appHas
 		},
 	}
 
-	owner, err := utils.GetOwnerFromUrl(repo)
+	normalizedUrl, err := gitproviders.NewNormalizedRepoURL(repoURL)
 	if err != nil {
-		return fmt.Errorf("failed to retrieve owner: %w", err)
+		return fmt.Errorf("error normalizing url: %w", err)
 	}
 
-	configBranch, branchErr := a.GitProvider.GetDefaultBranch(repo)
+	configBranch, branchErr := a.GitProvider.GetDefaultBranch(normalizedUrl.String())
 	if branchErr != nil {
 		return branchErr
 	}
 
-	accountType, err := a.GitProvider.GetAccountType(owner)
+	accountType, err := a.GitProvider.GetAccountType(normalizedUrl.Owner())
 	if err != nil {
 		return fmt.Errorf("failed to retrieve account type: %w", err)
 	}
 
 	if accountType == gitproviders.AccountTypeOrg {
-		orgRepoRef := gitproviders.NewOrgRepositoryRef(a.GitProvider.GetProviderDomain(), owner, repoName)
+		orgRepoRef := gitproviders.NewOrgRepositoryRef(a.GitProvider.GetProviderDomain(), normalizedUrl.Owner(), normalizedUrl.RepositoryName())
 
 		prLink, err := a.GitProvider.CreatePullRequestToOrgRepo(orgRepoRef, configBranch, appHash, files, utils.GetCommitMessage(), fmt.Sprintf("gitops add %s", info.Name), fmt.Sprintf("Added yamls for %s", info.Name))
 		if err != nil {
@@ -707,7 +705,7 @@ func (a *App) createPullRequestToRepo(info *AppResourceInfo, repo string, appHas
 		return nil
 	}
 
-	userRepoRef := gitproviders.NewUserRepositoryRef(a.GitProvider.GetProviderDomain(), owner, repoName)
+	userRepoRef := gitproviders.NewUserRepositoryRef(a.GitProvider.GetProviderDomain(), normalizedUrl.Owner(), normalizedUrl.RepositoryName())
 
 	prLink, err := a.GitProvider.CreatePullRequestToUserRepo(userRepoRef, configBranch, appHash, files, utils.GetCommitMessage(), fmt.Sprintf("gitops add %s", info.Name), fmt.Sprintf("Added yamls for %s", info.Name))
 	if err != nil {

--- a/pkg/services/app/add.go
+++ b/pkg/services/app/add.go
@@ -241,7 +241,9 @@ func (a *App) updateParametersIfNecessary(params AddParams) (AddParams, error) {
 		if err != nil {
 			return params, fmt.Errorf("error normalizing url: %w", err)
 		}
+
 		params.Url = normalizedUrl.String()
+
 		// resetting Dir param since Url has priority over it
 		params.Dir = ""
 	}

--- a/pkg/services/app/add_test.go
+++ b/pkg/services/app/add_test.go
@@ -874,7 +874,7 @@ var _ = Describe("Add", func() {
 	Context("check for default values on AddParameters", func() {
 		It("default values for path and deploymentType and branch should be correct", func() {
 			addParams := AddParams{}
-			addParams.Url = "http://github.com/testrepo"
+			addParams.Url = "http://github.com/weaveworks/testrepo"
 
 			updated, err := appSrv.(*App).updateParametersIfNecessary(addParams)
 			Expect(err).ShouldNot(HaveOccurred())

--- a/pkg/services/app/add_test.go
+++ b/pkg/services/app/add_test.go
@@ -785,13 +785,13 @@ var _ = Describe("Add", func() {
 				return dummyPullRequest{}, nil
 			}
 
-			addParams.Url = "https://github.com/user/repo"
+			addParams.Url = "ssh://github.com/user/repo.git"
 			info = getAppResourceInfo(makeWegoApplication(addParams), "cluster")
 		})
 
 		It("generates an appropriate error when the owner cannot be retrieved from the URL", func() {
 			err := appSrv.(*App).createPullRequestToRepo(info, "foo", "hash", []byte{}, []byte{}, []byte{})
-			Expect(err.Error()).To(HavePrefix("failed to retrieve owner"))
+			Expect(err.Error()).To(HavePrefix("error normalizing url"))
 		})
 
 		It("generates an appropriate error when the account type cannot be retrieved for an owner", func() {
@@ -874,7 +874,7 @@ var _ = Describe("Add", func() {
 	Context("check for default values on AddParameters", func() {
 		It("default values for path and deploymentType and branch should be correct", func() {
 			addParams := AddParams{}
-			addParams.Url = "http://something"
+			addParams.Url = "http://github.com/testrepo"
 
 			updated, err := appSrv.(*App).updateParametersIfNecessary(addParams)
 			Expect(err).ShouldNot(HaveOccurred())
@@ -890,7 +890,7 @@ var _ = Describe("Add", func() {
 
 			_, err := appSrv.(*App).updateParametersIfNecessary(addParams)
 			Expect(err).Should(HaveOccurred())
-			Expect(err.Error()).Should(ContainSubstring("error validating url"))
+			Expect(err.Error()).Should(ContainSubstring("error normalizing url"))
 			Expect(err.Error()).Should(ContainSubstring(addParams.Url))
 
 		})
@@ -1039,6 +1039,42 @@ var _ = Describe("Add Gitlab", func() {
 				name, url, branch, secretRef, namespace := fluxClient.CreateSourceGitArgsForCall(0)
 				Expect(name).To(Equal("bar"))
 				Expect(url).To(Equal("ssh://git@gitlab.com/foo/bar.git"))
+				Expect(branch).To(Equal("main"))
+				Expect(secretRef).To(Equal("wego-test-cluster-bar"))
+				Expect(namespace).To(Equal("wego-system"))
+			})
+		})
+	})
+
+	Context("add app from a subgroup", func() {
+		BeforeEach(func() {
+			addParams.Url = "ssh://git@gitlab.com/group/subgroup/bar.git"
+			addParams.AppConfigUrl = ""
+
+			gitClient.OpenStub = func(s string) (*gogit.Repository, error) {
+				r, err := gogit.Init(memory.NewStorage(), memfs.New())
+				Expect(err).ShouldNot(HaveOccurred())
+
+				_, err = r.CreateRemote(&config.RemoteConfig{
+					Name: "origin",
+					URLs: []string{"git@gitlab.com:group/subgroup/bar.git"},
+				})
+				Expect(err).ShouldNot(HaveOccurred())
+				return r, nil
+			}
+		})
+
+		Describe("generates source manifest", func() {
+			It("creates GitRepository when source type is git", func() {
+				addParams.SourceType = wego.SourceTypeGit
+				err := appSrv.Add(addParams)
+				Expect(err).ShouldNot(HaveOccurred())
+
+				Expect(fluxClient.CreateSourceGitCallCount()).To(Equal(1))
+
+				name, url, branch, secretRef, namespace := fluxClient.CreateSourceGitArgsForCall(0)
+				Expect(name).To(Equal("bar"))
+				Expect(url).To(Equal("ssh://git@gitlab.com/group/subgroup/bar.git"))
 				Expect(branch).To(Equal("main"))
 				Expect(secretRef).To(Equal("wego-test-cluster-bar"))
 				Expect(namespace).To(Equal("wego-system"))

--- a/pkg/services/app/commit.go
+++ b/pkg/services/app/commit.go
@@ -34,6 +34,7 @@ func (a *App) GetCommits(params CommitParams, application *wego.Application) ([]
 
 	if accountType == gitproviders.AccountTypeUser {
 		userRepoRef := gitproviders.NewUserRepositoryRef(a.GitProvider.GetProviderDomain(), normalizedUrl.Owner(), normalizedUrl.RepositoryName())
+
 		commits, err = a.GitProvider.GetCommitsFromUserRepo(userRepoRef, application.Spec.Branch, params.PageSize, params.PageToken)
 		if err != nil {
 			return nil, fmt.Errorf("unable to get Commits for user repo: %w", err)

--- a/pkg/services/app/commit.go
+++ b/pkg/services/app/commit.go
@@ -3,7 +3,6 @@ package app
 import (
 	"fmt"
 
-	"github.com/fluxcd/go-git-providers/github"
 	"github.com/fluxcd/go-git-providers/gitprovider"
 	wego "github.com/weaveworks/weave-gitops/api/v1alpha1"
 	"github.com/weaveworks/weave-gitops/pkg/gitproviders"
@@ -34,14 +33,13 @@ func (a *App) GetCommits(params CommitParams, application *wego.Application) ([]
 	var commits []gitprovider.Commit
 
 	if accountType == gitproviders.AccountTypeUser {
-		userRepoRef := gitproviders.NewUserRepositoryRef(github.DefaultDomain, normalizedUrl.Owner(), normalizedUrl.RepositoryName())
-
+		userRepoRef := gitproviders.NewUserRepositoryRef(a.GitProvider.GetProviderDomain(), normalizedUrl.Owner(), normalizedUrl.RepositoryName())
 		commits, err = a.GitProvider.GetCommitsFromUserRepo(userRepoRef, application.Spec.Branch, params.PageSize, params.PageToken)
 		if err != nil {
 			return nil, fmt.Errorf("unable to get Commits for user repo: %w", err)
 		}
 	} else {
-		orgRepoRef := gitproviders.NewOrgRepositoryRef(github.DefaultDomain, normalizedUrl.Owner(), normalizedUrl.RepositoryName())
+		orgRepoRef := gitproviders.NewOrgRepositoryRef(a.GitProvider.GetProviderDomain(), normalizedUrl.Owner(), normalizedUrl.RepositoryName())
 		commits, err = a.GitProvider.GetCommitsFromOrgRepo(orgRepoRef, application.Spec.Branch, params.PageSize, params.PageToken)
 		if err != nil {
 			return nil, fmt.Errorf("unable to get Commits for org repo: %w", err)

--- a/pkg/services/app/remove.go
+++ b/pkg/services/app/remove.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 
 	wego "github.com/weaveworks/weave-gitops/api/v1alpha1"
+	"github.com/weaveworks/weave-gitops/pkg/gitproviders"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -74,7 +75,12 @@ func (a *App) Remove(params RemoveParams) error {
 		return fmt.Errorf("failed to obtain config URL and branch: %w", err)
 	}
 
-	remover, err := a.cloneRepo(a.ConfigGit, cloneURL, branch, params.DryRun)
+	normalizedUrl, err := gitproviders.NewNormalizedRepoURL(cloneURL)
+	if err != nil {
+		return fmt.Errorf("error normalizing url: %w", err)
+	}
+
+	remover, err := a.cloneRepo(a.ConfigGit, normalizedUrl.String(), branch, params.DryRun)
 
 	if err != nil {
 		return fmt.Errorf("failed to clone configuration repo: %w", err)

--- a/pkg/services/auth/auth.go
+++ b/pkg/services/auth/auth.go
@@ -67,9 +67,9 @@ func getGitProviderWithClients(
 		return nil, fmt.Errorf("could not determine git provider token name: %w", varNameErr)
 	}
 
-	token, tokenErr := osysClient.GetGitProviderToken(tokenVarName)
+	token, err := osysClient.GetGitProviderToken(tokenVarName)
 
-	if tokenErr == osys.ErrNoGitProviderTokenSet {
+	if err == osys.ErrNoGitProviderTokenSet {
 		// No provider token set, we need to do the auth flow.
 		logger.Warningf("Setting the %q environment variable to a valid token will allow ongoing use of the CLI without requiring a browser-based auth flow...\n", tokenVarName)
 

--- a/pkg/services/auth/auth.go
+++ b/pkg/services/auth/auth.go
@@ -44,21 +44,16 @@ func NewAuthCLIHandler(name gitproviders.GitProviderName) (BlockingCLIAuthHandle
 
 // GetGitProvider returns a GitProvider containing either the token stored in the <git provider>_TOKEN env var
 // or a token retrieved via the CLI auth flow
-func GetGitProvider(ctx context.Context, url string) (gitproviders.GitProvider, error) {
-	providerName, err := gitproviders.DetectGitProviderFromUrl(url)
-	if err != nil {
-		return nil, fmt.Errorf("error detecting git provider: %w", err)
-	}
-
-	authHandler, err := NewAuthCLIHandler(providerName)
-	if err != nil {
-		return nil, fmt.Errorf("could not get auth handler for provider %s: %w", providerName, err)
+func GetGitProvider(ctx context.Context, normalizedUrl gitproviders.NormalizedRepoURL) (gitproviders.GitProvider, error) {
+	authHandler, authErr := NewAuthCLIHandler(normalizedUrl.Provider())
+	if authErr != nil {
+		return nil, fmt.Errorf("could not get auth handler for provider %s: %w", normalizedUrl.Provider(), authErr)
 	}
 
 	osysClient := osys.New()
 	logger := logger.NewCLILogger(osysClient.Stdout())
 
-	return getGitProviderWithClients(ctx, providerName, osysClient, authHandler, logger)
+	return getGitProviderWithClients(ctx, normalizedUrl.Provider(), osysClient, authHandler, logger)
 }
 
 func getGitProviderWithClients(

--- a/pkg/services/auth/auth.go
+++ b/pkg/services/auth/auth.go
@@ -62,13 +62,9 @@ func getGitProviderWithClients(
 	osysClient osys.Osys,
 	authHandler BlockingCLIAuthHandler,
 	logger logger.Logger) (gitproviders.GitProvider, error) {
-	tokenVarName, err := getTokenVarName(providerName)
-	if err != nil {
-		return nil, fmt.Errorf("could not determine git provider token name: %w", err)
-	}
+	token, tokenErr := osysClient.GetGitProviderToken(providerName)
 
-	token, err := osysClient.GetGitProviderToken(tokenVarName)
-	if err == osys.ErrNoGitProviderTokenSet {
+	if tokenErr == osys.ErrNoGitProviderTokenSet {
 		// No provider token set, we need to do the auth flow.
 		logger.Warningf("Setting the %q environment variable to a valid token will allow ongoing use of the CLI without requiring a browser-based auth flow...\n", tokenErr)
 

--- a/pkg/services/auth/auth.go
+++ b/pkg/services/auth/auth.go
@@ -75,7 +75,7 @@ func getGitProviderWithClients(
 	token, err := osysClient.GetGitProviderToken(tokenVarName)
 	if err == osys.ErrNoGitProviderTokenSet {
 		// No provider token set, we need to do the auth flow.
-		logger.Warningf("Setting the %q environment variable to a valid token will allow ongoing use of the CLI without requiring a browser-based auth flow...\n", tokenVarName)
+		logger.Warningf("Setting the %q environment variable to a valid token will allow ongoing use of the CLI without requiring a browser-based auth flow...\n", tokenErr)
 
 		generatedToken, err := authHandler(ctx, osysClient.Stdout())
 		if err != nil {
@@ -94,17 +94,6 @@ func getGitProviderWithClients(
 	}
 
 	return provider, nil
-}
-
-func getTokenVarName(providerName gitproviders.GitProviderName) (string, error) {
-	switch providerName {
-	case gitproviders.GitProviderGitHub:
-		return "GITHUB_TOKEN", nil
-	case gitproviders.GitProviderGitLab:
-		return "GITLAB_TOKEN", nil
-	default:
-		return "", fmt.Errorf("unknown git provider: %q", providerName)
-	}
 }
 
 type SecretName struct {

--- a/pkg/services/auth/auth_test.go
+++ b/pkg/services/auth/auth_test.go
@@ -80,7 +80,7 @@ var _ = Describe("auth", func() {
 			}
 		})
 		It("create and stores a deploy key if none exists", func() {
-			_, err := as.CreateGitClient(ctx, testClustername, namespace.Name, repoUrl.String())
+			_, err := as.CreateGitClient(ctx, repoUrl, testClustername, namespace.Name)
 			Expect(err).NotTo(HaveOccurred())
 			sn := SecretName{Name: secretName, Namespace: namespace.Name}
 			secret := &corev1.Secret{}
@@ -99,7 +99,7 @@ var _ = Describe("auth", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(k8sClient.Create(ctx, secret)).To(Succeed())
 
-			_, err = as.CreateGitClient(ctx, testClustername, namespace.Name, repoUrl.String())
+			_, err = as.CreateGitClient(ctx, repoUrl, testClustername, namespace.Name)
 			Expect(err).NotTo(HaveOccurred())
 			// We should NOT have uploaded anything since the key already exists
 			Expect(gp.UploadDeployKeyCallCount()).To(Equal(0))
@@ -110,7 +110,7 @@ var _ = Describe("auth", func() {
 			}
 			sn := SecretName{Name: secretName, Namespace: namespace.Name}
 
-			_, err = as.CreateGitClient(ctx, testClustername, namespace.Name, repoUrl.String())
+			_, err = as.CreateGitClient(ctx, repoUrl, testClustername, namespace.Name)
 			Expect(err).NotTo(HaveOccurred())
 
 			newSecret := &corev1.Secret{}

--- a/pkg/services/auth/auth_test.go
+++ b/pkg/services/auth/auth_test.go
@@ -140,7 +140,7 @@ var _ = Describe("auth", func() {
 			Context("informs the user that she can use a token for auth", func() {
 				BeforeEach(func() {
 					osysClient = &osysfakes.FakeOsys{
-						GetGitProviderTokenStub: func(providerName gitproviders.GitProviderName) (string, error) {
+						GetGitProviderTokenStub: func(tokenVarName string) (string, error) {
 							return "", osys.ErrNoGitProviderTokenSet
 						},
 					}
@@ -160,7 +160,7 @@ var _ = Describe("auth", func() {
 			Context("displays no message if token is set", func() {
 				BeforeEach(func() {
 					osysClient = &osysfakes.FakeOsys{
-						GetGitProviderTokenStub: func(providerName gitproviders.GitProviderName) (string, error) {
+						GetGitProviderTokenStub: func(tokenVarName string) (string, error) {
 							return "token", nil
 						},
 					}

--- a/pkg/services/auth/auth_test.go
+++ b/pkg/services/auth/auth_test.go
@@ -140,7 +140,7 @@ var _ = Describe("auth", func() {
 			Context("informs the user that she can use a token for auth", func() {
 				BeforeEach(func() {
 					osysClient = &osysfakes.FakeOsys{
-						GetGitProviderTokenStub: func(tokenVarName string) (string, error) {
+						GetGitProviderTokenStub: func(providerName gitproviders.GitProviderName) (string, error) {
 							return "", osys.ErrNoGitProviderTokenSet
 						},
 					}
@@ -160,7 +160,7 @@ var _ = Describe("auth", func() {
 			Context("displays no message if token is set", func() {
 				BeforeEach(func() {
 					osysClient = &osysfakes.FakeOsys{
-						GetGitProviderTokenStub: func(tokenVarName string) (string, error) {
+						GetGitProviderTokenStub: func(providerName gitproviders.GitProviderName) (string, error) {
 							return "token", nil
 						},
 					}

--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -103,53 +103,12 @@ func UrlToRepoName(url string) string {
 	return strings.TrimSuffix(filepath.Base(url), ".git")
 }
 
-func GetOwnerFromUrl(url string) (string, error) {
-	parts := strings.Split(url, "/")
-	if len(parts) < 2 {
-		return "", fmt.Errorf("could not get owner from url %s", url)
-	}
-
-	return parts[len(parts)-2], nil
-}
-
 func ValidateNamespace(ns string) error {
 	if errList := validation.ValidateNamespaceName(ns, false); len(errList) != 0 {
 		return fmt.Errorf("invalid namespace: %s", strings.Join(errList, ", "))
 	}
 
 	return nil
-}
-
-// SanitizeRepoUrl accepts a url like git@github.com:someuser/podinfo.git and converts it into
-// a string like ssh://git@github.com/someuser/podinfo.git. This helps standardize the different
-// user inputs that might be provided.
-func SanitizeRepoUrl(url string) string {
-	trimmed := ""
-	domain := "github"
-
-	if strings.Contains(url, "gitlab") {
-		domain = "gitlab"
-	}
-
-	if !strings.HasSuffix(url, ".git") {
-		url = url + ".git"
-	}
-
-	sshPrefix := fmt.Sprintf("git@%s.com:", domain)
-	if strings.HasPrefix(url, sshPrefix) {
-		trimmed = strings.TrimPrefix(url, sshPrefix)
-	}
-
-	httpsPrefix := fmt.Sprintf("https://%s.com/", domain)
-	if strings.HasPrefix(url, httpsPrefix) {
-		trimmed = strings.TrimPrefix(url, httpsPrefix)
-	}
-
-	if trimmed != "" {
-		return fmt.Sprintf("ssh://git@%s.com/%s", domain, trimmed)
-	}
-
-	return url
 }
 
 func PrintTable(writer io.Writer, header []string, rows [][]string) {

--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -125,23 +125,27 @@ func ValidateNamespace(ns string) error {
 // user inputs that might be provided.
 func SanitizeRepoUrl(url string) string {
 	trimmed := ""
+	domain := "github"
+	if strings.Contains(url, "gitlab") {
+		domain = "gitlab"
+	}
 
 	if !strings.HasSuffix(url, ".git") {
 		url = url + ".git"
 	}
 
-	sshPrefix := "git@github.com:"
+	sshPrefix := fmt.Sprintf("git@%s.com:", domain)
 	if strings.HasPrefix(url, sshPrefix) {
 		trimmed = strings.TrimPrefix(url, sshPrefix)
 	}
 
-	httpsPrefix := "https://github.com/"
+	httpsPrefix := fmt.Sprintf("https://%s.com/", domain)
 	if strings.HasPrefix(url, httpsPrefix) {
 		trimmed = strings.TrimPrefix(url, httpsPrefix)
 	}
 
 	if trimmed != "" {
-		return "ssh://git@github.com/" + trimmed
+		return fmt.Sprintf("ssh://git@%s.com/%s", domain, trimmed)
 	}
 
 	return url

--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -126,6 +126,7 @@ func ValidateNamespace(ns string) error {
 func SanitizeRepoUrl(url string) string {
 	trimmed := ""
 	domain := "github"
+
 	if strings.Contains(url, "gitlab") {
 		domain = "gitlab"
 	}

--- a/pkg/utils/common_test.go
+++ b/pkg/utils/common_test.go
@@ -129,4 +129,5 @@ var _ = DescribeTable("SanitizeRepoUrl", func(input string, expected string) {
 	// We need to refactor the SanitizeRepoUrl function .
 	// https://github.com/weaveworks/weave-gitops/issues/577
 	Entry("https style", "https://github.com/weaveworks/weave-gitops.git", "ssh://git@github.com/weaveworks/weave-gitops.git"),
+	Entry("gitlab", "ssh://git@gitlab.com/someuser/podinfo.git", "ssh://git@gitlab.com/someuser/podinfo.git"),
 )

--- a/pkg/utils/common_test.go
+++ b/pkg/utils/common_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 )
 
@@ -118,16 +117,3 @@ error occurred some error, retrying in 1s
 
 	})
 })
-
-var _ = DescribeTable("SanitizeRepoUrl", func(input string, expected string) {
-	result := SanitizeRepoUrl(input)
-	Expect(result).To(Equal(expected))
-},
-	Entry("git clone style", "git@github.com:someuser/podinfo.git", "ssh://git@github.com/someuser/podinfo.git"),
-	Entry("url style", "ssh://git@github.com/someuser/podinfo.git", "ssh://git@github.com/someuser/podinfo.git"),
-	// TODO: there is other code relying on everything looking like an SSH url.
-	// We need to refactor the SanitizeRepoUrl function .
-	// https://github.com/weaveworks/weave-gitops/issues/577
-	Entry("https style", "https://github.com/weaveworks/weave-gitops.git", "ssh://git@github.com/weaveworks/weave-gitops.git"),
-	Entry("gitlab", "ssh://git@gitlab.com/someuser/podinfo.git", "ssh://git@gitlab.com/someuser/podinfo.git"),
-)

--- a/test/acceptance/README.md
+++ b/test/acceptance/README.md
@@ -14,6 +14,8 @@ Additional env vars used to run tests locally are:
 export GITHUB_ORG=<github-org>
 export GITHUB_TOKEN=<api-token>
 export GITHUB_KEY=<ssh-key>
+export GITLAB_ORG=<gitlab-org/group>
+export GITLAB_TOKEN=<api-token>
 ```
 Please make sure that `GITHUB_TOKEN` has repo create and delete permissions on `GITHUB_ORG`
 

--- a/test/acceptance/test/add_tests.go
+++ b/test/acceptance/test/add_tests.go
@@ -184,10 +184,6 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 			installAndVerifyWego(WEGO_DEFAULT_NAMESPACE)
 		})
 
-		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
-			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitHub)
-		})
-
 		By("And I run gitops add command", func() {
 			runWegoAddCommand(repoAbsolutePath, addCommand, WEGO_DEFAULT_NAMESPACE)
 		})
@@ -440,10 +436,6 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 			installAndVerifyWego(WEGO_DEFAULT_NAMESPACE)
 		})
 
-		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
-			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitHub)
-		})
-
 		By("And I run gitops add command with --url and --app-config-url params", func() {
 			runWegoAddCommand(repoAbsolutePath+"/../", addCommand, WEGO_DEFAULT_NAMESPACE)
 		})
@@ -547,10 +539,6 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 			installAndVerifyWego(WEGO_DEFAULT_NAMESPACE)
 		})
 
-		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
-			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitHub)
-		})
-
 		By("And I run gitops add command with --url", func() {
 			runWegoAddCommand(repoAbsolutePath+"/../", addCommand, WEGO_DEFAULT_NAMESPACE)
 		})
@@ -587,10 +575,6 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 
 		By("And I install gitops to my active cluster", func() {
 			installAndVerifyWego(WEGO_DEFAULT_NAMESPACE)
-		})
-
-		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
-			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitHub)
 		})
 
 		By("And I run gitops add command from repo parent dir", func() {
@@ -643,10 +627,6 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 			installAndVerifyWego(WEGO_DEFAULT_NAMESPACE)
 		})
 
-		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
-			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitHub)
-		})
-
 		By("And I run gitops add command for 1st app", func() {
 			runWegoAddCommand(repoAbsolutePath, addCommand, WEGO_DEFAULT_NAMESPACE)
 		})
@@ -696,10 +676,6 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 
 		By("And I install gitops to my active cluster", func() {
 			installAndVerifyWego(WEGO_DEFAULT_NAMESPACE)
-		})
-
-		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
-			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitHub)
 		})
 
 		By("When I create a private repo for gitops app config", func() {
@@ -754,10 +730,6 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 
 		By("And I install gitops to my active cluster", func() {
 			installAndVerifyWego(WEGO_DEFAULT_NAMESPACE)
-		})
-
-		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
-			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitHub)
 		})
 
 		By("And I create a repo with my app1 and app2 workloads and run the add the command for each app", func() {
@@ -834,10 +806,6 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 
 		By("And I install gitops to my active cluster", func() {
 			installAndVerifyWego(WEGO_DEFAULT_NAMESPACE)
-		})
-
-		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
-			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitHub)
 		})
 
 		By("And I run gitops app add command for app1: "+appName1, func() {
@@ -1004,10 +972,6 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 
 		By("And I install gitops to my active cluster", func() {
 			installAndVerifyWego(WEGO_DEFAULT_NAMESPACE)
-		})
-
-		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
-			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitHub)
 		})
 
 		By("And I run gitops app add command for 1st app", func() {
@@ -1209,10 +1173,6 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 			installAndVerifyWego(WEGO_DEFAULT_NAMESPACE)
 		})
 
-		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
-			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitHub)
-		})
-
 		By("And I run gitops add command", func() {
 			runWegoAddCommand(repoAbsolutePath, addCommand, WEGO_DEFAULT_NAMESPACE)
 		})
@@ -1293,10 +1253,6 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 			installAndVerifyWego(WEGO_DEFAULT_NAMESPACE)
 		})
 
-		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
-			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitHub)
-		})
-
 		By("And I run gitops add command", func() {
 			runWegoAddCommand(repoAbsolutePath, addCommand, WEGO_DEFAULT_NAMESPACE)
 		})
@@ -1345,10 +1301,6 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 
 		By("And I install gitops to my active cluster", func() {
 			installAndVerifyWego(WEGO_DEFAULT_NAMESPACE)
-		})
-
-		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
-			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitHub)
 		})
 
 		By("And I run gitops add command", func() {
@@ -1421,10 +1373,6 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 
 		By("And I install gitops under my namespace: "+WEGO_DEFAULT_NAMESPACE, func() {
 			installAndVerifyWego(WEGO_DEFAULT_NAMESPACE)
-		})
-
-		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
-			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitHub)
 		})
 
 		By("And I create a namespace for helm-app", func() {
@@ -1505,10 +1453,6 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 			installAndVerifyWego(WEGO_DEFAULT_NAMESPACE)
 		})
 
-		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
-			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitHub)
-		})
-
 		By("And I run gitops add command", func() {
 			runWegoAddCommand(".", addCommand, WEGO_DEFAULT_NAMESPACE)
 		})
@@ -1544,10 +1488,6 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 
 		By("And I install gitops to my active cluster", func() {
 			installAndVerifyWego(WEGO_DEFAULT_NAMESPACE)
-		})
-
-		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
-			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitHub)
 		})
 
 		By("When I run gitops app add command for app", func() {
@@ -1606,10 +1546,6 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 			installAndVerifyWego(WEGO_DEFAULT_NAMESPACE)
 		})
 
-		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
-			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitHub)
-		})
-
 		By("And I run gitops add command with --app-config-url param", func() {
 			output, _ := runWegoAddCommandWithOutput(repoAbsolutePath, addCommand, WEGO_DEFAULT_NAMESPACE)
 			re := regexp.MustCompile(`(http|https):\/\/([\w\-_]+(?:(?:\.[\w\-_]+)+))([\w\-\.,@?^=%&amp;:/~\+#]*[\w\-\@?^=%&amp;/~\+#])?`)
@@ -1658,10 +1594,6 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 
 		By("And I install gitops to my active cluster", func() {
 			installAndVerifyWego(WEGO_DEFAULT_NAMESPACE)
-		})
-
-		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
-			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitHub)
 		})
 
 		By("And I run app add command for "+appName, func() {
@@ -1756,10 +1688,6 @@ var _ = Describe("Weave GitOps Add Tests With Long Cluster Name", func() {
 
 		By("And I install gitops to my active cluster", func() {
 			installAndVerifyWego(WEGO_DEFAULT_NAMESPACE)
-		})
-
-		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
-			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitHub)
 		})
 
 		By("And I run gitops app add command for app: "+appName, func() {

--- a/test/acceptance/test/add_tests.go
+++ b/test/acceptance/test/add_tests.go
@@ -210,7 +210,6 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 	})
 
 	It("Verify that gitops can deploy and remove a gitlab app after it is setup with an empty repo initially", func() {
-		DEFAULT_SSH_KEY_PATH := "~/.ssh/id_rsa"
 		var repoAbsolutePath string
 		private := true
 		tip := generateTestInputs()
@@ -228,10 +227,6 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 
 		By("And application workload is not already deployed to cluster", func() {
 			deleteWorkload(tip.workloadName, tip.workloadNamespace)
-		})
-
-		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
-			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitLab)
 		})
 
 		By("When I create an empty private repo", func() {
@@ -278,7 +273,6 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 	})
 
 	It("Verify that gitops can deploy and remove a gitlab app that belongs in a subgroup", func() {
-		DEFAULT_SSH_KEY_PATH := "~/.ssh/id_rsa"
 		var repoAbsolutePath string
 		private := true
 		tip := generateTestInputs()
@@ -298,10 +292,6 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 
 		By("And application workload is not already deployed to cluster", func() {
 			deleteWorkload(tip.workloadName, tip.workloadNamespace)
-		})
-
-		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
-			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitLab)
 		})
 
 		By("When I create an empty private repo", func() {
@@ -350,7 +340,6 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 	It("Verify that gitops can deploy app when user specifies branch, namespace, url, deployment-type", func() {
 		var repoAbsolutePath string
 		private := true
-		DEFAULT_SSH_KEY_PATH := "~/.ssh/id_rsa"
 		tip := generateTestInputs()
 		branchName := "test-branch-02"
 		wegoNamespace := "my-space"
@@ -382,10 +371,6 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 
 		By("And I install gitops under my namespace: "+wegoNamespace, func() {
 			installAndVerifyWego(wegoNamespace)
-		})
-
-		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
-			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitHub)
 		})
 
 		By("And I create a new branch", func() {
@@ -493,10 +478,6 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 
 		By("And application workload is not already deployed to cluster", func() {
 			deleteWorkload(tip.workloadName, tip.workloadNamespace)
-		})
-
-		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
-			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitLab)
 		})
 
 		By("When I create a private repo for gitops app config", func() {
@@ -1853,10 +1834,6 @@ var _ = Describe("Weave GitOps Add Tests With Long Cluster Name", func() {
 
 		By("And application workload is not already deployed to cluster", func() {
 			deleteWorkload(workloadName, workloadNamespace)
-		})
-
-		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
-			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitLab)
 		})
 
 		By("When I create a private repo for gitops app config", func() {

--- a/test/acceptance/test/add_tests.go
+++ b/test/acceptance/test/add_tests.go
@@ -184,10 +184,6 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 			installAndVerifyWego(WEGO_DEFAULT_NAMESPACE)
 		})
 
-		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
-			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitHub)
-		})
-
 		By("And I run gitops add command", func() {
 			runWegoAddCommand(repoAbsolutePath, addCommand, WEGO_DEFAULT_NAMESPACE)
 		})
@@ -229,10 +225,6 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 			deleteWorkload(tip.workloadName, tip.workloadNamespace)
 		})
 
-		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
-			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitLab)
-		})
-
 		By("When I create an empty private repo", func() {
 			repoAbsolutePath = initAndCreateEmptyRepo(tip.appRepoName, gitproviders.GitProviderGitLab, private, GITLAB_ORG)
 		})
@@ -259,75 +251,6 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 
 		By("And repos created have private visibility", func() {
 			Expect(getGitRepoVisibility(GITLAB_ORG, tip.appRepoName, gitproviders.GitProviderGitLab)).Should(ContainSubstring("private"))
-		})
-
-		By("When I remove an app", func() {
-			appRemoveOutput = runCommandAndReturnSessionOutput(WEGO_BIN_PATH + " app remove " + appName)
-		})
-
-		By("Then I should see app removing message", func() {
-			Eventually(appRemoveOutput).Should(gbytes.Say("► Removing application from cluster and repository"))
-			Eventually(appRemoveOutput).Should(gbytes.Say("► Committing and pushing gitops updates for application"))
-			Eventually(appRemoveOutput).Should(gbytes.Say("► Pushing app changes to repository"))
-		})
-
-		By("And app should get deleted from the cluster", func() {
-			_ = waitForAppRemoval(appName, THIRTY_SECOND_TIMEOUT)
-		})
-	})
-
-	It("Verify that gitops can deploy and remove a gitlab app that belongs in a subgroup", func() {
-		var repoAbsolutePath string
-		private := true
-		tip := generateTestInputs()
-		appName := tip.appRepoName
-		var appRemoveOutput *gexec.Session
-
-		addCommand := "app add . --auto-merge=true"
-
-		var gitlabSubGroupPath = GITLAB_ORG + "/" + GITLAB_SUBGROUP
-
-		defer deleteRepo(tip.appRepoName, gitlabSubGroupPath)
-		defer deleteWorkload(tip.workloadName, tip.workloadNamespace)
-
-		By("And application repo does not already exist", func() {
-			deleteRepo(tip.appRepoName, gitlabSubGroupPath)
-		})
-
-		By("And application workload is not already deployed to cluster", func() {
-			deleteWorkload(tip.workloadName, tip.workloadNamespace)
-		})
-
-		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
-			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitLab)
-		})
-
-		By("When I create an empty private repo", func() {
-			repoAbsolutePath = initAndCreateEmptyRepo(tip.appRepoName, gitproviders.GitProviderGitLab, private, gitlabSubGroupPath)
-		})
-
-		By("And I install gitops to my active cluster", func() {
-			installAndVerifyWego(WEGO_DEFAULT_NAMESPACE)
-		})
-
-		By("And I run gitops add command", func() {
-			runWegoAddCommand(repoAbsolutePath, addCommand, WEGO_DEFAULT_NAMESPACE)
-		})
-
-		By("Then I should see gitops add command linked the repo to the cluster", func() {
-			verifyWegoAddCommand(appName, WEGO_DEFAULT_NAMESPACE)
-		})
-
-		By("And I git add-commit-push app workload to repo", func() {
-			gitAddCommitPush(repoAbsolutePath, tip.appManifestFilePath)
-		})
-
-		By("And I should see workload is deployed to the cluster", func() {
-			verifyWorkloadIsDeployed(tip.workloadName, tip.workloadNamespace)
-		})
-
-		By("And repos created have private visibility", func() {
-			Expect(getGitRepoVisibility(gitlabSubGroupPath, tip.appRepoName, gitproviders.GitProviderGitLab)).Should(ContainSubstring("private"))
 		})
 
 		By("When I remove an app", func() {
@@ -448,10 +371,6 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 			installAndVerifyWego(WEGO_DEFAULT_NAMESPACE)
 		})
 
-		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
-			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitHub)
-		})
-
 		By("And I run gitops add command with --url and --app-config-url params", func() {
 			runWegoAddCommand(repoAbsolutePath+"/../", addCommand, WEGO_DEFAULT_NAMESPACE)
 		})
@@ -486,10 +405,6 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 
 		By("And application workload is not already deployed to cluster", func() {
 			deleteWorkload(tip.workloadName, tip.workloadNamespace)
-		})
-
-		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
-			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitLab)
 		})
 
 		By("When I create a private repo for gitops app config", func() {
@@ -559,10 +474,6 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 			installAndVerifyWego(WEGO_DEFAULT_NAMESPACE)
 		})
 
-		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
-			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitHub)
-		})
-
 		By("And I run gitops add command with --url", func() {
 			runWegoAddCommand(repoAbsolutePath+"/../", addCommand, WEGO_DEFAULT_NAMESPACE)
 		})
@@ -599,10 +510,6 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 
 		By("And I install gitops to my active cluster", func() {
 			installAndVerifyWego(WEGO_DEFAULT_NAMESPACE)
-		})
-
-		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
-			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitHub)
 		})
 
 		By("And I run gitops add command from repo parent dir", func() {
@@ -655,10 +562,6 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 			installAndVerifyWego(WEGO_DEFAULT_NAMESPACE)
 		})
 
-		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
-			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitHub)
-		})
-
 		By("And I run gitops add command for 1st app", func() {
 			runWegoAddCommand(repoAbsolutePath, addCommand, WEGO_DEFAULT_NAMESPACE)
 		})
@@ -708,10 +611,6 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 
 		By("And I install gitops to my active cluster", func() {
 			installAndVerifyWego(WEGO_DEFAULT_NAMESPACE)
-		})
-
-		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
-			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitHub)
 		})
 
 		By("When I create a private repo for gitops app config", func() {
@@ -766,10 +665,6 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 
 		By("And I install gitops to my active cluster", func() {
 			installAndVerifyWego(WEGO_DEFAULT_NAMESPACE)
-		})
-
-		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
-			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitHub)
 		})
 
 		By("And I create a repo with my app1 and app2 workloads and run the add the command for each app", func() {
@@ -846,10 +741,6 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 
 		By("And I install gitops to my active cluster", func() {
 			installAndVerifyWego(WEGO_DEFAULT_NAMESPACE)
-		})
-
-		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
-			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitHub)
 		})
 
 		By("And I run gitops app add command for app1: "+appName1, func() {
@@ -1016,10 +907,6 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 
 		By("And I install gitops to my active cluster", func() {
 			installAndVerifyWego(WEGO_DEFAULT_NAMESPACE)
-		})
-
-		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
-			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitHub)
 		})
 
 		By("And I run gitops app add command for 1st app", func() {
@@ -1221,10 +1108,6 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 			installAndVerifyWego(WEGO_DEFAULT_NAMESPACE)
 		})
 
-		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
-			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitHub)
-		})
-
 		By("And I run gitops add command", func() {
 			runWegoAddCommand(repoAbsolutePath, addCommand, WEGO_DEFAULT_NAMESPACE)
 		})
@@ -1305,10 +1188,6 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 			installAndVerifyWego(WEGO_DEFAULT_NAMESPACE)
 		})
 
-		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
-			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitHub)
-		})
-
 		By("And I run gitops add command", func() {
 			runWegoAddCommand(repoAbsolutePath, addCommand, WEGO_DEFAULT_NAMESPACE)
 		})
@@ -1357,10 +1236,6 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 
 		By("And I install gitops to my active cluster", func() {
 			installAndVerifyWego(WEGO_DEFAULT_NAMESPACE)
-		})
-
-		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
-			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitHub)
 		})
 
 		By("And I run gitops add command", func() {
@@ -1433,10 +1308,6 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 
 		By("And I install gitops under my namespace: "+WEGO_DEFAULT_NAMESPACE, func() {
 			installAndVerifyWego(WEGO_DEFAULT_NAMESPACE)
-		})
-
-		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
-			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitHub)
 		})
 
 		By("And I create a namespace for helm-app", func() {
@@ -1517,10 +1388,6 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 			installAndVerifyWego(WEGO_DEFAULT_NAMESPACE)
 		})
 
-		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
-			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitHub)
-		})
-
 		By("And I run gitops add command", func() {
 			runWegoAddCommand(".", addCommand, WEGO_DEFAULT_NAMESPACE)
 		})
@@ -1556,10 +1423,6 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 
 		By("And I install gitops to my active cluster", func() {
 			installAndVerifyWego(WEGO_DEFAULT_NAMESPACE)
-		})
-
-		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
-			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitHub)
 		})
 
 		By("When I run gitops app add command for app", func() {
@@ -1618,10 +1481,6 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 			installAndVerifyWego(WEGO_DEFAULT_NAMESPACE)
 		})
 
-		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
-			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitHub)
-		})
-
 		By("And I run gitops add command with --app-config-url param", func() {
 			output, _ := runWegoAddCommandWithOutput(repoAbsolutePath, addCommand, WEGO_DEFAULT_NAMESPACE)
 			re := regexp.MustCompile(`(http|https):\/\/([\w\-_]+(?:(?:\.[\w\-_]+)+))([\w\-\.,@?^=%&amp;:/~\+#]*[\w\-\@?^=%&amp;/~\+#])?`)
@@ -1670,10 +1529,6 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 
 		By("And I install gitops to my active cluster", func() {
 			installAndVerifyWego(WEGO_DEFAULT_NAMESPACE)
-		})
-
-		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
-			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitHub)
 		})
 
 		By("And I run app add command for "+appName, func() {
@@ -1770,10 +1625,6 @@ var _ = Describe("Weave GitOps Add Tests With Long Cluster Name", func() {
 			installAndVerifyWego(WEGO_DEFAULT_NAMESPACE)
 		})
 
-		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
-			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitHub)
-		})
-
 		By("And I run gitops app add command for app: "+appName, func() {
 			runWegoAddCommand(repoAbsolutePath, addCommand, WEGO_DEFAULT_NAMESPACE)
 		})
@@ -1846,10 +1697,6 @@ var _ = Describe("Weave GitOps Add Tests With Long Cluster Name", func() {
 
 		By("And application workload is not already deployed to cluster", func() {
 			deleteWorkload(workloadName, workloadNamespace)
-		})
-
-		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
-			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitLab)
 		})
 
 		By("When I create a private repo for gitops app config", func() {

--- a/test/acceptance/test/add_tests.go
+++ b/test/acceptance/test/add_tests.go
@@ -184,6 +184,10 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 			installAndVerifyWego(WEGO_DEFAULT_NAMESPACE)
 		})
 
+		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
+			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitHub)
+		})
+
 		By("And I run gitops add command", func() {
 			runWegoAddCommand(repoAbsolutePath, addCommand, WEGO_DEFAULT_NAMESPACE)
 		})
@@ -223,6 +227,10 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 
 		By("And application workload is not already deployed to cluster", func() {
 			deleteWorkload(tip.workloadName, tip.workloadNamespace)
+		})
+
+		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
+			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitLab)
 		})
 
 		By("When I create an empty private repo", func() {
@@ -288,6 +296,10 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 
 		By("And application workload is not already deployed to cluster", func() {
 			deleteWorkload(tip.workloadName, tip.workloadNamespace)
+		})
+
+		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
+			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitLab)
 		})
 
 		By("When I create an empty private repo", func() {
@@ -436,6 +448,10 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 			installAndVerifyWego(WEGO_DEFAULT_NAMESPACE)
 		})
 
+		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
+			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitHub)
+		})
+
 		By("And I run gitops add command with --url and --app-config-url params", func() {
 			runWegoAddCommand(repoAbsolutePath+"/../", addCommand, WEGO_DEFAULT_NAMESPACE)
 		})
@@ -470,6 +486,10 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 
 		By("And application workload is not already deployed to cluster", func() {
 			deleteWorkload(tip.workloadName, tip.workloadNamespace)
+		})
+
+		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
+			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitLab)
 		})
 
 		By("When I create a private repo for gitops app config", func() {
@@ -539,6 +559,10 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 			installAndVerifyWego(WEGO_DEFAULT_NAMESPACE)
 		})
 
+		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
+			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitHub)
+		})
+
 		By("And I run gitops add command with --url", func() {
 			runWegoAddCommand(repoAbsolutePath+"/../", addCommand, WEGO_DEFAULT_NAMESPACE)
 		})
@@ -575,6 +599,10 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 
 		By("And I install gitops to my active cluster", func() {
 			installAndVerifyWego(WEGO_DEFAULT_NAMESPACE)
+		})
+
+		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
+			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitHub)
 		})
 
 		By("And I run gitops add command from repo parent dir", func() {
@@ -627,6 +655,10 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 			installAndVerifyWego(WEGO_DEFAULT_NAMESPACE)
 		})
 
+		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
+			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitHub)
+		})
+
 		By("And I run gitops add command for 1st app", func() {
 			runWegoAddCommand(repoAbsolutePath, addCommand, WEGO_DEFAULT_NAMESPACE)
 		})
@@ -676,6 +708,10 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 
 		By("And I install gitops to my active cluster", func() {
 			installAndVerifyWego(WEGO_DEFAULT_NAMESPACE)
+		})
+
+		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
+			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitHub)
 		})
 
 		By("When I create a private repo for gitops app config", func() {
@@ -730,6 +766,10 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 
 		By("And I install gitops to my active cluster", func() {
 			installAndVerifyWego(WEGO_DEFAULT_NAMESPACE)
+		})
+
+		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
+			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitHub)
 		})
 
 		By("And I create a repo with my app1 and app2 workloads and run the add the command for each app", func() {
@@ -806,6 +846,10 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 
 		By("And I install gitops to my active cluster", func() {
 			installAndVerifyWego(WEGO_DEFAULT_NAMESPACE)
+		})
+
+		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
+			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitHub)
 		})
 
 		By("And I run gitops app add command for app1: "+appName1, func() {
@@ -972,6 +1016,10 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 
 		By("And I install gitops to my active cluster", func() {
 			installAndVerifyWego(WEGO_DEFAULT_NAMESPACE)
+		})
+
+		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
+			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitHub)
 		})
 
 		By("And I run gitops app add command for 1st app", func() {
@@ -1173,6 +1221,10 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 			installAndVerifyWego(WEGO_DEFAULT_NAMESPACE)
 		})
 
+		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
+			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitHub)
+		})
+
 		By("And I run gitops add command", func() {
 			runWegoAddCommand(repoAbsolutePath, addCommand, WEGO_DEFAULT_NAMESPACE)
 		})
@@ -1253,6 +1305,10 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 			installAndVerifyWego(WEGO_DEFAULT_NAMESPACE)
 		})
 
+		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
+			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitHub)
+		})
+
 		By("And I run gitops add command", func() {
 			runWegoAddCommand(repoAbsolutePath, addCommand, WEGO_DEFAULT_NAMESPACE)
 		})
@@ -1301,6 +1357,10 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 
 		By("And I install gitops to my active cluster", func() {
 			installAndVerifyWego(WEGO_DEFAULT_NAMESPACE)
+		})
+
+		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
+			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitHub)
 		})
 
 		By("And I run gitops add command", func() {
@@ -1373,6 +1433,10 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 
 		By("And I install gitops under my namespace: "+WEGO_DEFAULT_NAMESPACE, func() {
 			installAndVerifyWego(WEGO_DEFAULT_NAMESPACE)
+		})
+
+		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
+			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitHub)
 		})
 
 		By("And I create a namespace for helm-app", func() {
@@ -1453,6 +1517,10 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 			installAndVerifyWego(WEGO_DEFAULT_NAMESPACE)
 		})
 
+		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
+			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitHub)
+		})
+
 		By("And I run gitops add command", func() {
 			runWegoAddCommand(".", addCommand, WEGO_DEFAULT_NAMESPACE)
 		})
@@ -1488,6 +1556,10 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 
 		By("And I install gitops to my active cluster", func() {
 			installAndVerifyWego(WEGO_DEFAULT_NAMESPACE)
+		})
+
+		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
+			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitHub)
 		})
 
 		By("When I run gitops app add command for app", func() {
@@ -1546,6 +1618,10 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 			installAndVerifyWego(WEGO_DEFAULT_NAMESPACE)
 		})
 
+		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
+			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitHub)
+		})
+
 		By("And I run gitops add command with --app-config-url param", func() {
 			output, _ := runWegoAddCommandWithOutput(repoAbsolutePath, addCommand, WEGO_DEFAULT_NAMESPACE)
 			re := regexp.MustCompile(`(http|https):\/\/([\w\-_]+(?:(?:\.[\w\-_]+)+))([\w\-\.,@?^=%&amp;:/~\+#]*[\w\-\@?^=%&amp;/~\+#])?`)
@@ -1594,6 +1670,10 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 
 		By("And I install gitops to my active cluster", func() {
 			installAndVerifyWego(WEGO_DEFAULT_NAMESPACE)
+		})
+
+		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
+			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitHub)
 		})
 
 		By("And I run app add command for "+appName, func() {
@@ -1690,6 +1770,10 @@ var _ = Describe("Weave GitOps Add Tests With Long Cluster Name", func() {
 			installAndVerifyWego(WEGO_DEFAULT_NAMESPACE)
 		})
 
+		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
+			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitHub)
+		})
+
 		By("And I run gitops app add command for app: "+appName, func() {
 			runWegoAddCommand(repoAbsolutePath, addCommand, WEGO_DEFAULT_NAMESPACE)
 		})
@@ -1762,6 +1846,10 @@ var _ = Describe("Weave GitOps Add Tests With Long Cluster Name", func() {
 
 		By("And application workload is not already deployed to cluster", func() {
 			deleteWorkload(workloadName, workloadNamespace)
+		})
+
+		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
+			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitLab)
 		})
 
 		By("When I create a private repo for gitops app config", func() {

--- a/test/acceptance/test/add_tests.go
+++ b/test/acceptance/test/add_tests.go
@@ -51,10 +51,10 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 		addCommand1 := "app add . --auto-merge=true"
 		addCommand2 := "app add . --url=" + appRepoRemoteURL + " --auto-merge=true"
 
-		defer deleteRepo(tip.appRepoName)
+		defer deleteRepo(tip.appRepoName, GITHUB_ORG)
 
 		By("And application repo does not already exist", func() {
-			deleteRepo(tip.appRepoName)
+			deleteRepo(tip.appRepoName, GITHUB_ORG)
 		})
 
 		By("And application workload is not already deployed to cluster", func() {
@@ -62,7 +62,7 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 		})
 
 		By("When I create a private repo with my app workload", func() {
-			repoAbsolutePath = initAndCreateEmptyRepo(tip.appRepoName, private)
+			repoAbsolutePath = initAndCreateEmptyRepo(tip.appRepoName, "github", private)
 			gitAddCommitPush(repoAbsolutePath, tip.appManifestFilePath)
 		})
 
@@ -104,11 +104,11 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 
 		addCommand := "app add --url=" + appRepoRemoteURL + " --branch=" + branchName + " --dry-run" + " --auto-merge=true"
 
-		defer deleteRepo(tip.appRepoName)
+		defer deleteRepo(tip.appRepoName, GITHUB_ORG)
 		defer deleteWorkload(tip.workloadName, tip.workloadNamespace)
 
 		By("And application repo does not already exist", func() {
-			deleteRepo(tip.appRepoName)
+			deleteRepo(tip.appRepoName, GITHUB_ORG)
 		})
 
 		By("And application workload is not already deployed to cluster", func() {
@@ -116,7 +116,7 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 		})
 
 		By("When I create a private repo with my app workload", func() {
-			repoAbsolutePath = initAndCreateEmptyRepo(tip.appRepoName, private)
+			repoAbsolutePath = initAndCreateEmptyRepo(tip.appRepoName, "github", private)
 			gitAddCommitPush(repoAbsolutePath, tip.appManifestFilePath)
 		})
 
@@ -164,11 +164,11 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 
 		addCommand := "app add . --auto-merge=true"
 
-		defer deleteRepo(tip.appRepoName)
+		defer deleteRepo(tip.appRepoName, GITHUB_ORG)
 		defer deleteWorkload(tip.workloadName, tip.workloadNamespace)
 
 		By("And application repo does not already exist", func() {
-			deleteRepo(tip.appRepoName)
+			deleteRepo(tip.appRepoName, GITHUB_ORG)
 		})
 
 		By("And application workload is not already deployed to cluster", func() {
@@ -176,7 +176,7 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 		})
 
 		By("When I create an empty private repo", func() {
-			repoAbsolutePath = initAndCreateEmptyRepo(tip.appRepoName, private)
+			repoAbsolutePath = initAndCreateEmptyRepo(tip.appRepoName, "github", private)
 		})
 
 		By("And I install gitops to my active cluster", func() {
@@ -204,7 +204,55 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 		})
 
 		By("And repos created have private visibility", func() {
-			Expect(getRepoVisibility(GITHUB_ORG, tip.appRepoName)).Should(ContainSubstring("true"))
+			Expect(getGitHubRepoVisibility(GITHUB_ORG, tip.appRepoName)).Should(ContainSubstring("true"))
+		})
+	})
+
+	It("Verify that gitops can deploy a gitlab app after it is setup with an empty repo initially", func() {
+		var repoAbsolutePath string
+		private := true
+		tip := generateTestInputs()
+		appName := tip.appRepoName
+
+		addCommand := "app add . --auto-merge=true"
+
+		defer deleteRepo(tip.appRepoName, GITLAB_ORG)
+		defer deleteWorkload(tip.workloadName, tip.workloadNamespace)
+
+		By("And application repo does not already exist", func() {
+			deleteRepo(tip.appRepoName, GITLAB_ORG)
+		})
+
+		By("And application workload is not already deployed to cluster", func() {
+			deleteWorkload(tip.workloadName, tip.workloadNamespace)
+		})
+
+		By("When I create an empty private repo", func() {
+			repoAbsolutePath = initAndCreateEmptyRepo(tip.appRepoName, "gitlab", private)
+		})
+
+		By("And I install gitops to my active cluster", func() {
+			installAndVerifyWego(WEGO_DEFAULT_NAMESPACE)
+		})
+
+		By("And I run gitops add command", func() {
+			runWegoAddCommand(repoAbsolutePath, addCommand, WEGO_DEFAULT_NAMESPACE)
+		})
+
+		By("Then I should see gitops add command linked the repo to the cluster", func() {
+			verifyWegoAddCommand(appName, WEGO_DEFAULT_NAMESPACE)
+		})
+
+		By("And I git add-commit-push app workload to repo", func() {
+			gitAddCommitPush(repoAbsolutePath, tip.appManifestFilePath)
+		})
+
+		By("And I should see workload is deployed to the cluster", func() {
+			verifyWorkloadIsDeployed(tip.workloadName, tip.workloadNamespace)
+		})
+
+		By("And repos created have private visibility", func() {
+			Expect(getGitLabRepoVisibility(GITLAB_ORG, tip.appRepoName)).Should(ContainSubstring("private"))
 		})
 	})
 
@@ -220,12 +268,12 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 
 		addCommand := "app add --url=" + appRepoRemoteURL + " --branch=" + branchName + " --namespace=" + wegoNamespace + " --deployment-type=kustomize --app-config-url=NONE"
 
-		defer deleteRepo(tip.appRepoName)
+		defer deleteRepo(tip.appRepoName, GITHUB_ORG)
 		defer deleteWorkload(tip.workloadName, tip.workloadNamespace)
 		defer uninstallWegoRuntime(wegoNamespace)
 
 		By("And application repo does not already exist", func() {
-			deleteRepo(tip.appRepoName)
+			deleteRepo(tip.appRepoName, GITHUB_ORG)
 		})
 
 		By("And application workload is not already deployed to cluster", func() {
@@ -237,7 +285,7 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 		})
 
 		By("When I create a private repo with my app workload", func() {
-			repoAbsolutePath = initAndCreateEmptyRepo(tip.appRepoName, private)
+			repoAbsolutePath = initAndCreateEmptyRepo(tip.appRepoName, "github", private)
 			gitAddCommitPush(repoAbsolutePath, tip.appManifestFilePath)
 		})
 
@@ -289,13 +337,13 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 
 		addCommand := "app add --url=" + appRepoRemoteURL + " --app-config-url=" + configRepoRemoteURL + " --auto-merge=true"
 
-		defer deleteRepo(tip.appRepoName)
-		defer deleteRepo(appConfigRepoName)
+		defer deleteRepo(tip.appRepoName, GITHUB_ORG)
+		defer deleteRepo(appConfigRepoName, GITHUB_ORG)
 		defer deleteWorkload(tip.workloadName, tip.workloadNamespace)
 
 		By("And application repo does not already exist", func() {
-			deleteRepo(tip.appRepoName)
-			deleteRepo(appConfigRepoName)
+			deleteRepo(tip.appRepoName, GITHUB_ORG)
+			deleteRepo(appConfigRepoName, GITHUB_ORG)
 		})
 
 		By("And application workload is not already deployed to cluster", func() {
@@ -303,12 +351,12 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 		})
 
 		By("When I create a private repo for gitops app config", func() {
-			appConfigRepoAbsPath := initAndCreateEmptyRepo(appConfigRepoName, private)
+			appConfigRepoAbsPath := initAndCreateEmptyRepo(appConfigRepoName, "github", private)
 			gitAddCommitPush(appConfigRepoAbsPath, tip.appManifestFilePath)
 		})
 
 		By("When I create a private repo with my app workload", func() {
-			repoAbsolutePath = initAndCreateEmptyRepo(tip.appRepoName, private)
+			repoAbsolutePath = initAndCreateEmptyRepo(tip.appRepoName, "github", private)
 			gitAddCommitPush(repoAbsolutePath, tip.appManifestFilePath)
 		})
 
@@ -330,6 +378,55 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 		})
 	})
 
+	It("Verify that gitops can deploy a gitlab app with specified config-url and app-config-url set to <url>", func() {
+		var repoAbsolutePath string
+		var configRepoRemoteURL string
+		private := true
+		tip := generateTestInputs()
+		appName := tip.appRepoName
+		appConfigRepoName := "wego-config-repo-" + RandString(8)
+		appRepoRemoteURL := "ssh://git@gitlab.com/" + GITLAB_ORG + "/" + tip.appRepoName + ".git"
+		configRepoRemoteURL = "ssh://git@gitlab.com/" + GITLAB_ORG + "/" + appConfigRepoName + ".git"
+
+		addCommand := "app add --url=" + appRepoRemoteURL + " --app-config-url=" + configRepoRemoteURL + " --auto-merge=true"
+
+		defer deleteRepo(tip.appRepoName, GITLAB_ORG)
+		defer deleteRepo(appConfigRepoName, GITLAB_ORG)
+		defer deleteWorkload(tip.workloadName, tip.workloadNamespace)
+
+		By("And application repo does not already exist", func() {
+			deleteRepo(tip.appRepoName, GITLAB_ORG)
+			deleteRepo(appConfigRepoName, GITLAB_ORG)
+		})
+
+		By("And application workload is not already deployed to cluster", func() {
+			deleteWorkload(tip.workloadName, tip.workloadNamespace)
+		})
+
+		By("When I create a private repo for gitops app config", func() {
+			appConfigRepoAbsPath := initAndCreateEmptyRepo(appConfigRepoName, "gitlab", private)
+			gitAddCommitPush(appConfigRepoAbsPath, tip.appManifestFilePath)
+		})
+
+		By("When I create a private repo with my app workload", func() {
+			repoAbsolutePath = initAndCreateEmptyRepo(tip.appRepoName, "gitlab", private)
+			gitAddCommitPush(repoAbsolutePath, tip.appManifestFilePath)
+		})
+
+		By("And I install gitops to my active cluster", func() {
+			installAndVerifyWego(WEGO_DEFAULT_NAMESPACE)
+		})
+
+		By("And I run gitops add command with --url and --app-config-url params", func() {
+			runWegoAddCommand(repoAbsolutePath+"/../", addCommand, WEGO_DEFAULT_NAMESPACE)
+		})
+
+		By("Then I should see my workload deployed to the cluster", func() {
+			verifyWegoAddCommand(appName, WEGO_DEFAULT_NAMESPACE)
+			verifyWorkloadIsDeployed(tip.workloadName, tip.workloadNamespace)
+		})
+	})
+
 	It("Verify that gitops can deploy an app with specified config-url and app-config-url set to default", func() {
 		var repoAbsolutePath string
 		private := false
@@ -339,11 +436,11 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 
 		addCommand := "app add --url=" + appRepoRemoteURL + " --auto-merge=true"
 
-		defer deleteRepo(tip.appRepoName)
+		defer deleteRepo(tip.appRepoName, GITHUB_ORG)
 		defer deleteWorkload(tip.workloadName, tip.workloadNamespace)
 
 		By("And application repo does not already exist", func() {
-			deleteRepo(tip.appRepoName)
+			deleteRepo(tip.appRepoName, GITHUB_ORG)
 		})
 
 		By("And application workload is not already deployed to cluster", func() {
@@ -351,7 +448,7 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 		})
 
 		By("When I create a private repo with my app workload", func() {
-			repoAbsolutePath = initAndCreateEmptyRepo(tip.appRepoName, private)
+			repoAbsolutePath = initAndCreateEmptyRepo(tip.appRepoName, "github", private)
 			gitAddCommitPush(repoAbsolutePath, tip.appManifestFilePath)
 		})
 
@@ -381,11 +478,11 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 
 		addCommand := "app add " + tip.appRepoName + "/" + " --auto-merge=true"
 
-		defer deleteRepo(tip.appRepoName)
+		defer deleteRepo(tip.appRepoName, GITHUB_ORG)
 		defer deleteWorkload(tip.workloadName, tip.workloadNamespace)
 
 		By("And application repo does not already exist", func() {
-			deleteRepo(tip.appRepoName)
+			deleteRepo(tip.appRepoName, GITHUB_ORG)
 		})
 
 		By("And application workload is not already deployed to cluster", func() {
@@ -393,7 +490,7 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 		})
 
 		By("When I create a private repo with my app workload", func() {
-			repoAbsolutePath = initAndCreateEmptyRepo(tip.appRepoName, private)
+			repoAbsolutePath = initAndCreateEmptyRepo(tip.appRepoName, "github", private)
 			gitAddCommitPush(repoAbsolutePath, tip.appManifestFilePath)
 		})
 
@@ -416,7 +513,7 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 		})
 
 		By("And repos created have private visibility", func() {
-			Expect(getRepoVisibility(GITHUB_ORG, tip.appRepoName)).Should(ContainSubstring("true"))
+			Expect(getGitHubRepoVisibility(GITHUB_ORG, tip.appRepoName)).Should(ContainSubstring("true"))
 		})
 	})
 
@@ -429,12 +526,12 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 
 		addCommand := "app add . --name=" + appName + " --auto-merge=true"
 
-		defer deleteRepo(appRepoName)
+		defer deleteRepo(appRepoName, GITHUB_ORG)
 		defer deleteWorkload(tip1.workloadName, tip1.workloadNamespace)
 		defer deleteWorkload(tip2.workloadName, tip2.workloadNamespace)
 
 		By("And application repos do not already exist", func() {
-			deleteRepo(appRepoName)
+			deleteRepo(appRepoName, GITHUB_ORG)
 		})
 
 		By("And application workload is not already deployed to cluster", func() {
@@ -443,7 +540,7 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 		})
 
 		By("When I create an empty private repo for app1", func() {
-			repoAbsolutePath = initAndCreateEmptyRepo(appRepoName, true)
+			repoAbsolutePath = initAndCreateEmptyRepo(appRepoName, "github", true)
 		})
 
 		By("And I git add-commit-push for app with multiple workloads", func() {
@@ -489,16 +586,16 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 
 		addCommand := "app add . --app-config-url=" + configRepoRemoteURL + " --auto-merge=true"
 
-		defer deleteRepo(appRepoName1)
-		defer deleteRepo(appRepoName2)
-		defer deleteRepo(appConfigRepoName)
+		defer deleteRepo(appRepoName1, GITHUB_ORG)
+		defer deleteRepo(appRepoName2, GITHUB_ORG)
+		defer deleteRepo(appConfigRepoName, GITHUB_ORG)
 		defer deleteWorkload(tip1.workloadName, tip1.workloadNamespace)
 		defer deleteWorkload(tip2.workloadName, tip2.workloadNamespace)
 
 		By("And application repo does not already exist", func() {
-			deleteRepo(appRepoName1)
-			deleteRepo(appRepoName2)
-			deleteRepo(appConfigRepoName)
+			deleteRepo(appRepoName1, GITHUB_ORG)
+			deleteRepo(appRepoName2, GITHUB_ORG)
+			deleteRepo(appConfigRepoName, GITHUB_ORG)
 		})
 
 		By("And application workload is not already deployed to cluster", func() {
@@ -515,18 +612,18 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 		})
 
 		By("When I create a private repo for gitops app config", func() {
-			appConfigRepoAbsPath := initAndCreateEmptyRepo(appConfigRepoName, private)
+			appConfigRepoAbsPath := initAndCreateEmptyRepo(appConfigRepoName, "github", private)
 			gitAddCommitPush(appConfigRepoAbsPath, readmeFilePath)
 		})
 
 		By("And I create a repo with my app1 workload and run the add the command on it", func() {
-			repoAbsolutePath = initAndCreateEmptyRepo(appRepoName1, private)
+			repoAbsolutePath = initAndCreateEmptyRepo(appRepoName1, "github", private)
 			gitAddCommitPush(repoAbsolutePath, tip1.appManifestFilePath)
 			runWegoAddCommand(repoAbsolutePath, addCommand, WEGO_DEFAULT_NAMESPACE)
 		})
 
 		By("And I create a repo with my app2 workload and run the add the command on it", func() {
-			repoAbsolutePath = initAndCreateEmptyRepo(appRepoName2, private)
+			repoAbsolutePath = initAndCreateEmptyRepo(appRepoName2, "github", private)
 			gitAddCommitPush(repoAbsolutePath, tip2.appManifestFilePath)
 			runWegoAddCommand(repoAbsolutePath, addCommand, WEGO_DEFAULT_NAMESPACE)
 		})
@@ -551,12 +648,12 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 		addCommand1 := "app add . --path=./" + appName1 + " --name=" + appName1 + " --auto-merge=true"
 		addCommand2 := "app add . --path=./" + appName2 + " --name=" + appName2 + " --auto-merge=true"
 
-		defer deleteRepo(appRepoName)
+		defer deleteRepo(appRepoName, GITHUB_ORG)
 		defer deleteWorkload(tip1.workloadName, tip1.workloadNamespace)
 		defer deleteWorkload(tip2.workloadName, tip2.workloadNamespace)
 
 		By("And application repo does not already exist", func() {
-			deleteRepo(appRepoName)
+			deleteRepo(appRepoName, GITHUB_ORG)
 		})
 
 		By("And application workload is not already deployed to cluster", func() {
@@ -573,7 +670,7 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 		})
 
 		By("And I create a repo with my app1 and app2 workloads and run the add the command for each app", func() {
-			repoAbsolutePath = initAndCreateEmptyRepo(appRepoName, private)
+			repoAbsolutePath = initAndCreateEmptyRepo(appRepoName, "github", private)
 			app1Path := createSubDir(appName1, repoAbsolutePath)
 			app2Path := createSubDir(appName2, repoAbsolutePath)
 			gitAddCommitPush(app1Path, tip1.appManifestFilePath)
@@ -619,14 +716,14 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 		addCommand2 := "app add . --deployment-type=helm --path=./hello-world --name=" + appName2 + " --app-config-url=" + configRepoRemoteURL + " --auto-merge=true"
 		addCommand3 := "app add --url=" + helmRepoURL + " --chart=" + appName3 + " --app-config-url=" + configRepoRemoteURL + " --auto-merge=true"
 
-		defer deleteRepo(appFilesRepoName)
-		defer deleteRepo(appConfigRepoName)
+		defer deleteRepo(appFilesRepoName, GITHUB_ORG)
+		defer deleteRepo(appConfigRepoName, GITHUB_ORG)
 		defer deleteWorkload(workloadName1, workloadNamespace1)
 		defer deletePersistingHelmApp(WEGO_DEFAULT_NAMESPACE, workloadName3, EVENTUALLY_DEFAULT_TIMEOUT)
 
 		By("And application repo does not already exist", func() {
-			deleteRepo(appFilesRepoName)
-			deleteRepo(appConfigRepoName)
+			deleteRepo(appFilesRepoName, GITHUB_ORG)
+			deleteRepo(appConfigRepoName, GITHUB_ORG)
 		})
 
 		By("And application workload is not already deployed to cluster", func() {
@@ -635,12 +732,12 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 		})
 
 		By("When I create a private repo for gitops app config", func() {
-			appConfigRepoAbsPath := initAndCreateEmptyRepo(appConfigRepoName, private)
+			appConfigRepoAbsPath := initAndCreateEmptyRepo(appConfigRepoName, "github", private)
 			gitAddCommitPush(appConfigRepoAbsPath, readmeFilePath)
 		})
 
 		By("When I create a private repo with app1 workload", func() {
-			repoAbsolutePath = initAndCreateEmptyRepo(appFilesRepoName, private)
+			repoAbsolutePath = initAndCreateEmptyRepo(appFilesRepoName, "github", private)
 			gitAddCommitPush(repoAbsolutePath, appManifestFilePath1)
 		})
 
@@ -783,14 +880,14 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 		addCommand1 := "app add . --name=" + appName1 + " --auto-merge=true"
 		addCommand2 := "app add . --name=" + appName2 + " --auto-merge=true"
 
-		defer deleteRepo(tip1.appRepoName)
-		defer deleteRepo(tip2.appRepoName)
+		defer deleteRepo(tip1.appRepoName, GITHUB_ORG)
+		defer deleteRepo(tip2.appRepoName, GITHUB_ORG)
 		defer deleteWorkload(tip1.workloadName, tip1.workloadNamespace)
 		defer deleteWorkload(tip2.workloadName, tip2.workloadNamespace)
 
 		By("And application repos do not already exist", func() {
-			deleteRepo(tip1.appRepoName)
-			deleteRepo(tip2.appRepoName)
+			deleteRepo(tip1.appRepoName, GITHUB_ORG)
+			deleteRepo(tip2.appRepoName, GITHUB_ORG)
 		})
 
 		By("And application workload is not already deployed to cluster", func() {
@@ -799,11 +896,11 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 		})
 
 		By("When I create an empty private repo for app1", func() {
-			repoAbsolutePath1 = initAndCreateEmptyRepo(tip1.appRepoName, private)
+			repoAbsolutePath1 = initAndCreateEmptyRepo(tip1.appRepoName, "github", private)
 		})
 
 		By("When I create an empty public repo for app2", func() {
-			repoAbsolutePath2 = initAndCreateEmptyRepo(tip2.appRepoName, public)
+			repoAbsolutePath2 = initAndCreateEmptyRepo(tip2.appRepoName, "github", public)
 		})
 
 		By("And I git add-commit-push for app1 with workload", func() {
@@ -847,8 +944,8 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 		})
 
 		By("And repos created have proper visibility", func() {
-			Eventually(getRepoVisibility(GITHUB_ORG, tip1.appRepoName)).Should(ContainSubstring("true"))
-			Eventually(getRepoVisibility(GITHUB_ORG, tip2.appRepoName)).Should(ContainSubstring("false"))
+			Eventually(getGitHubRepoVisibility(GITHUB_ORG, tip1.appRepoName)).Should(ContainSubstring("true"))
+			Eventually(getGitHubRepoVisibility(GITHUB_ORG, tip2.appRepoName)).Should(ContainSubstring("false"))
 		})
 
 		By("When I check the app status for "+appName1, func() {
@@ -1006,14 +1103,14 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 
 		addCommand := "app add . --deployment-type=helm --path=./hello-world --name=" + appName + " --app-config-url=NONE"
 
-		defer deleteRepo(appRepoName)
+		defer deleteRepo(appRepoName, GITHUB_ORG)
 
 		By("Application and config repo does not already exist", func() {
-			deleteRepo(appRepoName)
+			deleteRepo(appRepoName, GITHUB_ORG)
 		})
 
 		By("When I create a private repo with my app workload", func() {
-			repoAbsolutePath = initAndCreateEmptyRepo(appRepoName, private)
+			repoAbsolutePath = initAndCreateEmptyRepo(appRepoName, "github", private)
 			gitAddCommitPush(repoAbsolutePath, appManifestFilePath)
 		})
 
@@ -1090,14 +1187,14 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 
 		addCommand := "app add . --deployment-type=helm --path=./hello-world --name=" + appName + " --auto-merge=true"
 
-		defer deleteRepo(appRepoName)
+		defer deleteRepo(appRepoName, GITHUB_ORG)
 
 		By("And application repo does not already exist", func() {
-			deleteRepo(appRepoName)
+			deleteRepo(appRepoName, GITHUB_ORG)
 		})
 
 		By("When I create a private repo with my app workload", func() {
-			repoAbsolutePath = initAndCreateEmptyRepo(appRepoName, public)
+			repoAbsolutePath = initAndCreateEmptyRepo(appRepoName, "github", public)
 			gitAddCommitPush(repoAbsolutePath, appManifestFilePath)
 		})
 
@@ -1120,7 +1217,7 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 		})
 
 		By("And repo created has public visibility", func() {
-			Eventually(getRepoVisibility(GITHUB_ORG, appRepoName)).Should(ContainSubstring("false"))
+			Eventually(getGitHubRepoVisibility(GITHUB_ORG, appRepoName)).Should(ContainSubstring("false"))
 		})
 	})
 
@@ -1137,21 +1234,21 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 
 		addCommand := fmt.Sprintf("app add . --app-config-url=%s --deployment-type=helm --path=./hello-world --name=%s --auto-merge=true", configRepoUrl, appName)
 
-		defer deleteRepo(appRepoName)
-		defer deleteRepo(configRepoName)
+		defer deleteRepo(appRepoName, GITHUB_ORG)
+		defer deleteRepo(configRepoName, GITHUB_ORG)
 
 		By("Application and config repo does not already exist", func() {
-			deleteRepo(appRepoName)
-			deleteRepo(configRepoName)
+			deleteRepo(appRepoName, GITHUB_ORG)
+			deleteRepo(configRepoName, GITHUB_ORG)
 		})
 
 		By("When I create a private repo with my app workload", func() {
-			repoAbsolutePath = initAndCreateEmptyRepo(appRepoName, private)
+			repoAbsolutePath = initAndCreateEmptyRepo(appRepoName, "github", private)
 			gitAddCommitPush(repoAbsolutePath, appManifestFilePath)
 		})
 
 		By("When I create a private repo for my config files", func() {
-			configRepoAbsolutePath = initAndCreateEmptyRepo(configRepoName, private)
+			configRepoAbsolutePath = initAndCreateEmptyRepo(configRepoName, "github", private)
 			gitAddCommitPush(configRepoAbsolutePath, configRepoFiles)
 		})
 
@@ -1214,11 +1311,11 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 
 		defer deletePersistingHelmApp(WEGO_DEFAULT_NAMESPACE, workloadName1, EVENTUALLY_DEFAULT_TIMEOUT)
 		defer deletePersistingHelmApp(WEGO_DEFAULT_NAMESPACE, workloadName2, EVENTUALLY_DEFAULT_TIMEOUT)
-		defer deleteRepo(appRepoName)
+		defer deleteRepo(appRepoName, GITHUB_ORG)
 		defer deleteNamespace(workloadNamespace2)
 
 		By("And application repo does not already exist", func() {
-			deleteRepo(appRepoName)
+			deleteRepo(appRepoName, GITHUB_ORG)
 		})
 
 		By("And application workload is not already deployed to cluster", func() {
@@ -1227,7 +1324,7 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 		})
 
 		By("When I create a private git repo", func() {
-			repoAbsolutePath = initAndCreateEmptyRepo(appRepoName, private)
+			repoAbsolutePath = initAndCreateEmptyRepo(appRepoName, "github", private)
 			gitAddCommitPush(repoAbsolutePath, readmeFilePath)
 		})
 
@@ -1339,15 +1436,15 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 
 		addCommand := "app add . --name=" + appName + " --auto-merge=false"
 
-		defer deleteRepo(tip.appRepoName)
+		defer deleteRepo(tip.appRepoName, GITHUB_ORG)
 		defer deleteWorkload(tip.workloadName, tip.workloadNamespace)
 
 		By("And application repo does not already exist", func() {
-			deleteRepo(tip.appRepoName)
+			deleteRepo(tip.appRepoName, GITHUB_ORG)
 		})
 
 		By("When I create an empty private repo for app", func() {
-			repoAbsolutePath = initAndCreateEmptyRepo(tip.appRepoName, true)
+			repoAbsolutePath = initAndCreateEmptyRepo(tip.appRepoName, "github", true)
 		})
 
 		By("And I git add-commit-push app manifest", func() {
@@ -1395,22 +1492,22 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 
 		addCommand := "app add . --app-config-url=" + configRepoRemoteURL
 
-		defer deleteRepo(tip.appRepoName)
-		defer deleteRepo(appConfigRepoName)
+		defer deleteRepo(tip.appRepoName, GITHUB_ORG)
+		defer deleteRepo(appConfigRepoName, GITHUB_ORG)
 		defer deleteWorkload(tip.workloadName, tip.workloadNamespace)
 
 		By("And application repo does not already exist", func() {
-			deleteRepo(tip.appRepoName)
-			deleteRepo(appConfigRepoName)
+			deleteRepo(tip.appRepoName, GITHUB_ORG)
+			deleteRepo(appConfigRepoName, GITHUB_ORG)
 		})
 
 		By("When I create a private repo for gitops app config", func() {
-			appConfigRepoAbsPath = initAndCreateEmptyRepo(appConfigRepoName, private)
+			appConfigRepoAbsPath = initAndCreateEmptyRepo(appConfigRepoName, "github", private)
 			gitAddCommitPush(appConfigRepoAbsPath, tip.appManifestFilePath)
 		})
 
 		By("When I create a private repo with my app workload", func() {
-			repoAbsolutePath = initAndCreateEmptyRepo(tip.appRepoName, private)
+			repoAbsolutePath = initAndCreateEmptyRepo(tip.appRepoName, "github", private)
 			gitAddCommitPush(repoAbsolutePath, tip.appManifestFilePath)
 		})
 
@@ -1453,15 +1550,15 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 		addCommand := "app add . --name=" + appName
 		addCommand2 := "app add . --name=" + appName2
 
-		defer deleteRepo(tip.appRepoName)
+		defer deleteRepo(tip.appRepoName, GITHUB_ORG)
 		defer deleteWorkload(tip.workloadName, tip.workloadNamespace)
 
 		By("And application repo does not already exist", func() {
-			deleteRepo(tip.appRepoName)
+			deleteRepo(tip.appRepoName, GITHUB_ORG)
 		})
 
 		By("When I create an empty private repo for app", func() {
-			repoAbsolutePath = initAndCreateEmptyRepo(tip.appRepoName, true)
+			repoAbsolutePath = initAndCreateEmptyRepo(tip.appRepoName, "github", true)
 		})
 
 		By("And I git add-commit-push for app with workload", func() {
@@ -1543,13 +1640,13 @@ var _ = Describe("Weave GitOps Add Tests With Long Cluster Name", func() {
 
 		addCommand := "app add . --app-config-url=" + configRepoRemoteURL + " --auto-merge=true"
 
-		defer deleteRepo(appFilesRepoName)
-		defer deleteRepo(appConfigRepoName)
+		defer deleteRepo(appFilesRepoName, GITHUB_ORG)
+		defer deleteRepo(appConfigRepoName, GITHUB_ORG)
 		defer deleteWorkload(workloadName, workloadNamespace)
 
 		By("And application repo does not already exist", func() {
-			deleteRepo(appFilesRepoName)
-			deleteRepo(appConfigRepoName)
+			deleteRepo(appFilesRepoName, GITHUB_ORG)
+			deleteRepo(appConfigRepoName, GITHUB_ORG)
 		})
 
 		By("And application workload is not already deployed to cluster", func() {
@@ -1557,12 +1654,12 @@ var _ = Describe("Weave GitOps Add Tests With Long Cluster Name", func() {
 		})
 
 		By("When I create a private repo for gitops app config", func() {
-			appConfigRepoAbsPath := initAndCreateEmptyRepo(appConfigRepoName, private)
+			appConfigRepoAbsPath := initAndCreateEmptyRepo(appConfigRepoName, "github", private)
 			gitAddCommitPush(appConfigRepoAbsPath, readmeFilePath)
 		})
 
 		By("When I create a private repo with app workload", func() {
-			repoAbsolutePath = initAndCreateEmptyRepo(appFilesRepoName, private)
+			repoAbsolutePath = initAndCreateEmptyRepo(appFilesRepoName, "github", private)
 			gitAddCommitPush(repoAbsolutePath, appManifestFilePath)
 		})
 

--- a/test/acceptance/test/add_tests.go
+++ b/test/acceptance/test/add_tests.go
@@ -204,7 +204,7 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 		})
 
 		By("And repos created have private visibility", func() {
-			Expect(getGitHubRepoVisibility(GITHUB_ORG, tip.appRepoName)).Should(ContainSubstring("true"))
+			Expect(getGitHubRepoVisibility(GITHUB_ORG, tip.appRepoName)).Should(ContainSubstring("private"))
 		})
 	})
 
@@ -513,7 +513,7 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 		})
 
 		By("And repos created have private visibility", func() {
-			Expect(getGitHubRepoVisibility(GITHUB_ORG, tip.appRepoName)).Should(ContainSubstring("true"))
+			Expect(getGitHubRepoVisibility(GITHUB_ORG, tip.appRepoName)).Should(ContainSubstring("private"))
 		})
 	})
 
@@ -944,8 +944,8 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 		})
 
 		By("And repos created have proper visibility", func() {
-			Eventually(getGitHubRepoVisibility(GITHUB_ORG, tip1.appRepoName)).Should(ContainSubstring("true"))
-			Eventually(getGitHubRepoVisibility(GITHUB_ORG, tip2.appRepoName)).Should(ContainSubstring("false"))
+			Eventually(getGitHubRepoVisibility(GITHUB_ORG, tip1.appRepoName)).Should(ContainSubstring("private"))
+			Eventually(getGitHubRepoVisibility(GITHUB_ORG, tip2.appRepoName)).Should(ContainSubstring("public"))
 		})
 
 		By("When I check the app status for "+appName1, func() {

--- a/test/acceptance/test/add_tests.go
+++ b/test/acceptance/test/add_tests.go
@@ -225,6 +225,10 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 			deleteWorkload(tip.workloadName, tip.workloadNamespace)
 		})
 
+		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
+			setupGitlabSSHKey(DEFAULT_SSH_KEY_PATH)
+		})
+
 		By("When I create an empty private repo", func() {
 			repoAbsolutePath = initAndCreateEmptyRepo(tip.appRepoName, gitproviders.GitProviderGitLab, private, GITLAB_ORG)
 		})
@@ -405,6 +409,10 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 
 		By("And application workload is not already deployed to cluster", func() {
 			deleteWorkload(tip.workloadName, tip.workloadNamespace)
+		})
+
+		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
+			setupGitlabSSHKey(DEFAULT_SSH_KEY_PATH)
 		})
 
 		By("When I create a private repo for gitops app config", func() {
@@ -1697,6 +1705,10 @@ var _ = Describe("Weave GitOps Add Tests With Long Cluster Name", func() {
 
 		By("And application workload is not already deployed to cluster", func() {
 			deleteWorkload(workloadName, workloadNamespace)
+		})
+
+		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
+			setupGitlabSSHKey(DEFAULT_SSH_KEY_PATH)
 		})
 
 		By("When I create a private repo for gitops app config", func() {

--- a/test/acceptance/test/add_tests.go
+++ b/test/acceptance/test/add_tests.go
@@ -1805,7 +1805,7 @@ var _ = Describe("Weave GitOps Add Tests With Long Cluster Name", func() {
 		})
 	})
 
-	It("SmokeTest - Verify that gitops can deploy an app with app-config-url set to a gitlab <url>", func() {
+	It("SmokeTest1 - Verify that gitops can deploy an app with app-config-url set to a gitlab <url>", func() {
 		var repoAbsolutePath string
 		var configRepoRemoteURL string
 		var listOutput string

--- a/test/acceptance/test/add_tests.go
+++ b/test/acceptance/test/add_tests.go
@@ -272,7 +272,7 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 		})
 	})
 
-	It("SmokeMy - Verify that gitops can deploy and remove a gitlab app that belongs in a subgroup", func() {
+	It("Verify that gitops can deploy and remove a gitlab app that belongs in a subgroup", func() {
 		var repoAbsolutePath string
 		private := true
 		tip := generateTestInputs()

--- a/test/acceptance/test/add_tests.go
+++ b/test/acceptance/test/add_tests.go
@@ -1805,7 +1805,7 @@ var _ = Describe("Weave GitOps Add Tests With Long Cluster Name", func() {
 		})
 	})
 
-	It("SmokeTest1 - Verify that gitops can deploy an app with app-config-url set to a gitlab <url>", func() {
+	It("SmokeTest - Verify that gitops can deploy an app with app-config-url set to a gitlab <url>", func() {
 		var repoAbsolutePath string
 		var configRepoRemoteURL string
 		var listOutput string

--- a/test/acceptance/test/add_tests.go
+++ b/test/acceptance/test/add_tests.go
@@ -185,7 +185,7 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 		})
 
 		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
-			setupSSHKey(DEFAULT_SSH_KEY_PATH)
+			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitHub)
 		})
 
 		By("And I run gitops add command", func() {
@@ -210,6 +210,7 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 	})
 
 	It("Verify that gitops can deploy and remove a gitlab app after it is setup with an empty repo initially", func() {
+		DEFAULT_SSH_KEY_PATH := "~/.ssh/id_rsa"
 		var repoAbsolutePath string
 		private := true
 		tip := generateTestInputs()
@@ -227,6 +228,10 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 
 		By("And application workload is not already deployed to cluster", func() {
 			deleteWorkload(tip.workloadName, tip.workloadNamespace)
+		})
+
+		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
+			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitLab)
 		})
 
 		By("When I create an empty private repo", func() {
@@ -273,6 +278,7 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 	})
 
 	It("Verify that gitops can deploy and remove a gitlab app that belongs in a subgroup", func() {
+		DEFAULT_SSH_KEY_PATH := "~/.ssh/id_rsa"
 		var repoAbsolutePath string
 		private := true
 		tip := generateTestInputs()
@@ -292,6 +298,10 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 
 		By("And application workload is not already deployed to cluster", func() {
 			deleteWorkload(tip.workloadName, tip.workloadNamespace)
+		})
+
+		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
+			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitLab)
 		})
 
 		By("When I create an empty private repo", func() {
@@ -375,7 +385,7 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 		})
 
 		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
-			setupSSHKey(DEFAULT_SSH_KEY_PATH)
+			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitHub)
 		})
 
 		By("And I create a new branch", func() {
@@ -446,7 +456,7 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 		})
 
 		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
-			setupSSHKey(DEFAULT_SSH_KEY_PATH)
+			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitHub)
 		})
 
 		By("And I run gitops add command with --url and --app-config-url params", func() {
@@ -483,6 +493,10 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 
 		By("And application workload is not already deployed to cluster", func() {
 			deleteWorkload(tip.workloadName, tip.workloadNamespace)
+		})
+
+		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
+			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitLab)
 		})
 
 		By("When I create a private repo for gitops app config", func() {
@@ -553,7 +567,7 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 		})
 
 		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
-			setupSSHKey(DEFAULT_SSH_KEY_PATH)
+			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitHub)
 		})
 
 		By("And I run gitops add command with --url", func() {
@@ -595,7 +609,7 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 		})
 
 		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
-			setupSSHKey(DEFAULT_SSH_KEY_PATH)
+			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitHub)
 		})
 
 		By("And I run gitops add command from repo parent dir", func() {
@@ -649,7 +663,7 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 		})
 
 		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
-			setupSSHKey(DEFAULT_SSH_KEY_PATH)
+			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitHub)
 		})
 
 		By("And I run gitops add command for 1st app", func() {
@@ -704,7 +718,7 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 		})
 
 		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
-			setupSSHKey(DEFAULT_SSH_KEY_PATH)
+			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitHub)
 		})
 
 		By("When I create a private repo for gitops app config", func() {
@@ -762,7 +776,7 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 		})
 
 		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
-			setupSSHKey(DEFAULT_SSH_KEY_PATH)
+			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitHub)
 		})
 
 		By("And I create a repo with my app1 and app2 workloads and run the add the command for each app", func() {
@@ -842,7 +856,7 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 		})
 
 		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
-			setupSSHKey(DEFAULT_SSH_KEY_PATH)
+			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitHub)
 		})
 
 		By("And I run gitops app add command for app1: "+appName1, func() {
@@ -1012,7 +1026,7 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 		})
 
 		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
-			setupSSHKey(DEFAULT_SSH_KEY_PATH)
+			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitHub)
 		})
 
 		By("And I run gitops app add command for 1st app", func() {
@@ -1215,7 +1229,7 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 		})
 
 		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
-			setupSSHKey(DEFAULT_SSH_KEY_PATH)
+			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitHub)
 		})
 
 		By("And I run gitops add command", func() {
@@ -1299,7 +1313,7 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 		})
 
 		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
-			setupSSHKey(DEFAULT_SSH_KEY_PATH)
+			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitHub)
 		})
 
 		By("And I run gitops add command", func() {
@@ -1353,7 +1367,7 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 		})
 
 		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
-			setupSSHKey(DEFAULT_SSH_KEY_PATH)
+			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitHub)
 		})
 
 		By("And I run gitops add command", func() {
@@ -1429,7 +1443,7 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 		})
 
 		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
-			setupSSHKey(DEFAULT_SSH_KEY_PATH)
+			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitHub)
 		})
 
 		By("And I create a namespace for helm-app", func() {
@@ -1511,7 +1525,7 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 		})
 
 		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
-			setupSSHKey(DEFAULT_SSH_KEY_PATH)
+			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitHub)
 		})
 
 		By("And I run gitops add command", func() {
@@ -1552,7 +1566,7 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 		})
 
 		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
-			setupSSHKey(DEFAULT_SSH_KEY_PATH)
+			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitHub)
 		})
 
 		By("When I run gitops app add command for app", func() {
@@ -1612,7 +1626,7 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 		})
 
 		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
-			setupSSHKey(DEFAULT_SSH_KEY_PATH)
+			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitHub)
 		})
 
 		By("And I run gitops add command with --app-config-url param", func() {
@@ -1666,7 +1680,7 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 		})
 
 		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
-			setupSSHKey(DEFAULT_SSH_KEY_PATH)
+			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitHub)
 		})
 
 		By("And I run app add command for "+appName, func() {
@@ -1764,7 +1778,7 @@ var _ = Describe("Weave GitOps Add Tests With Long Cluster Name", func() {
 		})
 
 		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
-			setupSSHKey(DEFAULT_SSH_KEY_PATH)
+			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitHub)
 		})
 
 		By("And I run gitops app add command for app: "+appName, func() {
@@ -1841,6 +1855,10 @@ var _ = Describe("Weave GitOps Add Tests With Long Cluster Name", func() {
 			deleteWorkload(workloadName, workloadNamespace)
 		})
 
+		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
+			setupSSHKey(DEFAULT_SSH_KEY_PATH, gitproviders.GitProviderGitLab)
+		})
+
 		By("When I create a private repo for gitops app config", func() {
 			appConfigRepoAbsPath := initAndCreateEmptyRepo(appConfigRepoName, gitproviders.GitProviderGitLab, private, GITLAB_ORG)
 			gitAddCommitPush(appConfigRepoAbsPath, readmeFilePath)
@@ -1853,10 +1871,6 @@ var _ = Describe("Weave GitOps Add Tests With Long Cluster Name", func() {
 
 		By("And I install gitops to my active cluster", func() {
 			installAndVerifyWego(WEGO_DEFAULT_NAMESPACE)
-		})
-
-		By("And I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
-			setupSSHKey(DEFAULT_SSH_KEY_PATH)
 		})
 
 		By("And I run gitops app add command for app: "+appName, func() {

--- a/test/acceptance/test/testsuite_common_test.go
+++ b/test/acceptance/test/testsuite_common_test.go
@@ -42,6 +42,7 @@ var _ = BeforeSuite(func() {
 	SetDefaultEventuallyTimeout(EVENTUALLY_DEFAULT_TIMEOUT)
 	DEFAULT_SSH_KEY_PATH = os.Getenv("HOME") + "/.ssh/id_rsa"
 	GITHUB_ORG = os.Getenv("GITHUB_ORG")
+	GITLAB_ORG = os.Getenv("GITLAB_ORG")
 	WEGO_BIN_PATH = os.Getenv("WEGO_BIN_PATH")
 	if WEGO_BIN_PATH == "" {
 		WEGO_BIN_PATH = "/usr/local/bin/gitops"

--- a/test/acceptance/test/testsuite_common_test.go
+++ b/test/acceptance/test/testsuite_common_test.go
@@ -43,6 +43,7 @@ var _ = BeforeSuite(func() {
 	DEFAULT_SSH_KEY_PATH = os.Getenv("HOME") + "/.ssh/id_rsa"
 	GITHUB_ORG = os.Getenv("GITHUB_ORG")
 	GITLAB_ORG = os.Getenv("GITLAB_ORG")
+	GITLAB_SUBGROUP = os.Getenv("GITLAB_SUBGROUP")
 	WEGO_BIN_PATH = os.Getenv("WEGO_BIN_PATH")
 	if WEGO_BIN_PATH == "" {
 		WEGO_BIN_PATH = "/usr/local/bin/gitops"

--- a/test/acceptance/test/utils.go
+++ b/test/acceptance/test/utils.go
@@ -155,7 +155,6 @@ func setupSSHKey(sshKeyPath string, providerName gitproviders.GitProviderName) {
 
 	if _, err := os.Stat(sshKeyPath); os.IsNotExist(err) {
 		command := exec.Command("sh", "-c", fmt.Sprintf(`
-						   ssh keygen -R git@gitlab.com &&
                            echo "%s" >> %s &&
                            chmod 0600 %s &&
                            ls -la %s`, os.Getenv(keyName), sshKeyPath, sshKeyPath, sshKeyPath))
@@ -246,6 +245,7 @@ func initAndCreateEmptyRepo(appRepoName string, providerName gitproviders.GitPro
 
 	err = utils.WaitUntil(os.Stdout, time.Second*3, time.Second*30, func() error {
 		command := exec.Command("sh", "-c", fmt.Sprintf(`
+		ssh keygen -R git@gitlab.com &&
 		git clone git@%s.com:%s/%s.git %s`,
 			providerName, org, appRepoName,
 			repoAbsolutePath))

--- a/test/acceptance/test/utils.go
+++ b/test/acceptance/test/utils.go
@@ -245,7 +245,7 @@ func initAndCreateEmptyRepo(appRepoName string, providerName gitproviders.GitPro
 
 	err = utils.WaitUntil(os.Stdout, time.Second*3, time.Second*30, func() error {
 		command := exec.Command("sh", "-c", fmt.Sprintf(`
-		echo -e "Host *\n\tStrictHostKeyChecking no\n\n" >> ~/.ssh/config &&
+		ssh-keygen -R gitlab.com &&
 		git clone git@%s.com:%s/%s.git %s`,
 			providerName, org, appRepoName,
 			repoAbsolutePath))

--- a/test/acceptance/test/utils.go
+++ b/test/acceptance/test/utils.go
@@ -245,7 +245,7 @@ func initAndCreateEmptyRepo(appRepoName string, providerName gitproviders.GitPro
 
 	err = utils.WaitUntil(os.Stdout, time.Second*3, time.Second*30, func() error {
 		command := exec.Command("sh", "-c", fmt.Sprintf(`
-		git clone git@github.com:%s/%s.git %s %s`,
+		git clone git@%s.com:%s/%s.git %s`,
 			providerName, org, appRepoName,
 			repoAbsolutePath))
 		command.Stdout = os.Stdout

--- a/test/acceptance/test/utils.go
+++ b/test/acceptance/test/utils.go
@@ -285,7 +285,6 @@ func getGitHubRepoVisibility(org string, repo string) string {
 	Expect(err).ShouldNot(HaveOccurred())
 
 	visibility := string(*orgInfo.Get().Visibility)
-	log.Infof("Repo visibility private=%s", visibility)
 
 	return visibility
 }
@@ -311,7 +310,6 @@ func getGitLabRepoVisibility(org string, repo string) string {
 	Expect(err).ShouldNot(HaveOccurred())
 
 	visibility := string(*orgInfo.Get().Visibility)
-	log.Infof("Repo visibility private=%s", visibility)
 
 	return visibility
 }

--- a/test/acceptance/test/utils.go
+++ b/test/acceptance/test/utils.go
@@ -155,6 +155,7 @@ func setupSSHKey(sshKeyPath string, providerName gitproviders.GitProviderName) {
 
 	if _, err := os.Stat(sshKeyPath); os.IsNotExist(err) {
 		command := exec.Command("sh", "-c", fmt.Sprintf(`
+						   ssh keygen -R git@gitlab.com &&
                            echo "%s" >> %s &&
                            chmod 0600 %s &&
                            ls -la %s`, os.Getenv(keyName), sshKeyPath, sshKeyPath, sshKeyPath))

--- a/test/acceptance/test/utils.go
+++ b/test/acceptance/test/utils.go
@@ -285,10 +285,11 @@ func getGitRepoVisibility(org string, repo string, providerName gitproviders.Git
 		)
 		domain = github.DefaultDomain
 	case gitproviders.GitProviderGitLab:
+		token := os.Getenv("GITLAB_TOKEN")
 		gitProvider, err = gitlab.NewClient(
-			os.Getenv("GITLAB_TOKEN"),
+			token,
 			"oauth2",
-			gitprovider.WithOAuth2Token(os.Getenv("GITLAB_TOKEN")),
+			gitprovider.WithOAuth2Token(token),
 			gitprovider.WithDestructiveAPICalls(true),
 		)
 		domain = gitlab.DefaultDomain
@@ -737,10 +738,11 @@ func createGitRepository(repoName, branch string, private bool, providerName git
 
 		domain = github.DefaultDomain
 	case gitproviders.GitProviderGitLab:
+		token := os.Getenv("GITLAB_TOKEN")
 		gitProvider, err = gitlab.NewClient(
-			os.Getenv("GITLAB_TOKEN"),
+			token,
 			"oauth2",
-			gitprovider.WithOAuth2Token(os.Getenv("GITLAB_TOKEN")),
+			gitprovider.WithOAuth2Token(token),
 			gitprovider.WithDestructiveAPICalls(true),
 		)
 		if err != nil {

--- a/test/acceptance/test/utils.go
+++ b/test/acceptance/test/utils.go
@@ -141,6 +141,29 @@ func getUniqueWorkload(placeHolderSuffix string, uniqueSuffix string) string {
 	return absWorkloadManifestFilePath
 }
 
+func setupSSHKey(sshKeyPath string, providerName gitproviders.GitProviderName) {
+	var keyName string
+
+	switch providerName {
+	case gitproviders.GitProviderGitHub:
+		keyName = "GITHUB_KEY"
+	case gitproviders.GitProviderGitLab:
+		keyName = "GITLAB_KEY"
+	default:
+		Fail("invalid git provider")
+	}
+
+	if _, err := os.Stat(sshKeyPath); os.IsNotExist(err) {
+		command := exec.Command("sh", "-c", fmt.Sprintf(`
+                           echo "%s" >> %s &&
+                           chmod 0600 %s &&
+                           ls -la %s`, os.Getenv(keyName), sshKeyPath, sshKeyPath, sshKeyPath))
+		session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
+		Expect(err).ShouldNot(HaveOccurred())
+		Eventually(session).Should(gexec.Exit())
+	}
+}
+
 func ResetOrCreateCluster(namespace string, deleteWegoRuntime bool) (string, error) {
 	return ResetOrCreateClusterWithName(namespace, deleteWegoRuntime, "")
 }

--- a/test/acceptance/test/utils.go
+++ b/test/acceptance/test/utils.go
@@ -222,6 +222,7 @@ func initAndCreateEmptyRepo(appRepoName string, providerName gitproviders.GitPro
 
 	err = utils.WaitUntil(os.Stdout, time.Second*3, time.Second*30, func() error {
 		command := exec.Command("sh", "-c", fmt.Sprintf(`
+			ssh-keyscan gitlab.com >> ~/.ssh/known_hosts &&
 			git clone git@%s.com:%s/%s.git %s`,
 			providerName, org, appRepoName,
 			repoAbsolutePath))

--- a/test/acceptance/test/utils.go
+++ b/test/acceptance/test/utils.go
@@ -245,7 +245,7 @@ func initAndCreateEmptyRepo(appRepoName string, providerName gitproviders.GitPro
 
 	err = utils.WaitUntil(os.Stdout, time.Second*3, time.Second*30, func() error {
 		command := exec.Command("sh", "-c", fmt.Sprintf(`
-		ssh -T git@gitlab.com -v &&
+		echo -e "Host *\n\tStrictHostKeyChecking no\n\n" >> ~/.ssh/config &&
 		git clone git@%s.com:%s/%s.git %s`,
 			providerName, org, appRepoName,
 			repoAbsolutePath))

--- a/test/acceptance/test/utils.go
+++ b/test/acceptance/test/utils.go
@@ -243,10 +243,21 @@ func initAndCreateEmptyRepo(appRepoName string, providerName gitproviders.GitPro
 	err = createGitRepository(appRepoName, DEFAULT_BRANCH_NAME, isPrivateRepo, providerName, org)
 	Expect(err).ShouldNot(HaveOccurred())
 
+	var token string
+
+	switch providerName {
+	case gitproviders.GitProviderGitHub:
+		token = os.Getenv("GITHUB_TOKEN")
+	case gitproviders.GitProviderGitLab:
+		token = os.Getenv("GITLAB_TOKEN")
+	default:
+		Fail("invalid git provider")
+	}
+
 	err = utils.WaitUntil(os.Stdout, time.Second*3, time.Second*30, func() error {
 		command := exec.Command("sh", "-c", fmt.Sprintf(`
-                            git clone git@%s.com:%s/%s.git %s`,
-			providerName, org, appRepoName,
+                            git clone https://oauth2:%s@%s.com:%s/%s.git %s`,
+			token, providerName, org, appRepoName,
 			repoAbsolutePath))
 		command.Stdout = os.Stdout
 		command.Stderr = os.Stderr

--- a/test/acceptance/test/utils.go
+++ b/test/acceptance/test/utils.go
@@ -245,7 +245,7 @@ func initAndCreateEmptyRepo(appRepoName string, providerName gitproviders.GitPro
 
 	err = utils.WaitUntil(os.Stdout, time.Second*3, time.Second*30, func() error {
 		command := exec.Command("sh", "-c", fmt.Sprintf(`
-		ssh keygen -R git@gitlab.com &&
+		ssh -T git@gitlab.com -v &&
 		git clone git@%s.com:%s/%s.git %s`,
 			providerName, org, appRepoName,
 			repoAbsolutePath))

--- a/test/acceptance/test/utils.go
+++ b/test/acceptance/test/utils.go
@@ -141,29 +141,6 @@ func getUniqueWorkload(placeHolderSuffix string, uniqueSuffix string) string {
 	return absWorkloadManifestFilePath
 }
 
-func setupSSHKey(sshKeyPath string, providerName gitproviders.GitProviderName) {
-	var keyName string
-
-	switch providerName {
-	case gitproviders.GitProviderGitHub:
-		keyName = "GITHUB_KEY"
-	case gitproviders.GitProviderGitLab:
-		keyName = "GITLAB_KEY"
-	default:
-		Fail("invalid git provider")
-	}
-
-	if _, err := os.Stat(sshKeyPath); os.IsNotExist(err) {
-		command := exec.Command("sh", "-c", fmt.Sprintf(`
-                           echo "%s" >> %s &&
-                           chmod 0600 %s &&
-                           ls -la %s`, os.Getenv(keyName), sshKeyPath, sshKeyPath, sshKeyPath))
-		session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
-		Expect(err).ShouldNot(HaveOccurred())
-		Eventually(session).Should(gexec.Exit())
-	}
-}
-
 func ResetOrCreateCluster(namespace string, deleteWegoRuntime bool) (string, error) {
 	return ResetOrCreateClusterWithName(namespace, deleteWegoRuntime, "")
 }

--- a/test/acceptance/test/utils.go
+++ b/test/acceptance/test/utils.go
@@ -146,7 +146,8 @@ func setupGitlabSSHKey(sshKeyPath string) {
 		command := exec.Command("sh", "-c", fmt.Sprintf(`
                            echo "%s" >> %s &&
                            chmod 0600 %s &&
-                           ls -la %s`, os.Getenv("GITLAB_KEY"), sshKeyPath, sshKeyPath, sshKeyPath))
+                           ls -la %s &&
+						   ssh-keyscan gitlab.com >> ~/.ssh/known_hosts`, os.Getenv("GITLAB_KEY"), sshKeyPath, sshKeyPath, sshKeyPath))
 		session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 		Expect(err).ShouldNot(HaveOccurred())
 		Eventually(session).Should(gexec.Exit())
@@ -234,7 +235,6 @@ func initAndCreateEmptyRepo(appRepoName string, providerName gitproviders.GitPro
 
 	err = utils.WaitUntil(os.Stdout, time.Second*3, time.Second*30, func() error {
 		command := exec.Command("sh", "-c", fmt.Sprintf(`
-			ssh-keyscan gitlab.com >> ~/.ssh/known_hosts &&
 			git clone git@%s.com:%s/%s.git %s`,
 			providerName, org, appRepoName,
 			repoAbsolutePath))

--- a/test/acceptance/test/utils.go
+++ b/test/acceptance/test/utils.go
@@ -243,21 +243,10 @@ func initAndCreateEmptyRepo(appRepoName string, providerName gitproviders.GitPro
 	err = createGitRepository(appRepoName, DEFAULT_BRANCH_NAME, isPrivateRepo, providerName, org)
 	Expect(err).ShouldNot(HaveOccurred())
 
-	var token string
-
-	switch providerName {
-	case gitproviders.GitProviderGitHub:
-		token = os.Getenv("GITHUB_TOKEN")
-	case gitproviders.GitProviderGitLab:
-		token = os.Getenv("GITLAB_TOKEN")
-	default:
-		Fail("invalid git provider")
-	}
-
 	err = utils.WaitUntil(os.Stdout, time.Second*3, time.Second*30, func() error {
 		command := exec.Command("sh", "-c", fmt.Sprintf(`
-                            git clone https://oauth2:%s@%s.com:%s/%s.git %s`,
-			token, providerName, org, appRepoName,
+		git clone git@github.com:%s/%s.git %s %s`,
+			providerName, org, appRepoName,
 			repoAbsolutePath))
 		command.Stdout = os.Stdout
 		command.Stderr = os.Stderr

--- a/test/acceptance/test/utils.go
+++ b/test/acceptance/test/utils.go
@@ -739,6 +739,10 @@ func createGitRepository(repoName, branch string, private bool, providerName git
 		domain = github.DefaultDomain
 	case gitproviders.GitProviderGitLab:
 		token := os.Getenv("GITLAB_TOKEN")
+		fmt.Println("-+-----------------------------------------------")
+		fmt.Println(token)
+		fmt.Println("-+-----------------------------------------------")
+
 		gitProvider, err = gitlab.NewClient(
 			token,
 			"oauth2",

--- a/test/acceptance/test/utils.go
+++ b/test/acceptance/test/utils.go
@@ -146,8 +146,7 @@ func setupGitlabSSHKey(sshKeyPath string) {
 		command := exec.Command("sh", "-c", fmt.Sprintf(`
                            echo "%s" >> %s &&
                            chmod 0600 %s &&
-                           ls -la %s && 
-						   ssh-keyscan gitlab.com >> ~/.ssh/known_hosts`, os.Getenv("GITLAB_KEY"), sshKeyPath, sshKeyPath, sshKeyPath))
+                           ls -la %s`, os.Getenv("GITLAB_KEY"), sshKeyPath, sshKeyPath, sshKeyPath))
 		session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 		Expect(err).ShouldNot(HaveOccurred())
 		Eventually(session).Should(gexec.Exit())
@@ -235,6 +234,7 @@ func initAndCreateEmptyRepo(appRepoName string, providerName gitproviders.GitPro
 
 	err = utils.WaitUntil(os.Stdout, time.Second*3, time.Second*30, func() error {
 		command := exec.Command("sh", "-c", fmt.Sprintf(`
+			ssh-keyscan gitlab.com >> ~/.ssh/known_hosts &&
 			git clone git@%s.com:%s/%s.git %s`,
 			providerName, org, appRepoName,
 			repoAbsolutePath))

--- a/test/acceptance/test/utils.go
+++ b/test/acceptance/test/utils.go
@@ -739,9 +739,6 @@ func createGitRepository(repoName, branch string, private bool, providerName git
 		domain = github.DefaultDomain
 	case gitproviders.GitProviderGitLab:
 		token := os.Getenv("GITLAB_TOKEN")
-		fmt.Println("-+-----------------------------------------------")
-		fmt.Println(token)
-		fmt.Println("-+-----------------------------------------------")
 
 		gitProvider, err = gitlab.NewClient(
 			token,

--- a/test/acceptance/test/utils.go
+++ b/test/acceptance/test/utils.go
@@ -141,12 +141,22 @@ func getUniqueWorkload(placeHolderSuffix string, uniqueSuffix string) string {
 	return absWorkloadManifestFilePath
 }
 
-func setupSSHKey(sshKeyPath string) {
+func setupSSHKey(sshKeyPath string, providerName gitproviders.GitProviderName) {
+	var keyName string
+	switch providerName {
+	case gitproviders.GitProviderGitHub:
+		keyName = "GITHUB_KEY"
+	case gitproviders.GitProviderGitLab:
+		keyName = "GITLAB_KEY"
+	default:
+		Fail("invalid git provider")
+	}
+
 	if _, err := os.Stat(sshKeyPath); os.IsNotExist(err) {
 		command := exec.Command("sh", "-c", fmt.Sprintf(`
                            echo "%s" >> %s &&
                            chmod 0600 %s &&
-                           ls -la %s`, os.Getenv("GITHUB_KEY"), sshKeyPath, sshKeyPath, sshKeyPath))
+                           ls -la %s`, os.Getenv(keyName), sshKeyPath, sshKeyPath, sshKeyPath))
 		session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 		Expect(err).ShouldNot(HaveOccurred())
 		Eventually(session).Should(gexec.Exit())

--- a/test/acceptance/test/utils.go
+++ b/test/acceptance/test/utils.go
@@ -283,8 +283,10 @@ func getGitHubRepoVisibility(org string, repo string) string {
 
 	orgInfo, err := gitProvider.OrgRepositories().Get(context.Background(), orgRef)
 	Expect(err).ShouldNot(HaveOccurred())
+
 	visibility := string(*orgInfo.Get().Visibility)
 	log.Infof("Repo visibility private=%s", visibility)
+
 	return visibility
 }
 
@@ -307,8 +309,10 @@ func getGitLabRepoVisibility(org string, repo string) string {
 
 	orgInfo, err := gitProvider.OrgRepositories().Get(context.Background(), orgRef)
 	Expect(err).ShouldNot(HaveOccurred())
+
 	visibility := string(*orgInfo.Get().Visibility)
 	log.Infof("Repo visibility private=%s", visibility)
+
 	return visibility
 }
 
@@ -752,23 +756,25 @@ func createGitHubRepository(repoName, branch string, private bool) error {
 	}); err != nil {
 		return fmt.Errorf("error creating repo %s", err)
 	}
-	fmt.Printf("repo %s created ...\n", repoName)
 
+	fmt.Printf("repo %s created ...\n", repoName)
 	fmt.Printf("validating access to the repo %s ...\n", repoName)
+
 	err = utils.WaitUntil(os.Stdout, time.Second, THIRTY_SECOND_TIMEOUT, func() error {
 		_, err := gitProvider.OrgRepositories().Get(ctx, orgRef)
 		return err
 	})
+
 	if err != nil {
 		return fmt.Errorf("error validating access to the repository %w", err)
 	}
+
 	fmt.Printf("repo %s is accessible through the api ...\n", repoName)
 
 	return nil
 }
 
 func createGitLabRepository(repoName string, private bool) error {
-
 	visibility := gitprovider.RepositoryVisibilityPublic
 	if private {
 		visibility = gitprovider.RepositoryVisibilityPrivate
@@ -805,7 +811,9 @@ func createGitLabRepository(repoName string, private bool) error {
 	}
 
 	ctx := context.Background()
+
 	fmt.Printf("creating repo %s ...\n", repoName)
+
 	if err := utils.WaitUntil(os.Stdout, time.Second, THIRTY_SECOND_TIMEOUT, func() error {
 		_, err := gitProvider.OrgRepositories().Create(ctx, orgRef, repoInfo, repoCreateOpts)
 		if err != nil && strings.Contains(err.Error(), "rate limit exceeded") {

--- a/test/acceptance/test/utils.go
+++ b/test/acceptance/test/utils.go
@@ -141,29 +141,6 @@ func getUniqueWorkload(placeHolderSuffix string, uniqueSuffix string) string {
 	return absWorkloadManifestFilePath
 }
 
-func setupSSHKey(sshKeyPath string, providerName gitproviders.GitProviderName) {
-	var keyName string
-
-	switch providerName {
-	case gitproviders.GitProviderGitHub:
-		keyName = "GITHUB_KEY"
-	case gitproviders.GitProviderGitLab:
-		keyName = "GITLAB_KEY"
-	default:
-		Fail("invalid git provider")
-	}
-
-	if _, err := os.Stat(sshKeyPath); os.IsNotExist(err) {
-		command := exec.Command("sh", "-c", fmt.Sprintf(`
-                           echo "%s" >> %s &&
-                           chmod 0600 %s &&
-                           ls -la %s`, os.Getenv(keyName), sshKeyPath, sshKeyPath, sshKeyPath))
-		session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
-		Expect(err).ShouldNot(HaveOccurred())
-		Eventually(session).Should(gexec.Exit())
-	}
-}
-
 func ResetOrCreateCluster(namespace string, deleteWegoRuntime bool) (string, error) {
 	return ResetOrCreateClusterWithName(namespace, deleteWegoRuntime, "")
 }
@@ -245,8 +222,7 @@ func initAndCreateEmptyRepo(appRepoName string, providerName gitproviders.GitPro
 
 	err = utils.WaitUntil(os.Stdout, time.Second*3, time.Second*30, func() error {
 		command := exec.Command("sh", "-c", fmt.Sprintf(`
-		ssh-keyscan gitlab.com >> ~/.ssh/known_hosts &&
-		git clone git@%s.com:%s/%s.git %s`,
+			git clone git@%s.com:%s/%s.git %s`,
 			providerName, org, appRepoName,
 			repoAbsolutePath))
 		command.Stdout = os.Stdout

--- a/test/acceptance/test/utils.go
+++ b/test/acceptance/test/utils.go
@@ -272,8 +272,11 @@ func createGitRepoBranch(repoAbsolutePath string, branchName string) string {
 
 func getGitRepoVisibility(org string, repo string, providerName gitproviders.GitProviderName) string {
 	var gitProvider gitprovider.Client
+
 	var err error
+
 	var domain string
+
 	switch providerName {
 	case gitproviders.GitProviderGitHub:
 		gitProvider, err = github.NewClient(
@@ -292,6 +295,7 @@ func getGitRepoVisibility(org string, repo string, providerName gitproviders.Git
 	default:
 		Fail("invalid git provider")
 	}
+
 	Expect(err).ShouldNot(HaveOccurred())
 
 	orgRef := gitprovider.OrgRepositoryRef{
@@ -716,7 +720,9 @@ func createGitRepository(repoName, branch string, private bool, providerName git
 	}
 
 	var gitProvider gitprovider.Client
+
 	var err error
+
 	var domain string
 
 	switch providerName {
@@ -728,6 +734,7 @@ func createGitRepository(repoName, branch string, private bool, providerName git
 		if err != nil {
 			return err
 		}
+
 		domain = github.DefaultDomain
 	case gitproviders.GitProviderGitLab:
 		gitProvider, err = gitlab.NewClient(
@@ -739,6 +746,7 @@ func createGitRepository(repoName, branch string, private bool, providerName git
 		if err != nil {
 			return err
 		}
+
 		domain = gitlab.DefaultDomain
 	default:
 		Fail("invalid git provider")

--- a/test/acceptance/test/utils.go
+++ b/test/acceptance/test/utils.go
@@ -229,7 +229,7 @@ func initAndCreateEmptyRepo(appRepoName string, providerName gitproviders.GitPro
 	err := os.RemoveAll(repoAbsolutePath)
 	Expect(err).ShouldNot(HaveOccurred())
 
-	err = createGitRepository(appRepoName, DEFAULT_BRANCH_NAME, isPrivateRepo)
+	err = createGitRepository(appRepoName, DEFAULT_BRANCH_NAME, isPrivateRepo, providerName, org)
 	Expect(err).ShouldNot(HaveOccurred())
 
 	err = utils.WaitUntil(os.Stdout, time.Second*3, time.Second*30, func() error {

--- a/test/acceptance/test/utils.go
+++ b/test/acceptance/test/utils.go
@@ -143,6 +143,7 @@ func getUniqueWorkload(placeHolderSuffix string, uniqueSuffix string) string {
 
 func setupSSHKey(sshKeyPath string, providerName gitproviders.GitProviderName) {
 	var keyName string
+
 	switch providerName {
 	case gitproviders.GitProviderGitHub:
 		keyName = "GITHUB_KEY"

--- a/test/acceptance/test/utils.go
+++ b/test/acceptance/test/utils.go
@@ -245,7 +245,7 @@ func initAndCreateEmptyRepo(appRepoName string, providerName gitproviders.GitPro
 
 	err = utils.WaitUntil(os.Stdout, time.Second*3, time.Second*30, func() error {
 		command := exec.Command("sh", "-c", fmt.Sprintf(`
-		ssh-keygen -R gitlab.com &&
+		ssh-keyscan gitlab.com >> ~/.ssh/known_hosts &&
 		git clone git@%s.com:%s/%s.git %s`,
 			providerName, org, appRepoName,
 			repoAbsolutePath))


### PR DESCRIPTION
<!-- Use # to add the issue this pull request is related to -->
References: #724 

<!-- Describe what has changed in this PR -->
**What changed?**
Allow user to add/remove/get commits for a  gitlab user project and group project with gitlab token set. There was also changes made around normalizing a url. This part of it will need a good review as i removed sanitizeRepoUrl and that was used in a few random places. A repo can also be added that is part of a gitlab subgroup. There are not tests around subgroup and having a subgroup in a subgroup isnt supported.

Work that will be done in future prs:
- Add acceptance test with merge pr
- Add tests for subgroup
- Add ability to add a repo that is a subgroup in a subgroup

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**
unit tests and acceptance tests

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
**Release notes**
Add gitlab group project and user project if gitlab token is set as GITLAB_TOKEN

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
https://github.com/weaveworks/weave-gitops-docs/pull/83