### PR TITLE
Publish binary with latest postfix

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,7 @@
 on:
   push:
-    #branches:
-    #  - main
+    branches:
+      - main
   workflow_dispatch:
 
 name: Deploy
@@ -183,7 +183,7 @@ jobs:
 
   publish-binaries:
     runs-on: ${{matrix.os}}
-    needs: [build]
+    needs: [acceptance-tests]
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest]


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
It publishes the gitops binaries with `latest` postfix. 


<!-- Tell your future self why have you made these changes -->
**Why?**
So that it can be easily identified by the downstream projects e.g. gitops-enterprise for its automation testing.

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**
By build and autotmated acceptance tests as well as manually verifying on the S3 bucket if binaries with correct name and git hash are uploaded.