### PR TITLE
Fixed adding a Gitlab app via UI

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -633,7 +633,7 @@ func (s *applicationServer) AuthorizeGitlab(ctx context.Context, msg *pb.Authori
 		return nil, fmt.Errorf("could not exchange code: %w", err)
 	}
 
-	token, err := s.jwtClient.GenerateJWT(time.Duration(tokenState.ExpiresIn), gitproviders.GitProviderGitLab, tokenState.AccessToken)
+	token, err := s.jwtClient.GenerateJWT(time.Duration(tokenState.ExpiresIn)*time.Second, gitproviders.GitProviderGitLab, tokenState.AccessToken)
 	if err != nil {
 		return nil, fmt.Errorf("could not generate token: %w", err)
 	}


### PR DESCRIPTION
<!-- Use # to add the issue this pull request is related to -->
Closes: 

<!-- Describe what has changed in this PR -->
**What changed?**
Interpret integer as seconds


<!-- Tell your future self why have you made these changes -->
**Why?**
It was interpreting the integer as milliseconds instead of seconds, causing unauthorized errors as the token only had a few seconds of validity. 

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**
I manually added an app via UI, getting the next message afterwards:
<img width="1361" alt="image" src="https://user-images.githubusercontent.com/3892786/143968995-2c9e744f-95c0-470f-890e-594baa0422d7.png">


<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
**Release notes**

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**