### PR TITLE
Fix capi template being rendered without identityRef

### DIFF
--- a/pkg/capi/capi.go
+++ b/pkg/capi/capi.go
@@ -52,11 +52,11 @@ type TemplateParameter struct {
 }
 
 type Credentials struct {
-	Group     string
-	Version   string
-	Kind      string
-	Name      string
-	Namespace string
+	Group     string `json:"group"`
+	Version   string `json:"version"`
+	Kind      string `json:"kind"`
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
 }
 
 type CreatePullRequestFromTemplateParams struct {


### PR DESCRIPTION
<!-- Use # to add the issue this pull request is related to -->
Closes: weaveworks/weave-gitops-enterprise#211

<!-- Describe what has changed in this PR -->
**What changed?**
Added json keys to credentials struct

<!-- Tell your future self why have you made these changes -->
**Why?**
To fix credentials not being inject in render template error

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**
Tested locally

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
**Release notes**

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**