### PR TITLE
Add integration test coverage for adding an app in a GitLab repo

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,6 +73,7 @@ jobs:
 
   test:
     env:
+        GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
         GITHUB_TOKEN: "${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_TOKEN }}"
         KUBEBUILDER_ASSETS: ${{ github.workspace }}/kubebuilder/bin
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,6 +74,7 @@ jobs:
   test:
     env:
         GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
+        GITLAB_ORG: ${{ secrets.GITLAB_ORG }}
         GITHUB_TOKEN: "${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_TOKEN }}"
         KUBEBUILDER_ASSETS: ${{ github.workspace }}/kubebuilder/bin
     runs-on: ubuntu-latest

--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,7 @@ require (
 	github.com/spf13/viper v1.9.0
 	github.com/stretchr/testify v1.7.0
 	github.com/weaveworks/go-checkpoint v0.0.0-20170503165305-ebbb8b0518ab
+	github.com/xanzy/go-gitlab v0.43.0
 	go.uber.org/zap v1.19.0
 	golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f
 	golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b // indirect

--- a/test/integration/server/add_test.go
+++ b/test/integration/server/add_test.go
@@ -51,568 +51,575 @@ var _ = Describe("AddApplication", func() {
 		client = pb.NewApplicationsClient(conn)
 
 	})
-	Context("[github] via pull request", func() {
-		It("adds with no config repo specified", func() {
-			sourceRepoURL := fmt.Sprintf("https://github.com/%s/%s", org, sourceRepoName)
 
-			repo, ref, err := helpers.CreatePopulatedSourceRepo(ctx, gp, sourceRepoURL)
-			Expect(err).NotTo(HaveOccurred())
+	Context("GitHub", func() {
+		Context("via pull request", func() {
+			It("adds with no config repo specified", func() {
+				sourceRepoURL := fmt.Sprintf("https://github.com/%s/%s", org, sourceRepoName)
 
-			defer func() { Expect(repo.Delete(ctx)).To(Succeed()) }()
+				repo, ref, err := helpers.CreatePopulatedSourceRepo(ctx, gp, sourceRepoURL)
+				Expect(err).NotTo(HaveOccurred())
 
-			req := &pb.AddApplicationRequest{
-				Name:      "my-app",
-				Namespace: namespace.Name,
-				Url:       ref.GetCloneURL(gitprovider.TransportTypeSSH) + ".git",
-				Branch:    "main",
-				Path:      "k8s/overlays/development",
-			}
+				defer func() { Expect(repo.Delete(ctx)).To(Succeed()) }()
 
-			res, err := client.AddApplication(ctx, req)
-			Expect(err).NotTo(HaveOccurred())
+				req := &pb.AddApplicationRequest{
+					Name:      "my-app",
+					Namespace: namespace.Name,
+					Url:       ref.GetCloneURL(gitprovider.TransportTypeSSH) + ".git",
+					Branch:    "main",
+					Path:      "k8s/overlays/development",
+				}
 
-			Expect(res.Success).To(BeTrue(), "request should have been successful")
+				res, err := client.AddApplication(ctx, req)
+				Expect(err).NotTo(HaveOccurred())
 
-			_, err = repo.DeployKeys().Get(ctx, gitproviders.DeployKeyName)
-			Expect(err).NotTo(HaveOccurred(), "deploy key should have been found")
+				Expect(res.Success).To(BeTrue(), "request should have been successful")
 
-			prs, err := repo.PullRequests().List(ctx)
-			Expect(err).NotTo(HaveOccurred())
+				_, err = repo.DeployKeys().Get(ctx, gitproviders.DeployKeyName)
+				Expect(err).NotTo(HaveOccurred(), "deploy key should have been found")
 
-			Expect(prs).To(HaveLen(1))
+				prs, err := repo.PullRequests().List(ctx)
+				Expect(err).NotTo(HaveOccurred())
 
-			root := helpers.InAppRoot
+				Expect(prs).To(HaveLen(1))
 
-			fs := helpers.MakeWeGOFS(root, req.Name, clusterName)
+				root := helpers.InAppRoot
 
-			fetcher, err := helpers.NewFileFetcher(gitproviders.GitProviderGitHub, token)
-			Expect(err).NotTo(HaveOccurred())
+				fs := helpers.MakeWeGOFS(root, req.Name, clusterName)
 
-			actual, err := fetcher.GetFilesForPullRequest(ctx, 1, org, sourceRepoName, fs)
-			Expect(err).NotTo(HaveOccurred())
+				fetcher, err := helpers.NewFileFetcher(gitproviders.GitProviderGitHub, token)
+				Expect(err).NotTo(HaveOccurred())
 
-			expectedKustomization := kustomizev1.KustomizationSpec{
-				// Flux adds a prepending `./` to path arguments that doesn't already have it.
-				// https://github.com/fluxcd/flux2/blob/ca496d393d993ac5119ed84f83e010b8fe918c53/cmd/flux/create_kustomization.go#L115
-				Path: "./" + req.Path,
-				// Flux kustomization default; I couldn't find an export default from the package.
-				Interval: metav1.Duration{Duration: time.Duration(1 * time.Minute)},
-				Prune:    true,
-				SourceRef: kustomizev1.CrossNamespaceSourceReference{
-					Name: req.Name,
-					Kind: sourcev1.GitRepositoryKind,
-				},
-				Force: false,
-			}
+				actual, err := fetcher.GetFilesForPullRequest(ctx, 1, org, sourceRepoName, fs)
+				Expect(err).NotTo(HaveOccurred())
 
-			repoURL, err := gitproviders.NewRepoURL(sourceRepoURL)
-			Expect(err).NotTo(HaveOccurred())
+				expectedKustomization := kustomizev1.KustomizationSpec{
+					// Flux adds a prepending `./` to path arguments that doesn't already have it.
+					// https://github.com/fluxcd/flux2/blob/ca496d393d993ac5119ed84f83e010b8fe918c53/cmd/flux/create_kustomization.go#L115
+					Path: "./" + req.Path,
+					// Flux kustomization default; I couldn't find an export default from the package.
+					Interval: metav1.Duration{Duration: time.Duration(1 * time.Minute)},
+					Prune:    true,
+					SourceRef: kustomizev1.CrossNamespaceSourceReference{
+						Name: req.Name,
+						Kind: sourcev1.GitRepositoryKind,
+					},
+					Force: false,
+				}
 
-			expectedSource := sourcev1.GitRepositorySpec{
-				URL: req.Url,
-				SecretRef: &meta.LocalObjectReference{
-					Name: automation.CreateRepoSecretName(repoURL).String(),
-				},
-				Interval: metav1.Duration{Duration: time.Duration(30 * time.Second)},
-				Reference: &sourcev1.GitRepositoryRef{
-					Branch: req.Branch,
-				},
-				Ignore: helpers.GetIgnoreSpec(),
-			}
+				repoURL, err := gitproviders.NewRepoURL(sourceRepoURL)
+				Expect(err).NotTo(HaveOccurred())
 
-			expectedApp := wego.ApplicationSpec{
-				URL:            req.Url,
-				Branch:         req.Branch,
-				Path:           req.Path,
-				ConfigURL:      req.Url,
-				DeploymentType: wego.DeploymentTypeKustomize,
-				SourceType:     wego.SourceTypeGit,
-			}
+				expectedSource := sourcev1.GitRepositorySpec{
+					URL: req.Url,
+					SecretRef: &meta.LocalObjectReference{
+						Name: automation.CreateRepoSecretName(repoURL).String(),
+					},
+					Interval: metav1.Duration{Duration: time.Duration(30 * time.Second)},
+					Reference: &sourcev1.GitRepositoryRef{
+						Branch: req.Branch,
+					},
+					Ignore: helpers.GetIgnoreSpec(),
+				}
 
-			expected := helpers.GenerateExpectedFS(req, root, clusterName, expectedApp, expectedKustomization, expectedSource)
+				expectedApp := wego.ApplicationSpec{
+					URL:            req.Url,
+					Branch:         req.Branch,
+					Path:           req.Path,
+					ConfigURL:      req.Url,
+					DeploymentType: wego.DeploymentTypeKustomize,
+					SourceType:     wego.SourceTypeGit,
+				}
 
-			diff, err := helpers.DiffFS(actual, expected)
-			if err != nil {
-				GinkgoT().Errorf("%s: (-actual +expected): %s\n", err.Error(), diff)
-			}
+				expected := helpers.GenerateExpectedFS(req, root, clusterName, expectedApp, expectedKustomization, expectedSource)
+
+				diff, err := helpers.DiffFS(actual, expected)
+				if err != nil {
+					GinkgoT().Errorf("%s: (-actual +expected): %s\n", err.Error(), diff)
+				}
+			})
+
+			It("adds an app with an external config repo", func() {
+				sourceRepoURL := fmt.Sprintf("https://github.com/%s/%s", org, sourceRepoName)
+				configRepoURL := fmt.Sprintf("https://github.com/%s/%s", org, configRepoName)
+
+				configRepo, configRef, err := helpers.CreateRepo(ctx, gp, configRepoURL)
+				Expect(err).NotTo(HaveOccurred())
+
+				defer func() { Expect(configRepo.Delete(ctx)).To(Succeed()) }()
+
+				sourceRepo, sourceRef, err := helpers.CreatePopulatedSourceRepo(ctx, gp, sourceRepoURL)
+				Expect(err).NotTo(HaveOccurred())
+
+				defer func() { Expect(sourceRepo.Delete(ctx)).To(Succeed()) }()
+
+				req := &pb.AddApplicationRequest{
+					Name:      "my-app",
+					Namespace: namespace.Name,
+					Url:       sourceRef.GetCloneURL(gitprovider.TransportTypeSSH) + ".git",
+					Branch:    "main",
+					Path:      "k8s/overlays/development",
+					ConfigUrl: configRef.GetCloneURL(gitprovider.TransportTypeSSH) + ".git",
+				}
+
+				res, err := client.AddApplication(ctx, req)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(res.Success).To(BeTrue(), "request should have been successful")
+
+				_, err = configRepo.DeployKeys().Get(ctx, gitproviders.DeployKeyName)
+				Expect(err).NotTo(HaveOccurred(), "deploy key should have been found")
+
+				prs, err := configRepo.PullRequests().List(ctx)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(prs).To(HaveLen(1))
+
+				root := helpers.ExternalConfigRoot
+				fs := helpers.MakeWeGOFS(root, req.Name, clusterName)
+
+				fetcher, err := helpers.NewFileFetcher(gitproviders.GitProviderGitHub, token)
+				Expect(err).NotTo(HaveOccurred())
+
+				actual, err := fetcher.GetFilesForPullRequest(ctx, 1, org, configRepoName, fs)
+				Expect(err).NotTo(HaveOccurred())
+
+				normalizedUrl, err := gitproviders.NewRepoURL(req.Url)
+				Expect(err).NotTo(HaveOccurred())
+
+				expectedApp := wego.ApplicationSpec{
+					URL:            normalizedUrl.String(),
+					Branch:         req.Branch,
+					Path:           req.Path,
+					ConfigURL:      req.ConfigUrl,
+					DeploymentType: wego.DeploymentTypeKustomize,
+					SourceType:     wego.SourceTypeGit,
+				}
+
+				expectedKustomization := kustomizev1.KustomizationSpec{
+					Path:     "./" + req.Path,
+					Interval: metav1.Duration{Duration: time.Duration(1 * time.Minute)},
+					Prune:    true,
+					SourceRef: kustomizev1.CrossNamespaceSourceReference{
+						Name: req.Name,
+						Kind: sourcev1.GitRepositoryKind,
+					},
+					Force: false,
+				}
+
+				repoURL, err := gitproviders.NewRepoURL(sourceRepoURL)
+				Expect(err).NotTo(HaveOccurred())
+
+				expectedSource := sourcev1.GitRepositorySpec{
+					URL: req.Url,
+					SecretRef: &meta.LocalObjectReference{
+						// Might be a bug? Should be configRepoURL?
+						Name: automation.CreateRepoSecretName(repoURL).String(),
+					},
+					Interval: metav1.Duration{Duration: time.Duration(30 * time.Second)},
+					Reference: &sourcev1.GitRepositoryRef{
+						Branch: req.Branch,
+					},
+					Ignore: helpers.GetIgnoreSpec(),
+				}
+
+				expected := helpers.GenerateExpectedFS(req, root, clusterName, expectedApp, expectedKustomization, expectedSource)
+
+				diff, err := helpers.DiffFS(actual, expected)
+				if err != nil {
+					GinkgoT().Errorf("%s: (-actual +expected): %s\n", err.Error(), diff)
+				}
+			})
 		})
-
-		It("adds an app with an external config repo", func() {
-			sourceRepoURL := fmt.Sprintf("https://github.com/%s/%s", org, sourceRepoName)
-			configRepoURL := fmt.Sprintf("https://github.com/%s/%s", org, configRepoName)
-
-			configRepo, configRef, err := helpers.CreateRepo(ctx, gp, configRepoURL)
-			Expect(err).NotTo(HaveOccurred())
-
-			defer func() { Expect(configRepo.Delete(ctx)).To(Succeed()) }()
-
-			sourceRepo, sourceRef, err := helpers.CreatePopulatedSourceRepo(ctx, gp, sourceRepoURL)
-			Expect(err).NotTo(HaveOccurred())
-
-			defer func() { Expect(sourceRepo.Delete(ctx)).To(Succeed()) }()
-
-			req := &pb.AddApplicationRequest{
-				Name:      "my-app",
-				Namespace: namespace.Name,
-				Url:       sourceRef.GetCloneURL(gitprovider.TransportTypeSSH) + ".git",
-				Branch:    "main",
-				Path:      "k8s/overlays/development",
-				ConfigUrl: configRef.GetCloneURL(gitprovider.TransportTypeSSH) + ".git",
-			}
-
-			res, err := client.AddApplication(ctx, req)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(res.Success).To(BeTrue(), "request should have been successful")
-
-			_, err = configRepo.DeployKeys().Get(ctx, gitproviders.DeployKeyName)
-			Expect(err).NotTo(HaveOccurred(), "deploy key should have been found")
-
-			prs, err := configRepo.PullRequests().List(ctx)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(prs).To(HaveLen(1))
-
-			root := helpers.ExternalConfigRoot
-			fs := helpers.MakeWeGOFS(root, req.Name, clusterName)
-
-			fetcher, err := helpers.NewFileFetcher(gitproviders.GitProviderGitHub, token)
-			Expect(err).NotTo(HaveOccurred())
-
-			actual, err := fetcher.GetFilesForPullRequest(ctx, 1, org, configRepoName, fs)
-			Expect(err).NotTo(HaveOccurred())
-
-			normalizedUrl, err := gitproviders.NewRepoURL(req.Url)
-			Expect(err).NotTo(HaveOccurred())
-
-			expectedApp := wego.ApplicationSpec{
-				URL:            normalizedUrl.String(),
-				Branch:         req.Branch,
-				Path:           req.Path,
-				ConfigURL:      req.ConfigUrl,
-				DeploymentType: wego.DeploymentTypeKustomize,
-				SourceType:     wego.SourceTypeGit,
-			}
-
-			expectedKustomization := kustomizev1.KustomizationSpec{
-				Path:     "./" + req.Path,
-				Interval: metav1.Duration{Duration: time.Duration(1 * time.Minute)},
-				Prune:    true,
-				SourceRef: kustomizev1.CrossNamespaceSourceReference{
-					Name: req.Name,
-					Kind: sourcev1.GitRepositoryKind,
-				},
-				Force: false,
-			}
-
-			repoURL, err := gitproviders.NewRepoURL(sourceRepoURL)
-			Expect(err).NotTo(HaveOccurred())
-
-			expectedSource := sourcev1.GitRepositorySpec{
-				URL: req.Url,
-				SecretRef: &meta.LocalObjectReference{
-					// Might be a bug? Should be configRepoURL?
-					Name: automation.CreateRepoSecretName(repoURL).String(),
-				},
-				Interval: metav1.Duration{Duration: time.Duration(30 * time.Second)},
-				Reference: &sourcev1.GitRepositoryRef{
-					Branch: req.Branch,
-				},
-				Ignore: helpers.GetIgnoreSpec(),
-			}
-
-			expected := helpers.GenerateExpectedFS(req, root, clusterName, expectedApp, expectedKustomization, expectedSource)
-
-			diff, err := helpers.DiffFS(actual, expected)
-			if err != nil {
-				GinkgoT().Errorf("%s: (-actual +expected): %s\n", err.Error(), diff)
-			}
-		})
-	})
-	Context("[github] via auto merge", func() {
-		It("adds with no config repo specified", func() {
-			sourceRepoURL := fmt.Sprintf("https://github.com/%s/%s", org, sourceRepoName)
-
-			repo, ref, err := helpers.CreatePopulatedSourceRepo(ctx, gp, sourceRepoURL)
-			Expect(err).NotTo(HaveOccurred())
-
-			defer func() { Expect(repo.Delete(ctx)).To(Succeed()) }()
-
-			req := &pb.AddApplicationRequest{
-				Name:      "my-app",
-				Namespace: namespace.Name,
-				Url:       ref.GetCloneURL(gitprovider.TransportTypeSSH) + ".git",
-				Branch:    "main",
-				Path:      "k8s/overlays/development",
-				AutoMerge: true,
-			}
-
-			res, err := client.AddApplication(ctx, req)
-			Expect(err).NotTo(HaveOccurred())
-
-			Expect(res.Success).To(BeTrue(), "request should have been successful")
-
-			_, err = repo.DeployKeys().Get(ctx, gitproviders.DeployKeyName)
-			Expect(err).NotTo(HaveOccurred(), "deploy key should have been found")
-
-			prs, err := repo.PullRequests().List(ctx)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(prs).To(HaveLen(0))
-
-			root := helpers.InAppRoot
-
-			fs := helpers.MakeWeGOFS(root, req.Name, clusterName)
-
-			commits, _, err := gh.Repositories.ListCommits(ctx, org, sourceRepoName, &github.CommitsListOptions{SHA: "main"})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(commits).To(HaveLen(3))
-
-			appAddCommit := commits[0]
-
-			c, _, err := gh.Repositories.GetCommit(ctx, org, sourceRepoName, *appAddCommit.SHA)
-			Expect(err).NotTo(HaveOccurred())
-
-			actual, err := helpers.GetFileContents(ctx, gh, org, sourceRepoName, fs, c.Files)
-			Expect(err).NotTo(HaveOccurred())
-
-			expectedApp := wego.ApplicationSpec{
-				URL:            req.Url,
-				Branch:         req.Branch,
-				Path:           req.Path,
-				ConfigURL:      ref.GetCloneURL(gitprovider.TransportTypeSSH) + ".git",
-				DeploymentType: wego.DeploymentTypeKustomize,
-				SourceType:     wego.SourceTypeGit,
-			}
-
-			expectedKustomization := kustomizev1.KustomizationSpec{
-				// Flux adds a prepending `./` to path arguments that doesn't already have it.
-				// https://github.com/fluxcd/flux2/blob/ca496d393d993ac5119ed84f83e010b8fe918c53/cmd/flux/create_kustomization.go#L115
-				Path: "./" + req.Path,
-				// Flux kustomization default; I couldn't find an export default from the package.
-				Interval: metav1.Duration{Duration: time.Duration(1 * time.Minute)},
-				Prune:    true,
-				SourceRef: kustomizev1.CrossNamespaceSourceReference{
-					Name: req.Name,
-					Kind: sourcev1.GitRepositoryKind,
-				},
-				Force: false,
-			}
-
-			repoURL, err := gitproviders.NewRepoURL(sourceRepoURL)
-			Expect(err).NotTo(HaveOccurred())
-
-			expectedSrc := sourcev1.GitRepositorySpec{
-				URL: req.Url,
-				SecretRef: &meta.LocalObjectReference{
-					Name: automation.CreateRepoSecretName(repoURL).String(),
-				},
-				Interval: metav1.Duration{Duration: time.Duration(30 * time.Second)},
-				Reference: &sourcev1.GitRepositoryRef{
-					Branch: req.Branch,
-				},
-				Ignore: helpers.GetIgnoreSpec(),
-			}
-
-			expected := helpers.GenerateExpectedFS(req, root, clusterName, expectedApp, expectedKustomization, expectedSrc)
-
-			diff, err := helpers.DiffFS(actual, expected)
-			if err != nil {
-				GinkgoT().Errorf("%s: (-actual +expected): %s\n", err.Error(), diff)
-			}
-		})
-		It("with an external config repo", func() {
-			sourceRepoURL := fmt.Sprintf("https://github.com/%s/%s", org, sourceRepoName)
-			configRepoURL := fmt.Sprintf("https://github.com/%s/%s", org, configRepoName)
-
-			configRepo, configRef, err := helpers.CreateRepo(ctx, gp, configRepoURL)
-			Expect(err).NotTo(HaveOccurred())
-
-			defer func() { Expect(configRepo.Delete(ctx)).To(Succeed()) }()
-
-			sourceRepo, sourceRef, err := helpers.CreatePopulatedSourceRepo(ctx, gp, sourceRepoURL)
-			Expect(err).NotTo(HaveOccurred())
-
-			defer func() { Expect(sourceRepo.Delete(ctx)).To(Succeed()) }()
-
-			req := &pb.AddApplicationRequest{
-				Name:      "my-app",
-				Namespace: namespace.Name,
-				Url:       sourceRef.GetCloneURL(gitprovider.TransportTypeSSH) + ".git",
-				Branch:    "main",
-				Path:      "k8s/overlays/development",
-				ConfigUrl: configRef.GetCloneURL(gitprovider.TransportTypeSSH) + ".git",
-				AutoMerge: true,
-			}
-
-			res, err := client.AddApplication(ctx, req)
-			Expect(err).NotTo(HaveOccurred())
-
-			Expect(res.Success).To(BeTrue(), "request should have been successful")
-
-			_, err = sourceRepo.DeployKeys().Get(ctx, gitproviders.DeployKeyName)
-			Expect(err).NotTo(HaveOccurred(), "deploy key should have been found")
-
-			prs, err := configRepo.PullRequests().List(ctx)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(prs).To(HaveLen(0))
-
-			root := helpers.ExternalConfigRoot
-
-			fs := helpers.MakeWeGOFS(root, req.Name, clusterName)
-
-			commits, _, err := gh.Repositories.ListCommits(ctx, org, configRepoName, &github.CommitsListOptions{SHA: "main"})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(commits).To(HaveLen(2))
-
-			appAddCommit := commits[0]
-
-			c, _, err := gh.Repositories.GetCommit(ctx, org, configRepoName, *appAddCommit.SHA)
-			Expect(err).NotTo(HaveOccurred())
-
-			actual, err := helpers.GetFileContents(ctx, gh, org, configRepoName, fs, c.Files)
-			Expect(err).NotTo(HaveOccurred())
-
-			expectedApp := wego.ApplicationSpec{
-				URL:            req.Url,
-				Branch:         req.Branch,
-				Path:           req.Path,
-				ConfigURL:      req.ConfigUrl,
-				DeploymentType: wego.DeploymentTypeKustomize,
-				SourceType:     wego.SourceTypeGit,
-			}
-
-			expectedKustomization := kustomizev1.KustomizationSpec{
-				// Flux adds a prepending `./` to path arguments that doesn't already have it.
-				// https://github.com/fluxcd/flux2/blob/ca496d393d993ac5119ed84f83e010b8fe918c53/cmd/flux/create_kustomization.go#L115
-				Path: "./" + req.Path,
-				// Flux kustomization default; I couldn't find an export default from the package.
-				Interval: metav1.Duration{Duration: time.Duration(1 * time.Minute)},
-				Prune:    true,
-				SourceRef: kustomizev1.CrossNamespaceSourceReference{
-					Name: req.Name,
-					Kind: sourcev1.GitRepositoryKind,
-				},
-				Force: false,
-			}
-
-			repoURL, err := gitproviders.NewRepoURL(sourceRepoURL)
-			Expect(err).NotTo(HaveOccurred())
-
-			expectedSrc := sourcev1.GitRepositorySpec{
-				URL: req.Url,
-				SecretRef: &meta.LocalObjectReference{
-					Name: automation.CreateRepoSecretName(repoURL).String(),
-				},
-				Interval: metav1.Duration{Duration: time.Duration(30 * time.Second)},
-				Reference: &sourcev1.GitRepositoryRef{
-					Branch: req.Branch,
-				},
-				Ignore: helpers.GetIgnoreSpec(),
-			}
-
-			expected := helpers.GenerateExpectedFS(req, root, clusterName, expectedApp, expectedKustomization, expectedSrc)
-
-			diff, err := helpers.DiffFS(actual, expected)
-			if err != nil {
-				GinkgoT().Errorf("%s: (-actual +expected): %s\n", err.Error(), diff)
-			}
-		})
-	})
-	Context("[gitlab] via merge request", func() {
-		It("adds with no config repo specified", func() {
-			org = os.Getenv("GITLAB_ORG")
-			token := os.Getenv("GITLAB_TOKEN")
-			ctx = middleware.ContextWithGRPCAuth(context.Background(), token)
-
-			gp, err = gitlab.NewClient(
-				token,
-				"oauth2",
-				gitprovider.WithDestructiveAPICalls(true),
-			)
-			Expect(err).NotTo(HaveOccurred())
-
-			sourceRepoURL := fmt.Sprintf("https://gitlab.com/%s/%s", org, sourceRepoName)
-
-			repo, ref, err := helpers.CreatePopulatedSourceRepo(ctx, gp, sourceRepoURL)
-			Expect(err).NotTo(HaveOccurred())
-
-			Expect(err).NotTo(HaveOccurred())
-
-			defer func() { Expect(repo.Delete(ctx)).To(Succeed()) }()
-
-			req := &pb.AddApplicationRequest{
-				Name:      "my-app",
-				Namespace: namespace.Name,
-				Url:       ref.GetCloneURL(gitprovider.TransportTypeSSH) + ".git",
-				Branch:    "main",
-				Path:      "k8s/overlays/development",
-			}
-
-			res, err := client.AddApplication(ctx, req)
-			Expect(err).NotTo(HaveOccurred())
-
-			Expect(res.Success).To(BeTrue())
-
-			_, err = repo.DeployKeys().Get(ctx, gitproviders.DeployKeyName)
-			Expect(err).NotTo(HaveOccurred(), "deploy key should have been found")
-
-			prs, err := repo.PullRequests().List(ctx)
-			Expect(err).NotTo(HaveOccurred())
-
-			Expect(prs).To(HaveLen(1))
-
-			root := helpers.InAppRoot
-
-			fs := helpers.MakeWeGOFS(root, req.Name, clusterName)
-
-			gl, err := helpers.NewFileFetcher(gitproviders.GitProviderGitLab, token)
-			Expect(err).NotTo(HaveOccurred())
-
-			actual, err := gl.GetFilesForPullRequest(ctx, 1, org, sourceRepoName, fs)
-			Expect(err).NotTo(HaveOccurred())
-
-			expectedKustomization := kustomizev1.KustomizationSpec{
-				// Flux adds a prepending `./` to path arguments that doesn't already have it.
-				// https://github.com/fluxcd/flux2/blob/ca496d393d993ac5119ed84f83e010b8fe918c53/cmd/flux/create_kustomization.go#L115
-				Path: "./" + req.Path,
-				// Flux kustomization default; I couldn't find an export default from the package.
-				Interval: metav1.Duration{Duration: time.Duration(1 * time.Minute)},
-				Prune:    true,
-				SourceRef: kustomizev1.CrossNamespaceSourceReference{
-					Name: req.Name,
-					Kind: sourcev1.GitRepositoryKind,
-				},
-				Force: false,
-			}
-
-			repoURL, err := gitproviders.NewRepoURL(sourceRepoURL)
-			Expect(err).NotTo(HaveOccurred())
-
-			expectedSource := sourcev1.GitRepositorySpec{
-				URL: req.Url,
-				SecretRef: &meta.LocalObjectReference{
-					Name: automation.CreateRepoSecretName(repoURL).String(),
-				},
-				Interval: metav1.Duration{Duration: time.Duration(30 * time.Second)},
-				Reference: &sourcev1.GitRepositoryRef{
-					Branch: req.Branch,
-				},
-				Ignore: helpers.GetIgnoreSpec(),
-			}
-
-			expectedApp := wego.ApplicationSpec{
-				URL:            req.Url,
-				Branch:         req.Branch,
-				Path:           req.Path,
-				ConfigURL:      req.Url,
-				DeploymentType: wego.DeploymentTypeKustomize,
-				SourceType:     wego.SourceTypeGit,
-			}
-
-			expected := helpers.GenerateExpectedFS(req, root, clusterName, expectedApp, expectedKustomization, expectedSource)
-
-			diff, err := helpers.DiffFS(actual, expected)
-			if err != nil {
-				GinkgoT().Errorf("%s: (-actual +expected): %s\n", err.Error(), diff)
-			}
-		})
-		It("adds an app with an external config repo", func() {
-			org = os.Getenv("GITLAB_ORG")
-			token := os.Getenv("GITLAB_TOKEN")
-			ctx = middleware.ContextWithGRPCAuth(context.Background(), token)
-
-			gp, err = gitlab.NewClient(
-				token,
-				"oauth2",
-				gitprovider.WithDestructiveAPICalls(true),
-			)
-			Expect(err).NotTo(HaveOccurred())
-
-			sourceRepoURL := fmt.Sprintf("https://gitlab.com/%s/%s", org, sourceRepoName)
-			configRepoURL := fmt.Sprintf("https://gitlab.com/%s/%s", org, configRepoName)
-
-			configRepo, configRef, err := helpers.CreateRepo(ctx, gp, configRepoURL)
-			Expect(err).NotTo(HaveOccurred())
-
-			defer func() { Expect(configRepo.Delete(ctx)).To(Succeed()) }()
-
-			sourceRepo, sourceRef, err := helpers.CreatePopulatedSourceRepo(ctx, gp, sourceRepoURL)
-			Expect(err).NotTo(HaveOccurred())
-
-			defer func() { Expect(sourceRepo.Delete(ctx)).To(Succeed()) }()
-
-			req := &pb.AddApplicationRequest{
-				Name:      "my-app",
-				Namespace: namespace.Name,
-				Url:       sourceRef.GetCloneURL(gitprovider.TransportTypeSSH) + ".git",
-				Branch:    "main",
-				Path:      "k8s/overlays/development",
-				ConfigUrl: configRef.GetCloneURL(gitprovider.TransportTypeSSH) + ".git",
-			}
-
-			res, err := client.AddApplication(ctx, req)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(res.Success).To(BeTrue(), "request should have been successful")
-
-			_, err = configRepo.DeployKeys().Get(ctx, gitproviders.DeployKeyName)
-			Expect(err).NotTo(HaveOccurred(), "deploy key should have been found")
-
-			prs, err := configRepo.PullRequests().List(ctx)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(prs).To(HaveLen(1))
-
-			root := helpers.ExternalConfigRoot
-			fs := helpers.MakeWeGOFS(root, req.Name, clusterName)
-
-			fetcher, err := helpers.NewFileFetcher(gitproviders.GitProviderGitLab, token)
-			Expect(err).NotTo(HaveOccurred())
-
-			actual, err := fetcher.GetFilesForPullRequest(ctx, 1, org, configRepoName, fs)
-			Expect(err).NotTo(HaveOccurred())
-
-			normalizedUrl, err := gitproviders.NewRepoURL(req.Url)
-			Expect(err).NotTo(HaveOccurred())
-
-			expectedApp := wego.ApplicationSpec{
-				URL:            normalizedUrl.String(),
-				Branch:         req.Branch,
-				Path:           req.Path,
-				ConfigURL:      req.ConfigUrl,
-				DeploymentType: wego.DeploymentTypeKustomize,
-				SourceType:     wego.SourceTypeGit,
-			}
-
-			expectedKustomization := kustomizev1.KustomizationSpec{
-				Path:     "./" + req.Path,
-				Interval: metav1.Duration{Duration: time.Duration(1 * time.Minute)},
-				Prune:    true,
-				SourceRef: kustomizev1.CrossNamespaceSourceReference{
-					Name: req.Name,
-					Kind: sourcev1.GitRepositoryKind,
-				},
-				Force: false,
-			}
-
-			repoURL, err := gitproviders.NewRepoURL(sourceRepoURL)
-			Expect(err).NotTo(HaveOccurred())
-
-			expectedSource := sourcev1.GitRepositorySpec{
-				URL: req.Url,
-				SecretRef: &meta.LocalObjectReference{
-					// Might be a bug? Should be configRepoURL?
-					Name: automation.CreateRepoSecretName(repoURL).String(),
-				},
-				Interval: metav1.Duration{Duration: time.Duration(30 * time.Second)},
-				Reference: &sourcev1.GitRepositoryRef{
-					Branch: req.Branch,
-				},
-				Ignore: helpers.GetIgnoreSpec(),
-			}
-
-			expected := helpers.GenerateExpectedFS(req, root, clusterName, expectedApp, expectedKustomization, expectedSource)
-
-			diff, err := helpers.DiffFS(actual, expected)
-			if err != nil {
-				GinkgoT().Errorf("%s: (-actual +expected): %s\n", err.Error(), diff)
-			}
+		Context("via auto merge", func() {
+			It("adds with no config repo specified", func() {
+				sourceRepoURL := fmt.Sprintf("https://github.com/%s/%s", org, sourceRepoName)
+
+				repo, ref, err := helpers.CreatePopulatedSourceRepo(ctx, gp, sourceRepoURL)
+				Expect(err).NotTo(HaveOccurred())
+
+				defer func() { Expect(repo.Delete(ctx)).To(Succeed()) }()
+
+				req := &pb.AddApplicationRequest{
+					Name:      "my-app",
+					Namespace: namespace.Name,
+					Url:       ref.GetCloneURL(gitprovider.TransportTypeSSH) + ".git",
+					Branch:    "main",
+					Path:      "k8s/overlays/development",
+					AutoMerge: true,
+				}
+
+				res, err := client.AddApplication(ctx, req)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(res.Success).To(BeTrue(), "request should have been successful")
+
+				_, err = repo.DeployKeys().Get(ctx, gitproviders.DeployKeyName)
+				Expect(err).NotTo(HaveOccurred(), "deploy key should have been found")
+
+				prs, err := repo.PullRequests().List(ctx)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(prs).To(HaveLen(0))
+
+				root := helpers.InAppRoot
+
+				fs := helpers.MakeWeGOFS(root, req.Name, clusterName)
+
+				commits, _, err := gh.Repositories.ListCommits(ctx, org, sourceRepoName, &github.CommitsListOptions{SHA: "main"})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(commits).To(HaveLen(3))
+
+				appAddCommit := commits[0]
+
+				c, _, err := gh.Repositories.GetCommit(ctx, org, sourceRepoName, *appAddCommit.SHA)
+				Expect(err).NotTo(HaveOccurred())
+
+				actual, err := helpers.GetFileContents(ctx, gh, org, sourceRepoName, fs, c.Files)
+				Expect(err).NotTo(HaveOccurred())
+
+				expectedApp := wego.ApplicationSpec{
+					URL:            req.Url,
+					Branch:         req.Branch,
+					Path:           req.Path,
+					ConfigURL:      ref.GetCloneURL(gitprovider.TransportTypeSSH) + ".git",
+					DeploymentType: wego.DeploymentTypeKustomize,
+					SourceType:     wego.SourceTypeGit,
+				}
+
+				expectedKustomization := kustomizev1.KustomizationSpec{
+					// Flux adds a prepending `./` to path arguments that doesn't already have it.
+					// https://github.com/fluxcd/flux2/blob/ca496d393d993ac5119ed84f83e010b8fe918c53/cmd/flux/create_kustomization.go#L115
+					Path: "./" + req.Path,
+					// Flux kustomization default; I couldn't find an export default from the package.
+					Interval: metav1.Duration{Duration: time.Duration(1 * time.Minute)},
+					Prune:    true,
+					SourceRef: kustomizev1.CrossNamespaceSourceReference{
+						Name: req.Name,
+						Kind: sourcev1.GitRepositoryKind,
+					},
+					Force: false,
+				}
+
+				repoURL, err := gitproviders.NewRepoURL(sourceRepoURL)
+				Expect(err).NotTo(HaveOccurred())
+
+				expectedSrc := sourcev1.GitRepositorySpec{
+					URL: req.Url,
+					SecretRef: &meta.LocalObjectReference{
+						Name: automation.CreateRepoSecretName(repoURL).String(),
+					},
+					Interval: metav1.Duration{Duration: time.Duration(30 * time.Second)},
+					Reference: &sourcev1.GitRepositoryRef{
+						Branch: req.Branch,
+					},
+					Ignore: helpers.GetIgnoreSpec(),
+				}
+
+				expected := helpers.GenerateExpectedFS(req, root, clusterName, expectedApp, expectedKustomization, expectedSrc)
+
+				diff, err := helpers.DiffFS(actual, expected)
+				if err != nil {
+					GinkgoT().Errorf("%s: (-actual +expected): %s\n", err.Error(), diff)
+				}
+			})
+			It("with an external config repo", func() {
+				sourceRepoURL := fmt.Sprintf("https://github.com/%s/%s", org, sourceRepoName)
+				configRepoURL := fmt.Sprintf("https://github.com/%s/%s", org, configRepoName)
+
+				configRepo, configRef, err := helpers.CreateRepo(ctx, gp, configRepoURL)
+				Expect(err).NotTo(HaveOccurred())
+
+				defer func() { Expect(configRepo.Delete(ctx)).To(Succeed()) }()
+
+				sourceRepo, sourceRef, err := helpers.CreatePopulatedSourceRepo(ctx, gp, sourceRepoURL)
+				Expect(err).NotTo(HaveOccurred())
+
+				defer func() { Expect(sourceRepo.Delete(ctx)).To(Succeed()) }()
+
+				req := &pb.AddApplicationRequest{
+					Name:      "my-app",
+					Namespace: namespace.Name,
+					Url:       sourceRef.GetCloneURL(gitprovider.TransportTypeSSH) + ".git",
+					Branch:    "main",
+					Path:      "k8s/overlays/development",
+					ConfigUrl: configRef.GetCloneURL(gitprovider.TransportTypeSSH) + ".git",
+					AutoMerge: true,
+				}
+
+				res, err := client.AddApplication(ctx, req)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(res.Success).To(BeTrue(), "request should have been successful")
+
+				_, err = sourceRepo.DeployKeys().Get(ctx, gitproviders.DeployKeyName)
+				Expect(err).NotTo(HaveOccurred(), "deploy key should have been found")
+
+				prs, err := configRepo.PullRequests().List(ctx)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(prs).To(HaveLen(0))
+
+				root := helpers.ExternalConfigRoot
+
+				fs := helpers.MakeWeGOFS(root, req.Name, clusterName)
+
+				commits, _, err := gh.Repositories.ListCommits(ctx, org, configRepoName, &github.CommitsListOptions{SHA: "main"})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(commits).To(HaveLen(2))
+
+				appAddCommit := commits[0]
+
+				c, _, err := gh.Repositories.GetCommit(ctx, org, configRepoName, *appAddCommit.SHA)
+				Expect(err).NotTo(HaveOccurred())
+
+				actual, err := helpers.GetFileContents(ctx, gh, org, configRepoName, fs, c.Files)
+				Expect(err).NotTo(HaveOccurred())
+
+				expectedApp := wego.ApplicationSpec{
+					URL:            req.Url,
+					Branch:         req.Branch,
+					Path:           req.Path,
+					ConfigURL:      req.ConfigUrl,
+					DeploymentType: wego.DeploymentTypeKustomize,
+					SourceType:     wego.SourceTypeGit,
+				}
+
+				expectedKustomization := kustomizev1.KustomizationSpec{
+					// Flux adds a prepending `./` to path arguments that doesn't already have it.
+					// https://github.com/fluxcd/flux2/blob/ca496d393d993ac5119ed84f83e010b8fe918c53/cmd/flux/create_kustomization.go#L115
+					Path: "./" + req.Path,
+					// Flux kustomization default; I couldn't find an export default from the package.
+					Interval: metav1.Duration{Duration: time.Duration(1 * time.Minute)},
+					Prune:    true,
+					SourceRef: kustomizev1.CrossNamespaceSourceReference{
+						Name: req.Name,
+						Kind: sourcev1.GitRepositoryKind,
+					},
+					Force: false,
+				}
+
+				repoURL, err := gitproviders.NewRepoURL(sourceRepoURL)
+				Expect(err).NotTo(HaveOccurred())
+
+				expectedSrc := sourcev1.GitRepositorySpec{
+					URL: req.Url,
+					SecretRef: &meta.LocalObjectReference{
+						Name: automation.CreateRepoSecretName(repoURL).String(),
+					},
+					Interval: metav1.Duration{Duration: time.Duration(30 * time.Second)},
+					Reference: &sourcev1.GitRepositoryRef{
+						Branch: req.Branch,
+					},
+					Ignore: helpers.GetIgnoreSpec(),
+				}
+
+				expected := helpers.GenerateExpectedFS(req, root, clusterName, expectedApp, expectedKustomization, expectedSrc)
+
+				diff, err := helpers.DiffFS(actual, expected)
+				if err != nil {
+					GinkgoT().Errorf("%s: (-actual +expected): %s\n", err.Error(), diff)
+				}
+			})
 		})
 	})
+
+	Context("GitLab", func() {
+		Context("via merge request", func() {
+			It("adds with no config repo specified", func() {
+				org = os.Getenv("GITLAB_ORG")
+				token := os.Getenv("GITLAB_TOKEN")
+				ctx = middleware.ContextWithGRPCAuth(context.Background(), token)
+
+				gp, err = gitlab.NewClient(
+					token,
+					"oauth2",
+					gitprovider.WithDestructiveAPICalls(true),
+				)
+				Expect(err).NotTo(HaveOccurred())
+
+				sourceRepoURL := fmt.Sprintf("https://gitlab.com/%s/%s", org, sourceRepoName)
+
+				repo, ref, err := helpers.CreatePopulatedSourceRepo(ctx, gp, sourceRepoURL)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(err).NotTo(HaveOccurred())
+
+				defer func() { Expect(repo.Delete(ctx)).To(Succeed()) }()
+
+				req := &pb.AddApplicationRequest{
+					Name:      "my-app",
+					Namespace: namespace.Name,
+					Url:       ref.GetCloneURL(gitprovider.TransportTypeSSH) + ".git",
+					Branch:    "main",
+					Path:      "k8s/overlays/development",
+				}
+
+				res, err := client.AddApplication(ctx, req)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(res.Success).To(BeTrue())
+
+				_, err = repo.DeployKeys().Get(ctx, gitproviders.DeployKeyName)
+				Expect(err).NotTo(HaveOccurred(), "deploy key should have been found")
+
+				prs, err := repo.PullRequests().List(ctx)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(prs).To(HaveLen(1))
+
+				root := helpers.InAppRoot
+
+				fs := helpers.MakeWeGOFS(root, req.Name, clusterName)
+
+				gl, err := helpers.NewFileFetcher(gitproviders.GitProviderGitLab, token)
+				Expect(err).NotTo(HaveOccurred())
+
+				actual, err := gl.GetFilesForPullRequest(ctx, 1, org, sourceRepoName, fs)
+				Expect(err).NotTo(HaveOccurred())
+
+				expectedKustomization := kustomizev1.KustomizationSpec{
+					// Flux adds a prepending `./` to path arguments that doesn't already have it.
+					// https://github.com/fluxcd/flux2/blob/ca496d393d993ac5119ed84f83e010b8fe918c53/cmd/flux/create_kustomization.go#L115
+					Path: "./" + req.Path,
+					// Flux kustomization default; I couldn't find an export default from the package.
+					Interval: metav1.Duration{Duration: time.Duration(1 * time.Minute)},
+					Prune:    true,
+					SourceRef: kustomizev1.CrossNamespaceSourceReference{
+						Name: req.Name,
+						Kind: sourcev1.GitRepositoryKind,
+					},
+					Force: false,
+				}
+
+				repoURL, err := gitproviders.NewRepoURL(sourceRepoURL)
+				Expect(err).NotTo(HaveOccurred())
+
+				expectedSource := sourcev1.GitRepositorySpec{
+					URL: req.Url,
+					SecretRef: &meta.LocalObjectReference{
+						Name: automation.CreateRepoSecretName(repoURL).String(),
+					},
+					Interval: metav1.Duration{Duration: time.Duration(30 * time.Second)},
+					Reference: &sourcev1.GitRepositoryRef{
+						Branch: req.Branch,
+					},
+					Ignore: helpers.GetIgnoreSpec(),
+				}
+
+				expectedApp := wego.ApplicationSpec{
+					URL:            req.Url,
+					Branch:         req.Branch,
+					Path:           req.Path,
+					ConfigURL:      req.Url,
+					DeploymentType: wego.DeploymentTypeKustomize,
+					SourceType:     wego.SourceTypeGit,
+				}
+
+				expected := helpers.GenerateExpectedFS(req, root, clusterName, expectedApp, expectedKustomization, expectedSource)
+
+				diff, err := helpers.DiffFS(actual, expected)
+				if err != nil {
+					GinkgoT().Errorf("%s: (-actual +expected): %s\n", err.Error(), diff)
+				}
+			})
+			It("adds an app with an external config repo", func() {
+				org = os.Getenv("GITLAB_ORG")
+				token := os.Getenv("GITLAB_TOKEN")
+				ctx = middleware.ContextWithGRPCAuth(context.Background(), token)
+
+				gp, err = gitlab.NewClient(
+					token,
+					"oauth2",
+					gitprovider.WithDestructiveAPICalls(true),
+				)
+				Expect(err).NotTo(HaveOccurred())
+
+				sourceRepoURL := fmt.Sprintf("https://gitlab.com/%s/%s", org, sourceRepoName)
+				configRepoURL := fmt.Sprintf("https://gitlab.com/%s/%s", org, configRepoName)
+
+				configRepo, configRef, err := helpers.CreateRepo(ctx, gp, configRepoURL)
+				Expect(err).NotTo(HaveOccurred())
+
+				defer func() { Expect(configRepo.Delete(ctx)).To(Succeed()) }()
+
+				sourceRepo, sourceRef, err := helpers.CreatePopulatedSourceRepo(ctx, gp, sourceRepoURL)
+				Expect(err).NotTo(HaveOccurred())
+
+				defer func() { Expect(sourceRepo.Delete(ctx)).To(Succeed()) }()
+
+				req := &pb.AddApplicationRequest{
+					Name:      "my-app",
+					Namespace: namespace.Name,
+					Url:       sourceRef.GetCloneURL(gitprovider.TransportTypeSSH) + ".git",
+					Branch:    "main",
+					Path:      "k8s/overlays/development",
+					ConfigUrl: configRef.GetCloneURL(gitprovider.TransportTypeSSH) + ".git",
+				}
+
+				res, err := client.AddApplication(ctx, req)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(res.Success).To(BeTrue(), "request should have been successful")
+
+				_, err = configRepo.DeployKeys().Get(ctx, gitproviders.DeployKeyName)
+				Expect(err).NotTo(HaveOccurred(), "deploy key should have been found")
+
+				prs, err := configRepo.PullRequests().List(ctx)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(prs).To(HaveLen(1))
+
+				root := helpers.ExternalConfigRoot
+				fs := helpers.MakeWeGOFS(root, req.Name, clusterName)
+
+				fetcher, err := helpers.NewFileFetcher(gitproviders.GitProviderGitLab, token)
+				Expect(err).NotTo(HaveOccurred())
+
+				actual, err := fetcher.GetFilesForPullRequest(ctx, 1, org, configRepoName, fs)
+				Expect(err).NotTo(HaveOccurred())
+
+				normalizedUrl, err := gitproviders.NewRepoURL(req.Url)
+				Expect(err).NotTo(HaveOccurred())
+
+				expectedApp := wego.ApplicationSpec{
+					URL:            normalizedUrl.String(),
+					Branch:         req.Branch,
+					Path:           req.Path,
+					ConfigURL:      req.ConfigUrl,
+					DeploymentType: wego.DeploymentTypeKustomize,
+					SourceType:     wego.SourceTypeGit,
+				}
+
+				expectedKustomization := kustomizev1.KustomizationSpec{
+					Path:     "./" + req.Path,
+					Interval: metav1.Duration{Duration: time.Duration(1 * time.Minute)},
+					Prune:    true,
+					SourceRef: kustomizev1.CrossNamespaceSourceReference{
+						Name: req.Name,
+						Kind: sourcev1.GitRepositoryKind,
+					},
+					Force: false,
+				}
+
+				repoURL, err := gitproviders.NewRepoURL(sourceRepoURL)
+				Expect(err).NotTo(HaveOccurred())
+
+				expectedSource := sourcev1.GitRepositorySpec{
+					URL: req.Url,
+					SecretRef: &meta.LocalObjectReference{
+						// Might be a bug? Should be configRepoURL?
+						Name: automation.CreateRepoSecretName(repoURL).String(),
+					},
+					Interval: metav1.Duration{Duration: time.Duration(30 * time.Second)},
+					Reference: &sourcev1.GitRepositoryRef{
+						Branch: req.Branch,
+					},
+					Ignore: helpers.GetIgnoreSpec(),
+				}
+
+				expected := helpers.GenerateExpectedFS(req, root, clusterName, expectedApp, expectedKustomization, expectedSource)
+
+				diff, err := helpers.DiffFS(actual, expected)
+				if err != nil {
+					GinkgoT().Errorf("%s: (-actual +expected): %s\n", err.Error(), diff)
+				}
+			})
+		})
+	})
+
 })

--- a/test/integration/server/add_test.go
+++ b/test/integration/server/add_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/weaveworks/weave-gitops/pkg/server/middleware"
 	"github.com/weaveworks/weave-gitops/pkg/services/automation"
 	"github.com/weaveworks/weave-gitops/test/integration/server/helpers"
-	glAPI "github.com/xanzy/go-gitlab"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
@@ -86,7 +85,10 @@ var _ = Describe("AddApplication", func() {
 
 			fs := helpers.MakeWeGOFS(root, req.Name, clusterName)
 
-			actual, err := helpers.GetFilesForPullRequest(ctx, gh, org, sourceRepoName, fs)
+			fetcher, err := helpers.NewFileFetcher(gitproviders.GitProviderGitHub, token)
+			Expect(err).NotTo(HaveOccurred())
+
+			actual, err := fetcher.GetFilesForPullRequest(ctx, 1, org, sourceRepoName, fs)
 			Expect(err).NotTo(HaveOccurred())
 
 			expectedKustomization := kustomizev1.KustomizationSpec{
@@ -172,7 +174,10 @@ var _ = Describe("AddApplication", func() {
 			root := helpers.ExternalConfigRoot
 			fs := helpers.MakeWeGOFS(root, req.Name, clusterName)
 
-			actual, err := helpers.GetFilesForPullRequest(ctx, gh, org, configRepoName, fs)
+			fetcher, err := helpers.NewFileFetcher(gitproviders.GitProviderGitHub, token)
+			Expect(err).NotTo(HaveOccurred())
+
+			actual, err := fetcher.GetFilesForPullRequest(ctx, 1, org, configRepoName, fs)
 			Expect(err).NotTo(HaveOccurred())
 
 			normalizedUrl, err := gitproviders.NewRepoURL(req.Url)
@@ -459,10 +464,10 @@ var _ = Describe("AddApplication", func() {
 
 			fs := helpers.MakeWeGOFS(root, req.Name, clusterName)
 
-			gl, err := glAPI.NewClient(token)
+			gl, err := helpers.NewFileFetcher(gitproviders.GitProviderGitLab, token)
 			Expect(err).NotTo(HaveOccurred())
 
-			actual, err := helpers.GetFilesForPullRequest_Gitlab(ctx, gl, org, sourceRepoName, fs)
+			actual, err := gl.GetFilesForPullRequest(ctx, 1, org, sourceRepoName, fs)
 			Expect(err).NotTo(HaveOccurred())
 
 			expectedKustomization := kustomizev1.KustomizationSpec{

--- a/test/integration/server/helpers/fetcher.go
+++ b/test/integration/server/helpers/fetcher.go
@@ -1,0 +1,75 @@
+package helpers
+
+import (
+	"context"
+	"fmt"
+
+	ghAPI "github.com/google/go-github/v32/github"
+	"github.com/weaveworks/weave-gitops/pkg/gitproviders"
+	glAPI "github.com/xanzy/go-gitlab"
+)
+
+type FileFetcher interface {
+	GetFilesForPullRequest(ctx context.Context, id int, org, repoName string, fs WeGODirectoryFS) (WeGODirectoryFS, error)
+}
+
+func NewFileFetcher(name gitproviders.GitProviderName, token string) (FileFetcher, error) {
+	switch name {
+	case gitproviders.GitProviderGitHub:
+		return githubPrClient{
+			client: NewGithubClient(context.Background(), token),
+		}, nil
+	case gitproviders.GitProviderGitLab:
+		gl, err := glAPI.NewClient(token)
+		if err != nil {
+			return nil, err
+		}
+
+		return gitlabPrClient{
+			client: gl,
+		}, nil
+	}
+
+	return nil, fmt.Errorf("unkown git provider: %s", name)
+}
+
+type githubPrClient struct {
+	client *ghAPI.Client
+}
+
+func (gh githubPrClient) GetFilesForPullRequest(ctx context.Context, id int, org, repoName string, fs WeGODirectoryFS) (WeGODirectoryFS, error) {
+	files, _, err := gh.client.PullRequests.ListFiles(ctx, org, repoName, 1, &ghAPI.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("error listing files for %q: %w", repoName, err)
+	}
+
+	return GetFileContents(ctx, gh.client, org, repoName, fs, files)
+}
+
+type gitlabPrClient struct {
+	client *glAPI.Client
+}
+
+func (gl gitlabPrClient) GetFilesForPullRequest(ctx context.Context, id int, org, repoName string, fs WeGODirectoryFS) (WeGODirectoryFS, error) {
+	pid := fmt.Sprintf("%s/%s", org, repoName)
+	mr, _, err := gl.client.MergeRequests.GetMergeRequestChanges(pid, id, nil)
+
+	if err != nil {
+		return nil, fmt.Errorf("could not get merge request: %w", err)
+	}
+
+	files := map[string][]byte{}
+
+	for _, c := range mr.Changes {
+		path := c.OldPath
+
+		file, _, err := gl.client.RepositoryFiles.GetRawFile(pid, path, &glAPI.GetRawFileOptions{Ref: &mr.DiffRefs.HeadSha})
+		if err != nil {
+			return nil, fmt.Errorf("could not get merge request: %w", err)
+		}
+
+		files[path] = file
+	}
+
+	return toK8sObjects(files, fs)
+}

--- a/test/integration/server/helpers/fetcher.go
+++ b/test/integration/server/helpers/fetcher.go
@@ -39,8 +39,8 @@ type githubPrClient struct {
 	client *ghAPI.Client
 }
 
-func (gh githubPrClient) GetFilesForPullRequest(ctx context.Context, id int, org, repoName string, fs WeGODirectoryFS) (WeGODirectoryFS, error) {
-	files, _, err := gh.client.PullRequests.ListFiles(ctx, org, repoName, 1, &ghAPI.ListOptions{})
+func (gh githubPrClient) GetFilesForPullRequest(ctx context.Context, prID int, org, repoName string, fs WeGODirectoryFS) (WeGODirectoryFS, error) {
+	files, _, err := gh.client.PullRequests.ListFiles(ctx, org, repoName, prID, &ghAPI.ListOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("error listing files for %q: %w", repoName, err)
 	}
@@ -52,9 +52,9 @@ type gitlabPrClient struct {
 	client *glAPI.Client
 }
 
-func (gl gitlabPrClient) GetFilesForPullRequest(ctx context.Context, id int, org, repoName string, fs WeGODirectoryFS) (WeGODirectoryFS, error) {
+func (gl gitlabPrClient) GetFilesForPullRequest(ctx context.Context, prID int, org, repoName string, fs WeGODirectoryFS) (WeGODirectoryFS, error) {
 	pid := fmt.Sprintf("%s/%s", org, repoName)
-	mr, _, err := gl.client.MergeRequests.GetMergeRequestChanges(pid, id, nil)
+	mr, _, err := gl.client.MergeRequests.GetMergeRequestChanges(pid, prID, nil)
 
 	if err != nil {
 		return nil, fmt.Errorf("could not get merge request: %w", err)

--- a/test/integration/server/helpers/fetcher.go
+++ b/test/integration/server/helpers/fetcher.go
@@ -1,3 +1,5 @@
+// +build !unittest
+
 package helpers
 
 import (

--- a/test/integration/server/helpers/fetcher.go
+++ b/test/integration/server/helpers/fetcher.go
@@ -67,7 +67,7 @@ func (gl gitlabPrClient) GetFilesForPullRequest(ctx context.Context, prID int, o
 
 		file, _, err := gl.client.RepositoryFiles.GetRawFile(pid, path, &glAPI.GetRawFileOptions{Ref: &mr.DiffRefs.HeadSha})
 		if err != nil {
-			return nil, fmt.Errorf("could not get merge request: %w", err)
+			return nil, fmt.Errorf("could not raw file for merge request: %w", err)
 		}
 
 		files[path] = file

--- a/test/integration/server/helpers/helpers.go
+++ b/test/integration/server/helpers/helpers.go
@@ -19,7 +19,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	ghAPI "github.com/google/go-github/v32/github"
-	glAPI "github.com/xanzy/go-gitlab"
 
 	"github.com/fluxcd/source-controller/pkg/sourceignore"
 	wego "github.com/weaveworks/weave-gitops/api/v1alpha1"
@@ -275,39 +274,6 @@ func toK8sObjects(changes map[string][]byte, fs WeGODirectoryFS) (WeGODirectoryF
 	}
 
 	return fs, nil
-}
-
-func GetFilesForPullRequest_Gitlab(ctx context.Context, gl *glAPI.Client, org, repoName string, fs WeGODirectoryFS) (WeGODirectoryFS, error) {
-	pid := fmt.Sprintf("%s/%s", org, repoName)
-	mr, _, err := gl.MergeRequests.GetMergeRequestChanges(pid, 1, nil)
-
-	if err != nil {
-		return nil, fmt.Errorf("could not get merge request: %w", err)
-	}
-
-	files := map[string][]byte{}
-
-	for _, c := range mr.Changes {
-		path := c.OldPath
-
-		file, _, err := gl.RepositoryFiles.GetRawFile(pid, path, &glAPI.GetRawFileOptions{Ref: &mr.DiffRefs.HeadSha})
-		if err != nil {
-			return nil, fmt.Errorf("could not get merge request: %w", err)
-		}
-
-		files[path] = file
-	}
-
-	return toK8sObjects(files, fs)
-}
-
-func GetFilesForPullRequest(ctx context.Context, gh *ghAPI.Client, org, repoName string, fs WeGODirectoryFS) (WeGODirectoryFS, error) {
-	files, _, err := gh.PullRequests.ListFiles(ctx, org, repoName, 1, &ghAPI.ListOptions{})
-	if err != nil {
-		return nil, fmt.Errorf("error listing files for %q: %w", repoName, err)
-	}
-
-	return GetFileContents(ctx, gh, org, repoName, fs, files)
 }
 
 func CreatePopulatedSourceRepo(ctx context.Context, gp gitprovider.Client, url string) (gitprovider.OrgRepository, *gitprovider.OrgRepositoryRef, error) {

--- a/test/integration/server/helpers/helpers.go
+++ b/test/integration/server/helpers/helpers.go
@@ -58,7 +58,7 @@ func CreateRepo(ctx context.Context, gp gitprovider.Client, url string) (gitprov
 		return nil, nil, fmt.Errorf("could not reconcile org repo: %w", err)
 	}
 
-	err = utils.WaitUntil(os.Stdout, 3*time.Second, 9*time.Second, func() error {
+	err = utils.WaitUntil(bytes.NewBuffer([]byte{}), 3*time.Second, 9*time.Second, func() error {
 		r, err := gp.OrgRepositories().Get(ctx, *ref)
 		if err != nil {
 			return err


### PR DESCRIPTION
Adds some much needed test coverage for GitLab. Only covers the Merge Request case (not auto-merge).

These tests have reached a tipping point IMO and need to be refactored into a table-style test to reduce some of the repetition. I will handle that in another PR, as getting the coverage is more important than making them DRY. 