### PR TITLE
Fix parsing a url as none

### DIFF
--- a/pkg/services/app/add.go
+++ b/pkg/services/app/add.go
@@ -816,7 +816,7 @@ func getAppResourceInfo(app wego.Application, clusterName string) (*AppResourceI
 		}
 	}
 
-	if app.Spec.ConfigURL != "" && app.Spec.ConfigURL != string(ConfigTypeNone) {
+	if IsExternalConfigUrl(app.Spec.ConfigURL) {
 		configRepoUrl, err = gitproviders.NewRepoURL(app.Spec.ConfigURL)
 		if err != nil {
 			return nil, err

--- a/pkg/services/app/add_test.go
+++ b/pkg/services/app/add_test.go
@@ -576,11 +576,12 @@ var _ = Describe("Add", func() {
 			It("generates the app yaml", func() {
 				repoURL := "ssh://git@github.com/example/my-source"
 				params := AddParams{
-					Name:      "my-app",
-					Namespace: wego.DefaultNamespace,
-					Url:       repoURL,
-					Path:      "manifests",
-					Branch:    "main",
+					Name:         "my-app",
+					Namespace:    wego.DefaultNamespace,
+					Url:          repoURL,
+					AppConfigUrl: "none",
+					Path:         "manifests",
+					Branch:       "main",
 				}
 
 				info, err := getAppResourceInfo(makeWegoApplication(params), "")


### PR DESCRIPTION
<!-- Use # to add the issue this pull request is related to -->
Closes: 

<!-- Describe what has changed in this PR -->
**What changed?**
When a gitlab app was being added there was a check for external config that forgot to capitalize none to NONE so the url was trying to get normalized.

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**
Added none as appConfigUrl to the unit test.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
**Release notes**

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**