### PR TITLE
Add `gitops get credentials` command

### DIFF
--- a/cmd/gitops/add/clusters/cmd.go
+++ b/cmd/gitops/add/clusters/cmd.go
@@ -7,7 +7,7 @@ import (
 	"github.com/go-resty/resty/v2"
 	"github.com/spf13/cobra"
 	"github.com/weaveworks/weave-gitops/pkg/adapters"
-	"github.com/weaveworks/weave-gitops/pkg/templates"
+	"github.com/weaveworks/weave-gitops/pkg/capi"
 )
 
 type clusterCommandFlags struct {
@@ -70,7 +70,7 @@ func getClusterCmdRunE(endpoint *string, client *resty.Client) func(*cobra.Comma
 			}
 		}
 
-		creds := templates.Credentials{}
+		creds := capi.Credentials{}
 		if flags.Credentials != "" {
 			creds, err = r.RetrieveCredentialsByName(flags.Credentials)
 			if err != nil {
@@ -79,10 +79,10 @@ func getClusterCmdRunE(endpoint *string, client *resty.Client) func(*cobra.Comma
 		}
 
 		if flags.DryRun {
-			return templates.RenderTemplateWithParameters(flags.Template, vals, creds, r, os.Stdout)
+			return capi.RenderTemplateWithParameters(flags.Template, vals, creds, r, os.Stdout)
 		}
 
-		params := templates.CreatePullRequestFromTemplateParams{
+		params := capi.CreatePullRequestFromTemplateParams{
 			TemplateName:    flags.Template,
 			ParameterValues: vals,
 			RepositoryURL:   flags.RepositoryURL,
@@ -94,6 +94,6 @@ func getClusterCmdRunE(endpoint *string, client *resty.Client) func(*cobra.Comma
 			Credentials:     creds,
 		}
 
-		return templates.CreatePullRequestFromTemplate(params, r, os.Stdout)
+		return capi.CreatePullRequestFromTemplate(params, r, os.Stdout)
 	}
 }

--- a/cmd/gitops/get/cmd.go
+++ b/cmd/gitops/get/cmd.go
@@ -3,6 +3,7 @@ package get
 import (
 	"github.com/go-resty/resty/v2"
 	"github.com/spf13/cobra"
+	"github.com/weaveworks/weave-gitops/cmd/gitops/get/credentials"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/get/templates"
 )
 
@@ -16,6 +17,7 @@ gitops get templates`,
 	}
 
 	cmd.AddCommand(templates.TemplateCommand(endpoint, client))
+	cmd.AddCommand(credentials.CredentialCommand(endpoint, client))
 
 	return cmd
 }

--- a/cmd/gitops/get/credentials/cmd.go
+++ b/cmd/gitops/get/credentials/cmd.go
@@ -1,0 +1,40 @@
+package credentials
+
+import (
+	"os"
+
+	"github.com/go-resty/resty/v2"
+	"github.com/spf13/cobra"
+	"github.com/weaveworks/weave-gitops/pkg/adapters"
+	"github.com/weaveworks/weave-gitops/pkg/capi"
+	"k8s.io/cli-runtime/pkg/printers"
+)
+
+func CredentialCommand(endpoint *string, client *resty.Client) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "credential",
+		Aliases: []string{"credentials"},
+		Short:   "Get CAPI credentials",
+		Example: `
+# Get all CAPI credentials
+gitops get credentials
+		`,
+		RunE: getTemplateCmdRunE(endpoint, client),
+	}
+
+	return cmd
+}
+
+func getTemplateCmdRunE(endpoint *string, client *resty.Client) func(*cobra.Command, []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		r, err := adapters.NewHttpClient(*endpoint, client, os.Stdout)
+		if err != nil {
+			return err
+		}
+
+		w := printers.GetNewTabWriter(os.Stdout)
+		defer w.Flush()
+
+		return capi.GetCredentials(r, w)
+	}
+}

--- a/cmd/gitops/get/templates/cmd.go
+++ b/cmd/gitops/get/templates/cmd.go
@@ -6,7 +6,7 @@ import (
 	"github.com/go-resty/resty/v2"
 	"github.com/spf13/cobra"
 	"github.com/weaveworks/weave-gitops/pkg/adapters"
-	"github.com/weaveworks/weave-gitops/pkg/templates"
+	"github.com/weaveworks/weave-gitops/pkg/capi"
 	"k8s.io/cli-runtime/pkg/printers"
 )
 
@@ -48,11 +48,11 @@ func getTemplateCmdRunE(endpoint *string, client *resty.Client) func(*cobra.Comm
 		defer w.Flush()
 
 		if flags.ListTemplateParameters {
-			return templates.GetTemplateParameters(args[0], r, w)
+			return capi.GetTemplateParameters(args[0], r, w)
 		}
 
 		if len(args) == 0 {
-			return templates.GetTemplates(r, w)
+			return capi.GetTemplates(r, w)
 		}
 
 		return nil

--- a/pkg/adapters/http.go
+++ b/pkg/adapters/http.go
@@ -7,7 +7,7 @@ import (
 	"net/url"
 
 	"github.com/go-resty/resty/v2"
-	"github.com/weaveworks/weave-gitops/pkg/templates"
+	"github.com/weaveworks/weave-gitops/pkg/capi"
 )
 
 const (
@@ -53,11 +53,11 @@ func (c *HttpClient) Source() string {
 }
 
 // RetrieveTemplates returns the list of all templates from the cluster service.
-func (c *HttpClient) RetrieveTemplates() ([]templates.Template, error) {
+func (c *HttpClient) RetrieveTemplates() ([]capi.Template, error) {
 	endpoint := "v1/templates"
 
 	type ListTemplatesResponse struct {
-		Templates []*templates.Template
+		Templates []*capi.Template
 	}
 
 	var templateList ListTemplatesResponse
@@ -74,9 +74,9 @@ func (c *HttpClient) RetrieveTemplates() ([]templates.Template, error) {
 		return nil, fmt.Errorf("response status for GET %q was %d", res.Request.URL, res.StatusCode())
 	}
 
-	var ts []templates.Template
+	var ts []capi.Template
 	for _, t := range templateList.Templates {
-		ts = append(ts, templates.Template{
+		ts = append(ts, capi.Template{
 			Name:        t.Name,
 			Description: t.Description,
 		})
@@ -87,11 +87,11 @@ func (c *HttpClient) RetrieveTemplates() ([]templates.Template, error) {
 
 // RetrieveTemplateParameters returns the list of all parameters of the
 // specified template.
-func (c *HttpClient) RetrieveTemplateParameters(name string) ([]templates.TemplateParameter, error) {
+func (c *HttpClient) RetrieveTemplateParameters(name string) ([]capi.TemplateParameter, error) {
 	endpoint := "v1/templates/{name}/params"
 
 	type ListTemplateParametersResponse struct {
-		Parameters []*templates.TemplateParameter
+		Parameters []*capi.TemplateParameter
 	}
 
 	var templateParametersList ListTemplateParametersResponse
@@ -111,9 +111,9 @@ func (c *HttpClient) RetrieveTemplateParameters(name string) ([]templates.Templa
 		return nil, fmt.Errorf("response status for GET %q was %d", res.Request.URL, res.StatusCode())
 	}
 
-	var tps []templates.TemplateParameter
+	var tps []capi.TemplateParameter
 	for _, p := range templateParametersList.Parameters {
-		tps = append(tps, templates.TemplateParameter{
+		tps = append(tps, capi.TemplateParameter{
 			Name:        p.Name,
 			Description: p.Description,
 			Required:    p.Required,
@@ -126,13 +126,13 @@ func (c *HttpClient) RetrieveTemplateParameters(name string) ([]templates.Templa
 
 // RenderTemplateWithParameters returns a YAML representation of the specified
 // template populated with the supplied parameters.
-func (c *HttpClient) RenderTemplateWithParameters(name string, parameters map[string]string, creds templates.Credentials) (string, error) {
+func (c *HttpClient) RenderTemplateWithParameters(name string, parameters map[string]string, creds capi.Credentials) (string, error) {
 	endpoint := "v1/templates/{name}/render"
 
 	// POST request payload
 	type TemplateParameterValuesAndCredentials struct {
-		Values      map[string]string     `json:"values"`
-		Credentials templates.Credentials `json:"credentials"`
+		Values      map[string]string `json:"values"`
+		Credentials capi.Credentials  `json:"credentials"`
 	}
 
 	// POST response payload
@@ -171,20 +171,20 @@ func (c *HttpClient) RenderTemplateWithParameters(name string, parameters map[st
 
 // CreatePullRequestFromTemplate commits the YAML template to the specified
 // branch and creates a pull request of that branch.
-func (c *HttpClient) CreatePullRequestFromTemplate(params templates.CreatePullRequestFromTemplateParams) (string, error) {
+func (c *HttpClient) CreatePullRequestFromTemplate(params capi.CreatePullRequestFromTemplateParams) (string, error) {
 	endpoint := "v1/clusters"
 
 	// POST request payload
 	type CreatePullRequestFromTemplateRequest struct {
-		RepositoryURL   string                `json:"repositoryUrl"`
-		HeadBranch      string                `json:"headBranch"`
-		BaseBranch      string                `json:"baseBranch"`
-		Title           string                `json:"title"`
-		Description     string                `json:"description"`
-		TemplateName    string                `json:"templateName"`
-		ParameterValues map[string]string     `json:"parameter_values"`
-		CommitMessage   string                `json:"commitMessage"`
-		Credentials     templates.Credentials `json:"credentials"`
+		RepositoryURL   string            `json:"repositoryUrl"`
+		HeadBranch      string            `json:"headBranch"`
+		BaseBranch      string            `json:"baseBranch"`
+		Title           string            `json:"title"`
+		Description     string            `json:"description"`
+		TemplateName    string            `json:"templateName"`
+		ParameterValues map[string]string `json:"parameter_values"`
+		CommitMessage   string            `json:"commitMessage"`
+		Credentials     capi.Credentials  `json:"credentials"`
 	}
 
 	// POST response payload
@@ -229,11 +229,11 @@ func (c *HttpClient) CreatePullRequestFromTemplate(params templates.CreatePullRe
 }
 
 // RetrieveCredentials returns a list of all CAPI credentials.
-func (c *HttpClient) RetrieveCredentials() ([]templates.Credentials, error) {
+func (c *HttpClient) RetrieveCredentials() ([]capi.Credentials, error) {
 	endpoint := "v1/credentials"
 
 	type ListCredentialsResponse struct {
-		Credentials []*templates.Credentials
+		Credentials []*capi.Credentials
 		Total       int32
 	}
 
@@ -252,9 +252,9 @@ func (c *HttpClient) RetrieveCredentials() ([]templates.Credentials, error) {
 		return nil, fmt.Errorf("response status for GET %q was %d", res.Request.URL, res.StatusCode())
 	}
 
-	var creds []templates.Credentials
+	var creds []capi.Credentials
 	for _, c := range credentialsList.Credentials {
-		creds = append(creds, templates.Credentials{
+		creds = append(creds, capi.Credentials{
 			Group:     c.Group,
 			Version:   c.Version,
 			Kind:      c.Kind,
@@ -267,8 +267,8 @@ func (c *HttpClient) RetrieveCredentials() ([]templates.Credentials, error) {
 }
 
 // RetrieveCredentialsByName returns a specific set of CAPI credentials.
-func (c *HttpClient) RetrieveCredentialsByName(name string) (templates.Credentials, error) {
-	var creds templates.Credentials
+func (c *HttpClient) RetrieveCredentialsByName(name string) (capi.Credentials, error) {
+	var creds capi.Credentials
 
 	credsList, err := c.RetrieveCredentials()
 	if err != nil {
@@ -277,7 +277,7 @@ func (c *HttpClient) RetrieveCredentialsByName(name string) (templates.Credentia
 
 	for _, c := range credsList {
 		if c.Name == name {
-			creds = templates.Credentials{
+			creds = capi.Credentials{
 				Group:     c.Group,
 				Version:   c.Version,
 				Kind:      c.Kind,

--- a/pkg/adapters/http_test.go
+++ b/pkg/adapters/http_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/jarcoal/httpmock"
 	"github.com/stretchr/testify/assert"
 	"github.com/weaveworks/weave-gitops/pkg/adapters"
-	"github.com/weaveworks/weave-gitops/pkg/templates"
+	"github.com/weaveworks/weave-gitops/pkg/capi"
 )
 
 const BaseURI = "https://weave.works/api"
@@ -18,13 +18,13 @@ func TestRetrieveTemplates(t *testing.T) {
 	tests := []struct {
 		name       string
 		responder  httpmock.Responder
-		assertFunc func(t *testing.T, templates []templates.Template, err error)
+		assertFunc func(t *testing.T, templates []capi.Template, err error)
 	}{
 		{
 			name:      "templates returned",
 			responder: httpmock.NewJsonResponderOrPanic(200, httpmock.File("./testdata/templates.json")),
-			assertFunc: func(t *testing.T, ts []templates.Template, err error) {
-				assert.ElementsMatch(t, ts, []templates.Template{
+			assertFunc: func(t *testing.T, ts []capi.Template, err error) {
+				assert.ElementsMatch(t, ts, []capi.Template{
 					{
 						Name:        "cluster-template",
 						Description: "this is test template 1",
@@ -43,14 +43,14 @@ func TestRetrieveTemplates(t *testing.T) {
 		{
 			name:      "error returned",
 			responder: httpmock.NewErrorResponder(errors.New("oops")),
-			assertFunc: func(t *testing.T, ts []templates.Template, err error) {
+			assertFunc: func(t *testing.T, ts []capi.Template, err error) {
 				assert.EqualError(t, err, "unable to GET templates from \"https://weave.works/api/v1/templates\": Get \"https://weave.works/api/v1/templates\": oops")
 			},
 		},
 		{
 			name:      "unexpected status code",
 			responder: httpmock.NewStringResponder(400, ""),
-			assertFunc: func(t *testing.T, ts []templates.Template, err error) {
+			assertFunc: func(t *testing.T, ts []capi.Template, err error) {
 				assert.EqualError(t, err, "response status for GET \"https://weave.works/api/v1/templates\" was 400")
 			},
 		},
@@ -75,13 +75,13 @@ func TestRetrieveTemplateParameters(t *testing.T) {
 	tests := []struct {
 		name       string
 		responder  httpmock.Responder
-		assertFunc func(t *testing.T, templates []templates.TemplateParameter, err error)
+		assertFunc func(t *testing.T, templates []capi.TemplateParameter, err error)
 	}{
 		{
 			name:      "template parameters returned",
 			responder: httpmock.NewJsonResponderOrPanic(200, httpmock.File("./testdata/template_parameters.json")),
-			assertFunc: func(t *testing.T, ts []templates.TemplateParameter, err error) {
-				assert.ElementsMatch(t, ts, []templates.TemplateParameter{
+			assertFunc: func(t *testing.T, ts []capi.TemplateParameter, err error) {
+				assert.ElementsMatch(t, ts, []capi.TemplateParameter{
 					{
 						Name:        "CLUSTER_NAME",
 						Description: "This is used for the cluster naming.",
@@ -93,14 +93,14 @@ func TestRetrieveTemplateParameters(t *testing.T) {
 		{
 			name:      "error returned",
 			responder: httpmock.NewErrorResponder(errors.New("oops")),
-			assertFunc: func(t *testing.T, ts []templates.TemplateParameter, err error) {
+			assertFunc: func(t *testing.T, ts []capi.TemplateParameter, err error) {
 				assert.EqualError(t, err, "unable to GET template parameters from \"https://weave.works/api/v1/templates/cluster-template/params\": Get \"https://weave.works/api/v1/templates/cluster-template/params\": oops")
 			},
 		},
 		{
 			name:      "unexpected status code",
 			responder: httpmock.NewStringResponder(400, ""),
-			assertFunc: func(t *testing.T, ts []templates.TemplateParameter, err error) {
+			assertFunc: func(t *testing.T, ts []capi.TemplateParameter, err error) {
 				assert.EqualError(t, err, "response status for GET \"https://weave.works/api/v1/templates/cluster-template/params\" was 400")
 			},
 		},
@@ -209,7 +209,7 @@ spec:
 
 			r, err := adapters.NewHttpClient(BaseURI, client, os.Stdout)
 			assert.NoError(t, err)
-			result, err := r.RenderTemplateWithParameters("cluster-template", nil, templates.Credentials{})
+			result, err := r.RenderTemplateWithParameters("cluster-template", nil, capi.Credentials{})
 			tt.assertFunc(t, result, err)
 		})
 	}
@@ -260,7 +260,7 @@ func TestCreatePullRequestFromTemplate(t *testing.T) {
 
 			c, err := adapters.NewHttpClient(BaseURI, client, os.Stdout)
 			assert.NoError(t, err)
-			result, err := c.CreatePullRequestFromTemplate(templates.CreatePullRequestFromTemplateParams{})
+			result, err := c.CreatePullRequestFromTemplate(capi.CreatePullRequestFromTemplateParams{})
 			tt.assertFunc(t, result, err)
 		})
 	}
@@ -270,13 +270,13 @@ func TestRetrieveCredentials(t *testing.T) {
 	tests := []struct {
 		name       string
 		responder  httpmock.Responder
-		assertFunc func(t *testing.T, credentials []templates.Credentials, err error)
+		assertFunc func(t *testing.T, credentials []capi.Credentials, err error)
 	}{
 		{
 			name:      "credentials returned",
 			responder: httpmock.NewJsonResponderOrPanic(200, httpmock.File("./testdata/credentials.json")),
-			assertFunc: func(t *testing.T, creds []templates.Credentials, err error) {
-				assert.ElementsMatch(t, creds, []templates.Credentials{
+			assertFunc: func(t *testing.T, creds []capi.Credentials, err error) {
+				assert.ElementsMatch(t, creds, []capi.Credentials{
 					{
 						Group:     "infrastructure.cluster.x-k8s.io",
 						Version:   "v1alpha3",
@@ -297,14 +297,14 @@ func TestRetrieveCredentials(t *testing.T) {
 		{
 			name:      "error returned",
 			responder: httpmock.NewErrorResponder(errors.New("oops")),
-			assertFunc: func(t *testing.T, creds []templates.Credentials, err error) {
+			assertFunc: func(t *testing.T, creds []capi.Credentials, err error) {
 				assert.EqualError(t, err, "unable to GET credentials from \"https://weave.works/api/v1/credentials\": Get \"https://weave.works/api/v1/credentials\": oops")
 			},
 		},
 		{
 			name:      "unexpected status code",
 			responder: httpmock.NewStringResponder(400, ""),
-			assertFunc: func(t *testing.T, creds []templates.Credentials, err error) {
+			assertFunc: func(t *testing.T, creds []capi.Credentials, err error) {
 				assert.EqualError(t, err, "response status for GET \"https://weave.works/api/v1/credentials\" was 400")
 			},
 		},
@@ -329,13 +329,13 @@ func TestRetrieveCredentialsByName(t *testing.T) {
 	tests := []struct {
 		name       string
 		responder  httpmock.Responder
-		assertFunc func(t *testing.T, credentials templates.Credentials, err error)
+		assertFunc func(t *testing.T, credentials capi.Credentials, err error)
 	}{
 		{
 			name:      "credentials returned",
 			responder: httpmock.NewJsonResponderOrPanic(200, httpmock.File("./testdata/credentials.json")),
-			assertFunc: func(t *testing.T, creds templates.Credentials, err error) {
-				assert.Equal(t, creds, templates.Credentials{
+			assertFunc: func(t *testing.T, creds capi.Credentials, err error) {
+				assert.Equal(t, creds, capi.Credentials{
 					Group:     "infrastructure.cluster.x-k8s.io",
 					Version:   "v1alpha3",
 					Kind:      "AWSClusterStaticIdentity",

--- a/pkg/capi/capi.go
+++ b/pkg/capi/capi.go
@@ -1,4 +1,4 @@
-package templates
+package capi
 
 import (
 	"fmt"
@@ -132,7 +132,7 @@ func GetTemplateParameters(name string, r TemplatesRetriever, w io.Writer) error
 	return nil
 }
 
-// RenderTemplate user a TemplatesRetriever adapter to show
+// RenderTemplate uses a TemplateRenderer adapter to show
 // a template populated with parameter values.
 func RenderTemplateWithParameters(name string, parameters map[string]string, creds Credentials, r TemplateRenderer, w io.Writer) error {
 	t, err := r.RenderTemplateWithParameters(name, parameters, creds)
@@ -160,3 +160,4 @@ func CreatePullRequestFromTemplate(params CreatePullRequestFromTemplateParams, r
 
 	return nil
 }
+

--- a/pkg/capi/capi.go
+++ b/pkg/capi/capi.go
@@ -161,3 +161,29 @@ func CreatePullRequestFromTemplate(params CreatePullRequestFromTemplateParams, r
 	return nil
 }
 
+// GetCredentials uses a CredentialsRetriever adapter to show
+// a list of CAPI credentials.
+func GetCredentials(r CredentialsRetriever, w io.Writer) error {
+	cs, err := r.RetrieveCredentials()
+	if err != nil {
+		return fmt.Errorf("unable to retrieve credentials from %q: %w", r.Source(), err)
+	}
+
+	if len(cs) > 0 {
+		fmt.Fprintf(w, "NAME\tINFRASTRUCTURE PROVIDER\n")
+
+		for _, c := range cs {
+			fmt.Fprintf(w, "%s", c.Name)
+			// Extract the infra provider name from ClusterKind
+			provider := c.Kind[:strings.Index(c.Kind, "Cluster")]
+			fmt.Fprintf(w, "\t%s", provider)
+			fmt.Fprintln(w, "")
+		}
+
+		return nil
+	}
+
+	fmt.Fprintf(w, "No credentials found.")
+
+	return nil
+}

--- a/pkg/capi/capi_test.go
+++ b/pkg/capi/capi_test.go
@@ -1,4 +1,4 @@
-package templates_test
+package capi_test
 
 import (
 	"bytes"
@@ -7,13 +7,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/weaveworks/weave-gitops/pkg/templates"
+	"github.com/weaveworks/weave-gitops/pkg/capi"
 )
 
 func TestGetTemplates(t *testing.T) {
 	tests := []struct {
 		name             string
-		ts               []templates.Template
+		ts               []capi.Template
 		err              error
 		expected         string
 		expectedErrorStr string
@@ -24,7 +24,7 @@ func TestGetTemplates(t *testing.T) {
 		},
 		{
 			name: "templates includes just name",
-			ts: []templates.Template{
+			ts: []capi.Template{
 				{
 					Name: "template-a",
 				},
@@ -36,7 +36,7 @@ func TestGetTemplates(t *testing.T) {
 		},
 		{
 			name: "templates include all fields",
-			ts: []templates.Template{
+			ts: []capi.Template{
 				{
 					Name:        "template-a",
 					Description: "a desc",
@@ -59,7 +59,7 @@ func TestGetTemplates(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c := NewFakeClient(tt.ts, nil, nil, "", tt.err)
 			w := new(bytes.Buffer)
-			err := templates.GetTemplates(c, w)
+			err := capi.GetTemplates(c, w)
 			assert.Equal(t, tt.expected, w.String())
 			if err != nil {
 				assert.EqualError(t, err, tt.expectedErrorStr)
@@ -71,7 +71,7 @@ func TestGetTemplates(t *testing.T) {
 func TestGetTemplateParameters(t *testing.T) {
 	tests := []struct {
 		name             string
-		tps              []templates.TemplateParameter
+		tps              []capi.TemplateParameter
 		err              error
 		expected         string
 		expectedErrorStr string
@@ -82,7 +82,7 @@ func TestGetTemplateParameters(t *testing.T) {
 		},
 		{
 			name: "template parameters include just name",
-			tps: []templates.TemplateParameter{
+			tps: []capi.TemplateParameter{
 				{
 					Name:     "template-param-a",
 					Required: true,
@@ -95,7 +95,7 @@ func TestGetTemplateParameters(t *testing.T) {
 		},
 		{
 			name: "templates include all fields",
-			tps: []templates.TemplateParameter{
+			tps: []capi.TemplateParameter{
 				{
 					Name:        "template-param-a",
 					Required:    true,
@@ -120,7 +120,7 @@ func TestGetTemplateParameters(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c := NewFakeClient(nil, tt.tps, nil, "", tt.err)
 			w := new(bytes.Buffer)
-			err := templates.GetTemplateParameters("foo", c, w)
+			err := capi.GetTemplateParameters("foo", c, w)
 			assert.Equal(t, tt.expected, w.String())
 			if err != nil {
 				assert.EqualError(t, err, tt.expectedErrorStr)
@@ -189,7 +189,7 @@ func TestRenderTemplate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c := NewFakeClient(nil, nil, nil, tt.result, tt.err)
 			w := new(bytes.Buffer)
-			err := templates.RenderTemplateWithParameters("foo", nil, templates.Credentials{}, c, w)
+			err := capi.RenderTemplateWithParameters("foo", nil, capi.Credentials{}, c, w)
 			assert.Equal(t, tt.expected, w.String())
 			if err != nil {
 				assert.EqualError(t, err, tt.expectedErrorStr)
@@ -222,7 +222,7 @@ func TestCreatePullRequest(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c := NewFakeClient(nil, nil, nil, tt.result, tt.err)
 			w := new(bytes.Buffer)
-			err := templates.CreatePullRequestFromTemplate(templates.CreatePullRequestFromTemplateParams{}, c, w)
+			err := capi.CreatePullRequestFromTemplate(capi.CreatePullRequestFromTemplateParams{}, c, w)
 			assert.Equal(t, tt.expected, w.String())
 			if err != nil {
 				assert.EqualError(t, err, tt.expectedErrorStr)
@@ -232,14 +232,14 @@ func TestCreatePullRequest(t *testing.T) {
 }
 
 type FakeClient struct {
-	ts  []templates.Template
-	ps  []templates.TemplateParameter
-	cs  []templates.Credentials
+	ts  []capi.Template
+	ps  []capi.TemplateParameter
+	cs  []capi.Credentials
 	s   string
 	err error
 }
 
-func NewFakeClient(ts []templates.Template, ps []templates.TemplateParameter, cs []templates.Credentials, s string, err error) *FakeClient {
+func NewFakeClient(ts []capi.Template, ps []capi.TemplateParameter, cs []capi.Credentials, s string, err error) *FakeClient {
 	return &FakeClient{
 		ts:  ts,
 		ps:  ps,
@@ -253,7 +253,7 @@ func (c *FakeClient) Source() string {
 	return "In-memory fake"
 }
 
-func (c *FakeClient) RetrieveTemplates() ([]templates.Template, error) {
+func (c *FakeClient) RetrieveTemplates() ([]capi.Template, error) {
 	if c.err != nil {
 		return nil, c.err
 	}
@@ -261,7 +261,7 @@ func (c *FakeClient) RetrieveTemplates() ([]templates.Template, error) {
 	return c.ts, nil
 }
 
-func (c *FakeClient) RetrieveTemplateParameters(name string) ([]templates.TemplateParameter, error) {
+func (c *FakeClient) RetrieveTemplateParameters(name string) ([]capi.TemplateParameter, error) {
 	if c.err != nil {
 		return nil, c.err
 	}
@@ -269,7 +269,7 @@ func (c *FakeClient) RetrieveTemplateParameters(name string) ([]templates.Templa
 	return c.ps, nil
 }
 
-func (c *FakeClient) RenderTemplateWithParameters(name string, parameters map[string]string, creds templates.Credentials) (string, error) {
+func (c *FakeClient) RenderTemplateWithParameters(name string, parameters map[string]string, creds capi.Credentials) (string, error) {
 	if c.err != nil {
 		return "", c.err
 	}
@@ -277,7 +277,7 @@ func (c *FakeClient) RenderTemplateWithParameters(name string, parameters map[st
 	return c.s, nil
 }
 
-func (c *FakeClient) CreatePullRequestFromTemplate(params templates.CreatePullRequestFromTemplateParams) (string, error) {
+func (c *FakeClient) CreatePullRequestFromTemplate(params capi.CreatePullRequestFromTemplateParams) (string, error) {
 	if c.err != nil {
 		return "", c.err
 	}


### PR DESCRIPTION
<!-- Use # to add the issue this pull request is related to -->
Closes: weaveworks/weave-gitops-enterprise#92

<!-- Describe what has changed in this PR -->
**What changed?**
Add `gitops get credentials` command

<!-- Tell your future self why have you made these changes -->
**Why?**
This is part of the ongoing effort to move enterprise commands into the gitops binary.

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**
Tested locally + unit tests

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
**Release notes**
A new command will appear: `gitops get credentials`

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
Follow-up PRs are needed to update the docs accordingly.