### PR TITLE
Move `app <app-name> get commits` to `get commits <app-name>`

### DIFF
--- a/cmd/gitops/app/cmd.go
+++ b/cmd/gitops/app/cmd.go
@@ -1,97 +1,18 @@
 package app
 
 import (
-	"context"
-	"fmt"
-
-	"github.com/fluxcd/go-git-providers/gitprovider"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/app/status"
-	"github.com/weaveworks/weave-gitops/pkg/apputils"
-	"github.com/weaveworks/weave-gitops/pkg/logger"
-	"github.com/weaveworks/weave-gitops/pkg/services/app"
-	"github.com/weaveworks/weave-gitops/pkg/utils"
-	"k8s.io/apimachinery/pkg/types"
 )
 
 var ApplicationCmd = &cobra.Command{
 	Use:   "app",
 	Short: "Manages your applications",
 	Example: `
-  # Get last 10 commits for an application
-  gitops app <app-name> get commits
-
   # Status an application under gitops control
   gitops app status <app-name>`,
-	Args: cobra.MinimumNArgs(3),
-	RunE: runCmd,
 }
 
 func init() {
 	ApplicationCmd.AddCommand(status.Cmd)
-}
-
-func runCmd(cmd *cobra.Command, args []string) error {
-	ctx := context.Background()
-
-	params := app.CommitParams{}
-	params.Name = args[0]
-	params.Namespace, _ = cmd.Parent().Flags().GetString("namespace")
-	// Hardcode PageSize and PageToken until there is a plan around pagination for cli
-	params.PageSize = 10
-	params.PageToken = 0
-
-	command := args[1]
-	object := args[2]
-
-	appService, appError := apputils.GetAppService(ctx, params.Name, params.Namespace)
-	if appError != nil {
-		return fmt.Errorf("failed to create app service: %w", appError)
-	}
-
-	appContent, err := appService.Get(types.NamespacedName{Name: params.Name, Namespace: params.Namespace})
-	if err != nil {
-		return fmt.Errorf("unable to get application for %s %w", params.Name, err)
-	}
-
-	if command != "get" {
-		_ = cmd.Help()
-		return fmt.Errorf("invalid command %s", command)
-	}
-
-	logger := apputils.GetLogger()
-
-	switch object {
-	case "commits":
-		commits, err := appService.GetCommits(params, appContent)
-		if err != nil {
-			return errors.Wrapf(err, "failed to get commits for app %s", params.Name)
-		}
-
-		printCommitTable(logger, commits)
-	default:
-		_ = cmd.Help()
-		return fmt.Errorf("unknown resource type \"%s\"", object)
-	}
-
-	return nil
-}
-
-func printCommitTable(logger logger.Logger, commits []gitprovider.Commit) {
-	header := []string{"Commit Hash", "Created At", "Author", "Message", "URL"}
-	rows := [][]string{}
-
-	for _, commit := range commits {
-		c := commit.Get()
-		rows = append(rows, []string{
-			utils.ConvertCommitHashToShort(c.Sha),
-			utils.CleanCommitCreatedAt(c.CreatedAt),
-			c.Author,
-			utils.CleanCommitMessage(c.Message),
-			utils.ConvertCommitURLToShort(c.URL),
-		})
-	}
-
-	utils.PrintTable(logger, header, rows)
 }

--- a/cmd/gitops/get/cmd.go
+++ b/cmd/gitops/get/cmd.go
@@ -5,6 +5,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/get/app"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/get/clusters"
+	"github.com/weaveworks/weave-gitops/cmd/gitops/get/commits"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/get/credentials"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/get/templates"
 )
@@ -17,6 +18,9 @@ func GetCommand(endpoint *string, client *resty.Client) *cobra.Command {
 # Get all applications under gitops control
 gitops get apps
 
+# Get last 10 commits for an application
+gitops get commits <app-name>
+
 # Get all CAPI templates
 gitops get templates
 
@@ -28,6 +32,7 @@ gitops get clusters`,
 	}
 
 	cmd.AddCommand(app.Cmd)
+	cmd.AddCommand(commits.Cmd)
 	cmd.AddCommand(templates.TemplateCommand(endpoint, client))
 	cmd.AddCommand(credentials.CredentialCommand(endpoint, client))
 	cmd.AddCommand(clusters.ClusterCommand(endpoint, client))

--- a/cmd/gitops/get/commits/cmd.go
+++ b/cmd/gitops/get/commits/cmd.go
@@ -1,0 +1,76 @@
+package commits
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/fluxcd/go-git-providers/gitprovider"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/weaveworks/weave-gitops/pkg/apputils"
+	"github.com/weaveworks/weave-gitops/pkg/logger"
+	"github.com/weaveworks/weave-gitops/pkg/services/app"
+	"github.com/weaveworks/weave-gitops/pkg/utils"
+
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var Cmd = &cobra.Command{
+	Use:   "commits",
+	Short: "Get most recent commits for an application",
+	Example: `
+# Get last 10 commits for an application
+gitops get commits <app-name>`,
+	Args: cobra.ExactArgs(1),
+	RunE: runCmd,
+}
+
+func runCmd(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	params := app.CommitParams{}
+	params.Name = args[0]
+	params.Namespace, _ = cmd.Parent().Flags().GetString("namespace")
+	// Hardcode PageSize and PageToken until there is a plan around pagination for cli
+	params.PageSize = 10
+	params.PageToken = 0
+
+	appService, appError := apputils.GetAppService(ctx, params.Name, params.Namespace)
+	if appError != nil {
+		return fmt.Errorf("failed to create app service: %w", appError)
+	}
+
+	appContent, err := appService.Get(types.NamespacedName{Name: params.Name, Namespace: params.Namespace})
+	if err != nil {
+		return fmt.Errorf("unable to get application for %s %w", params.Name, err)
+	}
+
+	logger := apputils.GetLogger()
+
+	commits, err := appService.GetCommits(params, appContent)
+	if err != nil {
+		return errors.Wrapf(err, "failed to get commits for app %s", params.Name)
+	}
+
+	printCommitTable(logger, commits)
+
+	return nil
+}
+
+func printCommitTable(logger logger.Logger, commits []gitprovider.Commit) {
+	header := []string{"Commit Hash", "Created At", "Author", "Message", "URL"}
+	rows := [][]string{}
+
+	for _, commit := range commits {
+		c := commit.Get()
+		rows = append(rows, []string{
+			utils.ConvertCommitHashToShort(c.Sha),
+			utils.CleanCommitCreatedAt(c.CreatedAt),
+			c.Author,
+			utils.CleanCommitMessage(c.Message),
+			utils.ConvertCommitURLToShort(c.URL),
+		})
+	}
+
+	utils.PrintTable(logger, header, rows)
+}

--- a/test/acceptance/test/add_tests.go
+++ b/test/acceptance/test/add_tests.go
@@ -415,7 +415,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 
 		By("When I check for list of commits for the app", func() {
-			commitList, _ = runCommandAndReturnStringOutput(fmt.Sprintf("%s app %s get commits --namespace=%s", WEGO_BIN_PATH, appName, wegoNamespace))
+			commitList, _ = runCommandAndReturnStringOutput(fmt.Sprintf("%s get commits %s --namespace=%s", WEGO_BIN_PATH, appName, wegoNamespace))
 		})
 
 		By("Then I should see the list of commits for app2", func() {
@@ -935,7 +935,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 
 		By("When I check for list of commits for app1", func() {
-			commitList1, _ = runCommandAndReturnStringOutput(fmt.Sprintf("%s app %s get commits", WEGO_BIN_PATH, appName1))
+			commitList1, _ = runCommandAndReturnStringOutput(fmt.Sprintf("%s get commits %s", WEGO_BIN_PATH, appName1))
 		})
 
 		By("Then I should see the list of commits for app1", func() {
@@ -945,7 +945,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 
 		By("When I check for list of commits for app2", func() {
-			commitList2, _ = runCommandAndReturnStringOutput(fmt.Sprintf("%s app %s get commits", WEGO_BIN_PATH, appName2))
+			commitList2, _ = runCommandAndReturnStringOutput(fmt.Sprintf("%s get commits %s", WEGO_BIN_PATH, appName2))
 		})
 
 		By("Then I should see the list of commits for app2", func() {
@@ -1140,7 +1140,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 
 		By("When I check for list of commits for app2", func() {
-			commitList2, _ = runCommandAndReturnStringOutput(fmt.Sprintf("%s app %s get commits", WEGO_BIN_PATH, appName2))
+			commitList2, _ = runCommandAndReturnStringOutput(fmt.Sprintf("%s get commits %s", WEGO_BIN_PATH, appName2))
 		})
 
 		By("Then I should see the list of commits for app2", func() {
@@ -1165,7 +1165,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 
 		By("When I check for list of commits for app1", func() {
-			commitList1, _ = runCommandAndReturnStringOutput(fmt.Sprintf("%s app %s get commits", WEGO_BIN_PATH, appName1))
+			commitList1, _ = runCommandAndReturnStringOutput(fmt.Sprintf("%s get commits %s", WEGO_BIN_PATH, appName1))
 		})
 
 		By("Then I should see the list of commits for app1", func() {
@@ -1176,7 +1176,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 
 		By("When I check for list of commits for a deleted app", func() {
-			_, commitList2 = runCommandAndReturnStringOutput(fmt.Sprintf("%s app %s get commits", WEGO_BIN_PATH, appName2))
+			_, commitList2 = runCommandAndReturnStringOutput(fmt.Sprintf("%s get commits %s", WEGO_BIN_PATH, appName2))
 		})
 
 		By("Then I should not see the list of commits for app2", func() {


### PR DESCRIPTION
<!-- Use # to add the issue this pull request is related to -->
Closes: #858 

<!-- Describe what has changed in this PR -->
**What changed?**
`gitops app <app-name> get commits` becomes `gitops get commits <app-name>`

<!-- Tell your future self why have you made these changes -->
**Why?**
This is part of the decision to change commands from `noun verb` to `verb noun`

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**
Tested locally

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
**Release notes**
CLI breaking change: `gitops app <app-name> get commits` has become `gitops get commits <app-name>`

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
Should be updated automatically