### PR TITLE
Ignore showing clusters PR url for statuses other than creation/deletion

### DIFF
--- a/pkg/clusters/clusters.go
+++ b/pkg/clusters/clusters.go
@@ -37,7 +37,7 @@ func GetClusters(r ClustersRetriever, w io.Writer) error {
 		fmt.Fprintf(w, "NAME\tSTATUS\tSTATUS_MESSAGE\n")
 
 		for _, c := range cs {
-			if c.PullRequest.Type == "create" {
+			if c.Status == "pullRequestCreated" && c.PullRequest.Type == "create" {
 				c.Status = "Creation PR"
 			} else if c.PullRequest.Type == "delete" {
 				c.Status = "Deletion PR"

--- a/pkg/clusters/clusters.go
+++ b/pkg/clusters/clusters.go
@@ -37,19 +37,7 @@ func GetClusters(r ClustersRetriever, w io.Writer) error {
 		fmt.Fprintf(w, "NAME\tSTATUS\tSTATUS_MESSAGE\n")
 
 		for _, c := range cs {
-			if c.Status == "pullRequestCreated" && c.PullRequest.Type == "create" {
-				c.Status = "Creation PR"
-			} else if c.PullRequest.Type == "delete" {
-				c.Status = "Deletion PR"
-			}
-
-			if c.Status == "Creation PR" || c.Status == "Deletion PR" {
-				fmt.Fprintf(w, "%s\t%s\t%s", c.Name, c.Status, c.PullRequest.Url)
-				fmt.Fprintln(w, "")
-			} else {
-				fmt.Fprintf(w, "%s\t%s", c.Name, c.Status)
-				fmt.Fprintln(w, "")
-			}
+			printCluster(c, w)
 		}
 
 		return nil
@@ -73,19 +61,7 @@ func GetClusterByName(name string, r ClustersRetriever, w io.Writer) error {
 
 		for _, c := range cs {
 			if c.Name == name {
-				if c.Status == "pullRequestCreated" && c.PullRequest.Type == "create" {
-					c.Status = "Creation PR"
-				} else if c.PullRequest.Type == "delete" {
-					c.Status = "Deletion PR"
-				}
-
-				if c.Status == "Creation PR" || c.Status == "Deletion PR" {
-					fmt.Fprintf(w, "%s\t%s\t%s", c.Name, c.Status, c.PullRequest.Url)
-					fmt.Fprintln(w, "")
-				} else {
-					fmt.Fprintf(w, "%s\t%s", c.Name, c.Status)
-					fmt.Fprintln(w, "")
-				}
+				printCluster(c, w)
 			}
 		}
 
@@ -127,4 +103,20 @@ type DeleteClustersParams struct {
 	Description   string
 	ClustersNames []string
 	CommitMessage string
+}
+
+func printCluster(c Cluster, w io.Writer) {
+	if c.Status == "pullRequestCreated" && c.PullRequest.Type == "create" {
+		c.Status = "Creation PR"
+	} else if c.PullRequest.Type == "delete" {
+		c.Status = "Deletion PR"
+	}
+
+	if c.Status == "Creation PR" || c.Status == "Deletion PR" {
+		fmt.Fprintf(w, "%s\t%s\t%s", c.Name, c.Status, c.PullRequest.Url)
+		fmt.Fprintln(w, "")
+	} else {
+		fmt.Fprintf(w, "%s\t%s", c.Name, c.Status)
+		fmt.Fprintln(w, "")
+	}
 }

--- a/pkg/clusters/clusters.go
+++ b/pkg/clusters/clusters.go
@@ -69,18 +69,23 @@ func GetClusterByName(name string, r ClustersRetriever, w io.Writer) error {
 	}
 
 	if len(cs) > 0 {
-		fmt.Fprintf(w, "NAME\tSTATUS\n")
+		fmt.Fprintf(w, "NAME\tSTATUS\tSTATUS_MESSAGE\n")
 
 		for _, c := range cs {
 			if c.Name == name {
-				if c.PullRequest.Type == "create" {
+				if c.Status == "pullRequestCreated" && c.PullRequest.Type == "create" {
 					c.Status = "Creation PR"
 				} else if c.PullRequest.Type == "delete" {
 					c.Status = "Deletion PR"
 				}
 
-				fmt.Fprintf(w, "%s\t%s", c.Name, c.Status)
-				fmt.Fprintln(w, "")
+				if c.Status == "Creation PR" || c.Status == "Deletion PR" {
+					fmt.Fprintf(w, "%s\t%s\t%s", c.Name, c.Status, c.PullRequest.Url)
+					fmt.Fprintln(w, "")
+				} else {
+					fmt.Fprintf(w, "%s\t%s", c.Name, c.Status)
+					fmt.Fprintln(w, "")
+				}
 			}
 		}
 

--- a/pkg/clusters/clusters_test.go
+++ b/pkg/clusters/clusters_test.go
@@ -76,7 +76,7 @@ func TestGetClusters(t *testing.T) {
 					Name:   "cluster-b",
 					Status: "foo",
 					PullRequest: clusters.PullRequest{
-						Type: "foo",
+						Type: "create",
 						Url:  "https://github.com/org/repo/pull/1",
 					},
 				},
@@ -120,7 +120,22 @@ func TestGetClusterByName(t *testing.T) {
 					Status: "status-a",
 				},
 			},
-			expected: "NAME\tSTATUS\ncluster-a\tstatus-a\n",
+			expected: "NAME\tSTATUS\tSTATUS_MESSAGE\ncluster-a\tstatus-a\n",
+		},
+		{
+			name:        "Print cluster PR url",
+			clusterName: "cluster-a",
+			cs: []clusters.Cluster{
+				{
+					Name:   "cluster-a",
+					Status: "pullRequestCreated",
+					PullRequest: clusters.PullRequest{
+						Type: "create",
+						Url:  "https://github.com/org/repo/pull/1",
+					},
+				},
+			},
+			expected: "NAME\tSTATUS\tSTATUS_MESSAGE\ncluster-a\tCreation PR\thttps://github.com/org/repo/pull/1\n",
 		},
 	}
 


### PR DESCRIPTION
<!-- Use # to add the issue this pull request is related to -->
Closes: 

<!-- Describe what has changed in this PR -->
**What changed?**
Updated the if condition for Creation PR status

<!-- Tell your future self why have you made these changes -->
**Why?**
To ignore printing PR for statuses other than creation and deletion

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
**Release notes**

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**