### PR TITLE
Fixes add-app in wego-server

### DIFF
--- a/pkg/kube/kubehttp.go
+++ b/pkg/kube/kubehttp.go
@@ -118,6 +118,7 @@ func inClusterConfigClusterName() string {
 	if clusterName == "" {
 		clusterName = "default"
 	}
+
 	return clusterName
 }
 

--- a/pkg/kube/kubehttp_test.go
+++ b/pkg/kube/kubehttp_test.go
@@ -343,7 +343,21 @@ metadata:
 			createKubeconfig("foo", "bar", dir, false)
 			_, _, err = kube.RestConfig()
 			Expect(err).To(HaveOccurred(), "Should receive an error about no current context ")
-
+		})
+		It("returns a sensisble clusterName inCluster", func() {
+			kube.InClusterConfig = func() (*rest.Config, error) { return nil, nil }
+			_, clusterName, err := kube.RestConfig()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(clusterName).To(Equal("default"))
+		})
+		It("derives the clusterName from the env inCluster", func() {
+			kube.InClusterConfig = func() (*rest.Config, error) { return nil, nil }
+			origcn := os.Getenv("CLUSTER_NAME")
+			defer os.Setenv("CLUSTER_NAME", origcn)
+			os.Setenv("CLUSTER_NAME", "foo")
+			_, clusterName, err := kube.RestConfig()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(clusterName).To(Equal("foo"))
 		})
 	})
 


### PR DESCRIPTION
- Fixes running add-app in-cluster

<!-- Use # to add the issue this pull request is related to -->
Closes: #976 

<!-- Describe what has changed in this PR -->
**What changed?**

Returns a clusterName if running in cluster instead of a URL

<!-- Tell your future self why have you made these changes -->
**Why?**

clusterName is interpolated into secret names and other things, URLs break k8s name validation and so breaks the add-app functionality when running in-cluster.

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**

Unit tests!