### PR TITLE
Commits show up in UI after authentication success

### DIFF
--- a/ui/components/CommitsTable.tsx
+++ b/ui/components/CommitsTable.tsx
@@ -20,6 +20,7 @@ import Link from "./Link";
 type Props = {
   className?: string;
   app: Application;
+  authSuccess: boolean;
   onAuthClick?: () => void;
 };
 
@@ -31,7 +32,7 @@ const timestamp = (isoStr: string) => {
   return DateTime.fromISO(isoStr).toRelative();
 };
 
-function CommitsTable({ className, app, onAuthClick }: Props) {
+function CommitsTable({ className, app, authSuccess, onAuthClick }: Props) {
   const { applicationsClient } = useContext(AppContext);
   const [commits, loading, error, req] = useRequestState<ListCommitsResponse>();
 
@@ -39,7 +40,6 @@ function CommitsTable({ className, app, onAuthClick }: Props) {
     if (!app || !app.name) {
       return;
     }
-
     req(
       applicationsClient.ListCommits({
         name: app.name,
@@ -47,7 +47,7 @@ function CommitsTable({ className, app, onAuthClick }: Props) {
         pageSize: 10,
       })
     );
-  }, [app]);
+  }, [app, authSuccess]);
 
   if (error) {
     return error.code === GrpcErrorCodes.Unauthenticated ? (

--- a/ui/components/__tests__/CommitsTable.test.tsx
+++ b/ui/components/__tests__/CommitsTable.test.tsx
@@ -38,7 +38,9 @@ describe("CommitsTable", () => {
       let c;
       await act(async () => {
         const { container: div } = render(
-          withTheme(withContext(<CommitsTable app={app} />, "/", ovr)),
+          withTheme(
+            withContext(<CommitsTable app={app} authSuccess={true} />, "/", ovr)
+          ),
           container
         );
         c = div;
@@ -60,7 +62,9 @@ describe("CommitsTable", () => {
 
     await act(async () => {
       render(
-        withTheme(withContext(<CommitsTable app={app} />, "/", ovr)),
+        withTheme(
+          withContext(<CommitsTable app={app} authSuccess={true} />, "/", ovr)
+        ),
         container
       );
     });

--- a/ui/pages/ApplicationDetail.tsx
+++ b/ui/pages/ApplicationDetail.tsx
@@ -142,6 +142,7 @@ function ApplicationDetail({ className, name }: Props) {
       <CommitsTable
         // Get CommitsTable to retry after auth
         app={application}
+        authSuccess={authSuccess}
         onAuthClick={() => setGithubAuthModalOpen(true)}
       />
       <Modal


### PR DESCRIPTION
Closes #943 

GitHub authorization now properly refreshes the commits table, and removes false authentication error. 

`authSuccess` is now passed as a prop to `CommitsTable`, and included in the commit request `useEffect` dependency array!