### PR TITLE
Move `app list` to `get apps`

### DIFF
--- a/cmd/gitops/app/cmd.go
+++ b/cmd/gitops/app/cmd.go
@@ -7,7 +7,6 @@ import (
 	"github.com/fluxcd/go-git-providers/gitprovider"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"github.com/weaveworks/weave-gitops/cmd/gitops/app/list"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/app/status"
 	"github.com/weaveworks/weave-gitops/pkg/apputils"
 	"github.com/weaveworks/weave-gitops/pkg/logger"
@@ -24,16 +23,12 @@ var ApplicationCmd = &cobra.Command{
   gitops app <app-name> get commits
 
   # Status an application under gitops control
-  gitops app status <app-name>
-
-  # List applications under gitops control
-  gitops app list`,
+  gitops app status <app-name>`,
 	Args: cobra.MinimumNArgs(3),
 	RunE: runCmd,
 }
 
 func init() {
-	ApplicationCmd.AddCommand(list.Cmd)
 	ApplicationCmd.AddCommand(status.Cmd)
 }
 

--- a/cmd/gitops/get/app/cmd.go
+++ b/cmd/gitops/get/app/cmd.go
@@ -1,4 +1,4 @@
-package list
+package app
 
 import (
 	"context"
@@ -9,9 +9,10 @@ import (
 )
 
 var Cmd = &cobra.Command{
-	Use:     "list",
+	Use:     "app",
+	Aliases: []string{"apps"},
 	Short:   "List applications under gitops control",
-	Example: "gitops app list",
+	Example: "gitops get apps",
 	RunE:    runCmd,
 }
 

--- a/cmd/gitops/get/cmd.go
+++ b/cmd/gitops/get/cmd.go
@@ -3,6 +3,7 @@ package get
 import (
 	"github.com/go-resty/resty/v2"
 	"github.com/spf13/cobra"
+	"github.com/weaveworks/weave-gitops/cmd/gitops/get/app"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/get/clusters"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/get/credentials"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/get/templates"
@@ -13,6 +14,9 @@ func GetCommand(endpoint *string, client *resty.Client) *cobra.Command {
 		Use:   "get",
 		Short: "Display one or many Weave GitOps resources",
 		Example: `
+# Get all applications under gitops control
+gitops get apps
+
 # Get all CAPI templates
 gitops get templates
 
@@ -23,6 +27,7 @@ gitops get credentials
 gitops get clusters`,
 	}
 
+	cmd.AddCommand(app.Cmd)
 	cmd.AddCommand(templates.TemplateCommand(endpoint, client))
 	cmd.AddCommand(credentials.CredentialCommand(endpoint, client))
 	cmd.AddCommand(clusters.ClusterCommand(endpoint, client))

--- a/test/acceptance/test/add_tests.go
+++ b/test/acceptance/test/add_tests.go
@@ -344,8 +344,8 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 			Expect(folderOutput).ShouldNot(ContainSubstring("targets"))
 		})
 
-		By("When I check for app list under user-specified namespace", func() {
-			appList, _ = runCommandAndReturnStringOutput(WEGO_BIN_PATH + " app list " + appName + " --namespace=" + wegoNamespace)
+		By("When I check for apps under user-specified namespace", func() {
+			appList, _ = runCommandAndReturnStringOutput(WEGO_BIN_PATH + " get apps " + appName + " --namespace=" + wegoNamespace)
 		})
 
 		By("Then I should see appName listed", func() {
@@ -909,8 +909,8 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 			Eventually(appStatus3).Should(ContainSubstring(`helmrelease/` + appName3))
 		})
 
-		By("When I check for apps list", func() {
-			listOutput, _ = runCommandAndReturnStringOutput(WEGO_BIN_PATH + " app list")
+		By("When I check for apps", func() {
+			listOutput, _ = runCommandAndReturnStringOutput(WEGO_BIN_PATH + " get apps")
 		})
 
 		By("Then I should see appNames for all apps listed", func() {
@@ -1062,8 +1062,8 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 			Eventually(appStatus2).Should(gbytes.Say(`kustomization/` + appName2))
 		})
 
-		By("When I check for apps list", func() {
-			listOutput, _ = runCommandAndReturnStringOutput(WEGO_BIN_PATH + " app list")
+		By("When I check for apps", func() {
+			listOutput, _ = runCommandAndReturnStringOutput(WEGO_BIN_PATH + " get apps")
 		})
 
 		By("Then I should see appNames for both apps listed", func() {
@@ -1455,8 +1455,8 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 			Expect(folderOutput).Should(ContainSubstring("targets"))
 		})
 
-		By("When I check for apps list", func() {
-			listOutput, _ = runCommandAndReturnStringOutput(WEGO_BIN_PATH + " app list")
+		By("When I check for apps", func() {
+			listOutput, _ = runCommandAndReturnStringOutput(WEGO_BIN_PATH + " get apps")
 		})
 
 		By("Then I should see appNames for both apps listed", func() {
@@ -1809,8 +1809,8 @@ var _ = Describe("Weave GitOps Add Tests With Long Cluster Name", func() {
 			Eventually(appStatus).Should(ContainSubstring(`kustomization/` + appName))
 		})
 
-		By("When I check for apps list", func() {
-			listOutput, _ = runCommandAndReturnStringOutput(WEGO_BIN_PATH + " app list")
+		By("When I check for apps", func() {
+			listOutput, _ = runCommandAndReturnStringOutput(WEGO_BIN_PATH + " get apps")
 		})
 
 		By("Then I should see appNames for all apps listed", func() {
@@ -1901,8 +1901,8 @@ var _ = Describe("Weave GitOps Add Tests With Long Cluster Name", func() {
 			Eventually(appStatus).Should(ContainSubstring(`kustomization/` + appName))
 		})
 
-		By("When I check for apps list", func() {
-			listOutput, _ = runCommandAndReturnStringOutput(WEGO_BIN_PATH + " app list")
+		By("When I check for apps", func() {
+			listOutput, _ = runCommandAndReturnStringOutput(WEGO_BIN_PATH + " get apps")
 		})
 
 		By("Then I should see appNames for all apps listed", func() {

--- a/test/acceptance/test/help_tests.go
+++ b/test/acceptance/test/help_tests.go
@@ -108,16 +108,16 @@ var _ = XDescribe("WEGO Help Tests", func() {
 		})
 	})
 
-	It("Verify that gitops app list help flag prints the help text", func() {
+	It("Verify that gitops get apps help flag prints the help text", func() {
 
-		By("When I run the command 'gitops app list -h' ", func() {
-			stringOutput, _ = runCommandAndReturnStringOutput(WEGO_BIN_PATH + " app list -h")
+		By("When I run the command 'gitops get apps -h' ", func() {
+			stringOutput, _ = runCommandAndReturnStringOutput(WEGO_BIN_PATH + " get apps -h")
 		})
 
-		By("Then I should see help message printed for gitops app list", func() {
-			Eventually(stringOutput).Should(MatchRegexp(`List applications\n*Usage:\n\s*gitops app list \[flags]`))
-			Eventually(stringOutput).Should(MatchRegexp(`Examples:\ngitops app list`))
-			Eventually(stringOutput).Should(MatchRegexp(fmt.Sprintf(`Flags:\n\s*-h, --help\s*help for list\n*\s*Global Flags:\n\s*--namespace string\s*gitops runtime namespace \(default "%s"\)\n\s*-v, --verbose\s*Enable verbose output`, wego.DefaultNamespace)))
+		By("Then I should see help message printed for gitops get apps", func() {
+			Eventually(stringOutput).Should(MatchRegexp(`List applications\n*Usage:\n\s*gitops get app \[flags]`))
+			Eventually(stringOutput).Should(MatchRegexp(`Examples:\ngitops get apps`))
+			Eventually(stringOutput).Should(MatchRegexp(fmt.Sprintf(`Flags:\n\s*-h, --help\s*help for app\n*\s*Global Flags:\n\s*--namespace string\s*gitops runtime namespace \(default "%s"\)\n\s*-v, --verbose\s*Enable verbose output`, wego.DefaultNamespace)))
 		})
 	})
 })

--- a/test/acceptance/test/utils.go
+++ b/test/acceptance/test/utils.go
@@ -483,7 +483,7 @@ func waitForAppRemoval(appName string, timeout time.Duration) error {
 	pollInterval := time.Second * 5
 
 	_ = utils.WaitUntil(os.Stdout, pollInterval, timeout, func() error {
-		command := exec.Command("sh", "-c", fmt.Sprintf("%s app list", WEGO_BIN_PATH))
+		command := exec.Command("sh", "-c", fmt.Sprintf("%s get apps", WEGO_BIN_PATH))
 		session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 		Expect(err).ShouldNot(HaveOccurred())
 		Eventually(session).Should(gexec.Exit())


### PR DESCRIPTION
<!-- Use # to add the issue this pull request is related to -->
Part of: #858  

<!-- Describe what has changed in this PR -->
**What changed?**
`gitops app list` becomes `gitops get apps`

<!-- Tell your future self why have you made these changes -->
**Why?**
This is part of the decision to change commands from `noun verb` to `verb noun`

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**
Tested locally

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
**Release notes**
CLI breaking change: `gitops app list` has become `gitops get apps`

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
Should be updated automatically