### PR TITLE
Fix Github auth when running from `wego ui run`

### DIFF
--- a/pkg/services/auth/auth.go
+++ b/pkg/services/auth/auth.go
@@ -197,7 +197,6 @@ func (a *authSvc) setupDeployKey(ctx context.Context, name SecretName, targetNam
 	}
 
 	if deployKeyExists {
-		a.logger.Successf("Existing deploy key found")
 		// The deploy key was found on the Git Provider, fetch it from the cluster.
 		secret, err := a.retrieveDeployKey(ctx, name)
 		if apierrors.IsNotFound(err) {


### PR DESCRIPTION
Closes #812 

The `gitops ui run` command wan't using the latest application handler where we have all of our auth middleware. This would have been missed when testing with the API server and dev frontend.