### PR TITLE
Adds back file required for consuming as a go module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,12 +61,14 @@ docker: ## Build wego-app docker image
 # Clean up images and binaries
 clean: ## Clean up images and binaries
 	rm -f bin/gitops
-	rm -rf pkg/flux/bin/
 	rm -rf cmd/gitops/ui/run/dist
 	rm -rf coverage
 	rm -rf node_modules
 	rm -f .deps
 	rm -rf dist
+	# There is an important (tracked) file in pkg/flux/bin so don't just nuke the whole folder
+	# -x: remove gitignored files too, -d: remove directories too
+	git clean -x -d --force pkg/flux/bin/
 
 fmt: ## Run go fmt against code
 	go fmt ./...

--- a/pkg/flux/bin/go_embed_fs_cannot_be_empty.txt
+++ b/pkg/flux/bin/go_embed_fs_cannot_be_empty.txt
@@ -1,0 +1,3 @@
+This file is here to stop `go:embed` complaining there aren't any files at `go build` time.
+
+This is important when weave-gitops is consumed as a go-module by other apps (e.g. EE)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Puts back a file needed to build as a go module originally introduced in https://github.com/weaveworks/weave-gitops/pull/765

<!-- Tell your future self why have you made these changes -->
**Why?**

It was probably removed as part of a `make clean`, so make sure to preserve that file when doing a `make clean`

**How did you test it?**

Pointing a consumer at this branch
