### PR TITLE
Removed namespace from wego-app manifests

### DIFF
--- a/manifests/crds/wego.weave.works_apps.yaml
+++ b/manifests/crds/wego.weave.works_apps.yaml
@@ -78,9 +78,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/manifests/wego-app/deployment.yaml
+++ b/manifests/wego-app/deployment.yaml
@@ -2,7 +2,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: wego-app
-  namespace: wego-system
 spec:
   replicas: 1
   template:

--- a/manifests/wego-app/role-binding.yaml
+++ b/manifests/wego-app/role-binding.yaml
@@ -2,7 +2,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: read-resources
-  namespace: wego-system
 subjects:
   - kind: ServiceAccount
     name: wego-app-service-account

--- a/manifests/wego-app/role.yaml
+++ b/manifests/wego-app/role.yaml
@@ -2,7 +2,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: resources-reader
-  namespace: wego-system
 rules:
   - apiGroups: [""]
     resources: ["secrets"]

--- a/manifests/wego-app/service-account.yaml
+++ b/manifests/wego-app/service-account.yaml
@@ -2,6 +2,5 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: wego-app-service-account
-  namespace: wego-system
 secrets:
   - name: wego-app-service-account-token

--- a/manifests/wego-app/service.yaml
+++ b/manifests/wego-app/service.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: wego-app
-  namespace: wego-system
 spec:
   selector:
     app: wego-app

--- a/test/acceptance/test/add_tests.go
+++ b/test/acceptance/test/add_tests.go
@@ -901,7 +901,7 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 			createAppReplicas(repoAbsolutePath1, appManifestFile1, replicaSetValue, tip1.workloadName)
 			gitUpdateCommitPush(repoAbsolutePath1)
 			_ = waitForReplicaCreation(tip1.workloadNamespace, replicaSetValue, EVENTUALLY_DEFAULT_TIMEOUT)
-			_ = runCommandPassThrough([]string{}, "sh", "-c", fmt.Sprintf("kubectl wait --for=condition=Ready --timeout=100s -n %s --all pods", tip1.workloadNamespace))
+			_ = runCommandPassThrough([]string{}, "sh", "-c", fmt.Sprintf("kubectl wait --for=condition=Ready --timeout=100s -n %s --all pods --selector='app!=wego-app'", tip1.workloadNamespace))
 		})
 
 		By("And number of app replicas should remain same", func() {
@@ -927,7 +927,7 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 
 		By("And I should see app replicas created in the cluster", func() {
 			_ = waitForReplicaCreation(tip1.workloadNamespace, replicaSetValue, EVENTUALLY_DEFAULT_TIMEOUT)
-			_ = runCommandPassThrough([]string{}, "sh", "-c", fmt.Sprintf("kubectl wait --for=condition=Ready --timeout=100s -n %s --all pods", tip1.workloadNamespace))
+			_ = runCommandPassThrough([]string{}, "sh", "-c", fmt.Sprintf("kubectl wait --for=condition=Ready --timeout=100s -n %s --all pods --selector='app!=wego-app'", tip1.workloadNamespace))
 			replicaOutput, _ := runCommandAndReturnStringOutput("kubectl get pods -n " + tip1.workloadNamespace + " --field-selector=status.phase=Running --no-headers=true | wc -l")
 			Expect(replicaOutput).To(ContainSubstring(strconv.Itoa(replicaSetValue)))
 		})
@@ -988,7 +988,7 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 			_, commitList2 = runCommandAndReturnStringOutput(fmt.Sprintf("%s app %s get commits", WEGO_BIN_PATH, appName2))
 		})
 
-		By("Then I should see the list of commits for app2", func() {
+		By("Then I should not see the list of commits for app2", func() {
 			Eventually(commitList2).Should(ContainSubstring(`Error:`))
 			Eventually(commitList2).Should(MatchRegexp(`\"` + appName2 + `\" not found`))
 		})

--- a/test/acceptance/test/utils.go
+++ b/test/acceptance/test/utils.go
@@ -552,7 +552,7 @@ func verifyWegoAddCommandWithDryRun(appRepoName string, wegoNamespace string) {
 func verifyWorkloadIsDeployed(workloadName string, workloadNamespace string) {
 	Expect(waitForResource("deploy", workloadName, workloadNamespace, INSTALL_PODS_READY_TIMEOUT)).To(Succeed())
 	Expect(waitForResource("pods", "", workloadNamespace, INSTALL_PODS_READY_TIMEOUT)).To(Succeed())
-	command := exec.Command("sh", "-c", fmt.Sprintf("kubectl wait --for=condition=Ready --timeout=60s -n %s --all pods", workloadNamespace))
+	command := exec.Command("sh", "-c", fmt.Sprintf("kubectl wait --for=condition=Ready --timeout=60s -n %s --all pods --selector='app!=wego-app'", workloadNamespace))
 	session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 	Expect(err).ShouldNot(HaveOccurred())
 	Eventually(session, INSTALL_PODS_READY_TIMEOUT).Should(gexec.Exit())

--- a/test/acceptance/test/utils.go
+++ b/test/acceptance/test/utils.go
@@ -378,6 +378,7 @@ func installAndVerifyWego(wegoNamespace string) {
 		session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 		Expect(err).ShouldNot(HaveOccurred())
 		Eventually(session, TIMEOUT_TWO_MINUTES).Should(gexec.Exit())
+		Expect(string(session.Err.Contents())).Should(BeEmpty())
 		VerifyControllersInCluster(wegoNamespace)
 	})
 }

--- a/test/acceptance/test/utils.go
+++ b/test/acceptance/test/utils.go
@@ -242,12 +242,6 @@ func initAndCreateEmptyRepo(appRepoName string, isPrivateRepo bool) string {
 	})
 	Expect(err).ShouldNot(HaveOccurred())
 
-	command := exec.Command("sh", "-c", fmt.Sprintf(`cd %s`,
-		repoAbsolutePath))
-	session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
-	Expect(err).NotTo(HaveOccurred())
-	Eventually(session).Should(gexec.Exit())
-
 	return repoAbsolutePath
 }
 
@@ -365,7 +359,7 @@ func VerifyControllersInCluster(namespace string) {
 	Expect(waitForResource("pods", "", namespace, INSTALL_PODS_READY_TIMEOUT))
 
 	By("And I wait for the gitops controllers to be ready", func() {
-		command := exec.Command("sh", "-c", fmt.Sprintf("kubectl wait --for=condition=Ready --timeout=%s -n %s --all pod", "120s", namespace))
+		command := exec.Command("sh", "-c", fmt.Sprintf("kubectl wait --for=condition=Ready --timeout=%s -n %s --all pod --selector='app!=wego-app'", "120s", namespace))
 		session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 		Expect(err).ShouldNot(HaveOccurred())
 		Eventually(session, INSTALL_PODS_READY_TIMEOUT).Should(gexec.Exit())


### PR DESCRIPTION
Added assertion to integration test using non-default ns to make sure it fails when error output is not empty

<!-- Use # to add the issue this pull request is related to -->
Closes: #776 

<!-- Describe what has changed in this PR -->
**What changed?**
Removed wego-system ns from wego-app manifests


<!-- Tell your future self why have you made these changes -->
**Why?**
It was causing an error at installation time when using a namespace different from the default

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**
Manually and  by fixing the integration test for this particular case

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
**Release notes**

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**