### PR TITLE
Simplify apputils app service creation

### DIFF
--- a/api/v1alpha1/application_types.go
+++ b/api/v1alpha1/application_types.go
@@ -87,6 +87,10 @@ type Application struct {
 	Status ApplicationStatus `json:"status,omitempty"`
 }
 
+func (a *Application) IsHelmRepository() bool {
+	return a.Spec.DeploymentType == DeploymentTypeHelm
+}
+
 //+kubebuilder:object:root=true
 
 // ApplicationList contains a list of Application

--- a/api/v1alpha1/application_types.go
+++ b/api/v1alpha1/application_types.go
@@ -88,7 +88,7 @@ type Application struct {
 }
 
 func (a *Application) IsHelmRepository() bool {
-	return a.Spec.DeploymentType == DeploymentTypeHelm
+	return a.Spec.SourceType == SourceTypeHelm
 }
 
 //+kubebuilder:object:root=true

--- a/cmd/gitops/app/add/cmd.go
+++ b/cmd/gitops/app/add/cmd.go
@@ -105,7 +105,15 @@ func runCmd(cmd *cobra.Command, args []string) error {
 
 	isHelmRepository := params.Chart != ""
 
-	appService, appError := apputils.GetAppService(ctx, params.Url, params.AppConfigUrl, params.Namespace, isHelmRepository, params.DryRun)
+	d := apputils.AppServiceData{
+		Namespace: params.Namespace,
+		URL:       params.Url,
+		ConfigURL: params.AppConfigUrl,
+		IsHelm:    isHelmRepository,
+		IsDryRun:  params.DryRun,
+	}
+
+	appService, appError := apputils.GetAppService(ctx, d)
 	if appError != nil {
 		return fmt.Errorf("failed to create app service: %w", appError)
 	}

--- a/cmd/gitops/app/add/cmd.go
+++ b/cmd/gitops/app/add/cmd.go
@@ -105,7 +105,7 @@ func runCmd(cmd *cobra.Command, args []string) error {
 
 	isHelmRepository := params.Chart != ""
 
-	appService, appError := apputils.GetAppServiceForAdd(ctx, params.Url, params.AppConfigUrl, params.Namespace, isHelmRepository, params.DryRun)
+	appService, appError := apputils.GetAppService(ctx, params.Url, params.AppConfigUrl, params.Namespace, isHelmRepository)
 	if appError != nil {
 		return fmt.Errorf("failed to create app service: %w", appError)
 	}

--- a/cmd/gitops/app/add/cmd.go
+++ b/cmd/gitops/app/add/cmd.go
@@ -105,7 +105,7 @@ func runCmd(cmd *cobra.Command, args []string) error {
 
 	isHelmRepository := params.Chart != ""
 
-	appService, appError := apputils.GetAppService(ctx, params.Url, params.AppConfigUrl, params.Namespace, isHelmRepository)
+	appService, appError := apputils.GetAppService(ctx, params.Url, params.AppConfigUrl, params.Namespace, isHelmRepository, params.DryRun)
 	if appError != nil {
 		return fmt.Errorf("failed to create app service: %w", appError)
 	}

--- a/cmd/gitops/app/cmd.go
+++ b/cmd/gitops/app/cmd.go
@@ -14,6 +14,7 @@ import (
 	"github.com/weaveworks/weave-gitops/cmd/gitops/app/status"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/app/unpause"
 	"github.com/weaveworks/weave-gitops/pkg/apputils"
+	"github.com/weaveworks/weave-gitops/pkg/kube"
 	"github.com/weaveworks/weave-gitops/pkg/logger"
 	"github.com/weaveworks/weave-gitops/pkg/services/app"
 	"github.com/weaveworks/weave-gitops/pkg/utils"
@@ -70,14 +71,18 @@ func runCmd(cmd *cobra.Command, args []string) error {
 	command := args[1]
 	object := args[2]
 
-	appService, appError := apputils.GetAppService(ctx, params.Name, params.Namespace)
-	if appError != nil {
-		return fmt.Errorf("failed to create app service: %w", appError)
+	kube, _, kubeErr := kube.NewKubeHTTPClient()
+	if kubeErr != nil {
+		return fmt.Errorf("error creating k8s http client: %w", kubeErr)
 	}
 
-	appContent, err := appService.Get(types.NamespacedName{Name: params.Name, Namespace: params.Namespace})
+	appObj, err := kube.GetApplication(context.Background(), types.NamespacedName{Name: params.Name, Namespace: params.Namespace})
 	if err != nil {
 		return fmt.Errorf("unable to get application for %s %w", params.Name, err)
+	}
+
+	if appObj.IsHelmRepository() {
+		return fmt.Errorf("unable to get commits for a helm chart")
 	}
 
 	if command != "get" {
@@ -85,11 +90,16 @@ func runCmd(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("invalid command %s", command)
 	}
 
+	appService, appError := apputils.GetAppService(ctx, appObj.Spec.URL, appObj.Spec.ConfigURL, appObj.Namespace, false)
+	if appError != nil {
+		return fmt.Errorf("failed to create app service: %w", appError)
+	}
+
 	logger := apputils.GetLogger()
 
 	switch object {
 	case "commits":
-		commits, err := appService.GetCommits(params, appContent)
+		commits, err := appService.GetCommits(params, appObj)
 		if err != nil {
 			return errors.Wrapf(err, "failed to get commits for app %s", params.Name)
 		}

--- a/cmd/gitops/app/cmd.go
+++ b/cmd/gitops/app/cmd.go
@@ -14,7 +14,6 @@ import (
 	"github.com/weaveworks/weave-gitops/cmd/gitops/app/status"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/app/unpause"
 	"github.com/weaveworks/weave-gitops/pkg/apputils"
-	"github.com/weaveworks/weave-gitops/pkg/kube"
 	"github.com/weaveworks/weave-gitops/pkg/logger"
 	"github.com/weaveworks/weave-gitops/pkg/services/app"
 	"github.com/weaveworks/weave-gitops/pkg/utils"
@@ -71,14 +70,9 @@ func runCmd(cmd *cobra.Command, args []string) error {
 	command := args[1]
 	object := args[2]
 
-	kube, _, kubeErr := kube.NewKubeHTTPClient()
-	if kubeErr != nil {
-		return fmt.Errorf("error creating k8s http client: %w", kubeErr)
-	}
-
-	appObj, err := kube.GetApplication(context.Background(), types.NamespacedName{Name: params.Name, Namespace: params.Namespace})
+	appObj, err := apputils.FetchAppByName(ctx, types.NamespacedName{Name: params.Name, Namespace: params.Namespace})
 	if err != nil {
-		return fmt.Errorf("unable to get application for %s %w", params.Name, err)
+		return fmt.Errorf("could not get application: %w", err)
 	}
 
 	if appObj.IsHelmRepository() {

--- a/cmd/gitops/app/cmd.go
+++ b/cmd/gitops/app/cmd.go
@@ -84,7 +84,7 @@ func runCmd(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("invalid command %s", command)
 	}
 
-	appService, appError := apputils.GetAppService(ctx, appObj.Spec.URL, appObj.Spec.ConfigURL, appObj.Namespace, false)
+	appService, appError := apputils.GetAppService(ctx, appObj.Spec.URL, appObj.Spec.ConfigURL, appObj.Namespace, false, false)
 	if appError != nil {
 		return fmt.Errorf("failed to create app service: %w", appError)
 	}

--- a/cmd/gitops/app/pause/cmd.go
+++ b/cmd/gitops/app/pause/cmd.go
@@ -33,12 +33,12 @@ func runCmd(cmd *cobra.Command, args []string) error {
 	params.Namespace, _ = cmd.Parent().Flags().GetString("namespace")
 	params.Name = args[0]
 
-	appObj, err := apputils.FetchAppByName(ctx, types.NamespacedName{Name: params.Name, Namespace: params.Namespace})
+	appSvcData, err := apputils.FetchAppByName(ctx, types.NamespacedName{Name: params.Name, Namespace: params.Namespace})
 	if err != nil {
 		return fmt.Errorf("could not get application: %w", err)
 	}
 
-	appService, appError := apputils.GetAppService(ctx, appObj.Spec.URL, appObj.Spec.ConfigURL, params.Namespace, appObj.IsHelmRepository(), false)
+	appService, appError := apputils.GetAppService(ctx, appSvcData)
 	if appError != nil {
 		return fmt.Errorf("failed to create app service: %w", appError)
 	}

--- a/cmd/gitops/app/pause/cmd.go
+++ b/cmd/gitops/app/pause/cmd.go
@@ -38,7 +38,7 @@ func runCmd(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("could not get application: %w", err)
 	}
 
-	appService, appError := apputils.GetAppService(ctx, appObj.Spec.URL, appObj.Spec.ConfigURL, params.Namespace, appObj.IsHelmRepository())
+	appService, appError := apputils.GetAppService(ctx, appObj.Spec.URL, appObj.Spec.ConfigURL, params.Namespace, appObj.IsHelmRepository(), false)
 	if appError != nil {
 		return fmt.Errorf("failed to create app service: %w", appError)
 	}

--- a/cmd/gitops/app/pause/cmd.go
+++ b/cmd/gitops/app/pause/cmd.go
@@ -8,7 +8,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/version"
 	"github.com/weaveworks/weave-gitops/pkg/apputils"
-	"github.com/weaveworks/weave-gitops/pkg/kube"
 	"github.com/weaveworks/weave-gitops/pkg/services/app"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -34,12 +33,7 @@ func runCmd(cmd *cobra.Command, args []string) error {
 	params.Namespace, _ = cmd.Parent().Flags().GetString("namespace")
 	params.Name = args[0]
 
-	kube, _, err := kube.NewKubeHTTPClient()
-	if err != nil {
-		return fmt.Errorf("failed to create kube client: %w", err)
-	}
-
-	appObj, err := kube.GetApplication(ctx, types.NamespacedName{Name: params.Name, Namespace: params.Namespace})
+	appObj, err := apputils.FetchAppByName(ctx, types.NamespacedName{Name: params.Name, Namespace: params.Namespace})
 	if err != nil {
 		return fmt.Errorf("could not get application: %w", err)
 	}

--- a/cmd/gitops/app/pause/cmd.go
+++ b/cmd/gitops/app/pause/cmd.go
@@ -8,7 +8,9 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/version"
 	"github.com/weaveworks/weave-gitops/pkg/apputils"
+	"github.com/weaveworks/weave-gitops/pkg/kube"
 	"github.com/weaveworks/weave-gitops/pkg/services/app"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 var params app.PauseParams
@@ -32,7 +34,17 @@ func runCmd(cmd *cobra.Command, args []string) error {
 	params.Namespace, _ = cmd.Parent().Flags().GetString("namespace")
 	params.Name = args[0]
 
-	appService, appError := apputils.GetAppService(ctx, params.Name, params.Namespace)
+	kube, _, err := kube.NewKubeHTTPClient()
+	if err != nil {
+		return fmt.Errorf("failed to create kube client: %w", err)
+	}
+
+	appObj, err := kube.GetApplication(ctx, types.NamespacedName{Name: params.Name, Namespace: params.Namespace})
+	if err != nil {
+		return fmt.Errorf("could not get application: %w", err)
+	}
+
+	appService, appError := apputils.GetAppService(ctx, appObj.Spec.URL, appObj.Spec.ConfigURL, params.Namespace, appObj.IsHelmRepository())
 	if appError != nil {
 		return fmt.Errorf("failed to create app service: %w", appError)
 	}

--- a/cmd/gitops/app/remove/cmd.go
+++ b/cmd/gitops/app/remove/cmd.go
@@ -54,7 +54,7 @@ func runCmd(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to fetch app %q: %w", params.Name, err)
 	}
 
-	appService, appError := apputils.GetAppService(ctx, appObj.Spec.URL, appObj.Spec.ConfigURL, appObj.Namespace, appObj.IsHelmRepository(), params.DryRun)
+	appService, appError := apputils.GetAppService(ctx, appObj)
 	if appError != nil {
 		return fmt.Errorf("failed to create app service: %w", appError)
 	}

--- a/cmd/gitops/app/remove/cmd.go
+++ b/cmd/gitops/app/remove/cmd.go
@@ -12,7 +12,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/version"
 	"github.com/weaveworks/weave-gitops/pkg/apputils"
-	"github.com/weaveworks/weave-gitops/pkg/kube"
 	"github.com/weaveworks/weave-gitops/pkg/services/app"
 	"github.com/weaveworks/weave-gitops/pkg/utils"
 	"k8s.io/apimachinery/pkg/types"
@@ -50,14 +49,9 @@ func runCmd(cmd *cobra.Command, args []string) error {
 	params.Name = args[0]
 	params.Namespace, _ = cmd.Parent().Flags().GetString("namespace")
 
-	kube, _, err := kube.NewKubeHTTPClient()
+	appObj, err := apputils.FetchAppByName(ctx, types.NamespacedName{Name: params.Name, Namespace: params.Namespace})
 	if err != nil {
-		return fmt.Errorf("failed to create kube client: %w", err)
-	}
-
-	appObj, err := kube.GetApplication(ctx, types.NamespacedName{Name: params.Name, Namespace: params.Namespace})
-	if err != nil {
-		return fmt.Errorf("could not get application: %w", err)
+		return fmt.Errorf("failed to fetch app %q: %w", params.Name, err)
 	}
 
 	appService, appError := apputils.GetAppService(ctx, appObj.Spec.URL, appObj.Spec.ConfigURL, appObj.Namespace, appObj.IsHelmRepository())

--- a/cmd/gitops/app/remove/cmd.go
+++ b/cmd/gitops/app/remove/cmd.go
@@ -12,8 +12,10 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/version"
 	"github.com/weaveworks/weave-gitops/pkg/apputils"
+	"github.com/weaveworks/weave-gitops/pkg/kube"
 	"github.com/weaveworks/weave-gitops/pkg/services/app"
 	"github.com/weaveworks/weave-gitops/pkg/utils"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 var params app.RemoveParams
@@ -48,7 +50,17 @@ func runCmd(cmd *cobra.Command, args []string) error {
 	params.Name = args[0]
 	params.Namespace, _ = cmd.Parent().Flags().GetString("namespace")
 
-	appService, appError := apputils.GetAppService(ctx, params.Name, params.Namespace)
+	kube, _, err := kube.NewKubeHTTPClient()
+	if err != nil {
+		return fmt.Errorf("failed to create kube client: %w", err)
+	}
+
+	appObj, err := kube.GetApplication(ctx, types.NamespacedName{Name: params.Name, Namespace: params.Namespace})
+	if err != nil {
+		return fmt.Errorf("could not get application: %w", err)
+	}
+
+	appService, appError := apputils.GetAppService(ctx, appObj.Spec.URL, appObj.Spec.ConfigURL, appObj.Namespace, appObj.IsHelmRepository())
 	if appError != nil {
 		return fmt.Errorf("failed to create app service: %w", appError)
 	}

--- a/cmd/gitops/app/remove/cmd.go
+++ b/cmd/gitops/app/remove/cmd.go
@@ -54,7 +54,7 @@ func runCmd(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to fetch app %q: %w", params.Name, err)
 	}
 
-	appService, appError := apputils.GetAppService(ctx, appObj.Spec.URL, appObj.Spec.ConfigURL, appObj.Namespace, appObj.IsHelmRepository())
+	appService, appError := apputils.GetAppService(ctx, appObj.Spec.URL, appObj.Spec.ConfigURL, appObj.Namespace, appObj.IsHelmRepository(), params.DryRun)
 	if appError != nil {
 		return fmt.Errorf("failed to create app service: %w", appError)
 	}

--- a/cmd/gitops/app/status/cmd.go
+++ b/cmd/gitops/app/status/cmd.go
@@ -30,7 +30,7 @@ var Cmd = &cobra.Command{
 			return fmt.Errorf("could not get application: %w", err)
 		}
 
-		appService, appError := apputils.GetAppService(ctx, appObj.Spec.URL, appObj.Spec.ConfigURL, appObj.Namespace, appObj.IsHelmRepository())
+		appService, appError := apputils.GetAppService(ctx, appObj.Spec.URL, appObj.Spec.ConfigURL, appObj.Namespace, appObj.IsHelmRepository(), false)
 		if appError != nil {
 			return fmt.Errorf("failed to create app service: %w", appError)
 		}

--- a/cmd/gitops/app/status/cmd.go
+++ b/cmd/gitops/app/status/cmd.go
@@ -30,7 +30,7 @@ var Cmd = &cobra.Command{
 			return fmt.Errorf("could not get application: %w", err)
 		}
 
-		appService, appError := apputils.GetAppService(ctx, appObj.Spec.URL, appObj.Spec.ConfigURL, appObj.Namespace, appObj.IsHelmRepository(), false)
+		appService, appError := apputils.GetAppService(ctx, appObj)
 		if appError != nil {
 			return fmt.Errorf("failed to create app service: %w", appError)
 		}

--- a/cmd/gitops/app/status/cmd.go
+++ b/cmd/gitops/app/status/cmd.go
@@ -6,7 +6,9 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/weaveworks/weave-gitops/pkg/apputils"
+	"github.com/weaveworks/weave-gitops/pkg/kube"
 	"github.com/weaveworks/weave-gitops/pkg/services/app"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 var Cmd = &cobra.Command{
@@ -24,7 +26,17 @@ var Cmd = &cobra.Command{
 		params.Name = args[0]
 		params.Namespace, _ = cmd.Parent().Parent().Flags().GetString("namespace")
 
-		appService, appError := apputils.GetAppService(ctx, params.Name, params.Namespace)
+		kube, _, err := kube.NewKubeHTTPClient()
+		if err != nil {
+			return fmt.Errorf("failed to create kube client: %w", err)
+		}
+
+		appObj, err := kube.GetApplication(ctx, types.NamespacedName{Name: params.Name, Namespace: params.Namespace})
+		if err != nil {
+			return fmt.Errorf("could not get application: %w", err)
+		}
+
+		appService, appError := apputils.GetAppService(ctx, appObj.Spec.URL, appObj.Spec.ConfigURL, appObj.Namespace, appObj.IsHelmRepository())
 		if appError != nil {
 			return fmt.Errorf("failed to create app service: %w", appError)
 		}

--- a/cmd/gitops/app/status/cmd.go
+++ b/cmd/gitops/app/status/cmd.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/weaveworks/weave-gitops/pkg/apputils"
-	"github.com/weaveworks/weave-gitops/pkg/kube"
 	"github.com/weaveworks/weave-gitops/pkg/services/app"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -26,12 +25,7 @@ var Cmd = &cobra.Command{
 		params.Name = args[0]
 		params.Namespace, _ = cmd.Parent().Parent().Flags().GetString("namespace")
 
-		kube, _, err := kube.NewKubeHTTPClient()
-		if err != nil {
-			return fmt.Errorf("failed to create kube client: %w", err)
-		}
-
-		appObj, err := kube.GetApplication(ctx, types.NamespacedName{Name: params.Name, Namespace: params.Namespace})
+		appObj, err := apputils.FetchAppByName(ctx, types.NamespacedName{Name: params.Name, Namespace: params.Namespace})
 		if err != nil {
 			return fmt.Errorf("could not get application: %w", err)
 		}

--- a/cmd/gitops/app/unpause/cmd.go
+++ b/cmd/gitops/app/unpause/cmd.go
@@ -8,7 +8,9 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/version"
 	"github.com/weaveworks/weave-gitops/pkg/apputils"
+	"github.com/weaveworks/weave-gitops/pkg/kube"
 	"github.com/weaveworks/weave-gitops/pkg/services/app"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 var params app.UnpauseParams
@@ -32,7 +34,17 @@ func runCmd(cmd *cobra.Command, args []string) error {
 	params.Namespace, _ = cmd.Parent().Flags().GetString("namespace")
 	params.Name = args[0]
 
-	appService, appError := apputils.GetAppService(ctx, params.Name, params.Namespace)
+	kube, _, err := kube.NewKubeHTTPClient()
+	if err != nil {
+		return fmt.Errorf("failed to create kube client: %w", err)
+	}
+
+	appObj, err := kube.GetApplication(ctx, types.NamespacedName{Name: params.Name, Namespace: params.Namespace})
+	if err != nil {
+		return fmt.Errorf("could not get application: %w", err)
+	}
+
+	appService, appError := apputils.GetAppService(ctx, appObj.Spec.URL, appObj.Spec.ConfigURL, appObj.Namespace, appObj.IsHelmRepository())
 	if appError != nil {
 		return fmt.Errorf("failed to create app service: %w", appError)
 	}

--- a/cmd/gitops/app/unpause/cmd.go
+++ b/cmd/gitops/app/unpause/cmd.go
@@ -8,7 +8,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/version"
 	"github.com/weaveworks/weave-gitops/pkg/apputils"
-	"github.com/weaveworks/weave-gitops/pkg/kube"
 	"github.com/weaveworks/weave-gitops/pkg/services/app"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -34,12 +33,7 @@ func runCmd(cmd *cobra.Command, args []string) error {
 	params.Namespace, _ = cmd.Parent().Flags().GetString("namespace")
 	params.Name = args[0]
 
-	kube, _, err := kube.NewKubeHTTPClient()
-	if err != nil {
-		return fmt.Errorf("failed to create kube client: %w", err)
-	}
-
-	appObj, err := kube.GetApplication(ctx, types.NamespacedName{Name: params.Name, Namespace: params.Namespace})
+	appObj, err := apputils.FetchAppByName(ctx, types.NamespacedName{Name: params.Name, Namespace: params.Namespace})
 	if err != nil {
 		return fmt.Errorf("could not get application: %w", err)
 	}

--- a/cmd/gitops/app/unpause/cmd.go
+++ b/cmd/gitops/app/unpause/cmd.go
@@ -38,7 +38,7 @@ func runCmd(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("could not get application: %w", err)
 	}
 
-	appService, appError := apputils.GetAppService(ctx, appObj.Spec.URL, appObj.Spec.ConfigURL, appObj.Namespace, appObj.IsHelmRepository(), false)
+	appService, appError := apputils.GetAppService(ctx, appObj)
 	if appError != nil {
 		return fmt.Errorf("failed to create app service: %w", appError)
 	}

--- a/cmd/gitops/app/unpause/cmd.go
+++ b/cmd/gitops/app/unpause/cmd.go
@@ -38,7 +38,7 @@ func runCmd(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("could not get application: %w", err)
 	}
 
-	appService, appError := apputils.GetAppService(ctx, appObj.Spec.URL, appObj.Spec.ConfigURL, appObj.Namespace, appObj.IsHelmRepository())
+	appService, appError := apputils.GetAppService(ctx, appObj.Spec.URL, appObj.Spec.ConfigURL, appObj.Namespace, appObj.IsHelmRepository(), false)
 	if appError != nil {
 		return fmt.Errorf("failed to create app service: %w", appError)
 	}

--- a/pkg/apputils/apputilsfakes/fake_app_factory.go
+++ b/pkg/apputils/apputilsfakes/fake_app_factory.go
@@ -11,12 +11,14 @@ import (
 )
 
 type FakeAppFactory struct {
-	GetAppServiceStub        func(context.Context, string, string) (app.AppService, error)
+	GetAppServiceStub        func(context.Context, string, string, string, bool) (app.AppService, error)
 	getAppServiceMutex       sync.RWMutex
 	getAppServiceArgsForCall []struct {
 		arg1 context.Context
 		arg2 string
 		arg3 string
+		arg4 string
+		arg5 bool
 	}
 	getAppServiceReturns struct {
 		result1 app.AppService
@@ -42,20 +44,22 @@ type FakeAppFactory struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeAppFactory) GetAppService(arg1 context.Context, arg2 string, arg3 string) (app.AppService, error) {
+func (fake *FakeAppFactory) GetAppService(arg1 context.Context, arg2 string, arg3 string, arg4 string, arg5 bool) (app.AppService, error) {
 	fake.getAppServiceMutex.Lock()
 	ret, specificReturn := fake.getAppServiceReturnsOnCall[len(fake.getAppServiceArgsForCall)]
 	fake.getAppServiceArgsForCall = append(fake.getAppServiceArgsForCall, struct {
 		arg1 context.Context
 		arg2 string
 		arg3 string
-	}{arg1, arg2, arg3})
+		arg4 string
+		arg5 bool
+	}{arg1, arg2, arg3, arg4, arg5})
 	stub := fake.GetAppServiceStub
 	fakeReturns := fake.getAppServiceReturns
-	fake.recordInvocation("GetAppService", []interface{}{arg1, arg2, arg3})
+	fake.recordInvocation("GetAppService", []interface{}{arg1, arg2, arg3, arg4, arg5})
 	fake.getAppServiceMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3)
+		return stub(arg1, arg2, arg3, arg4, arg5)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -69,17 +73,17 @@ func (fake *FakeAppFactory) GetAppServiceCallCount() int {
 	return len(fake.getAppServiceArgsForCall)
 }
 
-func (fake *FakeAppFactory) GetAppServiceCalls(stub func(context.Context, string, string) (app.AppService, error)) {
+func (fake *FakeAppFactory) GetAppServiceCalls(stub func(context.Context, string, string, string, bool) (app.AppService, error)) {
 	fake.getAppServiceMutex.Lock()
 	defer fake.getAppServiceMutex.Unlock()
 	fake.GetAppServiceStub = stub
 }
 
-func (fake *FakeAppFactory) GetAppServiceArgsForCall(i int) (context.Context, string, string) {
+func (fake *FakeAppFactory) GetAppServiceArgsForCall(i int) (context.Context, string, string, string, bool) {
 	fake.getAppServiceMutex.RLock()
 	defer fake.getAppServiceMutex.RUnlock()
 	argsForCall := fake.getAppServiceArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
 }
 
 func (fake *FakeAppFactory) GetAppServiceReturns(result1 app.AppService, result2 error) {

--- a/pkg/apputils/apputilsfakes/fake_app_factory.go
+++ b/pkg/apputils/apputilsfakes/fake_app_factory.go
@@ -11,14 +11,11 @@ import (
 )
 
 type FakeAppFactory struct {
-	GetAppServiceStub        func(context.Context, string, string, string, bool) (app.AppService, error)
+	GetAppServiceStub        func(context.Context, apputils.AppServiceData) (app.AppService, error)
 	getAppServiceMutex       sync.RWMutex
 	getAppServiceArgsForCall []struct {
 		arg1 context.Context
-		arg2 string
-		arg3 string
-		arg4 string
-		arg5 bool
+		arg2 apputils.AppServiceData
 	}
 	getAppServiceReturns struct {
 		result1 app.AppService
@@ -44,22 +41,19 @@ type FakeAppFactory struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeAppFactory) GetAppService(arg1 context.Context, arg2 string, arg3 string, arg4 string, arg5 bool) (app.AppService, error) {
+func (fake *FakeAppFactory) GetAppService(arg1 context.Context, arg2 apputils.AppServiceData) (app.AppService, error) {
 	fake.getAppServiceMutex.Lock()
 	ret, specificReturn := fake.getAppServiceReturnsOnCall[len(fake.getAppServiceArgsForCall)]
 	fake.getAppServiceArgsForCall = append(fake.getAppServiceArgsForCall, struct {
 		arg1 context.Context
-		arg2 string
-		arg3 string
-		arg4 string
-		arg5 bool
-	}{arg1, arg2, arg3, arg4, arg5})
+		arg2 apputils.AppServiceData
+	}{arg1, arg2})
 	stub := fake.GetAppServiceStub
 	fakeReturns := fake.getAppServiceReturns
-	fake.recordInvocation("GetAppService", []interface{}{arg1, arg2, arg3, arg4, arg5})
+	fake.recordInvocation("GetAppService", []interface{}{arg1, arg2})
 	fake.getAppServiceMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3, arg4, arg5)
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -73,17 +67,17 @@ func (fake *FakeAppFactory) GetAppServiceCallCount() int {
 	return len(fake.getAppServiceArgsForCall)
 }
 
-func (fake *FakeAppFactory) GetAppServiceCalls(stub func(context.Context, string, string, string, bool) (app.AppService, error)) {
+func (fake *FakeAppFactory) GetAppServiceCalls(stub func(context.Context, apputils.AppServiceData) (app.AppService, error)) {
 	fake.getAppServiceMutex.Lock()
 	defer fake.getAppServiceMutex.Unlock()
 	fake.GetAppServiceStub = stub
 }
 
-func (fake *FakeAppFactory) GetAppServiceArgsForCall(i int) (context.Context, string, string, string, bool) {
+func (fake *FakeAppFactory) GetAppServiceArgsForCall(i int) (context.Context, apputils.AppServiceData) {
 	fake.getAppServiceMutex.RLock()
 	defer fake.getAppServiceMutex.RUnlock()
 	argsForCall := fake.getAppServiceArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakeAppFactory) GetAppServiceReturns(result1 app.AppService, result2 error) {

--- a/pkg/apputils/utils.go
+++ b/pkg/apputils/utils.go
@@ -29,7 +29,7 @@ type DefaultAppFactory struct {
 }
 
 func (f *DefaultAppFactory) GetAppService(ctx context.Context, url, configUrl, namespace string, isHelmRepository bool) (app.AppService, error) {
-	return GetAppService(ctx, url, configUrl, namespace, isHelmRepository)
+	return GetAppService(ctx, url, configUrl, namespace, isHelmRepository, false)
 }
 
 func (f *DefaultAppFactory) GetKubeService() (kube.Kube, error) {
@@ -102,7 +102,7 @@ func FetchAppByName(ctx context.Context, name types.NamespacedName) (*wego.Appli
 	return appObj, nil
 }
 
-func getGitClients(ctx context.Context, url, configUrl, namespace string, isHelmRepository bool) (git.Git, git.Git, gitproviders.GitProvider, error) {
+func getGitClients(ctx context.Context, url, configUrl, namespace string, isHelmRepository bool, dryRun bool) (git.Git, git.Git, gitproviders.GitProvider, error) {
 	isExternalConfig := app.IsExternalConfigUrl(configUrl)
 
 	var providerUrl string

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -318,7 +318,13 @@ func (s *applicationServer) ListCommits(ctx context.Context, msg *pb.ListCommits
 		return nil, fmt.Errorf("unable to get application for %s %w", params.Name, err)
 	}
 
-	appService, appErr := s.appFactory.GetAppService(ctx, application.Spec.URL, application.Spec.ConfigURL, params.Namespace, application.IsHelmRepository())
+	appService, appErr := s.appFactory.GetAppService(ctx, apputils.AppServiceData{
+		Namespace: application.Namespace,
+		URL:       application.Spec.URL,
+		ConfigURL: application.Spec.ConfigURL,
+		IsHelm:    application.IsHelmRepository(),
+		IsDryRun:  false,
+	})
 	if appErr != nil {
 		return nil, fmt.Errorf("failed to create app service: %w", appErr)
 	}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/weaveworks/weave-gitops/pkg/apputils"
 	"github.com/weaveworks/weave-gitops/pkg/services/auth/authfakes"
 	"github.com/weaveworks/weave-gitops/pkg/testutils"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -558,8 +559,8 @@ var _ = Describe("ApplicationsServer", func() {
 				secretKey := rand.String(20)
 
 				appFactory := &apputilsfakes.FakeAppFactory{}
-				appFactory.GetAppServiceStub = func(ctx context.Context, url, configUrl, namespace string, b bool) (app.AppService, error) {
-					return app.New(ctx, nil, nil, nil, nil, nil, kubeClient, nil), nil
+				appFactory.GetAppServiceStub = func(c context.Context, asd apputils.AppServiceData) (app.AppService, error) {
+					return app.New(c, nil, nil, nil, nil, nil, kubeClient, nil), nil
 				}
 				appFactory.GetKubeServiceStub = func() (kube.Kube, error) {
 					return kubeClient, nil
@@ -654,8 +655,8 @@ var _ = Describe("ApplicationsServer", func() {
 				}
 
 				appFactory := &apputilsfakes.FakeAppFactory{}
-				appFactory.GetAppServiceStub = func(ctx context.Context, url, configUrl, namespace string, b bool) (app.AppService, error) {
-					return app.New(ctx, nil, nil, nil, nil, nil, kubeClient, nil), nil
+				appFactory.GetAppServiceStub = func(c context.Context, asd apputils.AppServiceData) (app.AppService, error) {
+					return app.New(c, nil, nil, nil, nil, nil, kubeClient, nil), nil
 				}
 				appFactory.GetKubeServiceStub = func() (kube.Kube, error) {
 					return kubeClient, nil
@@ -715,8 +716,8 @@ var _ = Describe("Applications handler", func() {
 		}
 
 		appFactory := &apputilsfakes.FakeAppFactory{}
-		appFactory.GetAppServiceStub = func(ctx context.Context, url, configUrl, namespace string, b bool) (app.AppService, error) {
-			return app.New(ctx, nil, nil, nil, nil, nil, k, nil), nil
+		appFactory.GetAppServiceStub = func(c context.Context, asd apputils.AppServiceData) (app.AppService, error) {
+			return app.New(c, nil, nil, nil, nil, nil, k, nil), nil
 		}
 		appFactory.GetKubeServiceStub = func() (kube.Kube, error) {
 			return k, nil
@@ -777,8 +778,8 @@ var _ = Describe("Applications handler", func() {
 			},
 		}
 
-		appFactory.GetAppServiceStub = func(ctx context.Context, url, configUrl, namespace string, b bool) (app.AppService, error) {
-			return app.New(ctx, nil, nil, nil, gitProviders, nil, kubeClient, nil), nil
+		appFactory.GetAppServiceStub = func(c context.Context, asd apputils.AppServiceData) (app.AppService, error) {
+			return app.New(c, nil, nil, nil, gitProviders, nil, kubeClient, nil), nil
 		}
 
 		appFactory.GetKubeServiceStub = func() (kube.Kube, error) {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -793,11 +793,14 @@ var _ = Describe("Applications handler", func() {
 			return gitproviders.AccountTypeUser, nil
 		}
 
+		k8s := fake.NewClientBuilder().WithScheme(kube.CreateScheme()).Build()
+		Expect(k8s.Create(context.Background(), testApp))
+
 		cfg := ApplicationsConfig{
 			Logger:     log,
 			AppFactory: appFactory,
 			JwtClient:  jwtClient,
-			KubeClient: fake.NewClientBuilder().WithScheme(kube.CreateScheme()).Build(),
+			KubeClient: k8s,
 		}
 
 		handler, err := NewApplicationsHandler(context.Background(), &cfg)
@@ -814,6 +817,8 @@ var _ = Describe("Applications handler", func() {
 		req.Header.Add("Authorization", "token my-jwt-token")
 
 		res, err := ts.Client().Do(req)
+		Expect(err).NotTo(HaveOccurred())
+
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.StatusCode).To(Equal(http.StatusOK))
 

--- a/pkg/server/suite_test.go
+++ b/pkg/server/suite_test.go
@@ -108,9 +108,10 @@ var _ = BeforeEach(func() {
 	k = &kube.KubeHTTP{Client: k8sClient, ClusterName: testClustername}
 
 	appFactory := &apputilsfakes.FakeAppFactory{}
-	appFactory.GetAppServiceStub = func(ctx context.Context, name, namespace string) (app.AppService, error) {
+	appFactory.GetAppServiceStub = func(ctx context.Context, url, configUrl, namespace string, b bool) (app.AppService, error) {
 		return app.New(ctx, nil, nil, nil, nil, nil, k, nil), nil
 	}
+
 	appFactory.GetKubeServiceStub = func() (kube.Kube, error) {
 		return k, nil
 	}

--- a/pkg/server/suite_test.go
+++ b/pkg/server/suite_test.go
@@ -9,6 +9,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/rand"
 
+	"github.com/weaveworks/weave-gitops/pkg/apputils"
 	"github.com/weaveworks/weave-gitops/pkg/services/auth"
 	"github.com/weaveworks/weave-gitops/pkg/services/auth/authfakes"
 
@@ -108,8 +109,8 @@ var _ = BeforeEach(func() {
 	k = &kube.KubeHTTP{Client: k8sClient, ClusterName: testClustername}
 
 	appFactory := &apputilsfakes.FakeAppFactory{}
-	appFactory.GetAppServiceStub = func(ctx context.Context, url, configUrl, namespace string, b bool) (app.AppService, error) {
-		return app.New(ctx, nil, nil, nil, nil, nil, k, nil), nil
+	appFactory.GetAppServiceStub = func(c context.Context, asd apputils.AppServiceData) (app.AppService, error) {
+		return app.New(c, nil, nil, nil, nil, nil, k, nil), nil
 	}
 
 	appFactory.GetKubeServiceStub = func() (kube.Kube, error) {

--- a/test/acceptance/test/add_tests.go
+++ b/test/acceptance/test/add_tests.go
@@ -1077,7 +1077,7 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 		})
 
 		By("Then I should get an error", func() {
-			Eventually(removeOutput.Err).Should(gbytes.Say(`Error: failed to create app service: error getting git clients: could not retrieve application "` + badAppName + `": could not get application: apps.wego.weave.works "` + badAppName + `" not found`))
+			Eventually(removeOutput.Err).Should(ContainSubstring(`could not get application: apps.wego.weave.works "` + badAppName + `" not found`))
 		})
 	})
 

--- a/test/acceptance/test/add_tests.go
+++ b/test/acceptance/test/add_tests.go
@@ -1056,7 +1056,7 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 		})
 
 		By("Then I should see an error", func() {
-			Eventually(reAddOutput).Should(ContainSubstring("Error: failed to add the app " + appName + ": unable to create resource, resource already exists in cluster"))
+			Eventually(reAddOutput).Should(ContainSubstring("resource already exists in cluster"))
 		})
 
 		By("And app status should remain same", func() {


### PR DESCRIPTION
I did some of this work as part of #634, but it made sense to pull it into a separate PR. This tries to flatten the calls in `apputils` a little bit.

The `fake.Client` stuff was cherry-picked from another PR and will get wiped out from the diff on rebase. It can be ignored.