### PR TITLE
Fix Github device-flow retry logic and add test coverage

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/weaveworks/weave-gitops
 go 1.16
 
 require (
+	github.com/benbjohnson/clock v1.1.0
 	github.com/deepmap/oapi-codegen v1.8.1
 	github.com/dnaeon/go-vcr v1.2.0
 	github.com/fluxcd/go-git-providers v0.2.1-0.20210920141513-ddc36f3d5f60


### PR DESCRIPTION
<!-- Use # to add the issue this pull request is related to -->
Closes: #782

<!-- Describe what has changed in this PR -->
**What changed?**
Adds logic to retry after a `slow_down` message from GH, with a back off interval. This required a more significant refactor to make it more easily testable. This [clock](https://github.com/benbjohnson/clock) package was very useful for mocking out time.