### PR TITLE
Pass version to deployment template as argument

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -76,5 +76,7 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ env.REGISTRY }}/weaveworks/${{ env.IMAGE_NAME }}:${{ github.event.release.tag_name }}
+          tags:
+            ${{ env.REGISTRY }}/weaveworks/${{ env.IMAGE_NAME }}:${{ github.event.release.tag_name }}
+            ${{ env.REGISTRY }}/weaveworks/${{ env.IMAGE_NAME }}:latest
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,7 +106,8 @@ jobs:
         GITHUB_ORG: weaveworks-gitops-test
         GITHUB_TOKEN: "${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_TOKEN }}"
         GITHUB_KEY: "${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_SSH_KEY }}"
-        ARTIFACTS_BASE_DIR: "/tmp/gitops-test"
+        ARTIFACTS_BASE_DIR: "/tmp/wego-test"
+        IS_TEST_ENV: "true"
     steps:
     - name: Install Go
       uses: actions/setup-go@v2
@@ -187,7 +188,8 @@ jobs:
         GITHUB_ORG: weaveworks-gitops-test
         GITHUB_TOKEN: "${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_TOKEN }}"
         GITHUB_KEY: "${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_SSH_KEY }}"
-        ARTIFACTS_BASE_DIR: "/tmp/gitops-test"
+        ARTIFACTS_BASE_DIR: "/tmp/wego-test"
+        IS_TEST_ENV: "true"
     steps:
     - name: Install Go
       uses: actions/setup-go@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
 # UI build
 FROM node:14-buster AS ui
 RUN apt-get update -y && apt-get install -y build-essential
-RUN mkdir -p /home/app/node_modules && chown -R node:node /home/app
+RUN mkdir -p /home/app && chown -R node:node /home/app
 WORKDIR /home/app
 USER node
 COPY --chown=node:node package*.json /home/app/
-RUN npm install
+COPY --chown=node:node Makefile /home/app/
+RUN make node_modules
 COPY --chown=node:node . /home/app/
 RUN make ui
 

--- a/manifests/manifests.go
+++ b/manifests/manifests.go
@@ -7,8 +7,6 @@ import (
 	"text/template"
 
 	"github.com/pkg/errors"
-
-	"github.com/weaveworks/weave-gitops/cmd/gitops/version"
 )
 
 var Manifests [][]byte
@@ -26,14 +24,14 @@ type deploymentParameters struct {
 var errInjectingValuesToTemplate = errors.New("error injecting values to template")
 
 // GenerateWegoAppDeploymentManifest generates wego-app deployment manifest from a template
-func GenerateWegoAppDeploymentManifest(deploymentTemplate []byte) ([]byte, error) {
-	deploymentValues := deploymentParameters{version.Version}
+func GenerateWegoAppDeploymentManifest(version string) ([]byte, error) {
+	deploymentValues := deploymentParameters{Version: version}
 
 	template := template.New("DeploymentTemplate")
 
 	var err error
 
-	template, err = template.Parse(string(deploymentTemplate))
+	template, err = template.Parse(string(WegoAppDeployment))
 	if err != nil {
 		return nil, fmt.Errorf("error parsing template %w", err)
 	}

--- a/manifests/manifests_test.go
+++ b/manifests/manifests_test.go
@@ -9,31 +9,15 @@ import (
 )
 
 var _ = Describe("Testing WegoAppDeployment", func() {
-
-	var localDeploymentManifest []byte
-	BeforeEach(func() {
-		localDeploymentManifest = WegoAppDeployment
-	})
-
-	It("should return the right version", func() {
-		deploymentYaml, err := GenerateWegoAppDeploymentManifest(localDeploymentManifest)
+	It("should contain the right version", func() {
+		v := version.Version
+		deploymentYaml, err := GenerateWegoAppDeploymentManifest(v)
 		Expect(err).NotTo(HaveOccurred())
 
 		var Deployment appsv1.Deployment
 		err = yaml.Unmarshal(deploymentYaml, &Deployment)
 		Expect(err).NotTo(HaveOccurred())
 
-		Expect(Deployment.Spec.Template.Spec.Containers[0].Image).To(ContainSubstring(version.Version))
+		Expect(Deployment.Spec.Template.Spec.Containers[0].Image).To(ContainSubstring(v))
 	})
-
-	It("should fail trying to parse the template", func() {
-
-		localDeploymentManifest = []byte("{{.wrongField}}")
-
-		_, err := GenerateWegoAppDeploymentManifest(localDeploymentManifest)
-		Expect(err).Should(HaveOccurred())
-		Expect(err.Error()).Should(ContainSubstring(errInjectingValuesToTemplate.Error()))
-		Expect(err.Error()).Should(ContainSubstring("wrongField"))
-	})
-
 })

--- a/pkg/services/gitops/install.go
+++ b/pkg/services/gitops/install.go
@@ -3,8 +3,10 @@ package gitops
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/pkg/errors"
+	"github.com/weaveworks/weave-gitops/cmd/gitops/version"
 	"github.com/weaveworks/weave-gitops/manifests"
 	"github.com/weaveworks/weave-gitops/pkg/kube"
 )
@@ -40,7 +42,12 @@ func (g *Gitops) Install(params InstallParams) ([]byte, error) {
 			}
 		}
 
-		wegoAppDeploymentManifest, err := manifests.GenerateWegoAppDeploymentManifest(manifests.WegoAppDeployment)
+		version := version.Version
+		if os.Getenv("IS_TEST_ENV") != "" {
+			version = "latest"
+		}
+
+		wegoAppDeploymentManifest, err := manifests.GenerateWegoAppDeploymentManifest(version)
 		if err != nil {
 			return nil, fmt.Errorf("error generating wego-app deployment, %w", err)
 		}


### PR DESCRIPTION
Having an `ErrImagePull` state on a pod seems to slow down tests by double. This fix ensures a `latest` tag is pushed during a release (although users should be discouraged from using that tag).

For acceptance tests, they will pull down the `latest` tag for now as a stop gap. I have already pushed a `latest` image from my laptop so that we don't have to wait for a release for the tag to be present.

Also fixes an error in the FE docker image build where `npm install` was being used incorrectly.