### PR TITLE
Pass user token to API when creating/deleting CAPI clusters

### DIFF
--- a/cmd/gitops/add/clusters/cmd.go
+++ b/cmd/gitops/add/clusters/cmd.go
@@ -1,6 +1,7 @@
 package clusters
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -82,6 +83,10 @@ func getClusterCmdRunE(endpoint *string, client *resty.Client) func(*cobra.Comma
 
 		if flags.DryRun {
 			return capi.RenderTemplateWithParameters(flags.Template, vals, creds, r, os.Stdout)
+		}
+
+		if flags.RepositoryURL == "" {
+			return errors.New("repository url is required")
 		}
 
 		token, err := apputils.GetTokenForRepositoryURL(flags.RepositoryURL)

--- a/cmd/gitops/add/clusters/cmd_test.go
+++ b/cmd/gitops/add/clusters/cmd_test.go
@@ -1,0 +1,24 @@
+package clusters_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/go-resty/resty/v2"
+	"github.com/jarcoal/httpmock"
+	"github.com/weaveworks/weave-gitops/cmd/gitops/add/clusters"
+)
+
+func TestClusterCommand_URL(t *testing.T) {
+	e := "http://localhost"
+	client := resty.New()
+	httpmock.ActivateNonDefault(client.GetClient())
+	cmd := clusters.ClusterCommand(&e, client)
+	actual := cmd.Execute()
+	expected := errors.New("repository url is required")
+
+	if actual == nil || !strings.Contains(actual.Error(), expected.Error()) {
+		t.Fatalf("expected %q but got %q", expected, actual)
+	}
+}

--- a/cmd/gitops/delete/clusters/cmd.go
+++ b/cmd/gitops/delete/clusters/cmd.go
@@ -1,11 +1,13 @@
 package clusters
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/go-resty/resty/v2"
 	"github.com/spf13/cobra"
 	"github.com/weaveworks/weave-gitops/pkg/adapters"
+	"github.com/weaveworks/weave-gitops/pkg/apputils"
 	"github.com/weaveworks/weave-gitops/pkg/clusters"
 )
 
@@ -51,14 +53,20 @@ func deleteClusterCmdRunE(endpoint *string, client *resty.Client) func(*cobra.Co
 			return err
 		}
 
+		token, err := apputils.GetTokenForRepositoryURL(clustersDeleteCmdFlags.RepositoryURL)
+		if err != nil {
+			return fmt.Errorf("failed to get token for git repository %q: %w", clustersDeleteCmdFlags.RepositoryURL, err)
+		}
+
 		return clusters.DeleteClusters(clusters.DeleteClustersParams{
-			RepositoryURL: clustersDeleteCmdFlags.RepositoryURL,
-			HeadBranch:    clustersDeleteCmdFlags.HeadBranch,
-			BaseBranch:    clustersDeleteCmdFlags.BaseBranch,
-			Title:         clustersDeleteCmdFlags.Title,
-			Description:   clustersDeleteCmdFlags.Description,
-			ClustersNames: args,
-			CommitMessage: clustersDeleteCmdFlags.CommitMessage,
+			GitProviderToken: token,
+			RepositoryURL:    clustersDeleteCmdFlags.RepositoryURL,
+			HeadBranch:       clustersDeleteCmdFlags.HeadBranch,
+			BaseBranch:       clustersDeleteCmdFlags.BaseBranch,
+			Title:            clustersDeleteCmdFlags.Title,
+			Description:      clustersDeleteCmdFlags.Description,
+			ClustersNames:    args,
+			CommitMessage:    clustersDeleteCmdFlags.CommitMessage,
 		}, r, os.Stdout)
 	}
 }

--- a/cmd/gitops/delete/clusters/cmd.go
+++ b/cmd/gitops/delete/clusters/cmd.go
@@ -1,6 +1,7 @@
 package clusters
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -51,6 +52,10 @@ func deleteClusterCmdRunE(endpoint *string, client *resty.Client) func(*cobra.Co
 		r, err := adapters.NewHttpClient(*endpoint, client, os.Stdout)
 		if err != nil {
 			return err
+		}
+
+		if clustersDeleteCmdFlags.RepositoryURL == "" {
+			return errors.New("repository url is required")
 		}
 
 		token, err := apputils.GetTokenForRepositoryURL(clustersDeleteCmdFlags.RepositoryURL)

--- a/cmd/gitops/delete/clusters/cmd_test.go
+++ b/cmd/gitops/delete/clusters/cmd_test.go
@@ -1,0 +1,25 @@
+package clusters_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/go-resty/resty/v2"
+	"github.com/jarcoal/httpmock"
+	"github.com/weaveworks/weave-gitops/cmd/gitops/delete/clusters"
+)
+
+func TestClusterCommand_URL(t *testing.T) {
+	e := "http://localhost"
+	client := resty.New()
+	httpmock.ActivateNonDefault(client.GetClient())
+	cmd := clusters.ClusterCommand(&e, client)
+	cmd.SetArgs([]string{"cluster-name"})
+	actual := cmd.Execute()
+	expected := errors.New("repository url is required")
+
+	if actual == nil || !strings.Contains(actual.Error(), expected.Error()) {
+		t.Fatalf("expected %q but got %q", expected, actual)
+	}
+}

--- a/pkg/adapters/http.go
+++ b/pkg/adapters/http.go
@@ -245,6 +245,7 @@ func (c *HTTPClient) CreatePullRequestFromTemplate(params capi.CreatePullRequest
 
 	res, err := c.client.R().
 		SetHeader("Accept", "application/json").
+		SetHeader("Git-Provider-Token", params.GitProviderToken).
 		SetBody(CreatePullRequestFromTemplateRequest{
 			RepositoryURL:   params.RepositoryURL,
 			HeadBranch:      params.HeadBranch,
@@ -442,6 +443,7 @@ func (c *HTTPClient) DeleteClusters(params clusters.DeleteClustersParams) (strin
 
 	res, err := c.client.R().
 		SetHeader("Accept", "application/json").
+		SetHeader("Git-Provider-Token", params.GitProviderToken).
 		SetBody(DeleteClustersPullRequestRequest{
 			HeadBranch:    params.HeadBranch,
 			BaseBranch:    params.BaseBranch,

--- a/pkg/apputils/utils.go
+++ b/pkg/apputils/utils.go
@@ -241,3 +241,29 @@ func GetAuthService(ctx context.Context, normalizedUrl gitproviders.RepoURL, dry
 
 	return auth.NewAuthService(fluxClient, rawClient, gitProvider, logger)
 }
+
+// GetTokenForRepositoryURL returns a token that is used to authenticate with
+// a git provider.
+func GetTokenForRepositoryURL(repoURL string) (string, error) {
+	clients, err := GetBaseClients()
+	if err != nil {
+		return "", err
+	}
+
+	normalizedURL, err := gitproviders.NewRepoURL(repoURL)
+	if err != nil {
+		return "", fmt.Errorf("failed to normalize URL %q: %w", repoURL, err)
+	}
+
+	authHandler, err := auth.NewAuthCLIHandler(normalizedURL.Provider())
+	if err != nil {
+		return "", fmt.Errorf("error initializing cli auth handler: %w", err)
+	}
+
+	token, err := auth.GetToken(normalizedURL, clients.Osys, clients.Logger, authHandler)
+	if err != nil {
+		return "", fmt.Errorf("failed to get git provider token: %w", err)
+	}
+
+	return token, nil
+}

--- a/pkg/capi/capi.go
+++ b/pkg/capi/capi.go
@@ -60,15 +60,16 @@ type Credentials struct {
 }
 
 type CreatePullRequestFromTemplateParams struct {
-	TemplateName    string
-	ParameterValues map[string]string
-	RepositoryURL   string
-	HeadBranch      string
-	BaseBranch      string
-	Title           string
-	Description     string
-	CommitMessage   string
-	Credentials     Credentials
+	GitProviderToken string
+	TemplateName     string
+	ParameterValues  map[string]string
+	RepositoryURL    string
+	HeadBranch       string
+	BaseBranch       string
+	Title            string
+	Description      string
+	CommitMessage    string
+	Credentials      Credentials
 }
 
 // GetTemplates uses a TemplatesRetriever adapter to show

--- a/pkg/clusters/clusters.go
+++ b/pkg/clusters/clusters.go
@@ -105,11 +105,12 @@ func DeleteClusters(params DeleteClustersParams, r ClustersRetriever, w io.Write
 }
 
 type DeleteClustersParams struct {
-	RepositoryURL string
-	HeadBranch    string
-	BaseBranch    string
-	Title         string
-	Description   string
-	ClustersNames []string
-	CommitMessage string
+	GitProviderToken string
+	RepositoryURL    string
+	HeadBranch       string
+	BaseBranch       string
+	Title            string
+	Description      string
+	ClustersNames    []string
+	CommitMessage    string
 }


### PR DESCRIPTION
<!-- Use # to add the issue this pull request is related to -->
Closes: weaveworks/weave-gitops-enterprise#203

<!-- Describe what has changed in this PR -->
**What changed?**
- Extract `GetToken` out of `InitGitProvider`
- Use `GetToken` to pass git provider token to API as a header

<!-- Tell your future self why have you made these changes -->
**Why?**
This change allows cluster creation/deletion PRs to be created under the user account.

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**
No new tests were added but tested locally.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
**Release notes**
N/A

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
Follow up PRs for docs should be created after the back end change to use the tokens.