### PR TITLE
Fail when app is added with prefix wego

### DIFF
--- a/pkg/services/app/add.go
+++ b/pkg/services/app/add.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/weaveworks/weave-gitops/pkg/git"
 	"github.com/weaveworks/weave-gitops/pkg/gitproviders"
@@ -71,6 +72,10 @@ func (a *AppSvc) Add(configGit git.Git, gitProvider gitproviders.GitProvider, pa
 	app, err := makeApplication(params)
 	if err != nil {
 		return err
+	}
+
+	if strings.HasPrefix(params.Name, "wego-") {
+		return fmt.Errorf("the prefix 'wego' is used by weave gitops and is not allowed for an app name")
 	}
 
 	appHash := automation.GetAppHash(app)

--- a/pkg/services/app/add_test.go
+++ b/pkg/services/app/add_test.go
@@ -173,6 +173,14 @@ var _ = Describe("Add", func() {
 		})
 	})
 
+	Context("Fails to add app that has the prefix wego as an app name", func() {
+		It("Adds an app with ", func() {
+			addParams.Name = "wego-appname"
+			err := appSrv.Add(gitClient, gitProviders, addParams)
+			Expect(err.Error()).Should(ContainSubstring("the prefix 'wego' is used by weave gitops and is not allowed for an app name"))
+		})
+	})
+
 	Context("ensure that app names are <= 63 characters in length", func() {
 		It("ensures that app names are <= 63 characters", func() {
 			addParams.Name = "a23456789012345678901234567890123456789012345678901234567890123"


### PR DESCRIPTION
<!-- Use # to add the issue this pull request is related to -->
Closes: #1075 

<!-- Describe what has changed in this PR -->
**What changed?**
Added a check on add to not allow a user to add and app with the prefix "wego-". This prevents the app name from matching the flux cluster name.


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**
Manually and with a unit test.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
**Release notes**

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**