### PR TITLE
build needs to be explicity dep for env variable to work

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -183,7 +183,7 @@ jobs:
 
   publish-binaries:
     runs-on: ${{matrix.os}}
-    needs: [acceptance-tests]
+    needs: [build, acceptance-tests]
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest]


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Make build job as an explicit dependency for the publish job.

<!-- Tell your future self why have you made these changes -->
**Why?**
It turns out indirect job dependency is not enough

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**
This is going to be tested through this pr