### PR TITLE
switch Dockerfile to "make node-modules" instead of "make ui-deps"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /home/app
 USER node
 COPY --chown=node:node package*.json /home/app/
 COPY --chown=node:node Makefile /home/app/
-RUN make ui-deps
+RUN make node-modules
 COPY --chown=node:node . /home/app/
 RUN make ui
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
A make target changed from `ui-deps` to `node-modules` but the Dockerfile was unchanged. This updates the Dockerfile to use `node-modules`

<!-- Tell your future self why have you made these changes -->
**Why?**
To fix a problem in the release process

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**
We will test it in the release

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
**Release notes**
No

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
No