### PR TITLE
Leave image as wego-app until we completely purge "wego"

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: gitops-app
+  IMAGE_NAME: wego-app
 
 jobs:
   goreleaser:

--- a/Makefile
+++ b/Makefile
@@ -51,8 +51,8 @@ debug: ## Compile binary with optimisations and inlining disabled
 bin: ## Build gitops binary
 	go build -ldflags $(LDFLAGS) -o bin/$(BINARY_NAME) cmd/gitops/*.go
 
-docker: ## Build gitops-app docker image
-	docker build -t ghcr.io/weaveworks/gitops-app:latest .
+docker: ## Build wego-app docker image
+	docker build -t ghcr.io/weaveworks/wego-app:latest .
 
 
 # Clean up images and binaries


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
This undoes the beginning of moving our UI image to `gitops-app` from `wego-app`. There are a variety of other things to update in that move.

<!-- Tell your future self why have you made these changes -->
**Why?**
So that a released version works correctly

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**
There are current no tests that are affected by this as the image is only pushed during release. The wego-app deployment always fails with an `ErrImagePull` (this should be fixed with the addition of `garden.io`)

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
**Release notes**
No

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
No