### PR TITLE
Add acceptance test for bug #810 and update how secret names are generated

### DIFF
--- a/.github/actions/run-acceptance-test/action.yml
+++ b/.github/actions/run-acceptance-test/action.yml
@@ -43,6 +43,13 @@ runs:
       sudo mv -f chromedriver /usr/local/bin/chromedriver
        wget  https://selenium-release.storage.googleapis.com/3.14/selenium-server-standalone-3.14.0.jar
        xvfb-run -a --server-args="-screen 0 1280x1024x24" java -jar ./selenium-server-standalone-3.14.0.jar &
+  - name: Setup Kubernetes
+    uses: engineerd/setup-kind@v0.5.0
+    with:
+      name: "${{ format('katc-{0}', github.run_id) }}"
+      version: "v0.11.0"
+      image: kindest/node:v1.21.1
+      skipClusterCreation: true
   - name: Download gitops binaries
     uses: actions/download-artifact@v2
     with:

--- a/.github/actions/run-acceptance-test/action.yml
+++ b/.github/actions/run-acceptance-test/action.yml
@@ -43,17 +43,6 @@ runs:
       sudo mv -f chromedriver /usr/local/bin/chromedriver
        wget  https://selenium-release.storage.googleapis.com/3.14/selenium-server-standalone-3.14.0.jar
        xvfb-run -a --server-args="-screen 0 1280x1024x24" java -jar ./selenium-server-standalone-3.14.0.jar &
-  - name: Setup Kubernetes
-    uses: engineerd/setup-kind@v0.5.0
-    with:
-      name: "${{ format('katc-{0}', github.run_id) }}"
-      version: "v0.11.0"
-      image: kindest/node:v1.21.1
-      config: "./test/acceptance/test/configs/kind-config.yaml"
-  - name: Kind-check
-    shell: bash
-    run: |
-      kubectl get pods -A
   - name: Download gitops binaries
     uses: actions/download-artifact@v2
     with:

--- a/.github/actions/run-acceptance-test/action.yml
+++ b/.github/actions/run-acceptance-test/action.yml
@@ -43,13 +43,17 @@ runs:
       sudo mv -f chromedriver /usr/local/bin/chromedriver
        wget  https://selenium-release.storage.googleapis.com/3.14/selenium-server-standalone-3.14.0.jar
        xvfb-run -a --server-args="-screen 0 1280x1024x24" java -jar ./selenium-server-standalone-3.14.0.jar &
-  - name: Setup Kubernetes
+  - name: Setup Kubernetes Tools
     uses: engineerd/setup-kind@v0.5.0
     with:
       name: "${{ format('katc-{0}', github.run_id) }}"
       version: "v0.11.0"
       image: kindest/node:v1.21.1
-      skipClusterCreation: true
+      config: "./test/acceptance/test/configs/kind-config.yaml"
+  - name: Kind-check
+    shell: bash
+    run: |
+      kubectl get pods -A
   - name: Download gitops binaries
     uses: actions/download-artifact@v2
     with:

--- a/pkg/services/app/add_test.go
+++ b/pkg/services/app/add_test.go
@@ -268,7 +268,7 @@ var _ = Describe("Add Gitlab", func() {
 				Expect(name).To(Equal("bar"))
 				Expect(url.String()).To(Equal("ssh://git@gitlab.com/foo/bar.git"))
 				Expect(branch).To(Equal("main"))
-				Expect(secretRef).To(Equal("wego-bar"))
+				Expect(secretRef).To(Equal("wego-gitlab-bar"))
 				Expect(namespace).To(Equal(wego.DefaultNamespace))
 			})
 		})

--- a/pkg/services/app/add_test.go
+++ b/pkg/services/app/add_test.go
@@ -268,7 +268,7 @@ var _ = Describe("Add Gitlab", func() {
 				Expect(name).To(Equal("bar"))
 				Expect(url.String()).To(Equal("ssh://git@gitlab.com/foo/bar.git"))
 				Expect(branch).To(Equal("main"))
-				Expect(secretRef).To(Equal("wego-test-cluster-bar"))
+				Expect(secretRef).To(Equal("wego-bar"))
 				Expect(namespace).To(Equal(wego.DefaultNamespace))
 			})
 		})

--- a/pkg/services/auth/auth.go
+++ b/pkg/services/auth/auth.go
@@ -95,7 +95,7 @@ func (a *authSvc) GetGitProvider() gitproviders.GitProvider {
 // This ensures that git operations are done with stored deploy keys instead of a user's local ssh-agent or equivalent.
 func (a *authSvc) CreateGitClient(ctx context.Context, repoUrl gitproviders.RepoURL, targetName string, namespace string) (git.Git, error) {
 	secretName := SecretName{
-		Name:      automation.CreateRepoSecretName(targetName, repoUrl),
+		Name:      automation.CreateRepoSecretName(repoUrl),
 		Namespace: namespace,
 	}
 
@@ -173,7 +173,7 @@ func (a *authSvc) provisionDeployKey(ctx context.Context, targetName string, nam
 
 // Generates an ssh keypair for upload to the Git Provider and for use in a git.Git client.
 func (a *authSvc) generateDeployKey(targetName string, secretName SecretName, repo gitproviders.RepoURL) (*ssh.PublicKeys, *corev1.Secret, error) {
-	secret, err := a.createKeyPairSecret(targetName, secretName, repo)
+	secret, err := a.createKeyPairSecret(secretName, repo)
 	if err != nil {
 		return nil, nil, fmt.Errorf("could not create key-pair secret: %w", err)
 	}
@@ -208,7 +208,7 @@ func (a *authSvc) retrieveDeployKey(ctx context.Context, name SecretName) (*core
 }
 
 // Uses flux to create a ssh key pair secret.
-func (a *authSvc) createKeyPairSecret(targetName string, name SecretName, repo gitproviders.RepoURL) (*corev1.Secret, error) {
+func (a *authSvc) createKeyPairSecret(name SecretName, repo gitproviders.RepoURL) (*corev1.Secret, error) {
 	secretData, err := a.fluxClient.CreateSecretGit(name.Name.String(), repo, name.Namespace)
 	if err != nil {
 		return nil, fmt.Errorf("could not create git secret: %w", err)

--- a/pkg/services/auth/auth_test.go
+++ b/pkg/services/auth/auth_test.go
@@ -50,7 +50,7 @@ var _ = Describe("auth", func() {
 		)
 		BeforeEach(func() {
 			ctx = context.Background()
-			secretName = automation.CreateRepoSecretName(testClustername, repoUrl)
+			secretName = automation.CreateRepoSecretName(repoUrl)
 			Expect(err).NotTo(HaveOccurred())
 			osysClient = osys.New()
 			gp = gitprovidersfakes.FakeGitProvider{}

--- a/pkg/services/automation/automation_test.go
+++ b/pkg/services/automation/automation_test.go
@@ -91,7 +91,7 @@ var _ = Describe("Generate manifests", func() {
 				Expect(name).To(Equal("bar"))
 				Expect(url.String()).To(Equal("ssh://git@github.com/foo/bar.git"))
 				Expect(branch).To(Equal("main"))
-				Expect(secretRef).To(Equal("wego-test-cluster-bar"))
+				Expect(secretRef).To(Equal("wego-bar"))
 				Expect(namespace).To(Equal(wego.DefaultNamespace))
 
 				appManifest, nonApps := extractApp(app, results)
@@ -224,7 +224,7 @@ var _ = Describe("Generate manifests", func() {
 					Expect(name).To(Equal("bar"))
 					Expect(url.String()).To(Equal("ssh://git@github.com/user/repo.git"))
 					Expect(branch).To(Equal("main"))
-					Expect(secretRef).To(Equal("wego-test-cluster-repo"))
+					Expect(secretRef).To(Equal("wego-repo"))
 					Expect(namespace).To(Equal(wego.DefaultNamespace))
 
 					appManifest, nonApps := extractApp(app, results)

--- a/pkg/services/automation/automation_test.go
+++ b/pkg/services/automation/automation_test.go
@@ -91,7 +91,7 @@ var _ = Describe("Generate manifests", func() {
 				Expect(name).To(Equal("bar"))
 				Expect(url.String()).To(Equal("ssh://git@github.com/foo/bar.git"))
 				Expect(branch).To(Equal("main"))
-				Expect(secretRef).To(Equal("wego-bar"))
+				Expect(secretRef).To(Equal("wego-github-bar"))
 				Expect(namespace).To(Equal(wego.DefaultNamespace))
 
 				appManifest, nonApps := extractApp(app, results)
@@ -224,7 +224,7 @@ var _ = Describe("Generate manifests", func() {
 					Expect(name).To(Equal("bar"))
 					Expect(url.String()).To(Equal("ssh://git@github.com/user/repo.git"))
 					Expect(branch).To(Equal("main"))
-					Expect(secretRef).To(Equal("wego-repo"))
+					Expect(secretRef).To(Equal("wego-github-repo"))
 					Expect(namespace).To(Equal(wego.DefaultNamespace))
 
 					appManifest, nonApps := extractApp(app, results)

--- a/pkg/services/automation/generator.go
+++ b/pkg/services/automation/generator.go
@@ -391,7 +391,12 @@ func AppDeployName(a models.Application) string {
 }
 
 func CreateRepoSecretName(gitSourceURL gitproviders.RepoURL) GeneratedSecretName {
-	return GeneratedSecretName(hashNameIfTooLong(fmt.Sprintf("wego-%s-%s", string(gitSourceURL.Provider()), replaceUnderscores(gitSourceURL.RepositoryName()))))
+	provider := string(gitSourceURL.Provider())
+	cleanRepoName := replaceUnderscores(gitSourceURL.RepositoryName())
+	qualifiedName := fmt.Sprintf("wego-%s-%s", provider, cleanRepoName)
+	lengthConstrainedName := hashNameIfTooLong(qualifiedName)
+
+	return GeneratedSecretName(lengthConstrainedName)
 }
 
 func SourceKind(a models.Application) ResourceKind {

--- a/pkg/services/automation/generator.go
+++ b/pkg/services/automation/generator.go
@@ -391,7 +391,7 @@ func AppDeployName(a models.Application) string {
 }
 
 func CreateRepoSecretName(gitSourceURL gitproviders.RepoURL) GeneratedSecretName {
-	return GeneratedSecretName(hashNameIfTooLong(fmt.Sprintf("wego-%s", GenerateResourceName(gitSourceURL))))
+	return GeneratedSecretName(hashNameIfTooLong(fmt.Sprintf("wego-%s-%s", string(gitSourceURL.Provider()), replaceUnderscores(gitSourceURL.RepositoryName()))))
 }
 
 func SourceKind(a models.Application) ResourceKind {
@@ -436,7 +436,11 @@ func GenerateResourceName(url gitproviders.RepoURL) string {
 }
 
 func ConstrainResourceName(str string) string {
-	return hashNameIfTooLong(strings.ReplaceAll(str, "_", "-"))
+	return hashNameIfTooLong(replaceUnderscores(str))
+}
+
+func replaceUnderscores(str string) string {
+	return strings.ReplaceAll(str, "_", "-")
 }
 
 func (rk ResourceKind) ToGVR() (schema.GroupVersionResource, error) {

--- a/pkg/services/automation/generator.go
+++ b/pkg/services/automation/generator.go
@@ -87,15 +87,15 @@ func NewAutomationGenerator(gp gitproviders.GitProvider, flux flux.Flux, logger 
 	}
 }
 
-func (a *AutomationGen) getAppSecretRef(ctx context.Context, app models.Application, clusterName string) (GeneratedSecretName, error) {
+func (a *AutomationGen) getAppSecretRef(ctx context.Context, app models.Application) (GeneratedSecretName, error) {
 	if app.SourceType != models.SourceTypeHelm {
-		return a.getSecretRef(ctx, app, app.GitSourceURL, clusterName)
+		return a.getSecretRef(ctx, app, app.GitSourceURL)
 	}
 
 	return "", nil
 }
 
-func (a *AutomationGen) getSecretRef(ctx context.Context, app models.Application, url gitproviders.RepoURL, clusterName string) (GeneratedSecretName, error) {
+func (a *AutomationGen) getSecretRef(ctx context.Context, app models.Application, url gitproviders.RepoURL) (GeneratedSecretName, error) {
 	var secretRef GeneratedSecretName
 
 	visibility, err := a.GitProvider.GetRepoVisibility(ctx, url)
@@ -104,7 +104,7 @@ func (a *AutomationGen) getSecretRef(ctx context.Context, app models.Application
 	}
 
 	if *visibility != gitprovider.RepositoryVisibilityPublic {
-		secretRef = CreateRepoSecretName(clusterName, url)
+		secretRef = CreateRepoSecretName(url)
 	}
 
 	return secretRef, nil
@@ -128,13 +128,13 @@ func (a *AutomationGen) generateAppAutomation(ctx context.Context, app models.Ap
 	return []AutomationManifest{appManifest, appGoatManifest}, nil
 }
 
-func (a *AutomationGen) generateAppSource(ctx context.Context, app models.Application, clusterName string) (AutomationManifest, error) {
+func (a *AutomationGen) generateAppSource(ctx context.Context, app models.Application) (AutomationManifest, error) {
 	var (
 		source []byte
 		err    error
 	)
 
-	appSecretRef, err := a.getAppSecretRef(ctx, app, clusterName)
+	appSecretRef, err := a.getAppSecretRef(ctx, app)
 	if err != nil {
 		return AutomationManifest{}, err
 	}
@@ -234,7 +234,7 @@ func (a *AutomationGen) GenerateAutomation(ctx context.Context, app models.Appli
 		return nil, err
 	}
 
-	source, err := a.generateAppSource(ctx, app, clusterName)
+	source, err := a.generateAppSource(ctx, app)
 	if err != nil {
 		return nil, err
 	}
@@ -390,8 +390,8 @@ func AppDeployName(a models.Application) string {
 	return a.Name
 }
 
-func CreateRepoSecretName(targetName string, gitSourceURL gitproviders.RepoURL) GeneratedSecretName {
-	return GeneratedSecretName(hashNameIfTooLong(fmt.Sprintf("wego-%s-%s", targetName, GenerateResourceName(gitSourceURL))))
+func CreateRepoSecretName(gitSourceURL gitproviders.RepoURL) GeneratedSecretName {
+	return GeneratedSecretName(hashNameIfTooLong(fmt.Sprintf("wego-%s", GenerateResourceName(gitSourceURL))))
 }
 
 func SourceKind(a models.Application) ResourceKind {

--- a/pkg/services/gitops/install.go
+++ b/pkg/services/gitops/install.go
@@ -137,7 +137,7 @@ func (g *Gitops) storeManifests(gitClient git.Git, gitProvider gitproviders.GitP
 	manifests := make(map[string][]byte, 3)
 	clusterPath := filepath.Join(git.WegoRoot, git.WegoClusterDir, cname)
 
-	gitsource, sourceName, err := g.genSource(cname, configBranch, params.Namespace, normalizedURL)
+	gitsource, sourceName, err := g.genSource(configBranch, params.Namespace, normalizedURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create source manifest: %w", err)
 	}
@@ -189,8 +189,8 @@ func (g *Gitops) storeManifests(gitClient git.Git, gitProvider gitproviders.GitP
 	return manifests, gitrepo.CommitAndPush(ctx, gitClient, "Add GitOps runtime manifests", g.logger)
 }
 
-func (g *Gitops) genSource(cname, branch string, namespace string, normalizedUrl gitproviders.RepoURL) ([]byte, string, error) {
-	secretRef := automation.CreateRepoSecretName(cname, normalizedUrl).String()
+func (g *Gitops) genSource(branch string, namespace string, normalizedUrl gitproviders.RepoURL) ([]byte, string, error) {
+	secretRef := automation.CreateRepoSecretName(normalizedUrl).String()
 
 	sourceManifest, err := g.flux.CreateSourceGit(secretRef, normalizedUrl, branch, secretRef, namespace)
 	if err != nil {

--- a/test/acceptance/test/add_tests.go
+++ b/test/acceptance/test/add_tests.go
@@ -568,7 +568,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 	})
 
-	FIt("Verify that gitops can deploy a single workload to multiple clusters with app manifests in config repo (Bug #810)", func() {
+	It("Verify that gitops can deploy a single workload to multiple clusters with app manifests in config repo (Bug #810)", func() {
 		var repoAbsolutePath string
 		tip := generateTestInputs()
 		appRepoName := "wego-test-app-" + RandString(8)

--- a/test/acceptance/test/add_tests.go
+++ b/test/acceptance/test/add_tests.go
@@ -32,10 +32,8 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		By("Given I have a brand new cluster", func() {
 			var err error
 
-			_, err = ResetOrCreateCluster(WEGO_DEFAULT_NAMESPACE, deleteWegoRuntime)
+			clusterName, err = ResetOrCreateCluster(WEGO_DEFAULT_NAMESPACE, deleteWegoRuntime)
 			Expect(err).ShouldNot(HaveOccurred())
-
-			clusterName = getClusterName()
 		})
 
 		By("And I have a gitops binary installed on my local machine", func() {
@@ -578,9 +576,8 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		addCommand := "add app . --name=" + appName + " --auto-merge=true"
 
 		cluster1 := clusterName
-		_, err := ResetOrCreateClusterWithName(WEGO_DEFAULT_NAMESPACE, deleteWegoRuntime, "", true)
+		cluster2, err := ResetOrCreateClusterWithName(WEGO_DEFAULT_NAMESPACE, deleteWegoRuntime, "", true)
 		Expect(err).ShouldNot(HaveOccurred())
-		cluster2 := getClusterName()
 
 		defer deleteRepo(appRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
 		defer func() {

--- a/test/acceptance/test/add_tests.go
+++ b/test/acceptance/test/add_tests.go
@@ -254,7 +254,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 
 		By("Then I should see app removing message", func() {
-			Eventually(appRemoveOutput).Should(gbytes.Say(fmt.Sprintf("► Removing application %q from cluster %q and repository", appName, clusterName)))
+			Eventually(appRemoveOutput).Should(gbytes.Say(fmt.Sprintf("► Removing application %q from cluster %q and repository", appName, clusterContext)))
 			Eventually(appRemoveOutput).Should(gbytes.Say("► Committing and pushing gitops updates for application"))
 			Eventually(appRemoveOutput).Should(gbytes.Say("► Pushing app changes to repository"))
 		})
@@ -425,7 +425,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 
 		By("Then I should see app removing message", func() {
-			Eventually(appRemoveOutput).Should(gbytes.Say(fmt.Sprintf("► Removing application %q from cluster %q and repository", appName, clusterName)))
+			Eventually(appRemoveOutput).Should(gbytes.Say(fmt.Sprintf("► Removing application %q from cluster %q and repository", appName, clusterContext)))
 			Eventually(appRemoveOutput).Should(gbytes.Say("► Committing and pushing gitops updates for application"))
 			Eventually(appRemoveOutput).Should(gbytes.Say("► Pushing app changes to repository"))
 		})
@@ -1100,7 +1100,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 
 		By("Then I should see app deleting message", func() {
-			Eventually(appRemoveOutput).Should(gbytes.Say(fmt.Sprintf("► Removing application %q from cluster %q and repository", appName2, clusterName)))
+			Eventually(appRemoveOutput).Should(gbytes.Say(fmt.Sprintf("► Removing application %q from cluster %q and repository", appName2, clusterContext)))
 			Eventually(appRemoveOutput).Should(gbytes.Say("► Committing and pushing gitops updates for application"))
 			Eventually(appRemoveOutput).Should(gbytes.Say("► Pushing app changes to repository"))
 		})
@@ -1400,7 +1400,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 
 		By("Then I should see app removing message", func() {
-			Eventually(appRemoveOutput).Should(gbytes.Say(fmt.Sprintf("► Removing application %q from cluster %q and repository", appName, clusterName)))
+			Eventually(appRemoveOutput).Should(gbytes.Say(fmt.Sprintf("► Removing application %q from cluster %q and repository", appName, clusterContext)))
 			Eventually(appRemoveOutput).Should(gbytes.Say("► Committing and pushing gitops updates for application"))
 			Eventually(appRemoveOutput).Should(gbytes.Say("► Pushing app changes to repository"))
 		})

--- a/test/acceptance/test/add_tests.go
+++ b/test/acceptance/test/add_tests.go
@@ -568,7 +568,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 	})
 
-	It("Verify that gitops can deploy a single workload to multiple clusters with app manifests in config repo (Bug #810)", func() {
+	FIt("Verify that gitops can deploy a single workload to multiple clusters with app manifests in config repo (Bug #810)", func() {
 		var repoAbsolutePath string
 		tip := generateTestInputs()
 		appRepoName := "wego-test-app-" + RandString(8)

--- a/test/acceptance/test/install_tests.go
+++ b/test/acceptance/test/install_tests.go
@@ -234,7 +234,7 @@ var _ = Describe("Weave GitOps Install Tests", func() {
 		namespace := "wego-system"
 
 		By("And I have a brand new cluster", func() {
-			_, err := ResetOrCreateCluster(namespace, true)
+			_, _, err := ResetOrCreateCluster(namespace, true)
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 

--- a/test/acceptance/test/install_tests.go
+++ b/test/acceptance/test/install_tests.go
@@ -61,7 +61,7 @@ var _ = Describe("Weave GitOps Install Tests", func() {
 		defer deleteNamespace(namespace)
 
 		By("And I have a brand new cluster", func() {
-			_, err := ResetOrCreateCluster(WEGO_DEFAULT_NAMESPACE, true)
+			_, _, err := ResetOrCreateCluster(WEGO_DEFAULT_NAMESPACE, true)
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 
@@ -85,7 +85,7 @@ var _ = Describe("Weave GitOps Install Tests", func() {
 		namespace := "test-namespace"
 
 		By("And I have a brand new cluster", func() {
-			_, err := ResetOrCreateCluster(namespace, true)
+			_, _, err := ResetOrCreateCluster(namespace, true)
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 
@@ -120,7 +120,7 @@ var _ = Describe("Weave GitOps Install Tests", func() {
 		namespace := "test-namespace"
 
 		By("And I have a brand new cluster", func() {
-			_, err := ResetOrCreateCluster(namespace, true)
+			_, _, err := ResetOrCreateCluster(namespace, true)
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 
@@ -165,7 +165,7 @@ var _ = Describe("Weave GitOps Install Tests", func() {
 		var uninstallDryRunOutput string
 
 		By("And I have a brand new cluster", func() {
-			_, err := ResetOrCreateCluster(WEGO_DEFAULT_NAMESPACE, true)
+			_, _, err := ResetOrCreateCluster(WEGO_DEFAULT_NAMESPACE, true)
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 

--- a/test/acceptance/test/scripts/kind-multi-cluster.sh
+++ b/test/acceptance/test/scripts/kind-multi-cluster.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+echo "Create a new kind cluster with name "$1
+kind create cluster --name=$1 --image=$2 --config=./configs/kind-config.yaml

--- a/test/acceptance/test/ui_tests.go
+++ b/test/acceptance/test/ui_tests.go
@@ -40,7 +40,7 @@ var _ = Describe("Weave GitOps UI Test", func() {
 
 		By("Given I have a brand new cluster", func() {
 
-			_, err = ResetOrCreateCluster(WEGO_DEFAULT_NAMESPACE, deleteWegoRuntime)
+			_, _, err = ResetOrCreateCluster(WEGO_DEFAULT_NAMESPACE, deleteWegoRuntime)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			Expect(FileExists(WEGO_BIN_PATH)).To(BeTrue())

--- a/test/acceptance/test/utils.go
+++ b/test/acceptance/test/utils.go
@@ -97,7 +97,7 @@ func deleteCluster(clusterName string) {
 	Expect(err).ShouldNot(HaveOccurred())
 }
 
-func getClusterName() string {
+func getClusterContext() string {
 	out, err := exec.Command("kubectl", "config", "current-context").Output()
 	Expect(err).ShouldNot(HaveOccurred())
 
@@ -241,7 +241,7 @@ func ResetOrCreateClusterWithName(namespace string, deleteWegoRuntime bool, clus
 		return clusterName, "", err
 	}
 
-	return clusterName, getClusterName(), nil
+	return clusterName, getClusterContext(), nil
 }
 
 func initAndCreateEmptyRepo(appRepoName string, providerName gitproviders.GitProviderName, isPrivateRepo bool, org string) string {

--- a/test/acceptance/test/utils.go
+++ b/test/acceptance/test/utils.go
@@ -184,7 +184,7 @@ func ResetOrCreateClusterWithName(namespace string, deleteWegoRuntime bool, clus
 
 	k8sVersion, found := os.LookupEnv("K8S_VERSION")
 	if !found {
-		k8sVersion = "1.20.2"
+		k8sVersion = "1.21.1"
 	}
 
 	if !contains(supportedProviders, provider) {

--- a/test/acceptance/test/utils.go
+++ b/test/acceptance/test/utils.go
@@ -38,6 +38,7 @@ const EVENTUALLY_DEFAULT_TIMEOUT time.Duration = 60 * time.Second
 const TIMEOUT_TWO_MINUTES time.Duration = 120 * time.Second
 const INSTALL_RESET_TIMEOUT time.Duration = 300 * time.Second
 const NAMESPACE_TERMINATE_TIMEOUT time.Duration = 600 * time.Second
+const INSTALL_SUCCESSFUL_TIMEOUT time.Duration = 3 * time.Minute
 const INSTALL_PODS_READY_TIMEOUT time.Duration = 3 * time.Minute
 const WEGO_DEFAULT_NAMESPACE = wego.DefaultNamespace
 const WEGO_UI_URL = "http://localhost:9001"
@@ -237,7 +238,7 @@ func ResetOrCreateClusterWithName(namespace string, deleteWegoRuntime bool, clus
 		return clusterName, err
 	}
 
-	return clusterName, nil
+	return getClusterName(), nil
 }
 
 func initAndCreateEmptyRepo(appRepoName string, providerName gitproviders.GitProviderName, isPrivateRepo bool, org string) string {
@@ -396,7 +397,7 @@ func installAndVerifyWego(wegoNamespace, repoURL string) {
 		command := exec.Command("sh", "-c", fmt.Sprintf("%s install --namespace=%s --app-config-url=%s", WEGO_BIN_PATH, wegoNamespace, repoURL))
 		session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 		Expect(err).ShouldNot(HaveOccurred())
-		Eventually(session, TIMEOUT_TWO_MINUTES).Should(gexec.Exit())
+		Eventually(session, INSTALL_SUCCESSFUL_TIMEOUT).Should(gexec.Exit())
 		Expect(string(session.Err.Contents())).Should(BeEmpty())
 		VerifyControllersInCluster(wegoNamespace)
 	})

--- a/test/acceptance/test/utils.go
+++ b/test/acceptance/test/utils.go
@@ -88,12 +88,14 @@ func FileExists(name string) bool {
 
 func selectCluster(context string) {
 	_, err := exec.Command("kubectl", "config", "use-context", context).Output()
+	fmt.Printf("CONTEXT: %s, ERR: %v\n", context, err)
 	Expect(err).ShouldNot(HaveOccurred())
 }
 
 func getClusterName() string {
 	out, err := exec.Command("kubectl", "config", "current-context").Output()
 	Expect(err).ShouldNot(HaveOccurred())
+	fmt.Printf("GOT CONTEXT: %s, ERR: %v\n", out, err)
 
 	return string(bytes.TrimSuffix(out, []byte("\n")))
 }

--- a/test/acceptance/test/utils.go
+++ b/test/acceptance/test/utils.go
@@ -178,7 +178,7 @@ func ResetOrCreateClusterWithName(namespace string, deleteWegoRuntime bool, clus
 	supportedK8SVersions := []string{"1.19.1", "1.20.2", "1.21.1"}
 
 	provider, found := os.LookupEnv("CLUSTER_PROVIDER")
-	if !found {
+	if keepExistingClusters || !found {
 		provider = "kind"
 	}
 

--- a/test/integration/server/add_test.go
+++ b/test/integration/server/add_test.go
@@ -107,7 +107,7 @@ var _ = Describe("AddApplication", func() {
 			expectedSource := sourcev1.GitRepositorySpec{
 				URL: req.Url,
 				SecretRef: &meta.LocalObjectReference{
-					Name: automation.CreateRepoSecretName(clusterName, repoURL).String(),
+					Name: automation.CreateRepoSecretName(repoURL).String(),
 				},
 				Interval: metav1.Duration{Duration: time.Duration(30 * time.Second)},
 				Reference: &sourcev1.GitRepositoryRef{
@@ -203,7 +203,7 @@ var _ = Describe("AddApplication", func() {
 				URL: req.Url,
 				SecretRef: &meta.LocalObjectReference{
 					// Might be a bug? Should be configRepoURL?
-					Name: automation.CreateRepoSecretName(clusterName, repoURL).String(),
+					Name: automation.CreateRepoSecretName(repoURL).String(),
 				},
 				Interval: metav1.Duration{Duration: time.Duration(30 * time.Second)},
 				Reference: &sourcev1.GitRepositoryRef{
@@ -295,7 +295,7 @@ var _ = Describe("AddApplication", func() {
 			expectedSrc := sourcev1.GitRepositorySpec{
 				URL: req.Url,
 				SecretRef: &meta.LocalObjectReference{
-					Name: automation.CreateRepoSecretName(clusterName, repoURL).String(),
+					Name: automation.CreateRepoSecretName(repoURL).String(),
 				},
 				Interval: metav1.Duration{Duration: time.Duration(30 * time.Second)},
 				Reference: &sourcev1.GitRepositoryRef{
@@ -392,7 +392,7 @@ var _ = Describe("AddApplication", func() {
 			expectedSrc := sourcev1.GitRepositorySpec{
 				URL: req.Url,
 				SecretRef: &meta.LocalObjectReference{
-					Name: automation.CreateRepoSecretName(clusterName, repoURL).String(),
+					Name: automation.CreateRepoSecretName(repoURL).String(),
 				},
 				Interval: metav1.Duration{Duration: time.Duration(30 * time.Second)},
 				Reference: &sourcev1.GitRepositoryRef{


### PR DESCRIPTION
<!-- Use # to add the issue this pull request is related to -->
Closes: #810 

<!-- Describe what has changed in this PR -->
**What changed?**
- Added acceptance test that creates multiple clusters and deploys an app from a single repository to both clusters
- Updated how secret names are generated (removed cluster name and added git provider name)

In the past, we attempted to remove deploy keys that were no longer being used so we included the cluster name in the deploy key name (allowing the deploy key for a single cluster to be removed while leaving others intact). We no longer remove deploy keys and all generated deploy keys have the same name: `wego-deploy-key`. The name genericizing (generification?) process was never extended to the secret names themselves, however, which still included cluster names. This caused no problems until we started trying to deploy an application into multiple clusters from the same repository. Initial testing of the multi-cluster scenario used two applications in the same repository (one with path `./` and one with another path). This worked because the applications did not share automation manifests. With a single application, though, we only have one copy of each automation manifest and a `GitRepository` manifest for a private repository contains a name reference to the secret. If the secret name includes the cluster name, deployment to one of the clusters will fail as the `GitRepository` manifest will have one or the other secret name. This PR removes the cluster name from a generated secret name.

<!-- Tell your future self why have you made these changes -->
**Why?**
To allow a single application to be deployed to multiple clusters from a common source repository.

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**
Manual tests and new acceptance test 

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
**Release notes**
No, since we don't currently claim to support multi-cluster

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
No, since we don't discuss the secrets in the current documentation.