### PR TITLE
Use fake k8s client instead of full etcd cluster

### DIFF
--- a/pkg/services/auth/auth_suite_test.go
+++ b/pkg/services/auth/auth_suite_test.go
@@ -5,8 +5,9 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/weaveworks/weave-gitops/pkg/testutils"
+	"github.com/weaveworks/weave-gitops/pkg/kube"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 var k8sClient client.Client
@@ -16,15 +17,6 @@ func TestGitProviderAuth(t *testing.T) {
 	RunSpecs(t, "Auth Suite")
 }
 
-var cleanupK8s func()
-
 var _ = BeforeSuite(func() {
-	k8sTestEnv, err := testutils.StartK8sTestEnvironment()
-	Expect(err).NotTo(HaveOccurred())
-	cleanupK8s = k8sTestEnv.Stop
-	k8sClient = k8sTestEnv.Client
-})
-
-var _ = AfterSuite(func() {
-	cleanupK8s()
+	k8sClient = fake.NewClientBuilder().WithScheme(kube.CreateScheme()).Build()
 })

--- a/pkg/services/auth/auth_test.go
+++ b/pkg/services/auth/auth_test.go
@@ -86,8 +86,8 @@ var _ = Describe("auth", func() {
 			secret := &corev1.Secret{}
 			Expect(k8sClient.Get(ctx, sn.NamespacedName(), secret)).To(Succeed())
 
-			Expect(secret.Data["identity"]).NotTo(BeNil())
-			Expect(secret.Data["identity.pub"]).NotTo(BeNil())
+			Expect(secret.StringData["identity"]).NotTo(BeNil())
+			Expect(secret.StringData["identity.pub"]).NotTo(BeNil())
 		})
 		It("uses an existing deploy key when present", func() {
 			gp.DeployKeyExistsStub = func(s1, s2 string) (bool, error) {


### PR DESCRIPTION
On recommendation from @hiddeco, Uses a lighter `fake` client. Hopefully reduces the incidents of `cannot listen: port already in use'