### PR TITLE
Adjustments to field ExpiresIn in TokenResponseState structure

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -633,7 +633,7 @@ func (s *applicationServer) AuthorizeGitlab(ctx context.Context, msg *pb.Authori
 		return nil, fmt.Errorf("could not exchange code: %w", err)
 	}
 
-	token, err := s.jwtClient.GenerateJWT(time.Duration(tokenState.ExpiresIn)*time.Second, gitproviders.GitProviderGitLab, tokenState.AccessToken)
+	token, err := s.jwtClient.GenerateJWT(tokenState.ExpiresInSeconds, gitproviders.GitProviderGitLab, tokenState.AccessToken)
 	if err != nil {
 		return nil, fmt.Errorf("could not generate token: %w", err)
 	}

--- a/pkg/services/auth/gitlab_test.go
+++ b/pkg/services/auth/gitlab_test.go
@@ -158,13 +158,13 @@ var _ = Describe("Gitlab auth flow", func() {
 		Expect(w.Body.String()).To(Equal(""))
 
 		expectedToken := types.TokenResponseState{
-			AccessToken:    "abc-123",
-			TokenType:      "shiny",
-			ExpiresIn:      5,
-			RefreshToken:   "xyz-456",
-			CreatedAt:      4,
-			HttpStatusCode: http.StatusOK,
-			Err:            nil,
+			AccessToken:      "abc-123",
+			TokenType:        "shiny",
+			ExpiresInSeconds: time.Second * 5,
+			RefreshToken:     "xyz-456",
+			CreatedAt:        4,
+			HttpStatusCode:   http.StatusOK,
+			Err:              nil,
 		}
 		Expect(tokenState).To(Equal(expectedToken))
 	})
@@ -395,6 +395,6 @@ var _ = Describe("GitlabAuthClient", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(tokenState.AccessToken).To(Equal(rs.AccessToken))
-		Expect(tokenState.ExpiresIn).To(Equal(rs.ExpiresIn))
+		Expect(tokenState.ExpiresInSeconds).To(Equal(time.Duration(rs.ExpiresIn) * time.Second))
 	})
 })

--- a/pkg/services/auth/types/token.go
+++ b/pkg/services/auth/types/token.go
@@ -1,18 +1,20 @@
 package types
 
 import (
+	"time"
+
 	"github.com/weaveworks/weave-gitops/pkg/services/auth/internal"
 )
 
 // TokenResponseState is used for passing state through HTTP middleware
 type TokenResponseState struct {
-	AccessToken    string
-	TokenType      string
-	ExpiresIn      int64
-	RefreshToken   string
-	CreatedAt      int64
-	HttpStatusCode int
-	Err            error
+	AccessToken      string
+	TokenType        string
+	ExpiresInSeconds time.Duration
+	RefreshToken     string
+	CreatedAt        int64
+	HttpStatusCode   int
+	Err              error
 }
 
 // SetGitlabTokenResponse will modify the TokenResponseState and populate the relevant fields from
@@ -20,7 +22,7 @@ type TokenResponseState struct {
 func (t *TokenResponseState) SetGitlabTokenResponse(token internal.GitlabTokenResponse) {
 	t.AccessToken = token.AccessToken
 	t.RefreshToken = token.RefreshToken
-	t.ExpiresIn = token.ExpiresIn
+	t.ExpiresInSeconds = time.Duration(token.ExpiresIn) * time.Second
 	t.CreatedAt = token.CreatedAt
 	t.TokenType = token.TokenType
 }

--- a/pkg/services/auth/types/token_test.go
+++ b/pkg/services/auth/types/token_test.go
@@ -1,0 +1,43 @@
+package types
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/weaveworks/weave-gitops/pkg/services/auth/internal"
+)
+
+var _ = Describe("TokenResponseState", func() {
+
+	var token *TokenResponseState
+	var tokenResponse internal.GitlabTokenResponse
+
+	accessToken := "kEq6PWZ8x37CNNmk"
+	tokenType := "test-token-type"
+	var seconds int64 = 600
+	refreshToken := "H2q4xABSMT"
+	var createdAt int64 = 32425434
+
+	_ = BeforeEach(func() {
+		token = &TokenResponseState{}
+		tokenResponse = internal.GitlabTokenResponse{
+			AccessToken:  accessToken,
+			TokenType:    tokenType,
+			ExpiresIn:    seconds,
+			RefreshToken: refreshToken,
+			CreatedAt:    createdAt,
+		}
+	})
+
+	It("populates fields properly", func() {
+		token.SetGitlabTokenResponse(tokenResponse)
+
+		Expect(token.AccessToken).To(Equal(accessToken))
+		Expect(token.TokenType).To(Equal(tokenType))
+		Expect(token.ExpiresInSeconds).To(Equal(time.Duration(seconds) * time.Second))
+		Expect(token.RefreshToken).To(Equal(refreshToken))
+		Expect(token.CreatedAt).To(Equal(createdAt))
+
+	})
+})

--- a/pkg/services/auth/types/types_suite_test.go
+++ b/pkg/services/auth/types/types_suite_test.go
@@ -1,0 +1,13 @@
+package types
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestTypes(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Types Suite")
+}


### PR DESCRIPTION
<!-- Use # to add the issue this pull request is related to -->
Closes: 

<!-- Describe what has changed in this PR -->
**What changed?**
Changes to the field `ExpiresIn` in `TokenResponseState`:
- Renamed from `ExpiresIn` to `ExpiresInSeconds`
- Changed type from `int64` to `time.Duration`

Added coverage to the function `SetGitlabTokenResponse`

<!-- Tell your future self why have you made these changes -->
**Why?**
To communicate better what that field is for.

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**
Added unit tests

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
**Release notes**

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**