### PR TITLE
Fixes `gitops install` wego-app.yaml deployment when running in container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ GIT_COMMIT=$(shell git log -n1 --pretty='%h')
 CURRENT_DIR=$(shell pwd)
 FORMAT_LIST=$(shell gofmt -l .)
 FLUX_VERSION=$(shell $(CURRENT_DIR)/tools/bin/stoml $(CURRENT_DIR)/tools/dependencies.toml flux.version)
-LDFLAGS = "-X github.com/weaveworks/weave-gitops/cmd/gitops/version.BuildTime=$(BUILD_TIME) -X github.com/weaveworks/weave-gitops/cmd/gitops/version.Branch=$(BRANCH) -X github.com/weaveworks/weave-gitops/cmd/gitops/version.GitCommit=$(GIT_COMMIT) -X github.com/weaveworks/weave-gitops/pkg/version.FluxVersion=$(FLUX_VERSION)"
+LDFLAGS = "-X github.com/weaveworks/weave-gitops/cmd/gitops/version.BuildTime=$(BUILD_TIME) -X github.com/weaveworks/weave-gitops/cmd/gitops/version.Branch=$(BRANCH) -X github.com/weaveworks/weave-gitops/cmd/gitops/version.GitCommit=$(GIT_COMMIT) -X github.com/weaveworks/weave-gitops/pkg/version.FluxVersion=$(FLUX_VERSION) -X github.com/weaveworks/weave-gitops/cmd/gitops/version.Version=$(VERSION)"
 
 KUBEBUILDER_ASSETS ?= "$(CURRENT_DIR)/tools/bin/envtest"
 

--- a/test/acceptance/test/version_tests.go
+++ b/test/acceptance/test/version_tests.go
@@ -24,8 +24,8 @@ var _ = Describe("Weave GitOps Version Test", func() {
 			session = runCommandAndReturnSessionOutput(WEGO_BIN_PATH + " version")
 		})
 
-		By("Then I should see the gitops version printed in format vm.n.n with newline character", func() {
-			Eventually(session).Should(gbytes.Say("Current Version: v[0-3].[0-9].[0-9]\n"))
+		By("Then I should see the gitops version printed with newline character", func() {
+			Eventually(session).Should(gbytes.Say("Current Version: \\S+\n"))
 		})
 
 		By("And git commit with commit id", func() {


### PR DESCRIPTION
- Container builds _in the container_ and doesn't use go-releaser and so
  doesn't have a version.Version

<!-- Describe what has changed in this PR -->
**What changed?**

`version.Version` is set when building `gitops` using `make bin` (used for local dev and inside the published container).

<!-- Tell your future self why have you made these changes -->
**Why?**

So that capi cluster bootstrapping doesn't show an imagepullerror as the version is used to generate the deployment.image when running `gitops install`

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**

`docker build -t...`