### PR TITLE
Fix manifest ordering bug and add type safety to yamls

### DIFF
--- a/pkg/services/app/add_test.go
+++ b/pkg/services/app/add_test.go
@@ -597,7 +597,7 @@ var _ = Describe("Add", func() {
 				result := wego.Application{}
 				// Convert back to a struct to make the comparison more forgiving.
 				// A straight string/byte comparison doesn't account for un-ordered keys in yaml.
-				Expect(yaml.Unmarshal(out, &result))
+				Expect(yaml.Unmarshal(out.ToAppYAML(), &result))
 
 				diff := cmp.Diff(result, desired2)
 				Expect(diff).To(Equal(""))
@@ -812,13 +812,13 @@ var _ = Describe("Add", func() {
 			})
 
 			It("creates the pull request against the default branch for an org app repository", func() {
-				Expect(appSrv.(*App).createPullRequestToRepo(ctx, info, info.appRepoUrl, "hash", []byte{}, []byte{}, []byte{})).To(Succeed())
+				Expect(appSrv.(*App).createPullRequestToRepo(ctx, info, info.appRepoUrl, "hash", emptyAppManifest(), emptySource(), emptyAutomation())).To(Succeed())
 				_, _, prInfo := gitProviders.CreatePullRequestArgsForCall(0)
 				Expect(prInfo.TargetBranch).To(Equal("default-app-branch"))
 			})
 
 			It("creates the pull request against the default branch for a user app repository", func() {
-				Expect(appSrv.(*App).createPullRequestToRepo(ctx, info, info.appRepoUrl, "hash", []byte{}, []byte{}, []byte{})).To(Succeed())
+				Expect(appSrv.(*App).createPullRequestToRepo(ctx, info, info.appRepoUrl, "hash", emptyAppManifest(), emptySource(), emptyAutomation())).To(Succeed())
 				_, _, prInfo := gitProviders.CreatePullRequestArgsForCall(0)
 				Expect(prInfo.TargetBranch).To(Equal("default-app-branch"))
 			})
@@ -830,13 +830,13 @@ var _ = Describe("Add", func() {
 			})
 
 			It("creates the pull request against the default branch for an org config repository", func() {
-				Expect(appSrv.(*App).createPullRequestToRepo(ctx, info, info.configRepoUrl, "hash", []byte{}, []byte{}, []byte{})).To(Succeed())
+				Expect(appSrv.(*App).createPullRequestToRepo(ctx, info, info.configRepoUrl, "hash", emptyAppManifest(), emptySource(), emptyAutomation())).To(Succeed())
 				_, _, prInfo := gitProviders.CreatePullRequestArgsForCall(0)
 				Expect(prInfo.TargetBranch).To(Equal("default-config-branch"))
 			})
 
 			It("creates the pull request against the default branch for a user config repository", func() {
-				Expect(appSrv.(*App).createPullRequestToRepo(ctx, info, info.configRepoUrl, "hash", []byte{}, []byte{}, []byte{})).To(Succeed())
+				Expect(appSrv.(*App).createPullRequestToRepo(ctx, info, info.configRepoUrl, "hash", emptyAppManifest(), emptySource(), emptyAutomation())).To(Succeed())
 				_, _, prInfo := gitProviders.CreatePullRequestArgsForCall(0)
 				Expect(prInfo.TargetBranch).To(Equal("default-config-branch"))
 			})
@@ -1163,4 +1163,16 @@ var _ = Describe("New directory structure", func() {
 func getHash(inputs ...string) string {
 	final := []byte(strings.Join(inputs, ""))
 	return fmt.Sprintf("%x", md5.Sum(final))
+}
+
+func emptySource() Source {
+	return source{yaml: []byte{}}
+}
+
+func emptyAutomation() Automation {
+	return automation{yaml: []byte{}}
+}
+
+func emptyAppManifest() AppManifest {
+	return appManifest{yaml: []byte{}}
 }

--- a/pkg/services/app/interfaces.go
+++ b/pkg/services/app/interfaces.go
@@ -1,0 +1,37 @@
+package app
+
+type Automation interface {
+	ToAutomationYAML() []byte
+}
+
+type automation struct {
+	yaml []byte
+}
+
+func (a automation) ToAutomationYAML() []byte {
+	return a.yaml
+}
+
+type Source interface {
+	ToSourceYAML() []byte
+}
+
+type source struct {
+	yaml []byte
+}
+
+func (s source) ToSourceYAML() []byte {
+	return s.yaml
+}
+
+type AppManifest interface {
+	ToAppYAML() []byte
+}
+
+type appManifest struct {
+	yaml []byte
+}
+
+func (a appManifest) ToAppYAML() []byte {
+	return a.yaml
+}


### PR DESCRIPTION
Fixes an issue where manifests were named backwards due to arguments being out of order. Notice the filenames here:

![Screenshot from 2021-10-15 10-18-27](https://user-images.githubusercontent.com/2802257/138142431-4ed38fd8-6bb3-471d-96f7-f93b52b2c6b8.png)


![Screenshot from 2021-10-15 10-18-21](https://user-images.githubusercontent.com/2802257/138142444-cf8920ef-96aa-4413-81d6-5bf15df18386.png)
This goes one step further and adds type safety so that a compile error will be thrown if the manifest files are added out of order.