### PR TITLE
Adds capi-app when upgrading

### DIFF
--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
+	"strconv"
 	"time"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
@@ -97,6 +98,8 @@ func upgrade(ctx context.Context, uv UpgradeValues, kube kube.Kube, gitClient gi
 	// Create pull request
 	path := filepath.Join(git.WegoRoot, git.WegoClusterDir, cname, git.WegoClusterOSWorkloadDir, WegoEnterpriseName)
 	wegoAppPath := filepath.Join(git.WegoRoot, git.WegoClusterDir, cname, git.WegoClusterOSWorkloadDir, "wego-app.yaml")
+	capiKeepPath := filepath.Join(git.WegoRoot, git.WegoAppDir, "capi", "templates", ".keep")
+	capiKeepContents := string(strconv.AppendQuote(nil, "# keep"))
 
 	pri := gitproviders.PullRequestInfo{
 		Title:         "Gitops upgrade",
@@ -108,6 +111,10 @@ func upgrade(ctx context.Context, uv UpgradeValues, kube kube.Kube, gitClient gi
 			{
 				Path:    &path,
 				Content: &stringOut,
+			},
+			{
+				Path:    &capiKeepPath,
+				Content: &capiKeepContents,
 			},
 			{
 				Path:    &wegoAppPath,

--- a/pkg/upgrade/upgrade_test.go
+++ b/pkg/upgrade/upgrade_test.go
@@ -36,6 +36,7 @@ func TestUpgradeDryRun(t *testing.T) {
 
 	// Run upgrade!
 	err := upgrade(context.TODO(), UpgradeValues{
+		AppConfigURL:  "ssh://git@github.com/my-org/my-management-cluster.git",
 		HeadBranch:    "upgrade-to-wge",
 		BaseBranch:    "main",
 		CommitMessage: "Upgrade to wge",
@@ -43,9 +44,10 @@ func TestUpgradeDryRun(t *testing.T) {
 		DryRun:        true,
 	}, k, gitClient, kubeClient, gitProvider, logger, &output)
 
+	assert.NoError(t, err)
 	assert.Contains(t, output.String(), "kind: HelmRelease")
 	assert.Contains(t, output.String(), "kind: HelmRepository")
-	assert.NoError(t, err)
+	assert.Contains(t, output.String(), "kind: Kustomization")
 }
 
 type mockPullRequest struct{}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

- We remove the `wego-app.yaml` as that functionality is provided by EE.
- Add a new kustomization that syncs the capi path

<!-- Tell your future self why have you made these changes -->
**Why?**

- Last pieces of the directory structure ADR that specifies capi paths

**How did you test it?**

- Manually
