### PR TITLE
Inform the user that setting the appropriate token allows skipping auth flow

### DIFF
--- a/pkg/osys/osys.go
+++ b/pkg/osys/osys.go
@@ -10,7 +10,7 @@ import (
 //counterfeiter:generate . Osys
 type Osys interface {
 	UserHomeDir() (string, error)
-	GetGitProviderToken() (string, error)
+	GetGitProviderToken(tokenVarName string) (string, error)
 	Getenv(envVar string) string
 	LookupEnv(envVar string) (string, bool)
 	Setenv(envVar, value string) error
@@ -56,8 +56,8 @@ func (o *OsysClient) Unsetenv(envVar string) error {
 
 var ErrNoGitProviderTokenSet = errors.New("no git provider token env variable set")
 
-func (o *OsysClient) GetGitProviderToken() (string, error) {
-	providerToken, found := o.LookupEnv("GITHUB_TOKEN")
+func (o *OsysClient) GetGitProviderToken(tokenVarName string) (string, error) {
+	providerToken, found := o.LookupEnv(tokenVarName)
 
 	if !found || providerToken == "" {
 		return "", ErrNoGitProviderTokenSet

--- a/pkg/osys/osysfakes/fake_osys.go
+++ b/pkg/osys/osysfakes/fake_osys.go
@@ -14,9 +14,10 @@ type FakeOsys struct {
 	exitArgsForCall []struct {
 		arg1 int
 	}
-	GetGitProviderTokenStub        func() (string, error)
+	GetGitProviderTokenStub        func(string) (string, error)
 	getGitProviderTokenMutex       sync.RWMutex
 	getGitProviderTokenArgsForCall []struct {
+		arg1 string
 	}
 	getGitProviderTokenReturns struct {
 		result1 string
@@ -151,17 +152,18 @@ func (fake *FakeOsys) ExitArgsForCall(i int) int {
 	return argsForCall.arg1
 }
 
-func (fake *FakeOsys) GetGitProviderToken() (string, error) {
+func (fake *FakeOsys) GetGitProviderToken(arg1 string) (string, error) {
 	fake.getGitProviderTokenMutex.Lock()
 	ret, specificReturn := fake.getGitProviderTokenReturnsOnCall[len(fake.getGitProviderTokenArgsForCall)]
 	fake.getGitProviderTokenArgsForCall = append(fake.getGitProviderTokenArgsForCall, struct {
-	}{})
+		arg1 string
+	}{arg1})
 	stub := fake.GetGitProviderTokenStub
 	fakeReturns := fake.getGitProviderTokenReturns
-	fake.recordInvocation("GetGitProviderToken", []interface{}{})
+	fake.recordInvocation("GetGitProviderToken", []interface{}{arg1})
 	fake.getGitProviderTokenMutex.Unlock()
 	if stub != nil {
-		return stub()
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -175,10 +177,17 @@ func (fake *FakeOsys) GetGitProviderTokenCallCount() int {
 	return len(fake.getGitProviderTokenArgsForCall)
 }
 
-func (fake *FakeOsys) GetGitProviderTokenCalls(stub func() (string, error)) {
+func (fake *FakeOsys) GetGitProviderTokenCalls(stub func(string) (string, error)) {
 	fake.getGitProviderTokenMutex.Lock()
 	defer fake.getGitProviderTokenMutex.Unlock()
 	fake.GetGitProviderTokenStub = stub
+}
+
+func (fake *FakeOsys) GetGitProviderTokenArgsForCall(i int) string {
+	fake.getGitProviderTokenMutex.RLock()
+	defer fake.getGitProviderTokenMutex.RUnlock()
+	argsForCall := fake.getGitProviderTokenArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeOsys) GetGitProviderTokenReturns(result1 string, result2 error) {

--- a/pkg/services/auth/authfakes/fake_github_auth_client.go
+++ b/pkg/services/auth/authfakes/fake_github_auth_client.go
@@ -4,7 +4,6 @@ package authfakes
 import (
 	"sync"
 
-	"github.com/weaveworks/weave-gitops/pkg/gitproviders"
 	"github.com/weaveworks/weave-gitops/pkg/services/auth"
 )
 
@@ -33,16 +32,6 @@ type FakeGithubAuthClient struct {
 	getDeviceCodeAuthStatusReturnsOnCall map[int]struct {
 		result1 string
 		result2 error
-	}
-	NameStub        func() gitproviders.GitProviderName
-	nameMutex       sync.RWMutex
-	nameArgsForCall []struct {
-	}
-	nameReturns struct {
-		result1 gitproviders.GitProviderName
-	}
-	nameReturnsOnCall map[int]struct {
-		result1 gitproviders.GitProviderName
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
@@ -168,59 +157,6 @@ func (fake *FakeGithubAuthClient) GetDeviceCodeAuthStatusReturnsOnCall(i int, re
 	}{result1, result2}
 }
 
-func (fake *FakeGithubAuthClient) Name() gitproviders.GitProviderName {
-	fake.nameMutex.Lock()
-	ret, specificReturn := fake.nameReturnsOnCall[len(fake.nameArgsForCall)]
-	fake.nameArgsForCall = append(fake.nameArgsForCall, struct {
-	}{})
-	stub := fake.NameStub
-	fakeReturns := fake.nameReturns
-	fake.recordInvocation("Name", []interface{}{})
-	fake.nameMutex.Unlock()
-	if stub != nil {
-		return stub()
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fakeReturns.result1
-}
-
-func (fake *FakeGithubAuthClient) NameCallCount() int {
-	fake.nameMutex.RLock()
-	defer fake.nameMutex.RUnlock()
-	return len(fake.nameArgsForCall)
-}
-
-func (fake *FakeGithubAuthClient) NameCalls(stub func() gitproviders.GitProviderName) {
-	fake.nameMutex.Lock()
-	defer fake.nameMutex.Unlock()
-	fake.NameStub = stub
-}
-
-func (fake *FakeGithubAuthClient) NameReturns(result1 gitproviders.GitProviderName) {
-	fake.nameMutex.Lock()
-	defer fake.nameMutex.Unlock()
-	fake.NameStub = nil
-	fake.nameReturns = struct {
-		result1 gitproviders.GitProviderName
-	}{result1}
-}
-
-func (fake *FakeGithubAuthClient) NameReturnsOnCall(i int, result1 gitproviders.GitProviderName) {
-	fake.nameMutex.Lock()
-	defer fake.nameMutex.Unlock()
-	fake.NameStub = nil
-	if fake.nameReturnsOnCall == nil {
-		fake.nameReturnsOnCall = make(map[int]struct {
-			result1 gitproviders.GitProviderName
-		})
-	}
-	fake.nameReturnsOnCall[i] = struct {
-		result1 gitproviders.GitProviderName
-	}{result1}
-}
-
 func (fake *FakeGithubAuthClient) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -228,8 +164,6 @@ func (fake *FakeGithubAuthClient) Invocations() map[string][][]interface{} {
 	defer fake.getDeviceCodeMutex.RUnlock()
 	fake.getDeviceCodeAuthStatusMutex.RLock()
 	defer fake.getDeviceCodeAuthStatusMutex.RUnlock()
-	fake.nameMutex.RLock()
-	defer fake.nameMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value


### PR DESCRIPTION
<!-- Use # to add the issue this pull request is related to -->
Closes: #750 

<!-- Describe what has changed in this PR -->
**What changed?**
If the auth service fails to find a token, a log message is emitted to inform the user that she may bypass the auth flow by setting it

<!-- Tell your future self why have you made these changes -->
**Why?**
So that a user will not repeatedly go through the auth flow for no reason

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
**Release notes**

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**