### PR TITLE
Fixes `gitops upgrade` with gitlab

### DIFF
--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -97,7 +97,6 @@ func upgrade(ctx context.Context, uv UpgradeValues, kube kube.Kube, gitClient gi
 
 	// Create pull request
 	path := filepath.Join(git.WegoRoot, git.WegoClusterDir, cname, git.WegoClusterOSWorkloadDir, WegoEnterpriseName)
-	wegoAppPath := filepath.Join(git.WegoRoot, git.WegoClusterDir, cname, git.WegoClusterOSWorkloadDir, "wego-app.yaml")
 	capiKeepPath := filepath.Join(git.WegoRoot, git.WegoAppDir, "capi", "templates", ".keep")
 	capiKeepContents := string(strconv.AppendQuote(nil, "# keep"))
 
@@ -115,10 +114,6 @@ func upgrade(ctx context.Context, uv UpgradeValues, kube kube.Kube, gitClient gi
 			{
 				Path:    &capiKeepPath,
 				Content: &capiKeepContents,
-			},
-			{
-				Path:    &wegoAppPath,
-				Content: nil,
 			},
 		},
 	}


### PR DESCRIPTION
- Don't try and delete a file for now
- This is okay as we sorted out https://github.com/weaveworks/weave-gitops/pull/1099

<!-- Use # to add the issue this pull request is related to -->
Closes: https://github.com/weaveworks/weave-gitops/issues/1124

<!-- Describe what has changed in this PR -->
**What changed?**

Don't try and delete the wego-app.yaml for now. Its not causing any issues and now no longer raises reconciliation errors.

<!-- Tell your future self why have you made these changes -->
**Why?**

go-git-provider gitlab doesn't support deleting files w/ `nil` (maybe it works with an empty string?)

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**

manually