### PR TITLE
Fix selenium for macOS on nightly

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/ory/go-acc v0.2.6
 	github.com/pkg/browser v0.0.0-20210706143420-7d21f8c997e2
 	github.com/pkg/errors v0.9.1
-	github.com/sclevine/agouti v0.0.0-20150218205057-b920a9cc7533
+	github.com/sclevine/agouti v0.0.0-20190613051229-00c1187c74ad
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/viper v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -1046,8 +1046,8 @@ github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb
 github.com/sagikazarmark/crypt v0.1.0/go.mod h1:B/mN0msZuINBtQ1zZLEQcegFJJf9vnYIR88KRMEuODE=
 github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da/go.mod h1:gi+0XIa01GRL2eRQVjQkKGqKF3SF9vZR/HnPullcV2E=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
-github.com/sclevine/agouti v0.0.0-20150218205057-b920a9cc7533 h1:C8CNhlXfT7crFBeOd6Jm3YJSbuDIO0WTtwJat7xk4Z0=
-github.com/sclevine/agouti v0.0.0-20150218205057-b920a9cc7533/go.mod h1:b4WX9W9L1sfQKXeJf1mUTLZKJ48R1S7H23Ji7oFO5Bw=
+github.com/sclevine/agouti v0.0.0-20190613051229-00c1187c74ad h1:iHldBFNRphEV/wQmj8WnOnosdQJEYg77MKE8GdsobNQ=
+github.com/sclevine/agouti v0.0.0-20190613051229-00c1187c74ad/go.mod h1:b4WX9W9L1sfQKXeJf1mUTLZKJ48R1S7H23Ji7oFO5Bw=
 github.com/sclevine/spec v1.4.0 h1:z/Q9idDcay5m5irkZ28M7PtQM4aOISzOpj4bUPkDee8=
 github.com/sclevine/spec v1.4.0/go.mod h1:LvpgJaFyvQzRvc1kaDs0bulYwzC70PbiYjC4QnFHkOM=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=

--- a/test/acceptance/test/add_tests.go
+++ b/test/acceptance/test/add_tests.go
@@ -21,7 +21,7 @@ import (
 
 var clusterName string
 
-var _ = Describe("Weave GitOps Add App Tests", func() {
+var _ = XDescribe("Weave GitOps Add App Tests", func() {
 
 	deleteWegoRuntime := false
 	if os.Getenv("DELETE_WEGO_RUNTIME_ON_EACH_TEST") == "true" {

--- a/test/acceptance/test/add_tests.go
+++ b/test/acceptance/test/add_tests.go
@@ -21,7 +21,7 @@ import (
 
 var clusterName string
 
-var _ = XDescribe("Weave GitOps Add App Tests", func() {
+var _ = Describe("Weave GitOps Add App Tests", func() {
 
 	deleteWegoRuntime := false
 	if os.Getenv("DELETE_WEGO_RUNTIME_ON_EACH_TEST") == "true" {

--- a/test/acceptance/test/ui_tests.go
+++ b/test/acceptance/test/ui_tests.go
@@ -81,9 +81,9 @@ var _ = Describe("Weave GitOps UI Test", func() {
 		expectedTitle := "Weave GitOps"
 
 		By("Then I should be able to navigate to WeGO dashboard", func() {
-			Expect(webDriver.Navigate(WEGO_UI_URL)).To(Succeed())
+			Expect(webDriver.Navigate(WEGO_UI_URL), THIRTY_SECOND_TIMEOUT).To(Succeed())
 			str, _ := webDriver.Title()
-			Expect(str).To(ContainSubstring(expectedTitle))
+			Eventually(str).Should(ContainSubstring(expectedTitle))
 			Expect(dashboardPage.ApplicationTab).Should(BeFound())
 		})
 	})

--- a/test/acceptance/test/ui_tests.go
+++ b/test/acceptance/test/ui_tests.go
@@ -3,14 +3,17 @@ package acceptance
 import (
 	"fmt"
 	"os"
+	"runtime"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/sclevine/agouti"
 	. "github.com/sclevine/agouti/matchers"
+	log "github.com/sirupsen/logrus"
 	"github.com/weaveworks/weave-gitops/test/acceptance/test/pages"
 )
 
+var err error
 var webDriver *agouti.Page
 
 func initializeUISteps() {
@@ -32,25 +35,36 @@ var _ = Describe("Weave GitOps UI Test", func() {
 	}
 
 	BeforeEach(func() {
+		os := runtime.GOOS
+		log.Infof("Running tests on OS: " + os)
+
 		By("Given I have a brand new cluster", func() {
-			var err error
+
 			_, err = ResetOrCreateCluster(WEGO_DEFAULT_NAMESPACE, deleteWegoRuntime)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			Expect(FileExists(WEGO_BIN_PATH)).To(BeTrue())
 			initializeUISteps()
 
-			By("When I open up a browser", func() {
-				webDriver, err = agouti.NewPage(SELENIUM_SERVICE_URL, agouti.Desired(agouti.Capabilities{
-					"chromeOptions": map[string][]string{
-						"args": {
-							"--disable-gpu",
-							"--no-sandbox",
-						}}}.Browser("chrome")))
-				Expect(err).NotTo(HaveOccurred())
-				if err != nil {
-					fmt.Println("Error creating new page: " + err.Error())
-					return
+			By("And I open up a browser", func() {
+
+				if os == "linux" {
+					webDriver, err = agouti.NewPage(SELENIUM_SERVICE_URL, agouti.Desired(agouti.Capabilities{
+						"chromeOptions": map[string][]string{
+							"args": {
+								"--disable-gpu",
+								"--no-sandbox",
+							}}}))
+					Expect(err).NotTo(HaveOccurred(), "Error creating new page")
+				}
+
+				if os == "darwin" {
+
+					chromeDriver := agouti.ChromeDriver(agouti.ChromeOptions("args", []string{"--disable-gpu", "--no-sandbox"}))
+					err = chromeDriver.Start()
+					Expect(err).NotTo(HaveOccurred())
+					webDriver, err = chromeDriver.NewPage()
+					Expect(err).NotTo(HaveOccurred(), "Error creating new page")
 				}
 			})
 		})

--- a/test/acceptance/test/ui_tests.go
+++ b/test/acceptance/test/ui_tests.go
@@ -81,9 +81,9 @@ var _ = Describe("Weave GitOps UI Test", func() {
 		expectedTitle := "Weave GitOps"
 
 		By("Then I should be able to navigate to WeGO dashboard", func() {
-			Expect(webDriver.Navigate(WEGO_UI_URL), THIRTY_SECOND_TIMEOUT).To(Succeed())
+			Expect(webDriver.Navigate(WEGO_UI_URL)).To(Succeed())
 			str, _ := webDriver.Title()
-			Eventually(str).Should(ContainSubstring(expectedTitle))
+			Eventually(str, THIRTY_SECOND_TIMEOUT).Should(ContainSubstring(expectedTitle))
 			Expect(dashboardPage.ApplicationTab).Should(BeFound())
 		})
 	})


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Changed the way `webDriver` is initialized for MacOS

<!-- Tell your future self why have you made these changes -->
**Why?**
MacOS now comes with selenium 4 by default in github actions. To have successful test runs, we need to initialize `webDriver` instance differently — depending on the OS in which the test is running. This only affects the UI tests.
