### PR TITLE
Move `app pause`/`app unpause` to `suspend app`/`resume app` respectively

### DIFF
--- a/cmd/gitops/app/cmd.go
+++ b/cmd/gitops/app/cmd.go
@@ -8,9 +8,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/app/list"
-	"github.com/weaveworks/weave-gitops/cmd/gitops/app/pause"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/app/status"
-	"github.com/weaveworks/weave-gitops/cmd/gitops/app/unpause"
 	"github.com/weaveworks/weave-gitops/pkg/apputils"
 	"github.com/weaveworks/weave-gitops/pkg/logger"
 	"github.com/weaveworks/weave-gitops/pkg/services/app"
@@ -29,13 +27,7 @@ var ApplicationCmd = &cobra.Command{
   gitops app status <app-name>
 
   # List applications under gitops control
-  gitops app list
-
-  # Pause gitops automation
-  gitops app pause <app-name>
-
-  # Unpause gitops automation
-  gitops app unpause <app-name>`,
+  gitops app list`,
 	Args: cobra.MinimumNArgs(3),
 	RunE: runCmd,
 }
@@ -43,8 +35,6 @@ var ApplicationCmd = &cobra.Command{
 func init() {
 	ApplicationCmd.AddCommand(list.Cmd)
 	ApplicationCmd.AddCommand(status.Cmd)
-	ApplicationCmd.AddCommand(pause.Cmd)
-	ApplicationCmd.AddCommand(unpause.Cmd)
 }
 
 func runCmd(cmd *cobra.Command, args []string) error {

--- a/cmd/gitops/main.go
+++ b/cmd/gitops/main.go
@@ -16,6 +16,8 @@ import (
 	"github.com/weaveworks/weave-gitops/cmd/gitops/flux"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/get"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/install"
+	"github.com/weaveworks/weave-gitops/cmd/gitops/resume"
+	"github.com/weaveworks/weave-gitops/cmd/gitops/suspend"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/ui"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/uninstall"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/upgrade"
@@ -127,6 +129,8 @@ func main() {
 	rootCmd.AddCommand(get.GetCommand(&options.endpoint, restyClient))
 	rootCmd.AddCommand(add.GetCommand(&options.endpoint, restyClient))
 	rootCmd.AddCommand(delete.DeleteCommand(&options.endpoint, restyClient))
+	rootCmd.AddCommand(resume.GetCommand())
+	rootCmd.AddCommand(suspend.GetCommand())
 	rootCmd.AddCommand(upgrade.Cmd)
 	rootCmd.AddCommand(docs.Cmd)
 

--- a/cmd/gitops/resume/app/cmd.go
+++ b/cmd/gitops/resume/app/cmd.go
@@ -1,4 +1,4 @@
-package pause
+package app
 
 import (
 	"context"
@@ -11,13 +11,13 @@ import (
 	"github.com/weaveworks/weave-gitops/pkg/services/app"
 )
 
-var params app.PauseParams
+var params app.UnpauseParams
 
 var Cmd = &cobra.Command{
-	Use:           "pause <app-name>",
-	Short:         "Pause an application",
+	Use:           "app <app-name>",
+	Short:         "Resume an application",
 	Args:          cobra.MinimumNArgs(1),
-	Example:       "gitops app pause podinfo",
+	Example:       "gitops resume app podinfo",
 	RunE:          runCmd,
 	SilenceUsage:  true,
 	SilenceErrors: true,
@@ -37,8 +37,8 @@ func runCmd(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to create app service: %w", appError)
 	}
 
-	if err := appService.Pause(params); err != nil {
-		return errors.Wrapf(err, "failed to pause the app %s", params.Name)
+	if err := appService.Unpause(params); err != nil {
+		return errors.Wrapf(err, "failed to unpause the app %s", params.Name)
 	}
 
 	return nil

--- a/cmd/gitops/resume/cmd.go
+++ b/cmd/gitops/resume/cmd.go
@@ -1,0 +1,20 @@
+package resume
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/weaveworks/weave-gitops/cmd/gitops/resume/app"
+)
+
+func GetCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "resume",
+		Short: "Resume your GitOps automations",
+		Example: `
+# Resume gitops automation
+gitops resume app <app-name>`,
+	}
+
+	cmd.AddCommand(app.Cmd)
+
+	return cmd
+}

--- a/cmd/gitops/suspend/app/cmd.go
+++ b/cmd/gitops/suspend/app/cmd.go
@@ -1,4 +1,4 @@
-package unpause
+package app
 
 import (
 	"context"
@@ -11,13 +11,13 @@ import (
 	"github.com/weaveworks/weave-gitops/pkg/services/app"
 )
 
-var params app.UnpauseParams
+var params app.PauseParams
 
 var Cmd = &cobra.Command{
-	Use:           "unpause <app-name>",
-	Short:         "Unpause an application",
+	Use:           "app <app-name>",
+	Short:         "Suspend an application",
 	Args:          cobra.MinimumNArgs(1),
-	Example:       "gitops app unpause podinfo",
+	Example:       "gitops suspend app podinfo",
 	RunE:          runCmd,
 	SilenceUsage:  true,
 	SilenceErrors: true,
@@ -37,8 +37,8 @@ func runCmd(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to create app service: %w", appError)
 	}
 
-	if err := appService.Unpause(params); err != nil {
-		return errors.Wrapf(err, "failed to unpause the app %s", params.Name)
+	if err := appService.Pause(params); err != nil {
+		return errors.Wrapf(err, "failed to pause the app %s", params.Name)
 	}
 
 	return nil

--- a/cmd/gitops/suspend/cmd.go
+++ b/cmd/gitops/suspend/cmd.go
@@ -1,0 +1,20 @@
+package suspend
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/weaveworks/weave-gitops/cmd/gitops/suspend/app"
+)
+
+func GetCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "suspend",
+		Short: "Suspend your GitOps automations",
+		Example: `
+# Suspend gitops automation
+gitops suspend app <app-name>`,
+	}
+
+	cmd.AddCommand(app.Cmd)
+
+	return cmd
+}

--- a/test/acceptance/test/add_tests.go
+++ b/test/acceptance/test/add_tests.go
@@ -361,8 +361,8 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 			Eventually(appStatus).Should(gbytes.Say(`kustomization/` + appName + `\s*True\s*.*` + branchName + `/.*False`))
 		})
 
-		By("When I pause the app under user-defined namespace", func() {
-			pauseOutput, _ = runCommandAndReturnStringOutput(WEGO_BIN_PATH + " app pause " + appName + " --namespace=" + wegoNamespace)
+		By("When I suspend the app under user-defined namespace", func() {
+			pauseOutput, _ = runCommandAndReturnStringOutput(WEGO_BIN_PATH + " suspend app " + appName + " --namespace=" + wegoNamespace)
 		})
 
 		By("Then I should see pause message", func() {
@@ -391,7 +391,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 
 		By("When I unpause the app under user-defined namespace", func() {
-			unpauseOutput, _ = runCommandAndReturnStringOutput(WEGO_BIN_PATH + " app unpause " + appName + " --namespace=" + wegoNamespace)
+			unpauseOutput, _ = runCommandAndReturnStringOutput(WEGO_BIN_PATH + " resume app " + appName + " --namespace=" + wegoNamespace)
 		})
 
 		By("Then I should see unpause message", func() {
@@ -1070,8 +1070,8 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 			Eventually(listOutput).Should(ContainSubstring(appName2))
 		})
 
-		By("When I pause an app: "+appName1, func() {
-			pauseOutput, _ = runCommandAndReturnStringOutput(WEGO_BIN_PATH + " app pause " + appName1)
+		By("When I suspend an app: "+appName1, func() {
+			pauseOutput, _ = runCommandAndReturnStringOutput(WEGO_BIN_PATH + " suspend app " + appName1)
 		})
 
 		By("Then I should see pause message", func() {
@@ -1099,8 +1099,8 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 			Expect(replicaOutput).To(ContainSubstring("1"))
 		})
 
-		By("When I re-run app pause command", func() {
-			pauseOutput, _ = runCommandAndReturnStringOutput(WEGO_BIN_PATH + " app pause " + appName1)
+		By("When I re-run suspend app command", func() {
+			pauseOutput, _ = runCommandAndReturnStringOutput(WEGO_BIN_PATH + " suspend app " + appName1)
 		})
 
 		By("Then I should see a console message without any errors", func() {
@@ -1108,7 +1108,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 
 		By("When I unpause an app: "+appName1, func() {
-			unpauseOutput, _ = runCommandAndReturnStringOutput(WEGO_BIN_PATH + " app unpause " + appName1)
+			unpauseOutput, _ = runCommandAndReturnStringOutput(WEGO_BIN_PATH + " resume app " + appName1)
 		})
 
 		By("Then I should see unpause message", func() {
@@ -1122,8 +1122,8 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 			Expect(replicaOutput).To(ContainSubstring(strconv.Itoa(replicaSetValue)))
 		})
 
-		By("When I re-run app unpause command", func() {
-			unpauseOutput, _ = runCommandAndReturnStringOutput(WEGO_BIN_PATH + " app unpause " + appName1)
+		By("When I re-run resume app command", func() {
+			unpauseOutput, _ = runCommandAndReturnStringOutput(WEGO_BIN_PATH + " resume app " + appName1)
 		})
 
 		By("Then I should see unpause message without any errors", func() {


### PR DESCRIPTION
<!-- Use # to add the issue this pull request is related to -->
Part of: #858  

<!-- Describe what has changed in this PR -->
**What changed?**
`gitops app pause` becomes `gitops suspend app`
`gitops app unpause` becomes `gitops resume app`

<!-- Tell your future self why have you made these changes -->
**Why?**
This is part of the decision to change commands from `noun verb` to `verb noun`

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**
Tested locally

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
**Release notes**
CLI breaking changes: 
- `gitops app pause` has become `gitops suspend app`
- `gitops app unpause` has become `gitops resume app`

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
Should be updated automatically