### PR TITLE
Link to license scan report instead of the project

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Weave GitOps
 [![LICENSE](https://img.shields.io/github/license/weaveworks/weave-gitops)](https://github.com/weaveworks/weave-gitops/blob/master/LICENSE)
 [![Contributors](https://img.shields.io/github/contributors/weaveworks/weave-gitops)](https://github.com/weaveworks/weave-gitops/graphs/contributors)
 [![Release](https://img.shields.io/github/v/release/weaveworks/weave-gitops?include_prereleases)](https://github.com/weaveworks/weave-gitops/releases/latest)
-[![FOSSA Status](https://app.fossa.com/api/projects/custom%2B19155%2Fgithub.com%2Fweaveworks%2Fweave-gitops.svg?type=shield)](https://app.fossa.com/projects/custom%2B19155%2Fgithub.com%2Fweaveworks%2Fweave-gitops?ref=badge_shield)
+[![FOSSA Status](https://app.fossa.com/api/projects/custom%2B19155%2Fgithub.com%2Fweaveworks%2Fweave-gitops.svg?type=shield)](https://app.fossa.com/reports/005da7c4-1f10-4889-9432-8b97c2084e41)
 
 ## Overview
 
@@ -142,4 +142,4 @@ Need help or want to contribute? Please see the links below.
 
 ## License scan details
 
-[![FOSSA Status](https://app.fossa.com/api/projects/custom%2B19155%2Fgithub.com%2Fweaveworks%2Fweave-gitops.svg?type=large)](https://app.fossa.com/projects/custom%2B19155%2Fgithub.com%2Fweaveworks%2Fweave-gitops?ref=badge_large)
+[![FOSSA Status](https://app.fossa.com/api/projects/custom%2B19155%2Fgithub.com%2Fweaveworks%2Fweave-gitops.svg?type=large)](https://app.fossa.com/reports/005da7c4-1f10-4889-9432-8b97c2084e41)


### PR DESCRIPTION
<!-- Use # to add the issue this pull request is related to -->
Closes: #826 

<!-- Describe what has changed in this PR -->
**What changed?**
Updated the README to point to the license scan report instead of the project

<!-- Tell your future self why have you made these changes -->
**Why?**
Linking to the project requires users to log in to see the report.  Linking to the report allows them to see a preview of the report and download a complete version.

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**
Previewed the readme file, copied the link to the report, opened an incognito window, pasted the link, viewed and downloaded the report

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
**Release notes**
No
<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
None - other than this is an update to the README.