### PR TITLE
Move `app add` to `add app`

### DIFF
--- a/cmd/gitops/add/app/cmd.go
+++ b/cmd/gitops/add/app/cmd.go
@@ -1,4 +1,4 @@
-package add
+package app
 
 // Provides support for adding an application to gitops managment.
 
@@ -25,20 +25,17 @@ const (
 var params app.AddParams
 
 var Cmd = &cobra.Command{
-	Use:   "add [--name <name>] [--url <url>] [--branch <branch>] [--path <path within repository>] <repository directory>",
+	Use:   "app [--name <name>] [--url <url>] [--branch <branch>] [--path <path within repository>] <repository directory>",
 	Short: "Add a workload repository to a gitops cluster",
 	Long: strings.TrimSpace(dedent.Dedent(`
         Associates an additional application in a git repository with a gitops cluster so that its contents may be managed via GitOps
     `)),
 	Example: `
   # Add application to gitops control from local git repository
-  gitops app add .
+  gitops add app .
 
   # Add podinfo application to gitops control from github repository
-  gitops app add --url git@github.com:myorg/podinfo
-
-  # Get status of podinfo application
-  gitops app status podinfo
+  gitops add app --url git@github.com:myorg/podinfo
 `,
 	RunE:          runCmd,
 	SilenceUsage:  true,
@@ -57,8 +54,8 @@ func init() {
 	Cmd.Flags().StringVar(&params.Chart, "chart", "", "Specify chart for helm source")
 	Cmd.Flags().StringVar(&params.AppConfigUrl, "app-config-url", "", "URL of external repository (if any) which will hold automation manifests; NONE to store only in the cluster")
 	Cmd.Flags().StringVar(&params.HelmReleaseTargetNamespace, "helm-release-target-namespace", "", "Namespace in which to deploy a helm chart; defaults to the gitops installation namespace")
-	Cmd.Flags().BoolVar(&params.DryRun, "dry-run", false, "If set, 'gitops app add' will not make any changes to the system; it will just display the actions that would have been taken")
-	Cmd.Flags().BoolVar(&params.AutoMerge, "auto-merge", false, "If set, 'gitops app add' will merge automatically into the set --branch")
+	Cmd.Flags().BoolVar(&params.DryRun, "dry-run", false, "If set, 'gitops add app' will not make any changes to the system; it will just display the actions that would have been taken")
+	Cmd.Flags().BoolVar(&params.AutoMerge, "auto-merge", false, "If set, 'gitops add app' will merge automatically into the set --branch")
 }
 
 func ensureUrlIsValid() error {

--- a/cmd/gitops/add/app/cmd_test.go
+++ b/cmd/gitops/add/app/cmd_test.go
@@ -1,4 +1,4 @@
-package add
+package app
 
 import (
 	"testing"

--- a/cmd/gitops/add/cmd.go
+++ b/cmd/gitops/add/cmd.go
@@ -3,6 +3,7 @@ package add
 import (
 	"github.com/go-resty/resty/v2"
 	"github.com/spf13/cobra"
+	"github.com/weaveworks/weave-gitops/cmd/gitops/add/app"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/add/clusters"
 )
 
@@ -11,11 +12,15 @@ func GetCommand(endpoint *string, client *resty.Client) *cobra.Command {
 		Use:   "add",
 		Short: "Add a new Weave GitOps resource",
 		Example: `
+# Add an application to gitops from local git repository
+gitops add app . --name <app-name>
+
 # Add a new cluster using a CAPI template
 gitops add cluster`,
 	}
 
 	cmd.AddCommand(clusters.ClusterCommand(endpoint, client))
+	cmd.AddCommand(app.Cmd)
 
 	return cmd
 }

--- a/cmd/gitops/app/cmd.go
+++ b/cmd/gitops/app/cmd.go
@@ -7,7 +7,6 @@ import (
 	"github.com/fluxcd/go-git-providers/gitprovider"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"github.com/weaveworks/weave-gitops/cmd/gitops/app/add"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/app/list"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/app/pause"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/app/remove"
@@ -26,9 +25,6 @@ var ApplicationCmd = &cobra.Command{
 	Example: `
   # Get last 10 commits for an application
   gitops app <app-name> get commits
-
-  # Add an application to gitops from local git repository
-  gitops app add . --name <app-name>
 
   # Remove an application from gitops
   gitops app remove <app-name>
@@ -49,7 +45,6 @@ var ApplicationCmd = &cobra.Command{
 }
 
 func init() {
-	ApplicationCmd.AddCommand(add.Cmd)
 	ApplicationCmd.AddCommand(remove.Cmd)
 	ApplicationCmd.AddCommand(list.Cmd)
 	ApplicationCmd.AddCommand(status.Cmd)

--- a/cmd/gitops/beta/cmd/add/app.go
+++ b/cmd/gitops/beta/cmd/add/app.go
@@ -23,7 +23,7 @@ var (
 var AppCmd = &cobra.Command{
 	Use:   "app",
 	Short: "Adds an application workload to the GitOps repository",
-	Long: `This command mirrors the original app add command in 
+	Long: `This command mirrors the original add app command in 
 	that it adds the definition for the application to the repository 
 	and sets up syncing into a cluster. It uses the new directory
 	structure.`,

--- a/cmd/gitops/main.go
+++ b/cmd/gitops/main.go
@@ -48,12 +48,12 @@ var rootCmd = &cobra.Command{
   gitops help app
 
   # Add application to gitops control from a local git repository
-  gitops app add . --name <myapp>
+  gitops add app . --name <myapp>
   OR
-  gitops app add <myapp-directory>
+  gitops add app <myapp-directory>
 
   # Add application to gitops control from a github repository
-  gitops app add \
+  gitops add app \
     --name <myapp> \
     --url git@github.com:myorg/<myapp> \
     --branch prod-<myapp>
@@ -61,9 +61,9 @@ var rootCmd = &cobra.Command{
   # Get status of application under gitops control
   gitops app status podinfo
 
-  # Get help for gitops app add command
-  gitops app add -h
-  gitops help app add
+  # Get help for gitops add app command
+  gitops add app -h
+  gitops help add app
 
   # Show manifests that would be installed by the gitops gitops install command
   gitops install --dry-run

--- a/pkg/osys/osys.go
+++ b/pkg/osys/osys.go
@@ -49,7 +49,7 @@ func (o *OsysClient) Unsetenv(envVar string) error {
 	return os.Unsetenv(envVar)
 }
 
-// The following three functions are used by both "app add" and "app remove".
+// The following three functions are used by both "add app" and "app remove".
 // They are here rather than in "utils" so they can use the (potentially mocked)
 // local versions of UserHomeDir, LookupEnv, and Stdin and so that they can also
 // be mocked (e.g. we might want to mock the private key password handing).

--- a/pkg/services/app/remove_test.go
+++ b/pkg/services/app/remove_test.go
@@ -61,7 +61,7 @@ func populateAppRepo() (string, error) {
 	return dir, nil
 }
 
-// Track all resources created during a "wego app add" so that they can be looked up by "kind" and "name"
+// Track all resources created during a "gitops add app" so that they can be looked up by "kind" and "name"
 func storeCreatedResource(manifestData []byte) error {
 	manifests := bytes.Split(manifestData, []byte("\n---\n"))
 	for _, manifest := range manifests {
@@ -209,7 +209,7 @@ func updateAppInfoFromParams() error {
 	return nil
 }
 
-// Run 'wego app add' and gather the resources we expect to be generated
+// Run 'gitops add app' and gather the resources we expect to be generated
 func runAddAndCollectInfo() error {
 	if err := updateAppInfoFromParams(); err != nil {
 		return err

--- a/test/acceptance/test/add_tests.go
+++ b/test/acceptance/test/add_tests.go
@@ -20,7 +20,7 @@ import (
 
 var clusterName string
 
-var _ = Describe("Weave GitOps App Add Tests", func() {
+var _ = Describe("Weave GitOps Add App Tests", func() {
 
 	deleteWegoRuntime := false
 	if os.Getenv("DELETE_WEGO_RUNTIME_ON_EACH_TEST") == "true" {
@@ -50,8 +50,8 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 		tip := generateTestInputs()
 		appRepoRemoteURL := "ssh://git@github.com/" + GITHUB_ORG + "/" + tip.appRepoName + ".git"
 
-		addCommand1 := "app add . --auto-merge=true"
-		addCommand2 := "app add . --url=" + appRepoRemoteURL + " --auto-merge=true"
+		addCommand1 := "add app . --auto-merge=true"
+		addCommand2 := "add app . --url=" + appRepoRemoteURL + " --auto-merge=true"
 
 		defer deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
 
@@ -104,7 +104,7 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 		appName := tip.appRepoName
 		appType := "Kustomization"
 
-		addCommand := "app add --url=" + appRepoRemoteURL + " --branch=" + branchName + " --dry-run" + " --auto-merge=true"
+		addCommand := "add app --url=" + appRepoRemoteURL + " --branch=" + branchName + " --dry-run" + " --auto-merge=true"
 
 		defer deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
 		defer deleteWorkload(tip.workloadName, tip.workloadNamespace)
@@ -130,7 +130,7 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 			createGitRepoBranch(repoAbsolutePath, branchName)
 		})
 
-		By("And I run 'gitops app add dry-run' command", func() {
+		By("And I run 'gitops add app dry-run' command", func() {
 			addCommandOutput, _ = runWegoAddCommandWithOutput(repoAbsolutePath, addCommand, WEGO_DEFAULT_NAMESPACE)
 		})
 
@@ -164,7 +164,7 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 		tip := generateTestInputs()
 		appName := tip.appRepoName
 
-		addCommand := "app add . --auto-merge=true"
+		addCommand := "add app . --auto-merge=true"
 
 		defer deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
 		defer deleteWorkload(tip.workloadName, tip.workloadNamespace)
@@ -213,7 +213,7 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 		appName := tip.appRepoName
 		var appRemoveOutput *gexec.Session
 
-		addCommand := "app add . --auto-merge=true"
+		addCommand := "add app . --auto-merge=true"
 
 		defer deleteRepo(tip.appRepoName, gitproviders.GitProviderGitLab, GITLAB_ORG)
 		defer deleteWorkload(tip.workloadName, tip.workloadNamespace)
@@ -289,7 +289,7 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 		appName := tip.appRepoName
 		appRepoRemoteURL := "ssh://git@github.com/" + GITHUB_ORG + "/" + appName + ".git"
 
-		addCommand := "app add --url=" + appRepoRemoteURL + " --branch=" + branchName + " --namespace=" + wegoNamespace + " --deployment-type=kustomize --app-config-url=NONE"
+		addCommand := "add app --url=" + appRepoRemoteURL + " --branch=" + branchName + " --namespace=" + wegoNamespace + " --deployment-type=kustomize --app-config-url=NONE"
 
 		defer deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
 		defer deleteWorkload(tip.workloadName, tip.workloadNamespace)
@@ -441,7 +441,7 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 		appRepoRemoteURL := "ssh://git@github.com/" + GITHUB_ORG + "/" + tip.appRepoName + ".git"
 		configRepoRemoteURL = "ssh://git@github.com/" + GITHUB_ORG + "/" + appConfigRepoName + ".git"
 
-		addCommand := "app add --url=" + appRepoRemoteURL + " --app-config-url=" + configRepoRemoteURL + " --auto-merge=true"
+		addCommand := "add app --url=" + appRepoRemoteURL + " --app-config-url=" + configRepoRemoteURL + " --auto-merge=true"
 
 		defer deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
 		defer deleteRepo(appConfigRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
@@ -491,7 +491,7 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 		appRepoRemoteURL := "ssh://git@gitlab.com/" + GITLAB_ORG + "/" + tip.appRepoName + ".git"
 		configRepoRemoteURL = "ssh://git@gitlab.com/" + GITLAB_ORG + "/" + appConfigRepoName + ".git"
 
-		addCommand := "app add --url=" + appRepoRemoteURL + " --app-config-url=" + configRepoRemoteURL + " --auto-merge=true"
+		addCommand := "add app --url=" + appRepoRemoteURL + " --app-config-url=" + configRepoRemoteURL + " --auto-merge=true"
 
 		defer deleteRepo(tip.appRepoName, gitproviders.GitProviderGitLab, GITLAB_ORG)
 		defer deleteRepo(appConfigRepoName, gitproviders.GitProviderGitHub, GITLAB_ORG)
@@ -555,7 +555,7 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 		appName := tip.appRepoName
 		appRepoRemoteURL := "ssh://git@github.com/" + GITHUB_ORG + "/" + tip.appRepoName + ".git"
 
-		addCommand := "app add --url=" + appRepoRemoteURL + " --auto-merge=true"
+		addCommand := "add app --url=" + appRepoRemoteURL + " --auto-merge=true"
 
 		defer deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
 		defer deleteWorkload(tip.workloadName, tip.workloadNamespace)
@@ -593,7 +593,7 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 		tip := generateTestInputs()
 		appName := tip.appRepoName
 
-		addCommand := "app add " + tip.appRepoName + "/" + " --auto-merge=true"
+		addCommand := "add app " + tip.appRepoName + "/" + " --auto-merge=true"
 
 		defer deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
 		defer deleteWorkload(tip.workloadName, tip.workloadNamespace)
@@ -637,7 +637,7 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 		appRepoName := "wego-test-app-" + RandString(8)
 		appName := appRepoName
 
-		addCommand := "app add . --name=" + appName + " --auto-merge=true"
+		addCommand := "add app . --name=" + appName + " --auto-merge=true"
 
 		defer deleteRepo(appRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
 		defer deleteWorkload(tip1.workloadName, tip1.workloadNamespace)
@@ -693,7 +693,7 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 		appName1 := appRepoName1
 		appName2 := appRepoName2
 
-		addCommand := "app add . --app-config-url=" + configRepoRemoteURL + " --auto-merge=true"
+		addCommand := "add app . --app-config-url=" + configRepoRemoteURL + " --auto-merge=true"
 
 		defer deleteRepo(appRepoName1, gitproviders.GitProviderGitHub, GITHUB_ORG)
 		defer deleteRepo(appRepoName2, gitproviders.GitProviderGitHub, GITHUB_ORG)
@@ -721,13 +721,13 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 			gitAddCommitPush(appConfigRepoAbsPath, readmeFilePath)
 		})
 
-		By("And I create a repo with my app1 workload and run the add the command on it", func() {
+		By("And I create a repo with my app1 workload and run the add app command on it", func() {
 			repoAbsolutePath = initAndCreateEmptyRepo(appRepoName1, gitproviders.GitProviderGitHub, private, GITHUB_ORG)
 			gitAddCommitPush(repoAbsolutePath, tip1.appManifestFilePath)
 			runWegoAddCommand(repoAbsolutePath, addCommand, WEGO_DEFAULT_NAMESPACE)
 		})
 
-		By("And I create a repo with my app2 workload and run the add the command on it", func() {
+		By("And I create a repo with my app2 workload and run the add app command on it", func() {
 			repoAbsolutePath = initAndCreateEmptyRepo(appRepoName2, gitproviders.GitProviderGitHub, private, GITHUB_ORG)
 			gitAddCommitPush(repoAbsolutePath, tip2.appManifestFilePath)
 			runWegoAddCommand(repoAbsolutePath, addCommand, WEGO_DEFAULT_NAMESPACE)
@@ -750,8 +750,8 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 		appName1 := "app1"
 		appName2 := "app2"
 
-		addCommand1 := "app add . --path=./" + appName1 + " --name=" + appName1 + " --auto-merge=true"
-		addCommand2 := "app add . --path=./" + appName2 + " --name=" + appName2 + " --auto-merge=true"
+		addCommand1 := "add app . --path=./" + appName1 + " --name=" + appName1 + " --auto-merge=true"
+		addCommand2 := "add app . --path=./" + appName2 + " --name=" + appName2 + " --auto-merge=true"
 
 		defer deleteRepo(appRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
 		defer deleteWorkload(tip1.workloadName, tip1.workloadNamespace)
@@ -770,7 +770,7 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 			installAndVerifyWego(WEGO_DEFAULT_NAMESPACE)
 		})
 
-		By("And I create a repo with my app1 and app2 workloads and run the add the command for each app", func() {
+		By("And I create a repo with my app1 and app2 workloads and run the add app command for each app", func() {
 			repoAbsolutePath = initAndCreateEmptyRepo(appRepoName, gitproviders.GitProviderGitHub, private, GITHUB_ORG)
 			app1Path := createSubDir(appName1, repoAbsolutePath)
 			app2Path := createSubDir(appName2, repoAbsolutePath)
@@ -813,9 +813,9 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 		appName3 := "loki"
 		workloadName3 := "loki-0"
 
-		addCommand1 := "app add . --app-config-url=" + configRepoRemoteURL + " --auto-merge=true"
-		addCommand2 := "app add . --deployment-type=helm --path=./hello-world --name=" + appName2 + " --app-config-url=" + configRepoRemoteURL + " --auto-merge=true"
-		addCommand3 := "app add --url=" + helmRepoURL + " --chart=" + appName3 + " --app-config-url=" + configRepoRemoteURL + " --auto-merge=true"
+		addCommand1 := "add app . --app-config-url=" + configRepoRemoteURL + " --auto-merge=true"
+		addCommand2 := "add app . --deployment-type=helm --path=./hello-world --name=" + appName2 + " --app-config-url=" + configRepoRemoteURL + " --auto-merge=true"
+		addCommand3 := "add app --url=" + helmRepoURL + " --chart=" + appName3 + " --app-config-url=" + configRepoRemoteURL + " --auto-merge=true"
 
 		defer deleteRepo(appFilesRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
 		defer deleteRepo(appConfigRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
@@ -846,7 +846,7 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 			installAndVerifyWego(WEGO_DEFAULT_NAMESPACE)
 		})
 
-		By("And I run gitops app add command for app1: "+appName1, func() {
+		By("And I run gitops add app command for app1: "+appName1, func() {
 			runWegoAddCommand(repoAbsolutePath, addCommand1, WEGO_DEFAULT_NAMESPACE)
 		})
 
@@ -859,7 +859,7 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 			gitAddCommitPush(repoAbsolutePath, appManifestFilePath2)
 		})
 
-		By("And I run gitops app add command for app2: "+appName2, func() {
+		By("And I run gitops add app command for app2: "+appName2, func() {
 			runWegoAddCommand(repoAbsolutePath, addCommand2, WEGO_DEFAULT_NAMESPACE)
 		})
 
@@ -869,7 +869,7 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 			Expect(waitForResource("configmaps", "helloworld-configmap", WEGO_DEFAULT_NAMESPACE, INSTALL_PODS_READY_TIMEOUT)).To(Succeed())
 		})
 
-		By("When I run gitops app add command for app3: "+appName3, func() {
+		By("When I run gitops add app command for app3: "+appName3, func() {
 			runWegoAddCommand(repoAbsolutePath, addCommand3, WEGO_DEFAULT_NAMESPACE)
 		})
 
@@ -974,8 +974,8 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 		public := false
 		replicaSetValue := 3
 
-		addCommand1 := "app add . --name=" + appName1 + " --auto-merge=true"
-		addCommand2 := "app add . --name=" + appName2 + " --auto-merge=true"
+		addCommand1 := "add app . --name=" + appName1 + " --auto-merge=true"
+		addCommand2 := "add app . --name=" + appName2 + " --auto-merge=true"
 
 		defer deleteRepo(tip1.appRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
 		defer deleteRepo(tip2.appRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
@@ -1012,19 +1012,19 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 			installAndVerifyWego(WEGO_DEFAULT_NAMESPACE)
 		})
 
-		By("And I run gitops app add command for 1st app", func() {
+		By("And I run gitops add app command for 1st app", func() {
 			runWegoAddCommand(repoAbsolutePath1, addCommand1, WEGO_DEFAULT_NAMESPACE)
 		})
 
-		By("And I run gitops app add command for 2nd app", func() {
+		By("And I run gitops add app command for 2nd app", func() {
 			runWegoAddCommand(repoAbsolutePath2, addCommand2, WEGO_DEFAULT_NAMESPACE)
 		})
 
-		By("Then I should see gitops app add command linked the repo1 to the cluster", func() {
+		By("Then I should see gitops add app command linked the repo1 to the cluster", func() {
 			verifyWegoAddCommand(appName1, WEGO_DEFAULT_NAMESPACE)
 		})
 
-		By("And I should see gitops app add command linked the repo2 to the cluster", func() {
+		By("And I should see gitops add app command linked the repo2 to the cluster", func() {
 			verifyWegoAddCommand(appName2, WEGO_DEFAULT_NAMESPACE)
 		})
 
@@ -1194,7 +1194,7 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 		appRepoName := "wego-test-app-" + RandString(8)
 		badAppName := "foo"
 
-		addCommand := "app add . --deployment-type=helm --path=./hello-world --name=" + appName + " --app-config-url=NONE"
+		addCommand := "add app . --deployment-type=helm --path=./hello-world --name=" + appName + " --app-config-url=NONE"
 
 		defer deleteRepo(appRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
 
@@ -1237,7 +1237,7 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 			VerifyControllersInCluster(WEGO_DEFAULT_NAMESPACE)
 		})
 
-		By("When I rerun gitops app add command", func() {
+		By("When I rerun gitops add app command", func() {
 			_, reAddOutput = runCommandAndReturnStringOutput(fmt.Sprintf("cd %s && %s %s", repoAbsolutePath, WEGO_BIN_PATH, addCommand))
 		})
 
@@ -1274,7 +1274,7 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 		appManifestFilePath := "./data/helm-repo/hello-world"
 		appRepoName := "wego-test-app-" + RandString(8)
 
-		addCommand := "app add . --deployment-type=helm --path=./hello-world --name=" + appName + " --auto-merge=true"
+		addCommand := "add app . --deployment-type=helm --path=./hello-world --name=" + appName + " --auto-merge=true"
 
 		defer deleteRepo(appRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
 
@@ -1317,7 +1317,7 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 		configRepoName := "wego-test-config-repo-" + RandString(8)
 		configRepoUrl := fmt.Sprintf("ssh://git@github.com/%s/%s.git", os.Getenv("GITHUB_ORG"), configRepoName)
 
-		addCommand := fmt.Sprintf("app add . --app-config-url=%s --deployment-type=helm --path=./hello-world --name=%s --auto-merge=true", configRepoUrl, appName)
+		addCommand := fmt.Sprintf("add app . --app-config-url=%s --deployment-type=helm --path=./hello-world --name=%s --auto-merge=true", configRepoUrl, appName)
 
 		defer deleteRepo(appRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
 		defer deleteRepo(configRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
@@ -1387,8 +1387,8 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 		appRepoRemoteURL := "ssh://git@github.com/" + GITHUB_ORG + "/" + appRepoName + ".git"
 		helmRepoURL := "https://charts.bitnami.com/bitnami"
 
-		addCommand1 := "app add --url=" + helmRepoURL + " --chart=" + appName1 + " --app-config-url=" + appRepoRemoteURL + " --auto-merge=true"
-		addCommand2 := "app add --url=" + helmRepoURL + " --chart=" + appName2 + " --app-config-url=" + appRepoRemoteURL + " --auto-merge=true --helm-release-target-namespace=" + workloadNamespace2
+		addCommand1 := "add app --url=" + helmRepoURL + " --chart=" + appName1 + " --app-config-url=" + appRepoRemoteURL + " --auto-merge=true"
+		addCommand2 := "add app --url=" + helmRepoURL + " --chart=" + appName2 + " --app-config-url=" + appRepoRemoteURL + " --auto-merge=true --helm-release-target-namespace=" + workloadNamespace2
 
 		defer deletePersistingHelmApp(WEGO_DEFAULT_NAMESPACE, workloadName1, EVENTUALLY_DEFAULT_TIMEOUT)
 		defer deletePersistingHelmApp(WEGO_DEFAULT_NAMESPACE, workloadName2, EVENTUALLY_DEFAULT_TIMEOUT)
@@ -1419,16 +1419,16 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 		})
 
 		By("And I add a invalid entry without --app-config-url set", func() {
-			addCommand := "app add --url=" + helmRepoURL + " --chart=" + appName1 + " --auto-merge=true"
+			addCommand := "add app --url=" + helmRepoURL + " --chart=" + appName1 + " --auto-merge=true"
 			_, err := runWegoAddCommandWithOutput(repoAbsolutePath, addCommand, WEGO_DEFAULT_NAMESPACE)
 			Eventually(err).Should(ContainSubstring("--app-config-url should be provided or set to NONE"))
 		})
 
-		By("And I run gitops app add command for 1st app", func() {
+		By("And I run gitops add app command for 1st app", func() {
 			runWegoAddCommand(repoAbsolutePath, addCommand1, WEGO_DEFAULT_NAMESPACE)
 		})
 
-		By("And I run gitops app add command for 2nd app", func() {
+		By("And I run gitops add app command for 2nd app", func() {
 			runWegoAddCommand(repoAbsolutePath, addCommand2, WEGO_DEFAULT_NAMESPACE)
 		})
 
@@ -1485,7 +1485,7 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 		workloadName := "loki-0"
 		helmRepoURL := "https://charts.kube-ops.io"
 
-		addCommand := "app add --url=" + helmRepoURL + " --chart=" + appName + " --app-config-url=NONE"
+		addCommand := "add app --url=" + helmRepoURL + " --chart=" + appName + " --app-config-url=NONE"
 
 		defer deletePersistingHelmApp(WEGO_DEFAULT_NAMESPACE, workloadName, EVENTUALLY_DEFAULT_TIMEOUT)
 
@@ -1513,7 +1513,7 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 		appName := tip.appRepoName
 		prLink := ""
 
-		addCommand := "app add . --name=" + appName + " --auto-merge=false"
+		addCommand := "add app . --name=" + appName + " --auto-merge=false"
 
 		defer deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
 		defer deleteWorkload(tip.workloadName, tip.workloadNamespace)
@@ -1534,7 +1534,7 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 			installAndVerifyWego(WEGO_DEFAULT_NAMESPACE)
 		})
 
-		By("When I run gitops app add command for app", func() {
+		By("When I run gitops add app command for app", func() {
 			output, _ := runWegoAddCommandWithOutput(repoAbsolutePath, addCommand, WEGO_DEFAULT_NAMESPACE)
 			re := regexp.MustCompile(`(http|ftp|https):\/\/([\w\-_]+(?:(?:\.[\w\-_]+)+))([\w\-\.,@?^=%&amp;:/~\+#]*[\w\-\@?^=%&amp;/~\+#])?`)
 			prLink = re.FindAllString(output, -1)[0]
@@ -1560,7 +1560,7 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 		appName := tip.appRepoName
 		prLink := ""
 
-		addCommand := "app add . --name=" + appName + " --auto-merge=false"
+		addCommand := "add app . --name=" + appName + " --auto-merge=false"
 
 		defer deleteRepo(tip.appRepoName, gitproviders.GitProviderGitLab, GITLAB_ORG)
 		defer deleteWorkload(tip.workloadName, tip.workloadNamespace)
@@ -1585,7 +1585,7 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 			installAndVerifyWego(WEGO_DEFAULT_NAMESPACE)
 		})
 
-		By("When I run gitops app add command for app", func() {
+		By("When I run gitops add app command for app", func() {
 			output, _ := runWegoAddCommandWithOutput(repoAbsolutePath, addCommand, WEGO_DEFAULT_NAMESPACE)
 			re := regexp.MustCompile(`(http|ftp|https):\/\/([\w\-_]+(?:(?:\.[\w\-_]+)+))([\w\-\.,@?^=%&amp;:/~\+#]*[\w\-\@?^=%&amp;/~\+#])?`)
 			prLink = re.FindAllString(output, -1)[0]
@@ -1616,7 +1616,7 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 		appConfigRepoName := "wego-config-repo-" + RandString(8)
 		configRepoRemoteURL = "ssh://git@github.com/" + GITHUB_ORG + "/" + appConfigRepoName + ".git"
 
-		addCommand := "app add . --app-config-url=" + configRepoRemoteURL
+		addCommand := "add app . --app-config-url=" + configRepoRemoteURL
 
 		defer deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
 		defer deleteRepo(appConfigRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
@@ -1669,8 +1669,8 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 		appName2 := tip2.appRepoName
 		prLink := "https://github.com/" + GITHUB_ORG + "/" + tip.appRepoName + "/pull/1"
 
-		addCommand := "app add . --name=" + appName
-		addCommand2 := "app add . --name=" + appName2
+		addCommand := "add app . --name=" + appName
+		addCommand2 := "add app . --name=" + appName2
 
 		defer deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
 		defer deleteWorkload(tip.workloadName, tip.workloadNamespace)
@@ -1691,7 +1691,7 @@ var _ = Describe("Weave GitOps App Add Tests", func() {
 			installAndVerifyWego(WEGO_DEFAULT_NAMESPACE)
 		})
 
-		By("And I run app add command for "+appName, func() {
+		By("And I run add app command for "+appName, func() {
 			runWegoAddCommand(repoAbsolutePath, addCommand, WEGO_DEFAULT_NAMESPACE)
 		})
 
@@ -1756,7 +1756,7 @@ var _ = Describe("Weave GitOps Add Tests With Long Cluster Name", func() {
 		workloadNamespace := tip.workloadNamespace
 		appManifestFilePath := tip.appManifestFilePath
 
-		addCommand := "app add . --app-config-url=" + configRepoRemoteURL + " --auto-merge=true"
+		addCommand := "add app . --app-config-url=" + configRepoRemoteURL + " --auto-merge=true"
 
 		defer deleteRepo(appFilesRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
 		defer deleteRepo(appConfigRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
@@ -1785,7 +1785,7 @@ var _ = Describe("Weave GitOps Add Tests With Long Cluster Name", func() {
 			installAndVerifyWego(WEGO_DEFAULT_NAMESPACE)
 		})
 
-		By("And I run gitops app add command for app: "+appName, func() {
+		By("And I run gitops add app command for app: "+appName, func() {
 			runWegoAddCommand(repoAbsolutePath, addCommand, WEGO_DEFAULT_NAMESPACE)
 		})
 
@@ -1844,7 +1844,7 @@ var _ = Describe("Weave GitOps Add Tests With Long Cluster Name", func() {
 		workloadNamespace := tip.workloadNamespace
 		appManifestFilePath := tip.appManifestFilePath
 
-		addCommand := "app add . --app-config-url=" + configRepoRemoteURL + " --auto-merge=true"
+		addCommand := "add app . --app-config-url=" + configRepoRemoteURL + " --auto-merge=true"
 
 		defer deleteRepo(appFilesRepoName, gitproviders.GitProviderGitLab, GITLAB_ORG)
 		defer deleteRepo(appConfigRepoName, gitproviders.GitProviderGitLab, GITLAB_ORG)
@@ -1877,7 +1877,7 @@ var _ = Describe("Weave GitOps Add Tests With Long Cluster Name", func() {
 			installAndVerifyWego(WEGO_DEFAULT_NAMESPACE)
 		})
 
-		By("And I run gitops app add command for app: "+appName, func() {
+		By("And I run gitops add app command for app: "+appName, func() {
 			runWegoAddCommand(repoAbsolutePath, addCommand, WEGO_DEFAULT_NAMESPACE)
 		})
 

--- a/test/acceptance/test/help_tests.go
+++ b/test/acceptance/test/help_tests.go
@@ -72,22 +72,22 @@ var _ = XDescribe("WEGO Help Tests", func() {
 		})
 	})
 
-	It("Verify that gitops app add help flag prints the help text", func() {
+	It("Verify that gitops add app help flag prints the help text", func() {
 
-		By("When I run the command 'gitops app add -h' ", func() {
-			stringOutput, _ = runCommandAndReturnStringOutput(WEGO_BIN_PATH + " app add -h")
+		By("When I run the command 'gitops add app -h' ", func() {
+			stringOutput, _ = runCommandAndReturnStringOutput(WEGO_BIN_PATH + " add app -h")
 		})
 
-		By("Then I should see help message printed for gitops app add", func() {
+		By("Then I should see help message printed for gitops add app", func() {
 			Eventually(stringOutput).Should(MatchRegexp(`Associates an additional application in a git repository with a gitops cluster so that its contents may be managed via GitOps\n*Usage:`))
-			Eventually(stringOutput).Should(MatchRegexp(`gitops app add \[--name <name>] \[--url <url>] \[--branch <branch>] \[--path <path within repository>] \ <repository directory> \[flags]`))
-			Eventually(stringOutput).Should(MatchRegexp(`Examples:\ngitops app add .\n*Flags:`))
+			Eventually(stringOutput).Should(MatchRegexp(`gitops add app \[--name <name>] \[--url <url>] \[--branch <branch>] \[--path <path within repository>] \ <repository directory> \[flags]`))
+			Eventually(stringOutput).Should(MatchRegexp(`Examples:\ngitops add app .\n*Flags:`))
 			Eventually(stringOutput).Should(MatchRegexp(`--app-config-url string\s*URL of external repository \(if any\) which will hold automation manifests; NONE to store only in the cluster`))
-			Eventually(stringOutput).Should(MatchRegexp(`--auto-merge\s*If set, 'gitops app add' will merge automatically into the set`))
+			Eventually(stringOutput).Should(MatchRegexp(`--auto-merge\s*If set, 'gitops add app' will merge automatically into the set`))
 			Eventually(stringOutput).Should(MatchRegexp(`--branch\n\s*--branch string\s*Branch to watch within git repository \(default "main"\)`))
 			Eventually(stringOutput).Should(MatchRegexp(`--chart string\s*Specify chart for helm source`))
 			Eventually(stringOutput).Should(MatchRegexp(`--deployment-type string\s*deployment type \[kustomize, helm] \(default "kustomize"\)`))
-			Eventually(stringOutput).Should(MatchRegexp(`--dry-run\s*If set, 'gitops app add' will not make any changes to the system; it will just display the actions that would have been taken`))
+			Eventually(stringOutput).Should(MatchRegexp(`--dry-run\s*If set, 'gitops add app' will not make any changes to the system; it will just display the actions that would have been taken`))
 			Eventually(stringOutput).Should(MatchRegexp(`-h, --help\s*help for add`))
 			Eventually(stringOutput).Should(MatchRegexp(`--name string\s*Name of remote git repository`))
 			Eventually(stringOutput).Should(MatchRegexp(`--path string\s*Path of files within git repository \(default "\.\/"\)`))


### PR DESCRIPTION
<!-- Use # to add the issue this pull request is related to -->
Part of: weaveworks/weave-gitops#858

<!-- Describe what has changed in this PR -->
**What changed?**
`gitops app add` becomes `gitops add app`


<!-- Tell your future self why have you made these changes -->
**Why?**
This is part of changing commands from `noun verb` to `verb noun`

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**
Tested locally

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
**Release notes**
CLI breaking change: `gitops app add` has become `gitops add app`

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
Docs will need to be updated so will do follow up PRs once this is merged