### PR TITLE
changes ProfileVersion to Version

### DIFF
--- a/cmd/gitops/upgrade/cmd.go
+++ b/cmd/gitops/upgrade/cmd.go
@@ -18,8 +18,8 @@ import (
 
 var upgradeCmdFlags upgrade.UpgradeValues
 
-var example = fmt.Sprintf(`  # Install GitOps in the %s namespace
-  gitops upgrade --profile-version 0.0.15 --app-config-url https://github.com/my-org/my-management-cluster.git`,
+var example = fmt.Sprintf(`  # Upgrade Weave GitOps in the %s namespace
+  gitops upgrade --version 0.0.15 --app-config-url https://github.com/my-org/my-management-cluster.git`,
 	wego.DefaultNamespace)
 
 var Cmd = &cobra.Command{
@@ -33,7 +33,7 @@ var Cmd = &cobra.Command{
 
 func init() {
 	Cmd.PersistentFlags().StringVar(&upgradeCmdFlags.AppConfigURL, "app-config-url", "", "URL of external repository that will hold automation manifests")
-	Cmd.PersistentFlags().StringVar(&upgradeCmdFlags.ProfileVersion, "profile-version", "", "Profile version to set the helm release version to")
+	Cmd.PersistentFlags().StringVar(&upgradeCmdFlags.Version, "version", "", "Version of Weave GitOps Enterprise to be installed")
 	Cmd.PersistentFlags().StringVar(&upgradeCmdFlags.BaseBranch, "base", "main", "The base branch to open the pull request against")
 	Cmd.PersistentFlags().StringVar(&upgradeCmdFlags.HeadBranch, "branch", "tier-upgrade-enterprise", "The branch to create the pull request from")
 	Cmd.PersistentFlags().StringVar(&upgradeCmdFlags.CommitMessage, "commit-message", "Upgrade to WGE", "The commit message")
@@ -41,7 +41,7 @@ func init() {
 	Cmd.PersistentFlags().BoolVar(&upgradeCmdFlags.DryRun, "dry-run", false, "Output the generated profile without creating a pull request")
 
 	cobra.CheckErr(Cmd.MarkPersistentFlagRequired("app-config-url"))
-	cobra.CheckErr(Cmd.MarkPersistentFlagRequired("profile-version"))
+	cobra.CheckErr(Cmd.MarkPersistentFlagRequired("version"))
 }
 
 func upgradeCmdRunE() func(*cobra.Command, []string) error {

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -32,14 +32,14 @@ import (
 )
 
 type UpgradeValues struct {
-	AppConfigURL   string
-	ProfileVersion string
-	BaseBranch     string
-	HeadBranch     string
-	CommitMessage  string
-	Namespace      string
-	Values         []string
-	DryRun         bool
+	AppConfigURL  string
+	Version       string
+	BaseBranch    string
+	HeadBranch    string
+	CommitMessage string
+	Namespace     string
+	Values        []string
+	DryRun        bool
 }
 
 const EnterpriseChartURL string = "https://charts.dev.wkp.weave.works/releases/charts-v3"
@@ -61,7 +61,7 @@ func upgrade(ctx context.Context, uv UpgradeValues, kube kube.Kube, gitClient gi
 		return fmt.Errorf("failed to get cluster name: %w", err)
 	}
 
-	resources, err := makeHelmResources(uv.Namespace, uv.ProfileVersion, cname, uv.AppConfigURL, uv.Values)
+	resources, err := makeHelmResources(uv.Namespace, uv.Version, cname, uv.AppConfigURL, uv.Values)
 	if err != nil {
 		return fmt.Errorf("error creating helm resources: %w", err)
 	}


### PR DESCRIPTION
<!-- Use # to add the issue this pull request is related to -->
Closes: #1136 

<!-- Describe what has changed in this PR -->
Changed help text relating to upgrade command and use of ProfileVersion to simply Version


<!-- Tell your future self why have you made these changes -->
Make it clearer to end users what the intent behind the flag is rather than expose internals.


<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
Relying on existing testing

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
**Release notes**
renamed flag in `upgrade` command from `--profile-version' to `--version`. 

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
[Complete](https://github.com/weaveworks/weave-gitops-docs/pull/160)