### PR TITLE
Only check for flux upgrades once a week

### DIFF
--- a/.github/workflows/upgrade-flux.yaml
+++ b/.github/workflows/upgrade-flux.yaml
@@ -3,7 +3,7 @@ name: Update Components
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 * * * *"
+    - cron: "0 0 * * 0"
 
 jobs:
   update-components:
@@ -29,7 +29,6 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@9825ae65b1cb54b543b938503728b432a0176d29 # v3
         with:
-#           token: ${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_TOKEN }}
           commit-message: |
             ${{ steps.update.outputs.pr_title }}
             ${{ steps.update.outputs.pr_body }}


### PR DESCRIPTION
We will realistically only upgrade flux once per release, and we release every two weeks. A once-a-week check should be fine. This cron expression is `At 00:00 on Sunday.`