### PR TITLE
Invert boldness in font definitions

### DIFF
--- a/ui/lib/fonts.ts
+++ b/ui/lib/fonts.ts
@@ -12,11 +12,11 @@ const Fonts = createGlobalStyle`
     @font-face {
         font-family: 'proxima-nova';
         src: url(${ProximaNovaBold})
+        font-weight: bold;
     }
     @font-face {
         font-family: 'proxima-nova';
         src: url(${ProximaNovaRegular});
-        font-weight: bold;
     }
     @font-face {
         font-family: 'Roboto Mono';


### PR DESCRIPTION
The bold was listed as regular weight, and vice versa, which made the
UI bold everywhere except for in headers.

<!-- Use # to add the issue this pull request is related to -->
Closes: 

<!-- Describe what has changed in this PR -->
**What changed?**
 Fix which version of proxima-nova is considered bold and which one isn't

<!-- Tell your future self why have you made these changes -->
**Why?**
The bold font was listed as regular, while the regular font was listed as bold - that made the whole UI bold, except for in headers and other places of emphasis.

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**
 Looking at the UI

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
**Release notes**
No

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
No