### PR TITLE
Add negative tests for GitOps Enterprise

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -138,7 +138,7 @@ jobs:
         $WEGO_BIN_PATH flux uninstall --silent
         $WEGO_BIN_PATH flux uninstall --namespace test-namespace --silent
         kubectl get all --all-namespaces -o wide
-        ginkgo --reportFile=${{ env.ARTIFACTS_BASE_DIR }}/test-results/acceptance-test-results.xml -v ./test/acceptance/test/...
+        ginkgo --reportFile=${{ env.ARTIFACTS_BASE_DIR }}/test-results/acceptance-test-results.xml --skip=@skipOnNightly -v ./test/acceptance/test/...
       if: always()
     - name: Store acceptance test results
       if: ${{ always() }}

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -258,7 +258,7 @@ jobs:
         $WEGO_BIN_PATH flux uninstall --silent
         $WEGO_BIN_PATH flux uninstall --namespace test-namespace --silent
         kubectl get all --all-namespaces -o wide
-        ginkgo --reportFile=${{ env.ARTIFACTS_BASE_DIR }}/test-results/acceptance-test-results.xml -v ./test/acceptance/test/...
+        ginkgo --reportFile=${{ env.ARTIFACTS_BASE_DIR }}/test-results/acceptance-test-results.xml --skip=@skipOnNightly -v ./test/acceptance/test/...
       if: always()
     - name: Store acceptance test results
       if: ${{ always() }}

--- a/test/acceptance/test/add_tests.go
+++ b/test/acceptance/test/add_tests.go
@@ -518,7 +518,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 	})
 
-	XIt("Test2 - Verify that gitops can deploy multiple workloads from a single app repo", func() {
+	It("Test2 - Verify that gitops can deploy multiple workloads from a single app repo", func() {
 		var repoAbsolutePath string
 		tip1 := generateTestInputs()
 		tip2 := generateTestInputs()
@@ -568,7 +568,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 	})
 
-	It("Verify that gitops can deploy a single workload to multiple clusters with app manifests in config repo (Bug #810)", func() {
+	XIt("Verify that gitops can deploy a single workload to multiple clusters with app manifests in config repo (Bug #810)", func() {
 		var repoAbsolutePath string
 		tip := generateTestInputs()
 		appRepoName := "wego-test-app-" + RandString(8)

--- a/test/acceptance/test/add_tests.go
+++ b/test/acceptance/test/add_tests.go
@@ -1073,7 +1073,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 
 		By("And I should see app replicas created in the cluster", func() {
-			_ = waitForReplicaCreation(tip1.workloadNamespace, replicaSetValue, EVENTUALLY_DEFAULT_TIMEOUT)
+			_ = waitForReplicaCreation(tip1.workloadNamespace, replicaSetValue, TIMEOUT_TWO_MINUTES)
 			_ = runCommandPassThrough([]string{}, "sh", "-c", fmt.Sprintf("kubectl wait --for=condition=Ready --timeout=100s -n %s --all pods --selector='app!=wego-app'", tip1.workloadNamespace))
 			replicaOutput, _ := runCommandAndReturnStringOutput("kubectl get pods -n " + tip1.workloadNamespace + " --field-selector=status.phase=Running --no-headers=true | wc -l")
 			Expect(replicaOutput).To(ContainSubstring(strconv.Itoa(replicaSetValue)))

--- a/test/acceptance/test/add_tests.go
+++ b/test/acceptance/test/add_tests.go
@@ -568,7 +568,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 	})
 
-	XIt("Verify that gitops can deploy a single workload to multiple clusters with app manifests in config repo (Bug #810)", func() {
+	It("@skipOnNightly Verify that gitops can deploy a single workload to multiple clusters with app manifests in config repo (Bug #810)", func() {
 		var repoAbsolutePath string
 		tip := generateTestInputs()
 		appRepoName := "wego-test-app-" + RandString(8)

--- a/test/acceptance/test/add_tests.go
+++ b/test/acceptance/test/add_tests.go
@@ -518,7 +518,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 	})
 
-	It("Test2 - Verify that gitops can deploy multiple workloads from a single app repo", func() {
+	XIt("Test2 - Verify that gitops can deploy multiple workloads from a single app repo", func() {
 		var repoAbsolutePath string
 		tip1 := generateTestInputs()
 		tip2 := generateTestInputs()

--- a/test/acceptance/test/utils.go
+++ b/test/acceptance/test/utils.go
@@ -431,7 +431,7 @@ func deleteNamespace(namespace string) {
 
 	command := exec.Command("kubectl", "delete", "ns", namespace)
 	session, _ := gexec.Start(command, GinkgoWriter, GinkgoWriter)
-	Eventually(session, TIMEOUT_TWO_MINUTES).Should(gexec.Exit())
+	Eventually(session, NAMESPACE_TERMINATE_TIMEOUT).Should(gexec.Exit())
 }
 
 func deleteRepo(appRepoName string, providerName gitproviders.GitProviderName, org string) {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Add a skip tag on a test that will _only_ skip running for **Nightly Tests**
- Add a minor enterprise test case that checks for error message generated for missing entitlements file 

<!-- Tell your future self why have you made these changes -->
**Why?**
- The skipped test was trying to create another kind cluster to test multiple cluster deployment. Since nightly tests run on single standing EKS/GKE clusters, the test kept failing. 
- We needed a test that would check error messages for missing entitlement file during `gitops upgrade`
