### PR TITLE
Add set text to source to avoid same name errors

### DIFF
--- a/pkg/flux/flux_test.go
+++ b/pkg/flux/flux_test.go
@@ -209,7 +209,7 @@ var _ = Describe("CreateHelmReleaseHelmRepository", func() {
 		runner.RunStub = func(s1 string, s2 ...string) ([]byte, error) {
 			return []byte("out"), nil
 		}
-		out, err := fluxClient.CreateHelmReleaseHelmRepository("my-name", "my-chart", wego.DefaultNamespace, "")
+		out, err := fluxClient.CreateHelmReleaseHelmRepository("my-name", "wego-app-my-name", "my-chart", wego.DefaultNamespace, "")
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(out).To(Equal([]byte("out")))
 
@@ -218,14 +218,14 @@ var _ = Describe("CreateHelmReleaseHelmRepository", func() {
 		cmd, args := runner.RunArgsForCall(0)
 		Expect(cmd).To(Equal(fluxPath()))
 
-		Expect(strings.Join(args, " ")).To(Equal(fmt.Sprintf("create helmrelease my-name --source HelmRepository/my-name --chart my-chart --namespace %s --interval 5m --export", wego.DefaultNamespace)))
+		Expect(strings.Join(args, " ")).To(Equal(fmt.Sprintf("create helmrelease my-name --source HelmRepository/wego-app-my-name --chart my-chart --namespace %s --interval 5m --export", wego.DefaultNamespace)))
 	})
 
 	It("creates a helm release with a helm repository and a target namespace", func() {
 		runner.RunStub = func(s1 string, s2 ...string) ([]byte, error) {
 			return []byte("out"), nil
 		}
-		out, err := fluxClient.CreateHelmReleaseHelmRepository("my-name", "my-chart", wego.DefaultNamespace, "sock-shop")
+		out, err := fluxClient.CreateHelmReleaseHelmRepository("my-name", "wego-app-my-name", "my-chart", wego.DefaultNamespace, "sock-shop")
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(out).To(Equal([]byte("out")))
 
@@ -234,7 +234,7 @@ var _ = Describe("CreateHelmReleaseHelmRepository", func() {
 		cmd, args := runner.RunArgsForCall(0)
 		Expect(cmd).To(Equal(fluxPath()))
 
-		Expect(strings.Join(args, " ")).To(Equal(fmt.Sprintf("create helmrelease my-name --source HelmRepository/my-name --chart my-chart --namespace %s --interval 5m --export --target-namespace sock-shop", wego.DefaultNamespace)))
+		Expect(strings.Join(args, " ")).To(Equal(fmt.Sprintf("create helmrelease my-name --source HelmRepository/wego-app-my-name --chart my-chart --namespace %s --interval 5m --export --target-namespace sock-shop", wego.DefaultNamespace)))
 	})
 })
 

--- a/pkg/flux/fluxfakes/fake_flux.go
+++ b/pkg/flux/fluxfakes/fake_flux.go
@@ -27,13 +27,14 @@ type FakeFlux struct {
 		result1 []byte
 		result2 error
 	}
-	CreateHelmReleaseHelmRepositoryStub        func(string, string, string, string) ([]byte, error)
+	CreateHelmReleaseHelmRepositoryStub        func(string, string, string, string, string) ([]byte, error)
 	createHelmReleaseHelmRepositoryMutex       sync.RWMutex
 	createHelmReleaseHelmRepositoryArgsForCall []struct {
 		arg1 string
 		arg2 string
 		arg3 string
 		arg4 string
+		arg5 string
 	}
 	createHelmReleaseHelmRepositoryReturns struct {
 		result1 []byte
@@ -286,7 +287,7 @@ func (fake *FakeFlux) CreateHelmReleaseGitRepositoryReturnsOnCall(i int, result1
 	}{result1, result2}
 }
 
-func (fake *FakeFlux) CreateHelmReleaseHelmRepository(arg1 string, arg2 string, arg3 string, arg4 string) ([]byte, error) {
+func (fake *FakeFlux) CreateHelmReleaseHelmRepository(arg1 string, arg2 string, arg3 string, arg4 string, arg5 string) ([]byte, error) {
 	fake.createHelmReleaseHelmRepositoryMutex.Lock()
 	ret, specificReturn := fake.createHelmReleaseHelmRepositoryReturnsOnCall[len(fake.createHelmReleaseHelmRepositoryArgsForCall)]
 	fake.createHelmReleaseHelmRepositoryArgsForCall = append(fake.createHelmReleaseHelmRepositoryArgsForCall, struct {
@@ -294,13 +295,14 @@ func (fake *FakeFlux) CreateHelmReleaseHelmRepository(arg1 string, arg2 string, 
 		arg2 string
 		arg3 string
 		arg4 string
-	}{arg1, arg2, arg3, arg4})
+		arg5 string
+	}{arg1, arg2, arg3, arg4, arg5})
 	stub := fake.CreateHelmReleaseHelmRepositoryStub
 	fakeReturns := fake.createHelmReleaseHelmRepositoryReturns
-	fake.recordInvocation("CreateHelmReleaseHelmRepository", []interface{}{arg1, arg2, arg3, arg4})
+	fake.recordInvocation("CreateHelmReleaseHelmRepository", []interface{}{arg1, arg2, arg3, arg4, arg5})
 	fake.createHelmReleaseHelmRepositoryMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3, arg4)
+		return stub(arg1, arg2, arg3, arg4, arg5)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -314,17 +316,17 @@ func (fake *FakeFlux) CreateHelmReleaseHelmRepositoryCallCount() int {
 	return len(fake.createHelmReleaseHelmRepositoryArgsForCall)
 }
 
-func (fake *FakeFlux) CreateHelmReleaseHelmRepositoryCalls(stub func(string, string, string, string) ([]byte, error)) {
+func (fake *FakeFlux) CreateHelmReleaseHelmRepositoryCalls(stub func(string, string, string, string, string) ([]byte, error)) {
 	fake.createHelmReleaseHelmRepositoryMutex.Lock()
 	defer fake.createHelmReleaseHelmRepositoryMutex.Unlock()
 	fake.CreateHelmReleaseHelmRepositoryStub = stub
 }
 
-func (fake *FakeFlux) CreateHelmReleaseHelmRepositoryArgsForCall(i int) (string, string, string, string) {
+func (fake *FakeFlux) CreateHelmReleaseHelmRepositoryArgsForCall(i int) (string, string, string, string, string) {
 	fake.createHelmReleaseHelmRepositoryMutex.RLock()
 	defer fake.createHelmReleaseHelmRepositoryMutex.RUnlock()
 	argsForCall := fake.createHelmReleaseHelmRepositoryArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
 }
 
 func (fake *FakeFlux) CreateHelmReleaseHelmRepositoryReturns(result1 []byte, result2 error) {

--- a/pkg/services/app/add_test.go
+++ b/pkg/services/app/add_test.go
@@ -265,7 +265,7 @@ var _ = Describe("Add Gitlab", func() {
 				Expect(fluxClient.CreateSourceGitCallCount()).To(Equal(1))
 
 				name, url, branch, secretRef, namespace := fluxClient.CreateSourceGitArgsForCall(0)
-				Expect(name).To(Equal("bar"))
+				Expect(name).To(Equal("wego-app-bar"))
 				Expect(url.String()).To(Equal("ssh://git@gitlab.com/foo/bar.git"))
 				Expect(branch).To(Equal("main"))
 				Expect(secretRef).To(Equal("wego-gitlab-bar"))

--- a/pkg/services/app/app.go
+++ b/pkg/services/app/app.go
@@ -15,6 +15,7 @@ import (
 	"github.com/weaveworks/weave-gitops/pkg/kube"
 	"github.com/weaveworks/weave-gitops/pkg/logger"
 	"github.com/weaveworks/weave-gitops/pkg/osys"
+	"github.com/weaveworks/weave-gitops/pkg/services/automation"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -127,8 +128,8 @@ func (a *AppSvc) pauseOrUnpause(suspendAction wego.SuspendActionType, name, name
 			a.Logger.Printf("app %s is already paused\n", name)
 			return nil
 		}
-
-		out, err := a.Flux.SuspendOrResumeApp(suspendAction, name, namespace, string(deploymentType))
+		sourceName := automation.CreateAppSourceName(name)
+		out, err := a.Flux.SuspendOrResumeApp(suspendAction, sourceName, namespace, string(deploymentType))
 		if err != nil {
 			return fmt.Errorf("unable to pause %s err: %s", name, err)
 		}

--- a/pkg/services/app/app.go
+++ b/pkg/services/app/app.go
@@ -128,7 +128,9 @@ func (a *AppSvc) pauseOrUnpause(suspendAction wego.SuspendActionType, name, name
 			a.Logger.Printf("app %s is already paused\n", name)
 			return nil
 		}
+
 		sourceName := automation.CreateAppSourceName(name)
+
 		out, err := a.Flux.SuspendOrResumeApp(suspendAction, sourceName, namespace, string(deploymentType))
 		if err != nil {
 			return fmt.Errorf("unable to pause %s err: %s", name, err)

--- a/pkg/services/app/app.go
+++ b/pkg/services/app/app.go
@@ -102,13 +102,14 @@ func (a *AppSvc) getSuspendedStatus(ctx context.Context, name, namespace string,
 
 func (a *AppSvc) pauseOrUnpause(suspendAction wego.SuspendActionType, name, namespace string) error {
 	ctx := context.Background()
+	sourceName := automation.CreateAppSourceName(name)
 
 	deploymentType, err := a.getDeploymentType(ctx, name, namespace)
 	if err != nil {
 		return fmt.Errorf("unable to determine deployment type for %s: %s", name, err)
 	}
 
-	suspendStatus, err := a.getSuspendedStatus(ctx, name, namespace, deploymentType)
+	suspendStatus, err := a.getSuspendedStatus(ctx, sourceName, namespace, deploymentType)
 	if err != nil {
 		return fmt.Errorf("failed to get suspended status: %s", err)
 	}
@@ -121,8 +122,6 @@ func (a *AppSvc) pauseOrUnpause(suspendAction wego.SuspendActionType, name, name
 	default:
 		return fmt.Errorf("invalid deployment type: %v", deploymentType)
 	}
-
-	sourceName := automation.CreateAppSourceName(name)
 
 	switch suspendAction {
 	case wego.SuspendAction:

--- a/pkg/services/app/app.go
+++ b/pkg/services/app/app.go
@@ -122,14 +122,14 @@ func (a *AppSvc) pauseOrUnpause(suspendAction wego.SuspendActionType, name, name
 		return fmt.Errorf("invalid deployment type: %v", deploymentType)
 	}
 
+	sourceName := automation.CreateAppSourceName(name)
+
 	switch suspendAction {
 	case wego.SuspendAction:
 		if suspendStatus {
 			a.Logger.Printf("app %s is already paused\n", name)
 			return nil
 		}
-
-		sourceName := automation.CreateAppSourceName(name)
 
 		out, err := a.Flux.SuspendOrResumeApp(suspendAction, sourceName, namespace, string(deploymentType))
 		if err != nil {
@@ -145,7 +145,7 @@ func (a *AppSvc) pauseOrUnpause(suspendAction wego.SuspendActionType, name, name
 			return nil
 		}
 
-		out, err := a.Flux.SuspendOrResumeApp(suspendAction, name, namespace, string(deploymentType))
+		out, err := a.Flux.SuspendOrResumeApp(suspendAction, sourceName, namespace, string(deploymentType))
 		if err != nil {
 			return fmt.Errorf("unable to unpause %s err: %s", name, err)
 		}

--- a/pkg/services/app/status.go
+++ b/pkg/services/app/status.go
@@ -18,6 +18,9 @@ type StatusParams struct {
 }
 
 func (a *AppSvc) Status(params StatusParams) (string, string, error) {
+	appName := params.Name
+	// Need to add this hardcoded text to name for flux to be able to find the correct source.
+	params.Name = "wego-app-" + params.Name
 	fluxOutput, err := a.Flux.GetAllResourcesStatus(params.Name, params.Namespace)
 	if err != nil {
 		return "", "", fmt.Errorf("failed getting app status: %w", err)
@@ -25,7 +28,7 @@ func (a *AppSvc) Status(params StatusParams) (string, string, error) {
 
 	ctx := context.Background()
 
-	deploymentType, err := a.getDeploymentType(ctx, params.Name, params.Namespace)
+	deploymentType, err := a.getDeploymentType(ctx, appName, params.Namespace)
 	if err != nil {
 		return "", "", fmt.Errorf("failed getting app deployment type: %w", err)
 	}

--- a/pkg/services/app/status.go
+++ b/pkg/services/app/status.go
@@ -19,18 +19,16 @@ type StatusParams struct {
 }
 
 func (a *AppSvc) Status(params StatusParams) (string, string, error) {
-	appName := params.Name
-	// Need to add this hardcoded text to name for flux to be able to find the correct source.
-	params.Name = automation.CreateAppSourceName(params.Name)
+	sourceName := automation.CreateAppSourceName(params.Name)
 
-	fluxOutput, err := a.Flux.GetAllResourcesStatus(params.Name, params.Namespace)
+	fluxOutput, err := a.Flux.GetAllResourcesStatus(params.Name, sourceName, params.Namespace)
 	if err != nil {
 		return "", "", fmt.Errorf("failed getting app status: %w", err)
 	}
 
 	ctx := context.Background()
 
-	deploymentType, err := a.getDeploymentType(ctx, appName, params.Namespace)
+	deploymentType, err := a.getDeploymentType(ctx, params.Name, params.Namespace)
 	if err != nil {
 		return "", "", fmt.Errorf("failed getting app deployment type: %w", err)
 	}

--- a/pkg/services/app/status.go
+++ b/pkg/services/app/status.go
@@ -21,6 +21,7 @@ func (a *AppSvc) Status(params StatusParams) (string, string, error) {
 	appName := params.Name
 	// Need to add this hardcoded text to name for flux to be able to find the correct source.
 	params.Name = "wego-app-" + params.Name
+
 	fluxOutput, err := a.Flux.GetAllResourcesStatus(params.Name, params.Namespace)
 	if err != nil {
 		return "", "", fmt.Errorf("failed getting app status: %w", err)

--- a/pkg/services/app/status.go
+++ b/pkg/services/app/status.go
@@ -8,6 +8,7 @@ import (
 	kustomizev2 "github.com/fluxcd/kustomize-controller/api/v1beta2"
 	"github.com/fluxcd/pkg/apis/meta"
 	wego "github.com/weaveworks/weave-gitops/api/v1alpha1"
+	"github.com/weaveworks/weave-gitops/pkg/services/automation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -20,7 +21,7 @@ type StatusParams struct {
 func (a *AppSvc) Status(params StatusParams) (string, string, error) {
 	appName := params.Name
 	// Need to add this hardcoded text to name for flux to be able to find the correct source.
-	params.Name = "wego-app-" + params.Name
+	params.Name = automation.CreateAppSourceName(params.Name)
 
 	fluxOutput, err := a.Flux.GetAllResourcesStatus(params.Name, params.Namespace)
 	if err != nil {

--- a/pkg/services/app/status_test.go
+++ b/pkg/services/app/status_test.go
@@ -89,7 +89,7 @@ var _ = Describe("Status", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 
 			_, name, deploymentType := kubeClient.GetResourceArgsForCall(0)
-			Expect(name).To(Equal(types.NamespacedName{Name: "wego-app-" + statusParams.Name, Namespace: statusParams.Namespace}))
+			Expect(name).To(Equal(types.NamespacedName{Name: statusParams.Name, Namespace: statusParams.Namespace}))
 			Expect(deploymentType).To(BeAssignableToTypeOf(&helmv2.HelmRelease{}))
 
 			Expect(lastRecon).To(Equal("2009-11-10 23:00:00 +0000 UTC"))

--- a/pkg/services/app/status_test.go
+++ b/pkg/services/app/status_test.go
@@ -65,7 +65,7 @@ var _ = Describe("Status", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 
 			_, name, deploymentType := kubeClient.GetResourceArgsForCall(0)
-			Expect(name).To(Equal(types.NamespacedName{Name: statusParams.Name, Namespace: statusParams.Namespace}))
+			Expect(name).To(Equal(types.NamespacedName{Name: "wego-app-" + statusParams.Name, Namespace: statusParams.Namespace}))
 			Expect(deploymentType).To(BeAssignableToTypeOf(&kustomizev2.Kustomization{}))
 
 			Expect(lastRecon).To(Equal("2009-11-10 23:00:00 +0000 UTC"))
@@ -89,7 +89,7 @@ var _ = Describe("Status", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 
 			_, name, deploymentType := kubeClient.GetResourceArgsForCall(0)
-			Expect(name).To(Equal(types.NamespacedName{Name: statusParams.Name, Namespace: statusParams.Namespace}))
+			Expect(name).To(Equal(types.NamespacedName{Name: "wego-app-" + statusParams.Name, Namespace: statusParams.Namespace}))
 			Expect(deploymentType).To(BeAssignableToTypeOf(&helmv2.HelmRelease{}))
 
 			Expect(lastRecon).To(Equal("2009-11-10 23:00:00 +0000 UTC"))

--- a/pkg/services/automation/automation_test.go
+++ b/pkg/services/automation/automation_test.go
@@ -127,7 +127,7 @@ var _ = Describe("Generate manifests", func() {
 				Expect(fluxClient.CreateSourceHelmCallCount()).To(Equal(1))
 
 				name, url, namespace := fluxClient.CreateSourceHelmArgsForCall(0)
-				Expect(name).To(Equal("loki"))
+				Expect(name).To(Equal("wego-app-loki"))
 				Expect(url).To(Equal("https://charts.kube-ops.io"))
 				Expect(namespace).To(Equal(wego.DefaultNamespace))
 
@@ -181,7 +181,7 @@ var _ = Describe("Generate manifests", func() {
 				Expect(fluxClient.CreateHelmReleaseGitRepositoryCallCount()).To(Equal(1))
 
 				name, source, path, namespace, targetNamespace := fluxClient.CreateHelmReleaseGitRepositoryArgsForCall(0)
-				Expect(name).To(Equal("bar"))
+				Expect(name).To(Equal("wego-app-bar"))
 				Expect(source).To(Equal("bar"))
 				Expect(path).To(Equal("./charts/my-chart"))
 				Expect(namespace).To(Equal(wego.DefaultNamespace))
@@ -199,7 +199,7 @@ var _ = Describe("Generate manifests", func() {
 				Expect(fluxClient.CreateHelmReleaseGitRepositoryCallCount()).To(Equal(1))
 
 				name, source, path, namespace, targetNamespace := fluxClient.CreateHelmReleaseGitRepositoryArgsForCall(0)
-				Expect(name).To(Equal("bar"))
+				Expect(name).To(Equal("wego-app-bar"))
 				Expect(source).To(Equal("bar"))
 				Expect(path).To(Equal("./charts/my-chart"))
 				Expect(namespace).To(Equal(wego.DefaultNamespace))
@@ -259,7 +259,7 @@ var _ = Describe("Generate manifests", func() {
 					Expect(fluxClient.CreateSourceHelmCallCount()).To(Equal(1))
 
 					name, url, namespace := fluxClient.CreateSourceHelmArgsForCall(0)
-					Expect(name).To(Equal("loki"))
+					Expect(name).To(Equal("wego-app-loki"))
 					Expect(url).To(Equal("https://charts.kube-ops.io"))
 					Expect(namespace).To(Equal(wego.DefaultNamespace))
 
@@ -349,8 +349,9 @@ var _ = Describe("Generate manifests", func() {
 
 					Expect(fluxClient.CreateHelmReleaseHelmRepositoryCallCount()).To(Equal(1))
 
-					name, chart, namespace, targetNamespace := fluxClient.CreateHelmReleaseHelmRepositoryArgsForCall(0)
+					name, source, chart, namespace, targetNamespace := fluxClient.CreateHelmReleaseHelmRepositoryArgsForCall(0)
 					Expect(name).To(Equal("loki"))
+					Expect(source).To(Equal("wego-app-loki"))
 					Expect(chart).To(Equal("loki"))
 					Expect(namespace).To(Equal(wego.DefaultNamespace))
 					Expect(targetNamespace).To(Equal(""))
@@ -371,7 +372,7 @@ var _ = Describe("Generate manifests", func() {
 					Expect(fluxClient.CreateHelmReleaseGitRepositoryCallCount()).To(Equal(1))
 
 					name, source, path, namespace, targetNamespace := fluxClient.CreateHelmReleaseGitRepositoryArgsForCall(0)
-					Expect(name).To(Equal("bar"))
+					Expect(name).To(Equal("wego-app-bar"))
 					Expect(source).To(Equal("bar"))
 					Expect(path).To(Equal("./charts/my-chart"))
 					Expect(namespace).To(Equal(wego.DefaultNamespace))
@@ -392,8 +393,9 @@ var _ = Describe("Generate manifests", func() {
 
 					Expect(fluxClient.CreateHelmReleaseHelmRepositoryCallCount()).To(Equal(1))
 
-					name, chart, namespace, targetNamespace := fluxClient.CreateHelmReleaseHelmRepositoryArgsForCall(0)
+					name, source, chart, namespace, targetNamespace := fluxClient.CreateHelmReleaseHelmRepositoryArgsForCall(0)
 					Expect(name).To(Equal("loki"))
+					Expect(source).To(Equal("wego-app-loki"))
 					Expect(chart).To(Equal("loki"))
 					Expect(namespace).To(Equal(wego.DefaultNamespace))
 					Expect(targetNamespace).To(Equal("sock-shop"))

--- a/pkg/services/automation/automation_test.go
+++ b/pkg/services/automation/automation_test.go
@@ -160,7 +160,7 @@ var _ = Describe("Generate manifests", func() {
 				Expect(fluxClient.CreateKustomizationCallCount()).To(Equal(1))
 
 				name, source, path, namespace := fluxClient.CreateKustomizationArgsForCall(0)
-				Expect(name).To(Equal("bar"))
+				Expect(name).To(Equal("wego-app-bar"))
 				Expect(source).To(Equal("wego-app-bar"))
 				Expect(path).To(Equal("./kustomize"))
 				Expect(namespace).To(Equal(wego.DefaultNamespace))
@@ -330,7 +330,7 @@ var _ = Describe("Generate manifests", func() {
 					Expect(fluxClient.CreateKustomizationCallCount()).To(Equal(1))
 
 					name, source, path, namespace := fluxClient.CreateKustomizationArgsForCall(0)
-					Expect(name).To(Equal("bar"))
+					Expect(name).To(Equal("wego-app-bar"))
 					Expect(source).To(Equal("wego-app-bar"))
 					Expect(path).To(Equal("./kustomize"))
 					Expect(namespace).To(Equal(wego.DefaultNamespace))

--- a/pkg/services/automation/automation_test.go
+++ b/pkg/services/automation/automation_test.go
@@ -88,7 +88,7 @@ var _ = Describe("Generate manifests", func() {
 				Expect(fluxClient.CreateSourceGitCallCount()).To(Equal(1))
 
 				name, url, branch, secretRef, namespace := fluxClient.CreateSourceGitArgsForCall(0)
-				Expect(name).To(Equal("bar"))
+				Expect(name).To(Equal("wego-app-bar"))
 				Expect(url.String()).To(Equal("ssh://git@github.com/foo/bar.git"))
 				Expect(branch).To(Equal("main"))
 				Expect(secretRef).To(Equal("wego-github-bar"))
@@ -161,7 +161,7 @@ var _ = Describe("Generate manifests", func() {
 
 				name, source, path, namespace := fluxClient.CreateKustomizationArgsForCall(0)
 				Expect(name).To(Equal("bar"))
-				Expect(source).To(Equal("bar"))
+				Expect(source).To(Equal("wego-app-bar"))
 				Expect(path).To(Equal("./kustomize"))
 				Expect(namespace).To(Equal(wego.DefaultNamespace))
 			})
@@ -221,7 +221,7 @@ var _ = Describe("Generate manifests", func() {
 					Expect(fluxClient.CreateSourceGitCallCount()).To(Equal(1))
 
 					name, url, branch, secretRef, namespace := fluxClient.CreateSourceGitArgsForCall(0)
-					Expect(name).To(Equal("bar"))
+					Expect(name).To(Equal("wego-app-bar"))
 					Expect(url.String()).To(Equal("ssh://git@github.com/user/repo.git"))
 					Expect(branch).To(Equal("main"))
 					Expect(secretRef).To(Equal("wego-github-repo"))
@@ -331,7 +331,7 @@ var _ = Describe("Generate manifests", func() {
 
 					name, source, path, namespace := fluxClient.CreateKustomizationArgsForCall(0)
 					Expect(name).To(Equal("bar"))
-					Expect(source).To(Equal("bar"))
+					Expect(source).To(Equal("wego-app-bar"))
 					Expect(path).To(Equal("./kustomize"))
 					Expect(namespace).To(Equal(wego.DefaultNamespace))
 				})

--- a/pkg/services/automation/generator.go
+++ b/pkg/services/automation/generator.go
@@ -261,13 +261,13 @@ func (a *AutomationGen) generateApplicationGoat(app models.Application, clusterN
 
 	switch app.AutomationType {
 	case models.AutomationTypeKustomize:
-		b, err = a.Flux.CreateKustomization(sourceName, sourceName, app.Path, app.Namespace)
+		b, err = a.Flux.CreateKustomization(app.Name, sourceName, app.Path, app.Namespace)
 	case models.AutomationTypeHelm:
 		switch app.SourceType {
 		case models.SourceTypeHelm:
-			b, err = a.Flux.CreateHelmReleaseHelmRepository(sourceName, app.Path, app.Namespace, app.HelmTargetNamespace)
+			b, err = a.Flux.CreateHelmReleaseHelmRepository(app.Name, sourceName, app.Path, app.Namespace, app.HelmTargetNamespace)
 		case models.SourceTypeGit:
-			b, err = a.Flux.CreateHelmReleaseGitRepository(sourceName, sourceName, app.Path, app.Namespace, app.HelmTargetNamespace)
+			b, err = a.Flux.CreateHelmReleaseGitRepository(app.Name, sourceName, app.Path, app.Namespace, app.HelmTargetNamespace)
 		default:
 			return AutomationManifest{}, fmt.Errorf("invalid source type: %v", app.SourceType)
 		}

--- a/pkg/services/automation/generator.go
+++ b/pkg/services/automation/generator.go
@@ -261,7 +261,7 @@ func (a *AutomationGen) generateApplicationGoat(app models.Application, clusterN
 
 	switch app.AutomationType {
 	case models.AutomationTypeKustomize:
-		b, err = a.Flux.CreateKustomization(app.Name, sourceName, app.Path, app.Namespace)
+		b, err = a.Flux.CreateKustomization(sourceName, sourceName, app.Path, app.Namespace)
 	case models.AutomationTypeHelm:
 		switch app.SourceType {
 		case models.SourceTypeHelm:

--- a/pkg/services/automation/generator.go
+++ b/pkg/services/automation/generator.go
@@ -139,7 +139,7 @@ func (a *AutomationGen) generateAppSource(ctx context.Context, app models.Applic
 		return AutomationManifest{}, err
 	}
 
-	sourceName := createAppSourceName(app.Name)
+	sourceName := CreateAppSourceName(app.Name)
 
 	switch app.SourceType {
 	case models.SourceTypeGit:
@@ -257,7 +257,7 @@ func (a *AutomationGen) generateApplicationGoat(app models.Application, clusterN
 		err error
 	)
 
-	sourceName := createAppSourceName(app.Name)
+	sourceName := CreateAppSourceName(app.Name)
 
 	switch app.AutomationType {
 	case models.AutomationTypeKustomize:
@@ -413,7 +413,7 @@ func CreateClusterSourceName(gitSourceURL gitproviders.RepoURL) string {
 	return lengthConstrainedName
 }
 
-func createAppSourceName(name string) string {
+func CreateAppSourceName(name string) string {
 	return fmt.Sprintf("wego-app-%s", name)
 }
 

--- a/pkg/services/automation/generator.go
+++ b/pkg/services/automation/generator.go
@@ -148,7 +148,7 @@ func (a *AutomationGen) generateAppSource(ctx context.Context, app models.Applic
 			source, err = AddWegoIgnore(source)
 		}
 	case models.SourceTypeHelm:
-		source, err = a.Flux.CreateSourceHelm(app.Name, app.HelmSourceURL, app.Namespace)
+		source, err = a.Flux.CreateSourceHelm(sourceName, app.HelmSourceURL, app.Namespace)
 	default:
 		return AutomationManifest{}, fmt.Errorf("unknown source type: %v", app.SourceType)
 	}
@@ -265,9 +265,9 @@ func (a *AutomationGen) generateApplicationGoat(app models.Application, clusterN
 	case models.AutomationTypeHelm:
 		switch app.SourceType {
 		case models.SourceTypeHelm:
-			b, err = a.Flux.CreateHelmReleaseHelmRepository(app.Name, app.Path, app.Namespace, app.HelmTargetNamespace)
+			b, err = a.Flux.CreateHelmReleaseHelmRepository(sourceName, app.Path, app.Namespace, app.HelmTargetNamespace)
 		case models.SourceTypeGit:
-			b, err = a.Flux.CreateHelmReleaseGitRepository(app.Name, app.Name, app.Path, app.Namespace, app.HelmTargetNamespace)
+			b, err = a.Flux.CreateHelmReleaseGitRepository(sourceName, sourceName, app.Path, app.Namespace, app.HelmTargetNamespace)
 		default:
 			return AutomationManifest{}, fmt.Errorf("invalid source type: %v", app.SourceType)
 		}

--- a/pkg/services/automation/generator.go
+++ b/pkg/services/automation/generator.go
@@ -403,6 +403,7 @@ func CreateRepoSecretName(gitSourceURL gitproviders.RepoURL) GeneratedSecretName
 	return GeneratedSecretName(lengthConstrainedName)
 }
 
+// The cluster source name and the app source name need to remain distinct to prevent https://github.com/weaveworks/weave-gitops/issues/1075 from coming back.
 func CreateClusterSourceName(gitSourceURL gitproviders.RepoURL) string {
 	provider := string(gitSourceURL.Provider())
 	cleanRepoName := replaceUnderscores(gitSourceURL.RepositoryName())

--- a/pkg/services/gitops/install.go
+++ b/pkg/services/gitops/install.go
@@ -191,13 +191,14 @@ func (g *Gitops) storeManifests(gitClient git.Git, gitProvider gitproviders.GitP
 
 func (g *Gitops) genSource(branch string, namespace string, normalizedUrl gitproviders.RepoURL) ([]byte, string, error) {
 	secretRef := automation.CreateRepoSecretName(normalizedUrl).String()
+	sourceName := automation.CreateClusterSourceName(normalizedUrl)
 
-	sourceManifest, err := g.flux.CreateSourceGit(secretRef, normalizedUrl, branch, secretRef, namespace)
+	sourceManifest, err := g.flux.CreateSourceGit(sourceName, normalizedUrl, branch, secretRef, namespace)
 	if err != nil {
 		return nil, secretRef, fmt.Errorf("could not create git source for repo %s : %w", normalizedUrl.String(), err)
 	}
 
-	return sourceManifest, secretRef, nil
+	return sourceManifest, sourceName, nil
 }
 
 func (g *Gitops) genKustomize(name, cname, path string, params InstallParams) ([]byte, error) {

--- a/pkg/services/gitopswriter/gitopswriter.go
+++ b/pkg/services/gitopswriter/gitopswriter.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
-	"github.com/weaveworks/weave-gitops/pkg/git"
 	"github.com/weaveworks/weave-gitops/pkg/gitproviders"
 	"github.com/weaveworks/weave-gitops/pkg/logger"
 	"github.com/weaveworks/weave-gitops/pkg/models"
@@ -145,7 +144,7 @@ func (dw *gitOpsDirectoryWriterSvc) RemoveApplication(ctx context.Context, app m
 }
 
 func addKustomizeResources(app models.Application, repoDir, clusterName string, resources ...string) (automation.AutomationManifest, error) {
-	userKustomizationRepoPath := getUserKustomizationRepoPath(clusterName)
+	userKustomizationRepoPath := automation.AutomationUserKustomizePath(clusterName)
 	userKustomization := filepath.Join(repoDir, userKustomizationRepoPath)
 
 	k, err := automation.GetOrCreateKustomize(userKustomization, app.Name, app.Namespace)
@@ -167,7 +166,7 @@ func addKustomizeResources(app models.Application, repoDir, clusterName string, 
 }
 
 func removeKustomizeResources(app models.Application, repoDir, clusterName string, resources ...string) (automation.AutomationManifest, error) {
-	userKustomizationRepoPath := getUserKustomizationRepoPath(clusterName)
+	userKustomizationRepoPath := automation.AutomationUserKustomizePath(clusterName)
 	userKustomization := filepath.Join(repoDir, userKustomizationRepoPath)
 
 	k, err := automation.GetOrCreateKustomize(userKustomization, app.Name, app.Namespace)
@@ -204,10 +203,6 @@ func removeKustomizeResources(app models.Application, repoDir, clusterName strin
 		Path:    userKustomizationRepoPath,
 		Content: userKustomizationManifest,
 	}, nil
-}
-
-func getUserKustomizationRepoPath(clusterName string) string {
-	return filepath.Join(git.WegoRoot, git.WegoClusterDir, clusterName, "user", "kustomization.yaml")
 }
 
 func appKustomizeReference(app models.Application) string {

--- a/test/acceptance/test/add_tests.go
+++ b/test/acceptance/test/add_tests.go
@@ -845,8 +845,8 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 
 		By("Then I should see the status for "+appName1, func() {
 			Eventually(appStatus1).Should(ContainSubstring(`Last successful reconciliation:`))
-			Eventually(appStatus1).Should(ContainSubstring(`gitrepository/` + appName1))
-			Eventually(appStatus1).Should(ContainSubstring(`kustomization/` + appName1))
+			Eventually(appStatus1).Should(ContainSubstring(`gitrepository/wego-app-` + appName1))
+			Eventually(appStatus1).Should(ContainSubstring(`kustomization/wego-app-` + appName1))
 		})
 
 		By("When I check the app status for app2", func() {
@@ -855,7 +855,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 
 		By("Then I should see the status for "+appName2, func() {
 			Eventually(appStatus2).Should(ContainSubstring(`Last successful reconciliation:`))
-			Eventually(appStatus2).Should(ContainSubstring(`gitrepository/` + appName2))
+			Eventually(appStatus2).Should(ContainSubstring(`gitrepository/wego-app-` + appName2))
 			Eventually(appStatus2).Should(ContainSubstring(`helmrelease/` + appName2))
 		})
 
@@ -1004,8 +1004,8 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 
 		By("Then I should see the status for "+appName1, func() {
 			Eventually(appStatus1).Should(gbytes.Say(`Last successful reconciliation:`))
-			Eventually(appStatus1).Should(gbytes.Say(`gitrepository/` + appName1))
-			Eventually(appStatus1).Should(gbytes.Say(`kustomization/` + appName1))
+			Eventually(appStatus1).Should(gbytes.Say(`gitrepository/wego-app-` + appName1))
+			Eventually(appStatus1).Should(gbytes.Say(`kustomization/wego-app-` + appName1))
 		})
 
 		By("When I check the app status for "+appName2, func() {
@@ -1014,8 +1014,8 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 
 		By("Then I should see the status for "+appName2, func() {
 			Eventually(appStatus2).Should(gbytes.Say(`Last successful reconciliation:`))
-			Eventually(appStatus2).Should(gbytes.Say(`gitrepository/` + appName2))
-			Eventually(appStatus2).Should(gbytes.Say(`kustomization/` + appName2))
+			Eventually(appStatus2).Should(gbytes.Say(`gitrepository/wego-app-` + appName2))
+			Eventually(appStatus2).Should(gbytes.Say(`kustomization/wego-app-` + appName2))
 		})
 
 		By("When I check for apps", func() {
@@ -1040,7 +1040,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 
 		By("Then I should see pause status as suspended=true", func() {
-			Eventually(appStatus1).Should(gbytes.Say(`kustomization/` + appName1 + `\s*True\s*.*True`))
+			Eventually(appStatus1).Should(gbytes.Say(`kustomization/wego-app-` + appName1 + `\s*True\s*.*True`))
 		})
 
 		By("And changes to the app files should not be synchronized", func() {
@@ -1092,7 +1092,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 
 		By("Then I should see pause status as suspended=false", func() {
-			Eventually(appStatus1).Should(gbytes.Say(`kustomization/` + appName1 + `\s*True\s*.*False`))
+			Eventually(appStatus1).Should(gbytes.Say(`kustomization/wego-app-` + appName1 + `\s*True\s*.*False`))
 		})
 
 		By("When I delete an app", func() {
@@ -1705,8 +1705,8 @@ var _ = Describe("Weave GitOps Add Tests With Long Cluster Name", func() {
 
 		By("Then I should see the status for "+appName, func() {
 			Eventually(appStatus).Should(ContainSubstring(`Last successful reconciliation:`))
-			Eventually(appStatus).Should(ContainSubstring(`gitrepository/` + appName))
-			Eventually(appStatus).Should(ContainSubstring(`kustomization/` + appName))
+			Eventually(appStatus).Should(ContainSubstring(`gitrepository/wego-app-` + appName))
+			Eventually(appStatus).Should(ContainSubstring(`kustomization/wego-app-` + appName))
 		})
 
 		By("When I check for apps", func() {
@@ -1793,8 +1793,8 @@ var _ = Describe("Weave GitOps Add Tests With Long Cluster Name", func() {
 
 		By("Then I should see the status for "+appName, func() {
 			Eventually(appStatus).Should(ContainSubstring(`Last successful reconciliation:`))
-			Eventually(appStatus).Should(ContainSubstring(`gitrepository/` + appName))
-			Eventually(appStatus).Should(ContainSubstring(`kustomization/` + appName))
+			Eventually(appStatus).Should(ContainSubstring(`gitrepository/wego-app-` + appName))
+			Eventually(appStatus).Should(ContainSubstring(`kustomization/wego-app-` + appName))
 		})
 
 		By("When I check for apps", func() {

--- a/test/acceptance/test/utils.go
+++ b/test/acceptance/test/utils.go
@@ -576,7 +576,7 @@ func verifyWegoAddCommand(appName string, wegoNamespace string) {
 	session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 	Expect(err).ShouldNot(HaveOccurred())
 	Eventually(session, INSTALL_PODS_READY_TIMEOUT).Should(gexec.Exit())
-	Expect(waitForResource("GitRepositories", appName, wegoNamespace, INSTALL_PODS_READY_TIMEOUT)).To(Succeed())
+	Expect(waitForResource("GitRepositories", "wego-app-"+appName, wegoNamespace, INSTALL_PODS_READY_TIMEOUT)).To(Succeed())
 }
 
 func verifyWegoHelmAddCommand(appName string, wegoNamespace string) {

--- a/test/acceptance/test/utils.go
+++ b/test/acceptance/test/utils.go
@@ -584,7 +584,7 @@ func verifyWegoHelmAddCommand(appName string, wegoNamespace string) {
 	session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 	Expect(err).ShouldNot(HaveOccurred())
 	Eventually(session, INSTALL_PODS_READY_TIMEOUT).Should(gexec.Exit())
-	Expect(waitForResource("HelmRepositories", appName, wegoNamespace, INSTALL_PODS_READY_TIMEOUT)).To(Succeed())
+	Expect(waitForResource("HelmRepositories", "wego-app-"+appName, wegoNamespace, INSTALL_PODS_READY_TIMEOUT)).To(Succeed())
 }
 
 func verifyWegoAddCommandWithDryRun(appRepoName string, wegoNamespace string) {

--- a/test/integration/server/add_test.go
+++ b/test/integration/server/add_test.go
@@ -101,7 +101,7 @@ var _ = Describe("AddApplication", func() {
 					Interval: metav1.Duration{Duration: time.Duration(1 * time.Minute)},
 					Prune:    true,
 					SourceRef: kustomizev1.CrossNamespaceSourceReference{
-						Name: req.Name,
+						Name: fmt.Sprintf("wego-app-%s", req.Name),
 						Kind: sourcev1.GitRepositoryKind,
 					},
 					Force: false,
@@ -199,7 +199,7 @@ var _ = Describe("AddApplication", func() {
 					Interval: metav1.Duration{Duration: time.Duration(1 * time.Minute)},
 					Prune:    true,
 					SourceRef: kustomizev1.CrossNamespaceSourceReference{
-						Name: req.Name,
+						Name: fmt.Sprintf("wego-app-%s", req.Name),
 						Kind: sourcev1.GitRepositoryKind,
 					},
 					Force: false,
@@ -292,7 +292,7 @@ var _ = Describe("AddApplication", func() {
 					Interval: metav1.Duration{Duration: time.Duration(1 * time.Minute)},
 					Prune:    true,
 					SourceRef: kustomizev1.CrossNamespaceSourceReference{
-						Name: req.Name,
+						Name: fmt.Sprintf("wego-app-%s", req.Name),
 						Kind: sourcev1.GitRepositoryKind,
 					},
 					Force: false,
@@ -389,7 +389,7 @@ var _ = Describe("AddApplication", func() {
 					Interval: metav1.Duration{Duration: time.Duration(1 * time.Minute)},
 					Prune:    true,
 					SourceRef: kustomizev1.CrossNamespaceSourceReference{
-						Name: req.Name,
+						Name: fmt.Sprintf("wego-app-%s", req.Name),
 						Kind: sourcev1.GitRepositoryKind,
 					},
 					Force: false,
@@ -482,7 +482,7 @@ var _ = Describe("AddApplication", func() {
 					Interval: metav1.Duration{Duration: time.Duration(1 * time.Minute)},
 					Prune:    true,
 					SourceRef: kustomizev1.CrossNamespaceSourceReference{
-						Name: req.Name,
+						Name: fmt.Sprintf("wego-app-%s", req.Name),
 						Kind: sourcev1.GitRepositoryKind,
 					},
 					Force: false,
@@ -590,7 +590,7 @@ var _ = Describe("AddApplication", func() {
 					Interval: metav1.Duration{Duration: time.Duration(1 * time.Minute)},
 					Prune:    true,
 					SourceRef: kustomizev1.CrossNamespaceSourceReference{
-						Name: req.Name,
+						Name: fmt.Sprintf("wego-app-%s", req.Name),
 						Kind: sourcev1.GitRepositoryKind,
 					},
 					Force: false,

--- a/test/integration/server/helpers/helpers.go
+++ b/test/integration/server/helpers/helpers.go
@@ -1,3 +1,4 @@
+//go:build !unittest
 // +build !unittest
 
 package helpers
@@ -167,7 +168,7 @@ func GenerateExpectedFS(req *pb.AddApplicationRequest, root, clusterName string,
 				APIVersion: kustomizev2.GroupVersion.String(),
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      req.Name,
+				Name:      fmt.Sprintf("wego-app-%s", req.Name),
 				Namespace: req.Namespace,
 			},
 			Spec: k,

--- a/test/integration/server/helpers/helpers.go
+++ b/test/integration/server/helpers/helpers.go
@@ -178,7 +178,7 @@ func GenerateExpectedFS(req *pb.AddApplicationRequest, root, clusterName string,
 				APIVersion: sourcev1.GroupVersion.String(),
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "wego-app-" + req.Name,
+				Name:      fmt.Sprintf("wego-app-%s", req.Name),
 				Namespace: req.Namespace,
 			},
 			Spec: s,

--- a/test/integration/server/helpers/helpers.go
+++ b/test/integration/server/helpers/helpers.go
@@ -1,3 +1,4 @@
+//go:build !unittest
 // +build !unittest
 
 package helpers
@@ -178,7 +179,7 @@ func GenerateExpectedFS(req *pb.AddApplicationRequest, root, clusterName string,
 				APIVersion: sourcev1.GroupVersion.String(),
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      req.Name,
+				Name:      "wego-app-" + req.Name,
 				Namespace: req.Namespace,
 			},
 			Spec: s,

--- a/test/integration/server/helpers/helpers.go
+++ b/test/integration/server/helpers/helpers.go
@@ -1,4 +1,3 @@
-//go:build !unittest
 // +build !unittest
 
 package helpers


### PR DESCRIPTION
<!-- Use # to add the issue this pull request is related to -->
Closes: #1075 

<!-- Describe what has changed in this PR -->
**What changed?**
Add auto to flux sourceRef and app to application sourceRef. This forces the user from being able to use the same name for the two sources. Changes the ref name in flux-user-kustomization-resource.yaml, flux-system-kustomization-resource.yaml, nginx-gitops-deploy.yaml and nginx-gitops-source.yaml.

I do want to point out that the get status output has changed a bit with these changes. It uses the source name so it looks like:
```
NAME                            READY   MESSAGE                                                         REVISION                                        SUSPENDED 
gitrepository/wego-app-nginx    True    Fetched revision: main/f69237519da2d3f242f978c424591d2e1810a023 main/f69237519da2d3f242f978c424591d2e1810a023   False    

NAME                            READY   MESSAGE                                                         REVISION                                        SUSPENDED 
kustomization/wego-app-nginx    True    Applied revision: main/f69237519da2d3f242f978c424591d2e1810a023 main/f69237519da2d3f242f978c424591d2e1810a023   False    
```

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**
Manually got an app deployed. Also updated the unit tests. The existing acceptance tests will cover these changes.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
**Release notes**

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**