### PR TITLE
1062 - Use the correct default config branch for auto-merge

### DIFF
--- a/pkg/services/gitopswriter/gitopswriter.go
+++ b/pkg/services/gitopswriter/gitopswriter.go
@@ -46,7 +46,12 @@ func (dw *gitOpsDirectoryWriterSvc) AddApplication(ctx context.Context, app mode
 		return fmt.Errorf("could not generate application GitOps Automation manifests: %w", err)
 	}
 
-	remover, repoDir, err := dw.RepoWriter.CloneRepo(ctx, app.Branch)
+	defaultBranch, err := dw.RepoWriter.GetDefaultBranch(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to retrieve default branch for repository: %w", err)
+	}
+
+	remover, repoDir, err := dw.RepoWriter.CloneRepo(ctx, defaultBranch)
 	if err != nil {
 		return fmt.Errorf("failed to clone repo: %w", err)
 	}
@@ -77,11 +82,6 @@ func (dw *gitOpsDirectoryWriterSvc) AddApplication(ctx context.Context, app mode
 		content := string(manifest.Content)
 
 		files = append(files, gitprovider.CommitFile{Path: &manifestPath, Content: &content})
-	}
-
-	defaultBranch, err := dw.RepoWriter.GetDefaultBranch(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to retrieve default branch for repository: %w", err)
 	}
 
 	prInfo := gitproviders.PullRequestInfo{


### PR DESCRIPTION
<!-- Use # to add the issue this pull request is related to -->
Closes: #1062 

<!-- Describe what has changed in this PR -->
**What changed?**
We now select the correct default branch before cloning an external config repository

<!-- Tell your future self why have you made these changes -->
**Why?**
To work correctly with repositories that use different default branches (such as old GitHub ones with `master`)

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**
- Manual tests
- New unit tests

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
**Release notes**
No

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
No