### PR TITLE
Support for npm installing the ui-lib via github repo

### DIFF
--- a/.github/workflows/frontend.yaml
+++ b/.github/workflows/frontend.yaml
@@ -47,4 +47,3 @@ jobs:
       - run: make ui-lint
       - run: make ui-test
       - run: make ui-audit
-      - run: make ui-lib

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -65,7 +65,7 @@ jobs:
           registry-url: "https://npm.pkg.github.com"
           scope: "@weaveworks"
       - run: npm install
-      - run: make ui-lib && cd dist && npm publish
+      - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   build-and-push-image:

--- a/Makefile
+++ b/Makefile
@@ -114,11 +114,6 @@ ui-audit: ## Run audit against the UI
 
 ui: ui-deps cmd/gitops/ui/run/dist/main.js ## Build the UI
 
-ui-lib: ui-deps dist/index.js dist/index.d.ts ## Build UI libraries
-# Remove font files from the npm module.
-	@find dist -type f -iname \*.otf -delete
-	@find dist -type f -iname \*.woff -delete
-
 cmd/gitops/ui/run/dist:
 	mkdir -p cmd/gitops/ui/run/dist
 
@@ -136,12 +131,6 @@ lib-test: dependencies ## Run the library integration test
 	docker run -e GITHUB_TOKEN=$$GITHUB_TOKEN -i --rm \
 		-v $(CURRENT_DIR):/go/src/github.com/weaveworks/weave-gitops \
 		 gitops-library-test
-
-dist/index.js: ui/index.ts
-	npm run build:lib && cp package.json dist
-
-dist/index.d.ts: ui/index.ts
-	npm run typedefs
 
 # Test coverage
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@weaveworks/weave-gitops",
   "version": "0.3.1",
+  "main": "dist/index.js",
+  "files": [
+    "dist/**/*.js",
+    "dist/**/*.d.ts"
+  ],
   "description": "Weave GitOps core",
   "targets": {
     "default": {
@@ -19,6 +24,7 @@
   },
   "scripts": {
     "preinstall": "npm install --package-lock-only --ignore-scripts && npx npm-force-resolutions",
+    "prepare": "npm run build:lib && npm run typedefs",
     "build": "parcel build --target default",
     "build:lib": "parcel build --target lib",
     "typedefs": "npx -p typescript tsc ui/**/*.ts ui/**/*.tsx --resolveJsonModule --skipLibCheck --esModuleInterop --jsx react-jsx --declaration --allowJs --emitDeclarationOnly --outDir dist",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "scripts": {
     "preinstall": "npm install --package-lock-only --ignore-scripts && npx npm-force-resolutions",
-    "prepare": "npm run build:lib && npm run typedefs",
+    "prepack": "npm run build:lib && npm run typedefs",
     "build": "parcel build --target default",
     "build:lib": "parcel build --target lib",
     "typedefs": "npx -p typescript tsc ui/**/*.ts ui/**/*.tsx --resolveJsonModule --skipLibCheck --esModuleInterop --jsx react-jsx --declaration --allowJs --emitDeclarationOnly --outDir dist",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "scripts": {
     "preinstall": "npm install --package-lock-only --ignore-scripts && npx npm-force-resolutions",
-    "prepack": "npm run build:lib && npm run typedefs",
+    "prepare": "npm run build:lib && npm run typedefs",
     "build": "parcel build --target default",
     "build:lib": "parcel build --target lib",
     "typedefs": "npx -p typescript tsc ui/**/*.ts ui/**/*.tsx --resolveJsonModule --skipLibCheck --esModuleInterop --jsx react-jsx --declaration --allowJs --emitDeclarationOnly --outDir dist",


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Adds a `prepare` step to the package.json [scripts section](https://docs.npmjs.com/cli/v7/using-npm/scripts#npm-install). npm/yarn will run `prepare` during `npm install weave-gitops` and so we can neatly bundle and generate typedefs in the consuming library's build process.

It also runs on `publish` which simplifies that process somewhat and we don't need to manually move files around.

<!-- Tell your future self why have you made these changes -->
**Why?**

Allows us to consume the weave-gitops ui library from git directly and from an arbitrary commit so that we can test changes more easily before they are merged to `main` or released.


<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**

`npm publish --prepare` will now do the same thing that `make ui-lib` used to do.

**Caveats**

`prepare` is _also_ run on a vanilla `npm install` / `npm ci` (e.g. not only on `npm install weave-gitops` ([justification](https://stackoverflow.com/a/63293078)). This will slow down a few of the of the gh-action jobs. (10s on my macbook but gh-actions can sometimes be slow).
