### PR TITLE
Replacing undescore with dashs on cluster names

### DIFF
--- a/pkg/kube/kubehttp.go
+++ b/pkg/kube/kubehttp.go
@@ -380,5 +380,7 @@ func sanitizeClusterName(s string) string {
 		return s[strings.LastIndex(s, "@")+1:]
 	}
 
+	s = strings.ReplaceAll(s, "_", "-")
+
 	return s
 }

--- a/pkg/kube/kubehttp_test.go
+++ b/pkg/kube/kubehttp_test.go
@@ -310,6 +310,7 @@ metadata:
 				{"user@weave.works@market.eu-west-2.eksctl.io-podinfo", "market.eu-west-2.eksctl.io-podinfo", "user@weave.works@market.eu-west-2.eksctl.io-podinfo"},
 				{"user@market.eu-west-2.eksctl.io-podinfo", "market.eu-west-2.eksctl.io-podinfo", "user@market.eu-west-2.eksctl.io-podinfo"},
 				{"user@market.eu-west-2.eksctl.io-podinfo", "market.eu-west-2.eksctl.io-podinfo", "market.eu-west-2.eksctl.io-podinfo"},
+				{"cluster_name", "cluster-name", "cluster_name"},
 			}
 			for _, test := range tests {
 				createKubeconfig(test.name, test.clusterName, dir, true)


### PR DESCRIPTION
<!-- Use # to add the issue this pull request is related to -->
Closes: #979 

<!-- Describe what has changed in this PR -->
**What changed?**
- Replacing `_` with `-` to comply with https://kubernetes.io/docs/concepts/overview/working-with-objects/names/

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
**Release notes**

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**