### PR TITLE
Move auto-generated CLI reference under "CLI Reference" menu item

### DIFF
--- a/tools/update-docs.sh
+++ b/tools/update-docs.sh
@@ -16,18 +16,21 @@ ex - installation.md << EOS
 wq!
 EOS
 # create CLI reference
-${WEAVE_GITOPS_BINARY} docs
-git add *.md
 git rm -f --ignore-unmatch cli-reference.md
-ex - gitops.md << EOS
+git rm -f --ignore-unmatch cli-reference
+mkdir -p cli-reference
+cd cli-reference
+ex - _category_.json << EOS
 1i
----
-sidebar_position: 3
----
- # CLI Reference
- .
+{
+  "label": "CLI Reference",
+  "position": 3
+}
+.
 wq!
 EOS
+${WEAVE_GITOPS_BINARY} docs
+git add *.md
 # create versioned docs
 cd $WEAVE_GITOPS_DOC_REPO
 version_number=$(cut -f2 -d'v' <<< $GITOPS_VERSION)


### PR DESCRIPTION
<!-- Use # to add the issue this pull request is related to -->
Closes:
- #973 

<!-- Describe what has changed in this PR -->
**What changed?**
The CLI commands are no longer at the top level of the docs; instead, they are under a "CLI Reference" menu item

<!-- Tell your future self why have you made these changes -->
**Why?**
To make the docs easier to read and navigate

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**
A separate forked repository

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
**Release notes**
No

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
These are the updates.