### PR TITLE
Add and Implement Theme Colors

### DIFF
--- a/ui/components/Alert.tsx
+++ b/ui/components/Alert.tsx
@@ -23,7 +23,7 @@ export interface Props {
 }
 
 /** Form Alert */
-function UnstyledAlert({ center, title, message, severity, className }: Props) {
+function Alert({ center, title, message, severity, className }: Props) {
   return (
     <Flex wide start={!center} className={className}>
       <MaterialAlert severity={severity}>
@@ -34,5 +34,4 @@ function UnstyledAlert({ center, title, message, severity, className }: Props) {
   );
 }
 
-export const Alert = styled(UnstyledAlert)``;
-export default Alert;
+export default styled(Alert)``;

--- a/ui/components/Button.tsx
+++ b/ui/components/Button.tsx
@@ -15,7 +15,7 @@ export interface Props extends ButtonProps {
 }
 
 /** Form Button */
-function UnstyledButton(props: Props) {
+function Button(props: Props) {
   return (
     <MaterialButton
       variant="outlined"
@@ -28,7 +28,7 @@ function UnstyledButton(props: Props) {
   );
 }
 
-export const Button = styled(UnstyledButton)`
+export default styled(Button)`
   display: flex;
   justify-content: space-evenly;
   &.auth-button {
@@ -43,5 +43,3 @@ export const Button = styled(UnstyledButton)`
     }
   }
 `;
-
-export default Button;

--- a/ui/components/ConditionsTable.tsx
+++ b/ui/components/ConditionsTable.tsx
@@ -12,10 +12,10 @@ function ConditionsTable({ className, conditions }: Props) {
   return (
     <DataTable
       fields={[
-        { label: "Type", value: (c) => c.type },
-        { label: "Status", value: (c) => c.status },
-        { label: "Reason", value: (c) => c.reason },
-        { label: "Message", value: (c) => c.message },
+        { label: "Type", value: "type" },
+        { label: "Status", value: "status" },
+        { label: "Reason", value: "reason" },
+        { label: "Message", value: "message" },
       ]}
       rows={conditions}
       sortFields={[""]}

--- a/ui/components/ConditionsTable.tsx
+++ b/ui/components/ConditionsTable.tsx
@@ -20,6 +20,7 @@ function ConditionsTable({ className, conditions }: Props) {
       rows={conditions}
       sortFields={[""]}
       className={className}
+      widths={["10%", "10%", "25%", "55%"]}
     />
   );
 }

--- a/ui/components/ConditionsTable.tsx
+++ b/ui/components/ConditionsTable.tsx
@@ -1,15 +1,7 @@
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-} from "@material-ui/core";
-import _ from "lodash";
 import * as React from "react";
 import styled from "styled-components";
 import { Condition } from "../lib/api/applications/applications.pb";
+import DataTable from "./DataTable";
 
 type Props = {
   className?: string;
@@ -18,31 +10,22 @@ type Props = {
 
 function ConditionsTable({ className, conditions }: Props) {
   return (
-    <div className={className}>
-      <TableContainer>
-        <Table>
-          <TableHead>
-            <TableRow>
-              <TableCell>Type</TableCell>
-              <TableCell>Status</TableCell>
-              <TableCell>Reason</TableCell>
-              <TableCell>Message</TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {_.map(conditions, (c) => (
-              <TableRow key={c.timestamp}>
-                <TableCell>{c.type}</TableCell>
-                <TableCell>{c.status}</TableCell>
-                <TableCell>{c.reason}</TableCell>
-                <TableCell>{c.message}</TableCell>
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
-      </TableContainer>
-    </div>
+    <DataTable
+      fields={[
+        { label: "Type", value: (c) => c.type },
+        { label: "Status", value: (c) => c.status },
+        { label: "Reason", value: (c) => c.reason },
+        { label: "Message", value: (c) => c.message },
+      ]}
+      rows={conditions}
+      sortFields={[""]}
+      className={className}
+    />
   );
 }
 
-export default styled(ConditionsTable)``;
+export default styled(ConditionsTable)`
+  &.MuiTableCell-head {
+    font-weight: 800;
+  }
+`;

--- a/ui/components/DataTable.tsx
+++ b/ui/components/DataTable.tsx
@@ -81,7 +81,7 @@ function DataTable({
 }
 
 export default styled(DataTable)`
-  &.MuiTableCell-head {
+  .MuiTableCell-head {
     font-weight: 800;
   }
 `;

--- a/ui/components/DataTable.tsx
+++ b/ui/components/DataTable.tsx
@@ -28,8 +28,7 @@ export interface Props {
   reverseSort?: boolean;
   /** an optional list of string widths for each field/column. */
   widths?: string[];
-};
-
+}
 
 const EmptyRow = styled(TableRow)<{ colSpan: number }>`
   font-style: italic;
@@ -39,7 +38,7 @@ const EmptyRow = styled(TableRow)<{ colSpan: number }>`
 `;
 
 /** Form DataTable */
-function UnstyledDataTable({
+function DataTable({
   className,
   fields,
   rows,
@@ -93,10 +92,8 @@ function UnstyledDataTable({
   );
 }
 
-export const DataTable = styled(UnstyledDataTable)`
+export default styled(DataTable)`
   th {
     font-weight: bold;
   }
 `;
-
-export default DataTable;

--- a/ui/components/DataTable.tsx
+++ b/ui/components/DataTable.tsx
@@ -20,6 +20,8 @@ type Props = {
   rows: any[];
   sortFields: string[];
   reverseSort?: boolean;
+  /** an optional list of string widths for each field/column. */
+  widths?: string[];
 };
 
 const EmptyRow = styled(TableRow)<{ colSpan: number }>`
@@ -35,6 +37,7 @@ function DataTable({
   rows,
   sortFields,
   reverseSort,
+  widths,
 }: Props) {
   const sorted = _.sortBy(rows, sortFields);
 
@@ -44,8 +47,8 @@ function DataTable({
 
   const r = _.map(sorted, (r, i) => (
     <TableRow key={i}>
-      {_.map(fields, (f) => (
-        <TableCell key={f.label}>
+      {_.map(fields, (f, i) => (
+        <TableCell style={widths && { width: widths[i] }} key={f.label}>
           <Text>{typeof f.value === "function" ? f.value(r) : r[f.value]}</Text>
         </TableCell>
       ))}
@@ -58,8 +61,10 @@ function DataTable({
         <Table aria-label="simple table">
           <TableHead>
             <TableRow>
-              {_.map(fields, (f) => (
-                <TableCell key={f.label}>{f.label}</TableCell>
+              {_.map(fields, (f, i) => (
+                <TableCell style={widths && { width: widths[i] }} key={f.label}>
+                  {f.label}
+                </TableCell>
               ))}
             </TableRow>
           </TableHead>

--- a/ui/components/DataTable.tsx
+++ b/ui/components/DataTable.tsx
@@ -93,7 +93,7 @@ function DataTable({
 }
 
 export default styled(DataTable)`
-  th {
-    font-weight: bold;
+  .MuiTableCell-head {
+    font-weight: 800;
   }
 `;

--- a/ui/components/DataTable.tsx
+++ b/ui/components/DataTable.tsx
@@ -24,7 +24,6 @@ type Props = {
 
 const EmptyRow = styled(TableRow)<{ colSpan: number }>`
   font-style: italic;
-
   td {
     text-align: center;
   }
@@ -82,7 +81,7 @@ function DataTable({
 }
 
 export default styled(DataTable)`
-  th {
-    font-weight: bold;
+  &.MuiTableCell-head {
+    font-weight: 800;
   }
 `;

--- a/ui/components/Layout.tsx
+++ b/ui/components/Layout.tsx
@@ -6,7 +6,6 @@ import useNavigation from "../hooks/navigation";
 import { PageRoute } from "../lib/types";
 import { formatURL, getNavValue } from "../lib/utils";
 import Flex from "./Flex";
-import Icon, { IconType } from "./Icon";
 import Link from "./Link";
 import Logo from "./Logo";
 
@@ -96,9 +95,10 @@ const TopToolBar = styled(Flex)`
   }
 `;
 
-const UserAvatar = styled(Icon)`
-  padding-right: ${(props) => props.theme.spacing.medium};
-`;
+//style for account icon - disabled while no account functionality exists
+// const UserAvatar = styled(Icon)`
+//   padding-right: ${(props) => props.theme.spacing.medium};
+// `;
 
 function Layout({ className, children }: Props) {
   const { currentPage } = useNavigation();
@@ -108,7 +108,7 @@ function Layout({ className, children }: Props) {
       <AppContainer>
         <TopToolBar between align>
           <Logo />
-          <UserAvatar size="xl" type={IconType.Account} color="white" />
+          {/* code for account icon - disabled while no account functionality exists <UserAvatar size="xl" type={IconType.Account} color="white" /> */}
         </TopToolBar>
         <Main wide>
           <NavContainer>

--- a/ui/components/Modal.tsx
+++ b/ui/components/Modal.tsx
@@ -34,7 +34,7 @@ export const Body = styled.div`
 `;
 
 /** Form Modal */
-function UnstyledModal({
+function Modal({
   className,
   bodyClassName,
   open,
@@ -68,5 +68,4 @@ function UnstyledModal({
   );
 }
 
-export const Modal = styled(UnstyledModal)``;
-export default Modal;
+export default styled(Modal)``;

--- a/ui/components/__tests__/__snapshots__/CommitsTable.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/CommitsTable.test.tsx.snap
@@ -18,8 +18,8 @@ exports[`CommitsTable snapshots renders 1`] = `
   color: #00b3ec;
 }
 
-.c0 th {
-  font-weight: bold;
+.c0 .MuiTableCell-head {
+  font-weight: 800;
 }
 
 .c2 {

--- a/ui/components/__tests__/__snapshots__/DataTable.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/DataTable.test.tsx.snap
@@ -9,8 +9,8 @@ exports[`DataTable snapshots renders 1`] = `
   font-style: normal;
 }
 
-.c0 th {
-  font-weight: bold;
+.c0 .MuiTableCell-head {
+  font-weight: 800;
 }
 
 <div

--- a/ui/lib/theme.ts
+++ b/ui/lib/theme.ts
@@ -99,13 +99,17 @@ export const muiTheme = createTheme({
   typography: { fontFamily: "proxima-nova" },
   palette: {
     primary: {
+      //dark blue
       main: "#006B8E",
     },
     secondary: {
+      //orange
       main: "#CC2C00",
     },
     text: {
+      //black
       primary: "#1a1a1a",
+      //gray
       secondary: "#737373",
       disabled: "#737373",
     },

--- a/ui/lib/theme.ts
+++ b/ui/lib/theme.ts
@@ -99,17 +99,17 @@ export const muiTheme = createTheme({
   typography: { fontFamily: "proxima-nova" },
   palette: {
     primary: {
-      //dark blue
+      //Main - Primary Color Dark - 10
       main: "#006B8E",
     },
     secondary: {
-      //orange
-      main: "#CC2C00",
+      //Feedback - Alert - Original
+      main: "#BC381D",
     },
     text: {
-      //black
+      //Neutral - Neutral - 40
       primary: "#1a1a1a",
-      //gray
+      //Neutral - Neutral - 30
       secondary: "#737373",
       disabled: "#737373",
     },

--- a/ui/lib/theme.ts
+++ b/ui/lib/theme.ts
@@ -84,6 +84,7 @@ export const GlobalStyle = createGlobalStyle`
   body {
     font-family: ${(props) => props.theme.fontFamilies.regular};
     font-size: ${theme.fontSizes.normal};
+    color: ${theme.colors.black};
     padding: 0;
     margin: 0;
     min-width: fit-content;
@@ -99,6 +100,11 @@ export const muiTheme = createTheme({
   palette: {
     secondary: {
       main: "#CC2C00",
+    },
+    text: {
+      primary: "#1a1a1a",
+      secondary: "#737373",
+      disabled: "#737373",
     },
   },
 });

--- a/ui/lib/theme.ts
+++ b/ui/lib/theme.ts
@@ -98,6 +98,9 @@ export const GlobalStyle = createGlobalStyle`
 export const muiTheme = createTheme({
   typography: { fontFamily: "proxima-nova" },
   palette: {
+    primary: {
+      main: "#006B8E",
+    },
     secondary: {
       main: "#CC2C00",
     },

--- a/ui/pages/ApplicationAdd.tsx
+++ b/ui/pages/ApplicationAdd.tsx
@@ -77,15 +77,11 @@ const SuccessMessage = styled(
                 <Flex wide center>
                   {autoMerged ? (
                     <Link to={PageRoute.Applications}>
-                      <Button color="primary" variant="outlined">
-                        View Applications
-                      </Button>
+                      <Button>View Applications</Button>
                     </Link>
                   ) : (
                     <a target="_blank" href={link}>
-                      <Button color="primary" variant="outlined">
-                        View Open Pull requests
-                      </Button>
+                      <Button>View Open Pull requests</Button>
                     </a>
                   )}
                 </Flex>
@@ -124,8 +120,11 @@ const FormElement = styled.div`
 `;
 
 function AddApplication({ className }: Props) {
-  const { getCallbackState, clearCallbackState, getProviderToken } =
-    React.useContext(AppContext);
+  const {
+    getCallbackState,
+    clearCallbackState,
+    getProviderToken,
+  } = React.useContext(AppContext);
   const formRef = React.useRef<HTMLFormElement>();
 
   let initialFormState = {
@@ -332,6 +331,7 @@ function AddApplication({ className }: Props) {
                 <FormControlLabel
                   control={
                     <Switch
+                      color="primary"
                       onChange={(e) =>
                         setFormState({
                           ...formState,

--- a/ui/stories/DataTable.stories.tsx
+++ b/ui/stories/DataTable.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, Story } from "@storybook/react";
 import * as React from "react";
-import { DataTable, Props } from "../components/DataTable";
+import DataTable, { Props } from "../components/DataTable";
 
 export default {
   title: "DataTable",

--- a/ui/stories/Modal.stories.tsx
+++ b/ui/stories/Modal.stories.tsx
@@ -1,7 +1,7 @@
 import { Meta, Story } from "@storybook/react";
 import React from "react";
 import Button from "../components/Button";
-import { Modal, Props } from "../components/Modal";
+import Modal, { Props } from "../components/Modal";
 
 export default {
   title: "Modal",


### PR DESCRIPTION
Parts of #1096 are completed in this PR - some parts are exclusive to Enterprise and are not fixed here. 
Closes #777 
Closes #914 

Theme colors - adds primary and text keys to customized mui palette, fixing black and grey text, light blue buttons, and AddApplication switch color

Aligns tables in ApplicationDetail with widths array prop

Removes Account Icon until functionality is added 