### PR TITLE
Export the ApplicationAdd page from the npm module

### DIFF
--- a/ui/index.ts
+++ b/ui/index.ts
@@ -4,12 +4,14 @@ import _useApplications from "./hooks/applications";
 import { Applications as appsClient } from "./lib/api/applications/applications.pb";
 import _Theme from "./lib/theme";
 import _ApplicationDetail from "./pages/ApplicationDetail";
+import _ApplicationAdd from "./pages/ApplicationAdd";
 import _Applications from "./pages/Applications";
 
 export const theme = _Theme;
 export const AppContextProvider = _AppContextProvider;
 export const Applications = _Applications;
 export const ApplicationDetail = _ApplicationDetail;
+export const ApplicationAdd = _ApplicationAdd;
 export const applicationsClient = appsClient;
 export const useApplications = _useApplications;
 export const LoadingPage = _LoadingPage;


### PR DESCRIPTION
- For consuming libs

<!-- Use # to add the issue this pull request is related to -->
Closes: #869 

<!-- Describe what has changed in this PR -->
**What changed?**

Adds an extra `ApplicationAdd` export to the npm module

<!-- Tell your future self why have you made these changes -->
**Why?**

So we can implement the ApplicationAdd flow in our app that embeds weave-gitops


<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**

Locally w/ 
```
cd weave-gitops
make ui-lib

cd ~/app

vim package.json
+  "resolutions": {
+    "**/react": "^17.0.2",
+    "**/react-dom": "^17.0.2"
+  },

yarn add ~/weave-gitops/dist/
```
