### PR TITLE
Create empty ssh key for git client to avoid creating real deploy keys when using dry-run.

### DIFF
--- a/pkg/services/auth/auth.go
+++ b/pkg/services/auth/auth.go
@@ -63,7 +63,7 @@ func (sn SecretName) NamespacedName() types.NamespacedName {
 }
 
 type AuthService interface {
-	CreateGitClient(ctx context.Context, repoUrl gitproviders.RepoURL, targetName string, namespace string) (git.Git, error)
+	CreateGitClient(ctx context.Context, repoUrl gitproviders.RepoURL, targetName string, namespace string, dryRun bool) (git.Git, error)
 	GetGitProvider() gitproviders.GitProvider
 }
 
@@ -93,7 +93,12 @@ func (a *authSvc) GetGitProvider() gitproviders.GitProvider {
 
 // CreateGitClient creates a git.Git client instrumented with existing or generated deploy keys.
 // This ensures that git operations are done with stored deploy keys instead of a user's local ssh-agent or equivalent.
-func (a *authSvc) CreateGitClient(ctx context.Context, repoUrl gitproviders.RepoURL, targetName string, namespace string) (git.Git, error) {
+func (a *authSvc) CreateGitClient(ctx context.Context, repoUrl gitproviders.RepoURL, targetName string, namespace string, dryRun bool) (git.Git, error) {
+	if dryRun {
+		d, _ := makePublicKey([]byte(""))
+		return git.New(d, wrapper.NewGoGit()), nil
+	}
+
 	secretName := SecretName{
 		Name:      app.CreateRepoSecretName(targetName, repoUrl.String()),
 		Namespace: namespace,

--- a/pkg/services/auth/auth_test.go
+++ b/pkg/services/auth/auth_test.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"bytes"
 	"context"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/weaveworks/weave-gitops/pkg/flux"
@@ -64,7 +65,7 @@ var _ = Describe("auth", func() {
 			}
 		})
 		It("create and stores a deploy key if none exists", func() {
-			_, err := as.CreateGitClient(ctx, repoUrl, testClustername, namespace.Name)
+			_, err := as.CreateGitClient(ctx, repoUrl, testClustername, namespace.Name, false)
 			Expect(err).NotTo(HaveOccurred())
 			sn := SecretName{Name: secretName, Namespace: namespace.Name}
 			secret := &corev1.Secret{}
@@ -72,6 +73,13 @@ var _ = Describe("auth", func() {
 
 			Expect(secret.StringData["identity"]).NotTo(BeNil())
 			Expect(secret.StringData["identity.pub"]).NotTo(BeNil())
+		})
+		FIt("doesn't create a deploy key when dry-run is true", func() {
+			_, err := as.CreateGitClient(ctx, repoUrl, testClustername, namespace.Name, true)
+			Expect(err).NotTo(HaveOccurred())
+			sn := SecretName{Name: secretName, Namespace: namespace.Name}
+			secret := &corev1.Secret{}
+			Expect(k8sClient.Get(ctx, sn.NamespacedName(), secret)).To(HaveOccurred())
 		})
 		It("uses an existing deploy key when present", func() {
 			gp.DeployKeyExistsReturns(true, nil)
@@ -81,7 +89,7 @@ var _ = Describe("auth", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(k8sClient.Create(ctx, secret)).To(Succeed())
 
-			_, err = as.CreateGitClient(ctx, repoUrl, testClustername, namespace.Name)
+			_, err = as.CreateGitClient(ctx, repoUrl, testClustername, namespace.Name, false)
 			Expect(err).NotTo(HaveOccurred())
 			// We should NOT have uploaded anything since the key already exists
 			Expect(gp.UploadDeployKeyCallCount()).To(Equal(0))
@@ -90,7 +98,7 @@ var _ = Describe("auth", func() {
 			gp.DeployKeyExistsReturns(true, nil)
 			sn := SecretName{Name: secretName, Namespace: namespace.Name}
 
-			_, err = as.CreateGitClient(ctx, repoUrl, testClustername, namespace.Name)
+			_, err = as.CreateGitClient(ctx, repoUrl, testClustername, namespace.Name, false)
 			Expect(err).NotTo(HaveOccurred())
 
 			newSecret := &corev1.Secret{}

--- a/pkg/services/auth/auth_test.go
+++ b/pkg/services/auth/auth_test.go
@@ -74,7 +74,7 @@ var _ = Describe("auth", func() {
 			Expect(secret.StringData["identity"]).NotTo(BeNil())
 			Expect(secret.StringData["identity.pub"]).NotTo(BeNil())
 		})
-		FIt("doesn't create a deploy key when dry-run is true", func() {
+		It("doesn't create a deploy key when dry-run is true", func() {
 			_, err := as.CreateGitClient(ctx, repoUrl, testClustername, namespace.Name, true)
 			Expect(err).NotTo(HaveOccurred())
 			sn := SecretName{Name: secretName, Namespace: namespace.Name}

--- a/pkg/services/factory.go
+++ b/pkg/services/factory.go
@@ -139,7 +139,7 @@ func (f *defaultFactory) GetGitClients(ctx context.Context, gpClient gitprovider
 
 	if !params.IsHelmRepository {
 		// We need to do this even if we have an external config to set up the deploy key for the app repo
-		appRepoClient, appRepoErr := authSvc.CreateGitClient(ctx, normalizedUrl, targetName, params.Namespace)
+		appRepoClient, appRepoErr := authSvc.CreateGitClient(ctx, normalizedUrl, targetName, params.Namespace, params.DryRun)
 		if appRepoErr != nil {
 			return nil, nil, appRepoErr
 		}
@@ -153,7 +153,7 @@ func (f *defaultFactory) GetGitClients(ctx context.Context, gpClient gitprovider
 			return nil, nil, fmt.Errorf("error normalizing url: %w", err)
 		}
 
-		configRepoClient, configRepoErr := authSvc.CreateGitClient(ctx, normalizedConfigUrl, targetName, params.Namespace)
+		configRepoClient, configRepoErr := authSvc.CreateGitClient(ctx, normalizedConfigUrl, targetName, params.Namespace, params.DryRun)
 		if configRepoErr != nil {
 			return nil, nil, configRepoErr
 		}


### PR DESCRIPTION
<!-- Use # to add the issue this pull request is related to -->
Closes: #1050 

<!-- Describe what has changed in this PR -->
**What changed?**
Avoid creating deploy key when running `add app` using `--dry-run` flag

<!-- Tell your future self why have you made these changes -->
**Why?**
To avoid the error "deploy key already exists" when adding the app without `dry-run` flag

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**
Manually and adding a unit test.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
**Release notes**

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**