### PR TITLE
Add SyncApplication Button to UI

### DIFF
--- a/ui/App.tsx
+++ b/ui/App.tsx
@@ -8,6 +8,7 @@ import {
   Switch,
 } from "react-router-dom";
 import { ToastContainer } from "react-toastify";
+import "react-toastify/dist/ReactToastify.css";
 import { ThemeProvider } from "styled-components";
 import ErrorBoundary from "./components/ErrorBoundary";
 import Layout from "./components/Layout";
@@ -73,7 +74,7 @@ export default function App() {
               </ErrorBoundary>
               <ToastContainer
                 position="top-center"
-                autoClose={10000}
+                autoClose={5000}
                 newestOnTop={false}
               />
             </Layout>

--- a/ui/components/__tests__/CommitsTable.test.tsx
+++ b/ui/components/__tests__/CommitsTable.test.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 import { unmountComponentAtNode } from "react-dom";
 import { act } from "react-dom/test-utils";
 import { ListCommitsResponse } from "../../lib/api/applications/applications.pb";
-import { withContext, withTheme } from "../../lib/test-utils";
+import { createMockClient, withContext, withTheme } from "../../lib/test-utils";
 import CommitsTable from "../CommitsTable";
 
 describe("CommitsTable", () => {
@@ -39,7 +39,9 @@ describe("CommitsTable", () => {
       await act(async () => {
         const { container: div } = render(
           withTheme(
-            withContext(<CommitsTable app={app} authSuccess={true} />, "/", ovr)
+            withContext(<CommitsTable app={app} authSuccess={true} />, "/", {
+              applicationsClient: createMockClient(ovr),
+            })
           ),
           container
         );
@@ -63,7 +65,9 @@ describe("CommitsTable", () => {
     await act(async () => {
       render(
         withTheme(
-          withContext(<CommitsTable app={app} authSuccess={true} />, "/", ovr)
+          withContext(<CommitsTable app={app} authSuccess={true} />, "/", {
+            applicationsClient: createMockClient(ovr),
+          })
         ),
         container
       );

--- a/ui/components/__tests__/GithubDeviceAuthModal.test.tsx
+++ b/ui/components/__tests__/GithubDeviceAuthModal.test.tsx
@@ -7,6 +7,7 @@ import { GitProvider } from "../../lib/api/applications/applications.pb";
 import { getProviderToken } from "../../lib/storage";
 import {
   ApplicationOverrides,
+  createMockClient,
   withContext,
   withTheme,
 } from "../../lib/test-utils";
@@ -45,7 +46,7 @@ describe("GithubDeviceAuthModal", () => {
                 onSuccess={() => null}
               />,
               "/",
-              ovr
+              { applicationsClient: createMockClient(ovr) }
             )
           ),
           container
@@ -73,7 +74,7 @@ describe("GithubDeviceAuthModal", () => {
               onSuccess={() => null}
             />,
             "/",
-            ovr
+            { applicationsClient: createMockClient(ovr) }
           )
         ),
         container
@@ -100,7 +101,7 @@ describe("GithubDeviceAuthModal", () => {
               onSuccess={() => null}
             />,
             "/",
-            ovr
+            { applicationsClient: createMockClient(ovr) }
           )
         ),
         container

--- a/ui/components/__tests__/Page.test.tsx
+++ b/ui/components/__tests__/Page.test.tsx
@@ -8,7 +8,7 @@ describe("Page", () => {
   describe("snapshots", () => {
     it("default", () => {
       const tree = renderer
-        .create(withTheme(withContext(<Page />, "")))
+        .create(withTheme(withContext(<Page />, "", {})))
         .toJSON();
       expect(tree).toMatchSnapshot();
     });

--- a/ui/components/__tests__/RepoInputWithAuth.test.tsx
+++ b/ui/components/__tests__/RepoInputWithAuth.test.tsx
@@ -8,7 +8,7 @@ import {
   GitProvider,
   ParseRepoURLResponse,
 } from "../../lib/api/applications/applications.pb";
-import { withContext, withTheme } from "../../lib/test-utils";
+import { createMockClient, withContext, withTheme } from "../../lib/test-utils";
 import { PageRoute } from "../../lib/types";
 import { gitlabOAuthRedirectURI } from "../../lib/utils";
 import RepoInputWithAuth from "../RepoInputWithAuth";
@@ -73,7 +73,7 @@ describe("RepoInputWithAuth", () => {
                 />
               </CallbackStateContextProvider>,
               "/",
-              c
+              { applicationsClient: createMockClient(c) }
             )
           )
         );
@@ -113,7 +113,7 @@ describe("RepoInputWithAuth", () => {
               </CallbackStateContextProvider>,
 
               "/",
-              c
+              { applicationsClient: createMockClient(c) }
             )
           )
         );
@@ -161,7 +161,7 @@ describe("RepoInputWithAuth", () => {
                 />
               </CallbackStateContextProvider>,
               "/",
-              c
+              { applicationsClient: createMockClient(c) }
             )
           )
         );

--- a/ui/contexts/AppContext.tsx
+++ b/ui/contexts/AppContext.tsx
@@ -7,7 +7,8 @@ import {
   getProviderToken,
   storeCallbackState,
   storeProviderToken,
-} from "../lib/storage";
+  notifySuccess,
+} from "../lib/utils";
 
 type AppState = {
   error: null | { fatal: boolean; message: string; detail?: string };
@@ -35,17 +36,19 @@ export type AppContextType = {
   storeCallbackState: typeof storeCallbackState;
   clearCallbackState: typeof clearCallbackState;
   navigate: (url: string) => void;
+  notifySuccess: typeof notifySuccess;
 };
 
 export const AppContext = React.createContext<AppContextType>(
   null as AppContextType
 );
 
-export interface Props {
-  applicationsClient: typeof Applications;
+export interface AppProps {
+  applicationsClient?: typeof Applications;
   linkResolver?: LinkResolver;
   children?: any;
   renderFooter?: boolean;
+  notifySuccess?: typeof notifySuccess;
 }
 
 // Due to the way the grpc-gateway typescript client is generated,
@@ -76,7 +79,7 @@ function wrapClient<T>(client: any, tokenGetter: () => string): T {
 export default function AppContextProvider({
   applicationsClient,
   ...props
-}: Props) {
+}: AppProps) {
   const [appState, setAppState] = React.useState({
     error: null,
   });
@@ -107,6 +110,7 @@ export default function AppContextProvider({
     storeCallbackState,
     getCallbackState,
     clearCallbackState,
+    notifySuccess: props.notifySuccess || notifySuccess,
     settings: {
       renderFooter: props.renderFooter,
     },

--- a/ui/contexts/AppContext.tsx
+++ b/ui/contexts/AppContext.tsx
@@ -7,8 +7,8 @@ import {
   getProviderToken,
   storeCallbackState,
   storeProviderToken,
-  notifySuccess,
-} from "../lib/utils";
+} from "../lib/storage";
+import { notifySuccess } from "../lib/utils";
 
 type AppState = {
   error: null | { fatal: boolean; message: string; detail?: string };

--- a/ui/hooks/__tests__/applications.test.tsx
+++ b/ui/hooks/__tests__/applications.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from "@testing-library/react";
 import _ from "lodash";
 import * as React from "react";
 import { Application } from "../../lib/api/applications/applications.pb";
-import { withContext } from "../../lib/test-utils";
+import { createMockClient, withContext } from "../../lib/test-utils";
 import useApplications from "../applications";
 
 describe("useApplications", () => {
@@ -42,7 +42,11 @@ describe("useApplications", () => {
       );
     };
 
-    render(withContext(TestComponent, `/`, mockResponses));
+    render(
+      withContext(TestComponent, `/`, {
+        applicationsClient: createMockClient(mockResponses),
+      })
+    );
 
     expect((await screen.findByTestId(name)).textContent).toEqual(name);
   });
@@ -63,7 +67,11 @@ describe("useApplications", () => {
       return <p data-testid="url">{app.url}</p>;
     };
 
-    render(withContext(TestComponent, `/`, mockResponses));
+    render(
+      withContext(TestComponent, `/`, {
+        applicationsClient: createMockClient(mockResponses),
+      })
+    );
 
     expect((await screen.findByTestId("url")).textContent).toEqual(url);
   });

--- a/ui/hooks/__tests__/auth.test.tsx
+++ b/ui/hooks/__tests__/auth.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import * as React from "react";
-import { withContext } from "../../lib/test-utils";
+import { createMockClient, withContext } from "../../lib/test-utils";
 import useAuth from "../auth";
 
 describe("useAuth", () => {
@@ -33,7 +33,11 @@ describe("useAuth", () => {
 
       return <div data-testid={id}>{userCode}</div>;
     };
-    render(withContext(TestComponent, `/`, ovr));
+    render(
+      withContext(TestComponent, `/`, {
+        applicationsClient: createMockClient(ovr),
+      })
+    );
     expect((await screen.findByTestId(id)).textContent).toEqual(userCode);
   });
   it("returns the github device auth status", async () => {
@@ -60,7 +64,11 @@ describe("useAuth", () => {
 
       return <div data-testid={id}>{accessToken}</div>;
     };
-    render(withContext(TestComponent, `/`, ovr));
+    render(
+      withContext(TestComponent, `/`, {
+        applicationsClient: createMockClient(ovr),
+      })
+    );
     expect((await screen.findByTestId(id)).textContent).toEqual(accessToken);
   });
 });

--- a/ui/hooks/__tests__/navigation.test.tsx
+++ b/ui/hooks/__tests__/navigation.test.tsx
@@ -22,7 +22,7 @@ describe("useNavigation", () => {
       return <p data-testid={id}>{currentPage}</p>;
     };
 
-    render(withContext(TestComponent, `/${myPage}`));
+    render(withContext(TestComponent, `/${myPage}`, {}));
 
     expect(screen.getByTestId(id).textContent).toEqual(myPage);
   });

--- a/ui/lib/test-utils.tsx
+++ b/ui/lib/test-utils.tsx
@@ -4,7 +4,7 @@ import _ from "lodash";
 import * as React from "react";
 import { Router } from "react-router-dom";
 import { ThemeProvider } from "styled-components";
-import AppContextProvider from "../contexts/AppContext";
+import AppContextProvider, { AppProps } from "../contexts/AppContext";
 import {
   Applications,
   GetApplicationRequest,
@@ -27,6 +27,7 @@ import {
   SyncApplicationResponse,
 } from "./api/applications/applications.pb";
 import theme, { muiTheme } from "./theme";
+import { RequestError } from "./types";
 
 export type ApplicationOverrides = {
   ListApplications?: (req: ListApplicationsRequest) => ListApplicationsResponse;
@@ -48,13 +49,18 @@ export type ApplicationOverrides = {
 
 // Don't make the user wire up all the promise stuff to be interface-compliant
 export const createMockClient = (
-  ovr: ApplicationOverrides
+  ovr: ApplicationOverrides,
+  error?: RequestError
 ): typeof Applications => {
   const promisified = _.reduce(
     ovr,
     (result, handlerFn, method) => {
-      result[method] = (req) =>
-        new Promise((accept) => accept(handlerFn(req) as any));
+      result[method] = (req) => {
+        if (error) {
+          return new Promise((_, reject) => reject(error));
+        }
+        return new Promise((accept) => accept(handlerFn(req) as any));
+      };
 
       return result;
     },
@@ -72,21 +78,14 @@ export function withTheme(element) {
   );
 }
 
-export function withContext(
-  TestComponent,
-  url: string,
-  appOverrides?: ApplicationOverrides
-) {
+export function withContext(TestComponent, url: string, ctxProps: AppProps) {
   const history = createMemoryHistory();
   history.push(url);
 
   const isElement = React.isValidElement(TestComponent);
   return (
     <Router history={history}>
-      <AppContextProvider
-        renderFooter
-        applicationsClient={createMockClient(appOverrides) as any}
-      >
+      <AppContextProvider renderFooter {...ctxProps}>
         {isElement ? TestComponent : <TestComponent />}
       </AppContextProvider>
     </Router>

--- a/ui/lib/test-utils.tsx
+++ b/ui/lib/test-utils.tsx
@@ -23,6 +23,8 @@ import {
   ListCommitsResponse,
   ParseRepoURLRequest,
   ParseRepoURLResponse,
+  SyncApplicationRequest,
+  SyncApplicationResponse,
 } from "./api/applications/applications.pb";
 import theme, { muiTheme } from "./theme";
 
@@ -41,6 +43,7 @@ export type ApplicationOverrides = {
     req: GetGithubAuthStatusRequest
   ) => GetGithubAuthStatusResponse;
   ParseRepoURL?: (req: ParseRepoURLRequest) => ParseRepoURLResponse;
+  SyncApplication?: (req: SyncApplicationRequest) => SyncApplicationResponse;
 };
 
 // Don't make the user wire up all the promise stuff to be interface-compliant

--- a/ui/pages/ApplicationDetail.tsx
+++ b/ui/pages/ApplicationDetail.tsx
@@ -27,7 +27,6 @@ import {
 } from "../lib/api/applications/applications.pb";
 import { getChildren } from "../lib/graph";
 import { PageRoute } from "../lib/types";
-import { notifySuccess } from "../lib/utils";
 
 type Props = {
   className?: string;
@@ -35,7 +34,8 @@ type Props = {
 };
 
 function ApplicationDetail({ className, name }: Props) {
-  const { applicationsClient, linkResolver } = React.useContext(AppContext);
+  const { applicationsClient, linkResolver, notifySuccess } =
+    React.useContext(AppContext);
   const [authSuccess, setAuthSuccess] = React.useState(false);
   const [githubAuthModalOpen, setGithubAuthModalOpen] = React.useState(false);
   const [removeAppModalOpen, setRemoveAppModalOpen] = React.useState(false);
@@ -76,7 +76,9 @@ function ApplicationDetail({ className, name }: Props) {
   }, [removeRes]);
 
   React.useEffect(() => {
-    if (syncRes) notifySuccess("App Sync Successful");
+    if (syncRes) {
+      notifySuccess("App Sync Successful");
+    }
   }, [syncRes]);
 
   if (error) {
@@ -133,11 +135,11 @@ function ApplicationDetail({ className, name }: Props) {
         </Flex>
       }
     >
-      {syncError || error ? (
+      {syncError ? (
         <Alert
           severity="error"
-          title="Error fetching Application"
-          message={error.message}
+          title="Error syncing Application"
+          message={syncError.message}
         />
       ) : (
         authSuccess && (

--- a/ui/pages/ApplicationDetail.tsx
+++ b/ui/pages/ApplicationDetail.tsx
@@ -27,6 +27,7 @@ import {
 } from "../lib/api/applications/applications.pb";
 import { getChildren } from "../lib/graph";
 import { PageRoute } from "../lib/types";
+import { notifySuccess } from "../lib/utils";
 
 type Props = {
   className?: string;
@@ -74,6 +75,10 @@ function ApplicationDetail({ className, name }: Props) {
     history.push(linkResolver(PageRoute.Applications));
   }, [removeRes]);
 
+  React.useEffect(() => {
+    if (syncRes) notifySuccess("App Sync Successful");
+  }, [syncRes]);
+
   if (error) {
     return (
       <ErrorPage
@@ -90,8 +95,6 @@ function ApplicationDetail({ className, name }: Props) {
 
   const { application = {} } = res;
 
-  console.log(syncError);
-
   return (
     <Page
       loading={loading}
@@ -99,13 +102,12 @@ function ApplicationDetail({ className, name }: Props) {
       title={name}
       className={className}
       topRight={
-        <Flex>
+        <Flex align>
           <Button
             color="primary"
             variant="contained"
             disabled={syncLoading}
             onClick={() => {
-              if (!authSuccess) return setGithubAuthModalOpen(true);
               syncRequest(
                 applicationsClient.SyncApplication({
                   name: application.name,
@@ -115,12 +117,12 @@ function ApplicationDetail({ className, name }: Props) {
             }}
           >
             {syncLoading ? (
-              <CircularProgress color="inherit" size="75%" />
+              <CircularProgress color="primary" size={"75%"} />
             ) : (
               "Sync App"
             )}
           </Button>
-          <Spacer margin="small" />
+          <Spacer padding="small" />
           <Button
             color="secondary"
             variant="contained"

--- a/ui/pages/__tests__/ApplicationDetail.test.tsx
+++ b/ui/pages/__tests__/ApplicationDetail.test.tsx
@@ -2,16 +2,17 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import "jest-styled-components";
 import * as React from "react";
 import { act } from "react-dom/test-utils";
+import { AppProps } from "../../contexts/AppContext";
 import {
   ListCommitsResponse,
   SyncApplicationResponse,
 } from "../../lib/api/applications/applications.pb";
-import { withContext, withTheme } from "../../lib/test-utils";
+import { createMockClient, withContext, withTheme } from "../../lib/test-utils";
 import ApplicationDetail from "../ApplicationDetail";
 
 describe("ApplicationDetail", () => {
   describe("Sync App Button", () => {
-    const apiMock = {
+    const apiOverrides = {
       GetApplication: () => ({
         application: {
           name: "pod-info",
@@ -40,7 +41,7 @@ describe("ApplicationDetail", () => {
           withContext(
             <ApplicationDetail name="pod-info" />,
             "/application_detail",
-            apiMock
+            { applicationsClient: createMockClient(apiOverrides) }
           )
         )
       );
@@ -48,8 +49,15 @@ describe("ApplicationDetail", () => {
     });
     it("should call a sync request", async () => {
       const promise = Promise.resolve();
+      const syncMock = jest.fn();
+      const mockClient = createMockClient(apiOverrides);
 
-      apiMock.SyncApplication = jest.fn();
+      mockClient.SyncApplication = (req) => {
+        syncMock(req);
+        return new Promise((accept) => {
+          accept({ success: true });
+        });
+      };
 
       await act(async () => {
         render(
@@ -57,7 +65,7 @@ describe("ApplicationDetail", () => {
             withContext(
               <ApplicationDetail name="pod-info" />,
               "/application_detail",
-              apiMock
+              { applicationsClient: mockClient }
             )
           )
         );
@@ -69,13 +77,63 @@ describe("ApplicationDetail", () => {
 
       fireEvent(button, new MouseEvent("click", { bubbles: true }));
 
-      expect(apiMock.SyncApplication).toHaveBeenCalledWith({
+      expect(syncMock).toHaveBeenCalledWith({
         name: "pod-info",
         namespace: "wego-systems",
       });
       await waitFor(() => promise);
     });
-    // it("should notify user on success", () => "");
-    // it("should notify user on failure", () => "");
+    it("should notify user on success", async () => {
+      const promise = Promise.resolve();
+      const props: AppProps = {
+        applicationsClient: createMockClient(apiOverrides),
+        notifySuccess: jest.fn(),
+      };
+
+      await act(async () => {
+        render(
+          withTheme(
+            withContext(
+              <ApplicationDetail name="pod-info" />,
+              "/application_detail",
+              props
+            )
+          )
+        );
+      });
+
+      const button = await (
+        await screen.findByText("Sync App")
+      ).closest("button");
+
+      fireEvent(button, new MouseEvent("click", { bubbles: true }));
+      await waitFor(() => promise);
+      expect(props.notifySuccess).toHaveBeenCalledTimes(1);
+    });
+    it("should notify user on failure", async () => {
+      const errorText = "uh-oh";
+      const mockClient = createMockClient(apiOverrides);
+      mockClient.SyncApplication = () =>
+        new Promise((_, reject) => reject({ message: errorText }));
+
+      await act(async () => {
+        render(
+          withTheme(
+            withContext(
+              <ApplicationDetail name="pod-info" />,
+              "/application_detail",
+              { applicationsClient: mockClient }
+            )
+          )
+        );
+      });
+
+      const button = await (
+        await screen.findByText("Sync App")
+      ).closest("button");
+      fireEvent(button, new MouseEvent("click", { bubbles: true }));
+      await screen.findByText(errorText);
+      await waitFor(() => mockClient.SyncApplication);
+    });
   });
 });

--- a/ui/pages/__tests__/ApplicationDetail.test.tsx
+++ b/ui/pages/__tests__/ApplicationDetail.test.tsx
@@ -1,0 +1,89 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import "jest-styled-components";
+import * as React from "react";
+import { act } from "react-dom/test-utils";
+import {
+  ListCommitsResponse,
+  SyncApplicationResponse,
+} from "../../lib/api/applications/applications.pb";
+import { withContext, withTheme } from "../../lib/test-utils";
+import ApplicationDetail from "../ApplicationDetail";
+
+describe("ApplicationDetail", () => {
+  describe("Sync App Button", () => {
+    it("should exist on page", async () => {
+      render(
+        withTheme(
+          withContext(
+            <ApplicationDetail name="pod-info" />,
+            "/application_detail",
+            {
+              GetApplication: () => ({
+                application: {
+                  name: "pod-info",
+                  namespace: "wego-systems",
+                },
+              }),
+              ListCommits: (): ListCommitsResponse => ({
+                commits: [
+                  {
+                    hash: "123abc",
+                    author: "Example User",
+                    date: "2021-09-10T23:45:09Z",
+                  },
+                ],
+              }),
+            }
+          )
+        )
+      );
+      expect(await screen.findByText("Sync App")).toBeTruthy();
+    });
+    it("should call a sync request", async () => {
+      const capture = jest.fn();
+      await act(async () => {
+        render(
+          withTheme(
+            withContext(
+              <ApplicationDetail name="pod-info" />,
+              "/application_detail",
+              {
+                GetApplication: () => ({
+                  application: {
+                    name: "pod-info",
+                    namespace: "wego-systems",
+                  },
+                }),
+                ListCommits: (): ListCommitsResponse => ({
+                  commits: [
+                    {
+                      hash: "123abc",
+                      author: "Example User",
+                      date: "2021-09-10T23:45:09Z",
+                    },
+                  ],
+                }),
+                SyncApplication: (req): SyncApplicationResponse => {
+                  capture(req);
+                  return {
+                    success: true,
+                  };
+                },
+              }
+            )
+          )
+        );
+      });
+      const button = await (
+        await screen.findByText("Sync App")
+      ).closest("button");
+      fireEvent(button, new MouseEvent("click", { bubbles: true }));
+      expect(capture).toHaveBeenCalledWith({
+        name: "pod-info",
+        namespace: "wego-systems",
+      });
+    });
+    // it("should notify user on success", () => "");
+    // it("should notify user on failure", () => "");
+  });
+});

--- a/ui/pages/__tests__/ApplicationDetail.test.tsx
+++ b/ui/pages/__tests__/ApplicationDetail.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import "jest-styled-components";
 import * as React from "react";
 import { act } from "react-dom/test-utils";
@@ -40,48 +40,56 @@ describe("ApplicationDetail", () => {
       expect(await screen.findByText("Sync App")).toBeTruthy();
     });
     it("should call a sync request", async () => {
+      const promise = Promise.resolve();
       const capture = jest.fn();
+
+      const apiMock = {
+        GetApplication: () => ({
+          application: {
+            name: "pod-info",
+            namespace: "wego-systems",
+          },
+        }),
+        ListCommits: (): ListCommitsResponse => ({
+          commits: [
+            {
+              hash: "123abc",
+              author: "Example User",
+              date: "2021-09-10T23:45:09Z",
+            },
+          ],
+        }),
+        SyncApplication: (req): SyncApplicationResponse => {
+          capture(req);
+          return {
+            success: true,
+          };
+        },
+      };
+
       await act(async () => {
         render(
           withTheme(
             withContext(
               <ApplicationDetail name="pod-info" />,
               "/application_detail",
-              {
-                GetApplication: () => ({
-                  application: {
-                    name: "pod-info",
-                    namespace: "wego-systems",
-                  },
-                }),
-                ListCommits: (): ListCommitsResponse => ({
-                  commits: [
-                    {
-                      hash: "123abc",
-                      author: "Example User",
-                      date: "2021-09-10T23:45:09Z",
-                    },
-                  ],
-                }),
-                SyncApplication: (req): SyncApplicationResponse => {
-                  capture(req);
-                  return {
-                    success: true,
-                  };
-                },
-              }
+              apiMock
             )
           )
         );
       });
+
       const button = await (
         await screen.findByText("Sync App")
       ).closest("button");
+
       fireEvent(button, new MouseEvent("click", { bubbles: true }));
+
       expect(capture).toHaveBeenCalledWith({
         name: "pod-info",
         namespace: "wego-systems",
       });
+      await waitFor(() => promise);
     });
     // it("should notify user on success", () => "");
     // it("should notify user on failure", () => "");

--- a/ui/pages/__tests__/ApplicationDetail.test.tsx
+++ b/ui/pages/__tests__/ApplicationDetail.test.tsx
@@ -11,29 +11,36 @@ import ApplicationDetail from "../ApplicationDetail";
 
 describe("ApplicationDetail", () => {
   describe("Sync App Button", () => {
+    const apiMock = {
+      GetApplication: () => ({
+        application: {
+          name: "pod-info",
+          namespace: "wego-systems",
+        },
+      }),
+      ListCommits: (): ListCommitsResponse => ({
+        commits: [
+          {
+            hash: "123abc",
+            author: "Example User",
+            date: "2021-09-10T23:45:09Z",
+          },
+        ],
+      }),
+      SyncApplication: (): SyncApplicationResponse => {
+        return {
+          success: true,
+        };
+      },
+    };
+
     it("should exist on page", async () => {
       render(
         withTheme(
           withContext(
             <ApplicationDetail name="pod-info" />,
             "/application_detail",
-            {
-              GetApplication: () => ({
-                application: {
-                  name: "pod-info",
-                  namespace: "wego-systems",
-                },
-              }),
-              ListCommits: (): ListCommitsResponse => ({
-                commits: [
-                  {
-                    hash: "123abc",
-                    author: "Example User",
-                    date: "2021-09-10T23:45:09Z",
-                  },
-                ],
-              }),
-            }
+            apiMock
           )
         )
       );
@@ -41,31 +48,8 @@ describe("ApplicationDetail", () => {
     });
     it("should call a sync request", async () => {
       const promise = Promise.resolve();
-      const capture = jest.fn();
 
-      const apiMock = {
-        GetApplication: () => ({
-          application: {
-            name: "pod-info",
-            namespace: "wego-systems",
-          },
-        }),
-        ListCommits: (): ListCommitsResponse => ({
-          commits: [
-            {
-              hash: "123abc",
-              author: "Example User",
-              date: "2021-09-10T23:45:09Z",
-            },
-          ],
-        }),
-        SyncApplication: (req): SyncApplicationResponse => {
-          capture(req);
-          return {
-            success: true,
-          };
-        },
-      };
+      apiMock.SyncApplication = jest.fn();
 
       await act(async () => {
         render(
@@ -85,7 +69,7 @@ describe("ApplicationDetail", () => {
 
       fireEvent(button, new MouseEvent("click", { bubbles: true }));
 
-      expect(capture).toHaveBeenCalledWith({
+      expect(apiMock.SyncApplication).toHaveBeenCalledWith({
         name: "pod-info",
         namespace: "wego-systems",
       });


### PR DESCRIPTION
Closes #1034 

A button handling the SyncApplication request has been added to ApplicationDetail, along with unit tests and numerous test-utils changes to facilitate mocking the API. Button is disabled while call is being made, but this state is not held on refresh. 

https://user-images.githubusercontent.com/65822698/142294107-7c1f4078-a35c-4a77-bb54-36f4a5dd696e.mov
