### PR TITLE
Fix goreleaser binary and docker push job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -76,7 +76,5 @@ jobs:
         with:
           context: .
           push: true
-          tags:
-            ${{ env.REGISTRY }}/weaveworks/${{ env.IMAGE_NAME }}:${{ github.event.release.tag_name }}
-            ${{ env.REGISTRY }}/weaveworks/${{ env.IMAGE_NAME }}:latest
+          tags: ${{ env.REGISTRY }}/weaveworks/${{ env.IMAGE_NAME }}:${{ github.event.release.tag_name }},${{ env.REGISTRY }}/weaveworks/${{ env.IMAGE_NAME }}:latest
           labels: ${{ steps.meta.outputs.labels }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,4 +1,4 @@
-project_name: wego
+project_name: gitops
 env:
   - GO111MODULE=on
 before:
@@ -9,20 +9,19 @@ checksum:
 release:
   prerelease: auto
 archives:
-  -
-   format: binary
-   replacements:
-     amd64: x86_64
-   name_template: "wego-{{.Os}}-{{.Arch}}"
+  - format: binary
+    replacements:
+      amd64: x86_64
+    name_template: "gitops-{{.Os}}-{{.Arch}}"
 builds:
   - <<: &build_defaults
-      binary: "wego-{{.Os}}-{{.Arch}}"
-      main: ./cmd/wego
+      binary: "gitops-{{.Os}}-{{.Arch}}"
+      main: ./cmd/gitops
       ldflags:
-        - -X github.com/weaveworks/weave-gitops/cmd/wego/version.Version={{.Version}}
-        - -X github.com/weaveworks/weave-gitops/cmd/wego/version.BuildTime={{.Date}}
-        - -X github.com/weaveworks/weave-gitops/cmd/wego/version.Branch={{ .Env.BRANCH}}
-        - -X github.com/weaveworks/weave-gitops/cmd/wego/version.GitCommit={{.Commit}}
+        - -X github.com/weaveworks/weave-gitops/cmd/gitops/version.Version={{.Version}}
+        - -X github.com/weaveworks/weave-gitops/cmd/gitops/version.BuildTime={{.Date}}
+        - -X github.com/weaveworks/weave-gitops/cmd/gitops/version.Branch={{ .Env.BRANCH}}
+        - -X github.com/weaveworks/weave-gitops/cmd/gitops/version.GitCommit={{.Commit}}
         - -X github.com/weaveworks/weave-gitops/pkg/version.FluxVersion={{ .Env.FLUX_VERSION }}
       env:
         - CGO_ENABLED=0
@@ -68,4 +67,3 @@ builds:
       - darwin
     goarch:
       - arm64
-


### PR DESCRIPTION
`goreleaser.yaml` still had "wego" as the binary name. Docker push `tags:` is a CSV list