### PR TITLE
Pass user token to API via an HTTP header

### DIFF
--- a/cmd/gitops/add/clusters/cmd_test.go
+++ b/cmd/gitops/add/clusters/cmd_test.go
@@ -3,7 +3,6 @@ package clusters_test
 import (
 	"encoding/json"
 	"net/http"
-	"os"
 	"testing"
 
 	"github.com/go-resty/resty/v2"
@@ -12,6 +11,7 @@ import (
 	"github.com/weaveworks/weave-gitops/cmd/gitops/cmderrors"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/root"
 	"github.com/weaveworks/weave-gitops/pkg/adapters"
+	"github.com/weaveworks/weave-gitops/pkg/testutils"
 )
 
 func TestSetSeparateValues(t *testing.T) {
@@ -145,8 +145,7 @@ func TestEndpointNotSet(t *testing.T) {
 }
 
 func TestGitProviderToken(t *testing.T) {
-	os.Setenv("GITHUB_TOKEN", "test-token")
-	defer os.Unsetenv("GITHUB_TOKEN")
+	t.Cleanup(testutils.Setenv("GITHUB_TOKEN", "test-token"))
 
 	client := resty.New()
 

--- a/cmd/gitops/add/clusters/cmd_test.go
+++ b/cmd/gitops/add/clusters/cmd_test.go
@@ -3,11 +3,13 @@ package clusters_test
 import (
 	"encoding/json"
 	"net/http"
+	"os"
 	"testing"
 
 	"github.com/go-resty/resty/v2"
 	"github.com/jarcoal/httpmock"
 	"github.com/stretchr/testify/assert"
+	"github.com/weaveworks/weave-gitops/cmd/gitops/cmderrors"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/root"
 	"github.com/weaveworks/weave-gitops/pkg/adapters"
 )
@@ -140,4 +142,78 @@ func TestEndpointNotSet(t *testing.T) {
 
 	err := cmd.Execute()
 	assert.EqualError(t, err, "the Weave GitOps Enterprise HTTP API endpoint flag (--endpoint) has not been set")
+}
+
+func TestGitProviderToken(t *testing.T) {
+	os.Setenv("GITHUB_TOKEN", "test-token")
+	defer os.Unsetenv("GITHUB_TOKEN")
+
+	client := resty.New()
+
+	httpmock.ActivateNonDefault(client.GetClient())
+	defer httpmock.DeactivateAndReset()
+
+	httpmock.RegisterResponder(
+		http.MethodPost,
+		"http://localhost:8000/v1/clusters",
+		func(r *http.Request) (*http.Response, error) {
+			h, ok := r.Header["Git-Provider-Token"]
+			assert.True(t, ok)
+			assert.Contains(t, h, "test-token")
+
+			return httpmock.NewJsonResponse(http.StatusOK, httpmock.File("../../../../pkg/adapters/testdata/pull_request_created.json"))
+		},
+	)
+
+	cmd := root.RootCmd(client)
+	cmd.SetArgs([]string{
+		"add", "cluster",
+		"--from-template=cluster-template-eks-fargate",
+		"--url=https://github.com/weaveworks/test-repo",
+		"--set=CLUSTER_NAME=dev",
+		"--set=AWS_REGION=us-east-1",
+		"--set=AWS_SSH_KEY_NAME=ssh_key",
+		"--set=KUBERNETES_VERSION=1.19",
+		"--endpoint", "http://localhost:8000",
+	})
+
+	err := cmd.Execute()
+	assert.NoError(t, err)
+}
+
+func TestGitProviderToken_NoURL(t *testing.T) {
+	client := resty.New()
+
+	cmd := root.RootCmd(client)
+	cmd.SetArgs([]string{
+		"add", "cluster",
+		"--from-template=cluster-template-eks-fargate",
+		"--set=CLUSTER_NAME=dev",
+		"--set=AWS_REGION=us-east-1",
+		"--set=AWS_SSH_KEY_NAME=ssh_key",
+		"--set=KUBERNETES_VERSION=1.19",
+		"--endpoint", "http://localhost:8000",
+	})
+
+	err := cmd.Execute()
+	assert.ErrorIs(t, err, cmderrors.ErrNoURL)
+}
+
+func TestGitProviderToken_InvalidURL(t *testing.T) {
+	client := resty.New()
+
+	cmd := root.RootCmd(client)
+	cmd.SetArgs([]string{
+		"add", "cluster",
+		"--from-template=cluster-template-eks-fargate",
+		"--url=invalid_url",
+		"--set=CLUSTER_NAME=dev",
+		"--set=AWS_REGION=us-east-1",
+		"--set=AWS_SSH_KEY_NAME=ssh_key",
+		"--set=KUBERNETES_VERSION=1.19",
+		"--endpoint", "http://localhost:8000",
+	})
+
+	err := cmd.Execute()
+	assert.EqualError(t, err, "cannot parse url: could not get provider name from URL invalid_url: no git providers found for \"invalid_url\"")
 }

--- a/cmd/gitops/cmderrors/errors.go
+++ b/cmd/gitops/cmderrors/errors.go
@@ -2,4 +2,7 @@ package cmderrors
 
 import "errors"
 
-var ErrNoWGEEndpoint = errors.New("the Weave GitOps Enterprise HTTP API endpoint flag (--endpoint) has not been set")
+var (
+	ErrNoWGEEndpoint = errors.New("the Weave GitOps Enterprise HTTP API endpoint flag (--endpoint) has not been set")
+	ErrNoURL         = errors.New("the url flag (--url) has not been set")
+)

--- a/cmd/gitops/delete/clusters/cmd_test.go
+++ b/cmd/gitops/delete/clusters/cmd_test.go
@@ -3,7 +3,6 @@ package clusters_test
 import (
 	"encoding/json"
 	"net/http"
-	"os"
 	"testing"
 
 	"github.com/go-resty/resty/v2"
@@ -11,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/cmderrors"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/root"
+	"github.com/weaveworks/weave-gitops/pkg/testutils"
 )
 
 func TestEndpointNotSet(t *testing.T) {
@@ -26,8 +26,7 @@ func TestEndpointNotSet(t *testing.T) {
 }
 
 func TestPayload(t *testing.T) {
-	os.Setenv("GITHUB_TOKEN", "test-token")
-	defer os.Unsetenv("GITHUB_TOKEN")
+	t.Cleanup(testutils.Setenv("GITHUB_TOKEN", "test-token"))
 
 	client := resty.New()
 
@@ -68,8 +67,7 @@ func TestPayload(t *testing.T) {
 }
 
 func TestGitProviderToken(t *testing.T) {
-	os.Setenv("GITHUB_TOKEN", "test-token")
-	defer os.Unsetenv("GITHUB_TOKEN")
+	t.Cleanup(testutils.Setenv("GITHUB_TOKEN", "test-token"))
 
 	client := resty.New()
 

--- a/pkg/adapters/http.go
+++ b/pkg/adapters/http.go
@@ -245,6 +245,7 @@ func (c *HTTPClient) CreatePullRequestFromTemplate(params capi.CreatePullRequest
 
 	res, err := c.client.R().
 		SetHeader("Accept", "application/json").
+		SetHeader("Git-Provider-Token", params.GitProviderToken).
 		SetBody(CreatePullRequestFromTemplateRequest{
 			RepositoryURL:   params.RepositoryURL,
 			HeadBranch:      params.HeadBranch,
@@ -434,6 +435,7 @@ func (c *HTTPClient) DeleteClusters(params clusters.DeleteClustersParams) (strin
 
 	res, err := c.client.R().
 		SetHeader("Accept", "application/json").
+		SetHeader("Git-Provider-Token", params.GitProviderToken).
 		SetBody(DeleteClustersPullRequestRequest{
 			HeadBranch:    params.HeadBranch,
 			BaseBranch:    params.BaseBranch,

--- a/pkg/adapters/http.go
+++ b/pkg/adapters/http.go
@@ -13,7 +13,8 @@ import (
 )
 
 const (
-	expiredHeaderName = "Entitlement-Expired-Message"
+	expiredHeaderName          = "Entitlement-Expired-Message"
+	gitProviderTokenHeaderName = "Git-Provider-Token"
 )
 
 // An HTTP client of the cluster service.
@@ -245,7 +246,7 @@ func (c *HTTPClient) CreatePullRequestFromTemplate(params capi.CreatePullRequest
 
 	res, err := c.client.R().
 		SetHeader("Accept", "application/json").
-		SetHeader("Git-Provider-Token", params.GitProviderToken).
+		SetHeader(gitProviderTokenHeaderName, params.GitProviderToken).
 		SetBody(CreatePullRequestFromTemplateRequest{
 			RepositoryURL:   params.RepositoryURL,
 			HeadBranch:      params.HeadBranch,
@@ -435,7 +436,7 @@ func (c *HTTPClient) DeleteClusters(params clusters.DeleteClustersParams) (strin
 
 	res, err := c.client.R().
 		SetHeader("Accept", "application/json").
-		SetHeader("Git-Provider-Token", params.GitProviderToken).
+		SetHeader(gitProviderTokenHeaderName, params.GitProviderToken).
 		SetBody(DeleteClustersPullRequestRequest{
 			HeadBranch:    params.HeadBranch,
 			BaseBranch:    params.BaseBranch,

--- a/pkg/capi/capi.go
+++ b/pkg/capi/capi.go
@@ -60,15 +60,16 @@ type Credentials struct {
 }
 
 type CreatePullRequestFromTemplateParams struct {
-	TemplateName    string
-	ParameterValues map[string]string
-	RepositoryURL   string
-	HeadBranch      string
-	BaseBranch      string
-	Title           string
-	Description     string
-	CommitMessage   string
-	Credentials     Credentials
+	GitProviderToken string
+	TemplateName     string
+	ParameterValues  map[string]string
+	RepositoryURL    string
+	HeadBranch       string
+	BaseBranch       string
+	Title            string
+	Description      string
+	CommitMessage    string
+	Credentials      Credentials
 }
 
 // GetTemplates uses a TemplatesRetriever adapter to show

--- a/pkg/clusters/clusters.go
+++ b/pkg/clusters/clusters.go
@@ -115,11 +115,12 @@ func DeleteClusters(params DeleteClustersParams, r ClustersRetriever, w io.Write
 }
 
 type DeleteClustersParams struct {
-	RepositoryURL string
-	HeadBranch    string
-	BaseBranch    string
-	Title         string
-	Description   string
-	ClustersNames []string
-	CommitMessage string
+	GitProviderToken string
+	RepositoryURL    string
+	HeadBranch       string
+	BaseBranch       string
+	Title            string
+	Description      string
+	ClustersNames    []string
+	CommitMessage    string
 }

--- a/pkg/testutils/testutils.go
+++ b/pkg/testutils/testutils.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/go-logr/logr"
 	"github.com/weaveworks/weave-gitops/pkg/flux"
@@ -198,4 +199,18 @@ func SetupFlux() (flux.Flux, string, error) {
 	}
 
 	return realFlux, dir, nil
+}
+
+func Setenv(k, v string) func() {
+	prev := os.Environ()
+	os.Setenv(k, v)
+
+	return func() {
+		os.Unsetenv(k)
+
+		for _, kv := range prev {
+			parts := strings.SplitN(kv, "=", 2)
+			os.Setenv(parts[0], parts[1])
+		}
+	}
 }


### PR DESCRIPTION
<!-- Use # to add the issue this pull request is related to -->
Closes: weaveworks/weave-gitops-enterprise#203

<!-- Describe what has changed in this PR -->
**What changed?**
- Refactored out code that returns the git provider token (either via an env var or via the git provider auth flow)
- Pass the git provider token to the API via an HTTP header


<!-- Tell your future self why have you made these changes -->
**Why?**
This is so that the Weave GitOps Enterprise API can make calls to the git provider on behalf of the end user.

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**
Tested locally + unit tests

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
**Release notes**
N/A

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
N/A