### PR TITLE
Fix overflowing text in graph nodes (#899)

### DIFF
--- a/ui/components/ReconciliationGraph.tsx
+++ b/ui/components/ReconciliationGraph.tsx
@@ -47,7 +47,7 @@ const NodeHtml = ({ object }: NodeHtmlProps) => {
         {object.name}
       </Flex>
       <Flex center wide align className="kind">
-        <div className='kind-text'>{object.groupVersionKind.kind}</div>
+        <div className="kind-text">{object.groupVersionKind.kind}</div>
       </Flex>
       <Flex center wide align>
         <div className={`status ${object.status}`}>


### PR DESCRIPTION
Closes:  #899 🌞 

Changes overflow attributes of the 'kind' field to overflow: hidden, and text-overflow: ellipsis. Check it out!!! 

<img width="1259" alt="TextOverflow" src="https://user-images.githubusercontent.com/65822698/139101242-babb5496-93e7-4dfc-bbe6-ddba2fefe2e0.png">

We could definitely expand on this quick fix as part of #876


