### PR TITLE
Check environment variables are set before running integration/acceptance tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,6 +76,7 @@ jobs:
         GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
         GITLAB_ORG: ${{ secrets.GITLAB_ORG }}
         GITHUB_TOKEN: "${{ secrets.WEAVE_GITOPS_TEST_WEAVEWORKS_WEAVE_GITOPS_BOT_TOKEN }}"
+        GITHUB_ORG: weaveworks-gitops-test
         KUBEBUILDER_ASSETS: ${{ github.workspace }}/kubebuilder/bin
     runs-on: ubuntu-latest
     steps:

--- a/test/acceptance/test/add_tests.go
+++ b/test/acceptance/test/add_tests.go
@@ -39,7 +39,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 
 		By("And I have a gitops binary installed on my local machine", func() {
-			Expect(FileExists(WEGO_BIN_PATH)).To(BeTrue())
+			Expect(FileExists(gitopsBinaryPath)).To(BeTrue())
 		})
 	})
 
@@ -49,19 +49,19 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		var exitCode int
 		private := true
 		tip := generateTestInputs()
-		appRepoRemoteURL := "ssh://git@github.com/" + GITHUB_ORG + "/" + tip.appRepoName + ".git"
+		appRepoRemoteURL := "ssh://git@github.com/" + githubOrg + "/" + tip.appRepoName + ".git"
 
 		addCommand1 := "add app . --auto-merge=true"
 		addCommand2 := "add app . --url=" + appRepoRemoteURL + " --auto-merge=true"
 
-		defer deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
+		defer deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, githubOrg)
 
 		By("And application repo does not already exist", func() {
-			deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
+			deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, githubOrg)
 		})
 
 		By("When I create a private repo with my app workload", func() {
-			repoAbsolutePath = initAndCreateEmptyRepo(tip.appRepoName, gitproviders.GitProviderGitHub, private, GITHUB_ORG)
+			repoAbsolutePath = initAndCreateEmptyRepo(tip.appRepoName, gitproviders.GitProviderGitHub, private, githubOrg)
 			gitAddCommitPush(repoAbsolutePath, tip.appManifestFilePath)
 		})
 
@@ -70,7 +70,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 
 		By("And I run gitops add command", func() {
-			command := exec.Command("sh", "-c", fmt.Sprintf("cd %s && %s %s", repoAbsolutePath, WEGO_BIN_PATH, addCommand1))
+			command := exec.Command("sh", "-c", fmt.Sprintf("cd %s && %s %s", repoAbsolutePath, gitopsBinaryPath, addCommand1))
 			session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 			Expect(err).ShouldNot(HaveOccurred())
 			Eventually(session).Should(gexec.Exit())
@@ -98,16 +98,16 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		private := true
 		tip := generateTestInputs()
 		branchName := "test-branch-01"
-		appRepoRemoteURL := "ssh://git@github.com/" + GITHUB_ORG + "/" + tip.appRepoName + ".git"
+		appRepoRemoteURL := "ssh://git@github.com/" + githubOrg + "/" + tip.appRepoName + ".git"
 		appName := tip.appRepoName
 
 		addCommand := "add app --url=" + appRepoRemoteURL + " --branch=" + branchName + " --dry-run" + " --auto-merge=true"
 
-		defer deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
+		defer deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, githubOrg)
 		defer deleteWorkload(tip.workloadName, tip.workloadNamespace)
 
 		By("And application repo does not already exist", func() {
-			deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
+			deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, githubOrg)
 		})
 
 		By("And application workload is not already deployed to cluster", func() {
@@ -115,7 +115,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 
 		By("When I create a private repo with my app workload", func() {
-			repoAbsolutePath = initAndCreateEmptyRepo(tip.appRepoName, gitproviders.GitProviderGitHub, private, GITHUB_ORG)
+			repoAbsolutePath = initAndCreateEmptyRepo(tip.appRepoName, gitproviders.GitProviderGitHub, private, githubOrg)
 			gitAddCommitPush(repoAbsolutePath, tip.appManifestFilePath)
 		})
 
@@ -145,7 +145,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 
 		// Test for WGE
 		By("When I try to upgrade gitops core to enterprise", func() {
-			_, errOutput = runCommandAndReturnStringOutput(WEGO_BIN_PATH + " upgrade")
+			_, errOutput = runCommandAndReturnStringOutput(gitopsBinaryPath + " upgrade")
 		})
 
 		By("Then I should see error message", func() {
@@ -153,7 +153,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 
 		By("When I try to upgrade gitops core to enterprise with config-repo & version provided", func() {
-			_, errOutput = runCommandAndReturnStringOutput(WEGO_BIN_PATH + " upgrade --config-repo=" + appRepoRemoteURL + " --version=0.0.1")
+			_, errOutput = runCommandAndReturnStringOutput(gitopsBinaryPath + " upgrade --config-repo=" + appRepoRemoteURL + " --version=0.0.1")
 		})
 
 		By("Then I should see error message", func() {
@@ -166,15 +166,15 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		private := true
 		tip := generateTestInputs()
 		appName := tip.appRepoName
-		appRepoRemoteURL := "ssh://git@github.com/" + GITHUB_ORG + "/" + tip.appRepoName + ".git"
+		appRepoRemoteURL := "ssh://git@github.com/" + githubOrg + "/" + tip.appRepoName + ".git"
 
 		addCommand := "add app . --auto-merge=true"
 
-		defer deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
+		defer deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, githubOrg)
 		defer deleteWorkload(tip.workloadName, tip.workloadNamespace)
 
 		By("And application repo does not already exist", func() {
-			deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
+			deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, githubOrg)
 		})
 
 		By("And application workload is not already deployed to cluster", func() {
@@ -182,7 +182,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 
 		By("When I create an empty private repo", func() {
-			repoAbsolutePath = initAndCreateEmptyRepo(tip.appRepoName, gitproviders.GitProviderGitHub, private, GITHUB_ORG)
+			repoAbsolutePath = initAndCreateEmptyRepo(tip.appRepoName, gitproviders.GitProviderGitHub, private, githubOrg)
 		})
 
 		By("And I install gitops to my active cluster", func() {
@@ -206,7 +206,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 
 		By("And repos created have private visibility", func() {
-			Expect(getGitRepoVisibility(GITHUB_ORG, tip.appRepoName, gitproviders.GitProviderGitHub)).Should(ContainSubstring("private"))
+			Expect(getGitRepoVisibility(githubOrg, tip.appRepoName, gitproviders.GitProviderGitHub)).Should(ContainSubstring("private"))
 		})
 	})
 
@@ -216,19 +216,19 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		private := true
 		tip := generateTestInputs()
 		appName := tip.appRepoName
-		appRepoRemoteURL := "ssh://git@gitlab.com/" + GITLAB_ORG + "/" + tip.appRepoName + ".git"
+		appRepoRemoteURL := "ssh://git@gitlab.com/" + gitlabOrg + "/" + tip.appRepoName + ".git"
 
 		addCommand := "add app . --auto-merge=true"
 
-		defer deleteRepo(tip.appRepoName, gitproviders.GitProviderGitLab, GITLAB_ORG)
+		defer deleteRepo(tip.appRepoName, gitproviders.GitProviderGitLab, gitlabOrg)
 		defer deleteWorkload(tip.workloadName, tip.workloadNamespace)
 
-		By("I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
-			setupGitlabSSHKey(DEFAULT_SSH_KEY_PATH)
+		By("I have my default ssh key on path "+sshKeyPath, func() {
+			setupGitlabSSHKey(sshKeyPath)
 		})
 
 		By("And application repo does not already exist", func() {
-			deleteRepo(tip.appRepoName, gitproviders.GitProviderGitLab, GITLAB_ORG)
+			deleteRepo(tip.appRepoName, gitproviders.GitProviderGitLab, gitlabOrg)
 		})
 
 		By("And application workload is not already deployed to cluster", func() {
@@ -236,7 +236,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 
 		By("When I create an empty private repo", func() {
-			repoAbsolutePath = initAndCreateEmptyRepo(tip.appRepoName, gitproviders.GitProviderGitLab, private, GITLAB_ORG)
+			repoAbsolutePath = initAndCreateEmptyRepo(tip.appRepoName, gitproviders.GitProviderGitLab, private, gitlabOrg)
 		})
 
 		By("And I install gitops to my active cluster", func() {
@@ -260,11 +260,11 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 
 		By("And repos created have private visibility", func() {
-			Expect(getGitRepoVisibility(GITLAB_ORG, tip.appRepoName, gitproviders.GitProviderGitLab)).Should(ContainSubstring("private"))
+			Expect(getGitRepoVisibility(gitlabOrg, tip.appRepoName, gitproviders.GitProviderGitLab)).Should(ContainSubstring("private"))
 		})
 
 		By("When I remove an app", func() {
-			appRemoveOutput, _ = runCommandAndReturnStringOutput(WEGO_BIN_PATH + " delete app " + appName)
+			appRemoveOutput, _ = runCommandAndReturnStringOutput(gitopsBinaryPath + " delete app " + appName)
 		})
 
 		By("Then I should see app removing message", func() {
@@ -283,19 +283,19 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		private := false
 		tip := generateTestInputs()
 		appName := tip.appRepoName
-		appRepoRemoteURL := "ssh://git@gitlab.com/" + GITLAB_PUBLIC_GROUP + "/" + tip.appRepoName + ".git"
+		appRepoRemoteURL := "ssh://git@gitlab.com/" + gitlabPublicGroup + "/" + tip.appRepoName + ".git"
 
 		addCommand := "add app . --auto-merge=true"
 
-		defer deleteRepo(tip.appRepoName, gitproviders.GitProviderGitLab, GITLAB_PUBLIC_GROUP)
+		defer deleteRepo(tip.appRepoName, gitproviders.GitProviderGitLab, gitlabPublicGroup)
 		defer deleteWorkload(tip.workloadName, tip.workloadNamespace)
 
-		By("I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
-			setupGitlabSSHKey(DEFAULT_SSH_KEY_PATH)
+		By("I have my default ssh key on path "+sshKeyPath, func() {
+			setupGitlabSSHKey(sshKeyPath)
 		})
 
 		By("And application repo does not already exist", func() {
-			deleteRepo(tip.appRepoName, gitproviders.GitProviderGitLab, GITLAB_PUBLIC_GROUP)
+			deleteRepo(tip.appRepoName, gitproviders.GitProviderGitLab, gitlabPublicGroup)
 		})
 
 		By("And application workload is not already deployed to cluster", func() {
@@ -303,7 +303,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 
 		By("When I create an empty public repo", func() {
-			repoAbsolutePath = initAndCreateEmptyRepo(tip.appRepoName, gitproviders.GitProviderGitLab, private, GITLAB_PUBLIC_GROUP)
+			repoAbsolutePath = initAndCreateEmptyRepo(tip.appRepoName, gitproviders.GitProviderGitLab, private, gitlabPublicGroup)
 		})
 
 		By("And I install gitops to my active cluster", func() {
@@ -327,7 +327,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 
 		By("And repos created have public visibility", func() {
-			Expect(getGitRepoVisibility(GITLAB_PUBLIC_GROUP, tip.appRepoName, gitproviders.GitProviderGitLab)).Should(ContainSubstring("public"))
+			Expect(getGitRepoVisibility(gitlabPublicGroup, tip.appRepoName, gitproviders.GitProviderGitLab)).Should(ContainSubstring("public"))
 		})
 
 	})
@@ -339,18 +339,18 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		tip := generateTestInputs()
 		appName := tip.appRepoName
 		appConfigRepoName := "config-repo-" + RandString(8)
-		appRepoRemoteURL := "https://github.com/" + GITHUB_ORG + "/" + tip.appRepoName + ".git"
-		configRepoRemoteURL = "https://github.com/" + GITHUB_ORG + "/" + appConfigRepoName + ".git"
+		appRepoRemoteURL := "https://github.com/" + githubOrg + "/" + tip.appRepoName + ".git"
+		configRepoRemoteURL = "https://github.com/" + githubOrg + "/" + appConfigRepoName + ".git"
 
 		addCommand := "add app --url=" + appRepoRemoteURL + " --config-repo=" + configRepoRemoteURL + " --auto-merge=true"
 
-		defer deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
-		defer deleteRepo(appConfigRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
+		defer deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, githubOrg)
+		defer deleteRepo(appConfigRepoName, gitproviders.GitProviderGitHub, githubOrg)
 		defer deleteWorkload(tip.workloadName, tip.workloadNamespace)
 
 		By("And application repo does not already exist", func() {
-			deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
-			deleteRepo(appConfigRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
+			deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, githubOrg)
+			deleteRepo(appConfigRepoName, gitproviders.GitProviderGitHub, githubOrg)
 		})
 
 		By("And application workload is not already deployed to cluster", func() {
@@ -358,12 +358,12 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 
 		By("When I create a private repo for gitops app config", func() {
-			appConfigRepoAbsPath := initAndCreateEmptyRepo(appConfigRepoName, gitproviders.GitProviderGitHub, private, GITHUB_ORG)
+			appConfigRepoAbsPath := initAndCreateEmptyRepo(appConfigRepoName, gitproviders.GitProviderGitHub, private, githubOrg)
 			gitAddCommitPush(appConfigRepoAbsPath, tip.appManifestFilePath)
 		})
 
 		By("When I create a private repo with my app workload", func() {
-			repoAbsolutePath = initAndCreateEmptyRepo(tip.appRepoName, gitproviders.GitProviderGitHub, private, GITHUB_ORG)
+			repoAbsolutePath = initAndCreateEmptyRepo(tip.appRepoName, gitproviders.GitProviderGitHub, private, githubOrg)
 			gitAddCommitPush(repoAbsolutePath, tip.appManifestFilePath)
 		})
 
@@ -389,22 +389,22 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		tip := generateTestInputs()
 		appName := tip.appRepoName
 		appConfigRepoName := "config-repo-" + RandString(8)
-		appRepoRemoteURL := "ssh://git@gitlab.com/" + GITLAB_ORG + "/" + tip.appRepoName + ".git"
-		configRepoRemoteURL = "ssh://git@gitlab.com/" + GITLAB_ORG + "/" + appConfigRepoName + ".git"
+		appRepoRemoteURL := "ssh://git@gitlab.com/" + gitlabOrg + "/" + tip.appRepoName + ".git"
+		configRepoRemoteURL = "ssh://git@gitlab.com/" + gitlabOrg + "/" + appConfigRepoName + ".git"
 
 		addCommand := "add app --url=" + appRepoRemoteURL + " --config-repo=" + configRepoRemoteURL + " --auto-merge=true"
 
-		defer deleteRepo(tip.appRepoName, gitproviders.GitProviderGitLab, GITLAB_ORG)
-		defer deleteRepo(appConfigRepoName, gitproviders.GitProviderGitHub, GITLAB_ORG)
+		defer deleteRepo(tip.appRepoName, gitproviders.GitProviderGitLab, gitlabOrg)
+		defer deleteRepo(appConfigRepoName, gitproviders.GitProviderGitHub, gitlabOrg)
 		defer deleteWorkload(tip.workloadName, tip.workloadNamespace)
 
-		By("I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
-			setupGitlabSSHKey(DEFAULT_SSH_KEY_PATH)
+		By("I have my default ssh key on path "+sshKeyPath, func() {
+			setupGitlabSSHKey(sshKeyPath)
 		})
 
 		By("And application repo does not already exist", func() {
-			deleteRepo(tip.appRepoName, gitproviders.GitProviderGitLab, GITLAB_ORG)
-			deleteRepo(appConfigRepoName, gitproviders.GitProviderGitLab, GITLAB_ORG)
+			deleteRepo(tip.appRepoName, gitproviders.GitProviderGitLab, gitlabOrg)
+			deleteRepo(appConfigRepoName, gitproviders.GitProviderGitLab, gitlabOrg)
 		})
 
 		By("And application workload is not already deployed to cluster", func() {
@@ -412,12 +412,12 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 
 		By("When I create a private repo for gitops app config", func() {
-			appConfigRepoAbsPath := initAndCreateEmptyRepo(appConfigRepoName, gitproviders.GitProviderGitLab, private, GITLAB_ORG)
+			appConfigRepoAbsPath := initAndCreateEmptyRepo(appConfigRepoName, gitproviders.GitProviderGitLab, private, gitlabOrg)
 			gitAddCommitPush(appConfigRepoAbsPath, tip.appManifestFilePath)
 		})
 
 		By("When I create a private repo with my app workload", func() {
-			repoAbsolutePath = initAndCreateEmptyRepo(tip.appRepoName, gitproviders.GitProviderGitLab, private, GITLAB_ORG)
+			repoAbsolutePath = initAndCreateEmptyRepo(tip.appRepoName, gitproviders.GitProviderGitLab, private, gitlabOrg)
 			gitAddCommitPush(repoAbsolutePath, tip.appManifestFilePath)
 		})
 
@@ -435,7 +435,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 
 		By("When I delete an app", func() {
-			appRemoveOutput, _ = runCommandAndReturnStringOutput(WEGO_BIN_PATH + " delete app " + appName)
+			appRemoveOutput, _ = runCommandAndReturnStringOutput(gitopsBinaryPath + " delete app " + appName)
 		})
 
 		By("Then I should see app removing message", func() {
@@ -454,15 +454,15 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		private := false
 		tip := generateTestInputs()
 		appName := tip.appRepoName
-		appRepoRemoteURL := "ssh://git@github.com/" + GITHUB_ORG + "/" + tip.appRepoName + ".git"
+		appRepoRemoteURL := "ssh://git@github.com/" + githubOrg + "/" + tip.appRepoName + ".git"
 
 		addCommand := "add app --url=" + appRepoRemoteURL + " --auto-merge=true"
 
-		defer deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
+		defer deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, githubOrg)
 		defer deleteWorkload(tip.workloadName, tip.workloadNamespace)
 
 		By("And application repo does not already exist", func() {
-			deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
+			deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, githubOrg)
 		})
 
 		By("And application workload is not already deployed to cluster", func() {
@@ -470,7 +470,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 
 		By("When I create a private repo with my app workload", func() {
-			repoAbsolutePath = initAndCreateEmptyRepo(tip.appRepoName, gitproviders.GitProviderGitHub, private, GITHUB_ORG)
+			repoAbsolutePath = initAndCreateEmptyRepo(tip.appRepoName, gitproviders.GitProviderGitHub, private, githubOrg)
 			gitAddCommitPush(repoAbsolutePath, tip.appManifestFilePath)
 		})
 
@@ -493,15 +493,15 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		private := true
 		tip := generateTestInputs()
 		appName := tip.appRepoName
-		appRepoRemoteURL := "ssh://git@github.com/" + GITHUB_ORG + "/" + tip.appRepoName + ".git"
+		appRepoRemoteURL := "ssh://git@github.com/" + githubOrg + "/" + tip.appRepoName + ".git"
 
 		addCommand := "add app " + tip.appRepoName + "/" + " --auto-merge=true"
 
-		defer deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
+		defer deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, githubOrg)
 		defer deleteWorkload(tip.workloadName, tip.workloadNamespace)
 
 		By("And application repo does not already exist", func() {
-			deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
+			deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, githubOrg)
 		})
 
 		By("And application workload is not already deployed to cluster", func() {
@@ -509,7 +509,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 
 		By("When I create a private repo with my app workload", func() {
-			repoAbsolutePath = initAndCreateEmptyRepo(tip.appRepoName, gitproviders.GitProviderGitHub, private, GITHUB_ORG)
+			repoAbsolutePath = initAndCreateEmptyRepo(tip.appRepoName, gitproviders.GitProviderGitHub, private, githubOrg)
 			gitAddCommitPush(repoAbsolutePath, tip.appManifestFilePath)
 		})
 
@@ -528,7 +528,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 
 		By("And repos created have private visibility", func() {
-			Expect(getGitRepoVisibility(GITHUB_ORG, tip.appRepoName, gitproviders.GitProviderGitHub)).Should(ContainSubstring("private"))
+			Expect(getGitRepoVisibility(githubOrg, tip.appRepoName, gitproviders.GitProviderGitHub)).Should(ContainSubstring("private"))
 		})
 	})
 
@@ -538,16 +538,16 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		tip2 := generateTestInputs()
 		appRepoName := "test-app-" + RandString(8)
 		appName := appRepoName
-		appRepoRemoteURL := "ssh://git@github.com/" + GITHUB_ORG + "/" + appRepoName + ".git"
+		appRepoRemoteURL := "ssh://git@github.com/" + githubOrg + "/" + appRepoName + ".git"
 
 		addCommand := "add app . --name=" + appName + " --auto-merge=true"
 
-		defer deleteRepo(appRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
+		defer deleteRepo(appRepoName, gitproviders.GitProviderGitHub, githubOrg)
 		defer deleteWorkload(tip1.workloadName, tip1.workloadNamespace)
 		defer deleteWorkload(tip2.workloadName, tip2.workloadNamespace)
 
 		By("And application repos do not already exist", func() {
-			deleteRepo(appRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
+			deleteRepo(appRepoName, gitproviders.GitProviderGitHub, githubOrg)
 		})
 
 		By("And application workload is not already deployed to cluster", func() {
@@ -556,7 +556,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 
 		By("When I create an empty private repo for app1", func() {
-			repoAbsolutePath = initAndCreateEmptyRepo(appRepoName, gitproviders.GitProviderGitHub, true, GITHUB_ORG)
+			repoAbsolutePath = initAndCreateEmptyRepo(appRepoName, gitproviders.GitProviderGitHub, true, githubOrg)
 		})
 
 		By("And I git add-commit-push for app with multiple workloads", func() {
@@ -587,7 +587,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		tip := generateTestInputs()
 		appRepoName := "test-app-" + RandString(8)
 		appName := appRepoName
-		appRepoRemoteURL := "ssh://git@github.com/" + GITHUB_ORG + "/" + appRepoName + ".git"
+		appRepoRemoteURL := "ssh://git@github.com/" + githubOrg + "/" + appRepoName + ".git"
 
 		addCommand := "add app . --name=" + appName + " --auto-merge=true"
 
@@ -595,7 +595,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		cluster2Name, cluster2Context, err := ResetOrCreateClusterWithName(WEGO_DEFAULT_NAMESPACE, deleteWegoRuntime, "", true)
 		Expect(err).ShouldNot(HaveOccurred())
 
-		defer deleteRepo(appRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
+		defer deleteRepo(appRepoName, gitproviders.GitProviderGitHub, githubOrg)
 		defer func() {
 			selectCluster(cluster1Context)
 			deleteWorkload(tip.workloadName, tip.workloadNamespace)
@@ -603,7 +603,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		}()
 
 		By("And application repos do not already exist", func() {
-			deleteRepo(appRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
+			deleteRepo(appRepoName, gitproviders.GitProviderGitHub, githubOrg)
 		})
 
 		By("And application workload is not already deployed to clusters", func() {
@@ -614,7 +614,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 
 		By("When I create an empty private repo for app", func() {
-			repoAbsolutePath = initAndCreateEmptyRepo(appRepoName, gitproviders.GitProviderGitHub, true, GITHUB_ORG)
+			repoAbsolutePath = initAndCreateEmptyRepo(appRepoName, gitproviders.GitProviderGitHub, true, githubOrg)
 		})
 
 		By("And I git add-commit-push for app", func() {
@@ -660,22 +660,22 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		appRepoName1 := "test-app-" + RandString(8)
 		appRepoName2 := "test-app-" + RandString(8)
 		appConfigRepoName := "config-repo-" + RandString(8)
-		configRepoRemoteURL = "ssh://git@github.com/" + GITHUB_ORG + "/" + appConfigRepoName + ".git"
+		configRepoRemoteURL = "ssh://git@github.com/" + githubOrg + "/" + appConfigRepoName + ".git"
 		appName1 := appRepoName1
 		appName2 := appRepoName2
 
 		addCommand := "add app . --config-repo=" + configRepoRemoteURL + " --auto-merge=true"
 
-		defer deleteRepo(appRepoName1, gitproviders.GitProviderGitHub, GITHUB_ORG)
-		defer deleteRepo(appRepoName2, gitproviders.GitProviderGitHub, GITHUB_ORG)
-		defer deleteRepo(appConfigRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
+		defer deleteRepo(appRepoName1, gitproviders.GitProviderGitHub, githubOrg)
+		defer deleteRepo(appRepoName2, gitproviders.GitProviderGitHub, githubOrg)
+		defer deleteRepo(appConfigRepoName, gitproviders.GitProviderGitHub, githubOrg)
 		defer deleteWorkload(tip1.workloadName, tip1.workloadNamespace)
 		defer deleteWorkload(tip2.workloadName, tip2.workloadNamespace)
 
 		By("And application repo does not already exist", func() {
-			deleteRepo(appRepoName1, gitproviders.GitProviderGitHub, GITHUB_ORG)
-			deleteRepo(appRepoName2, gitproviders.GitProviderGitHub, GITHUB_ORG)
-			deleteRepo(appConfigRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
+			deleteRepo(appRepoName1, gitproviders.GitProviderGitHub, githubOrg)
+			deleteRepo(appRepoName2, gitproviders.GitProviderGitHub, githubOrg)
+			deleteRepo(appConfigRepoName, gitproviders.GitProviderGitHub, githubOrg)
 		})
 
 		By("And application workload is not already deployed to cluster", func() {
@@ -684,7 +684,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 
 		By("When I create a private repo for gitops app config", func() {
-			appConfigRepoAbsPath := initAndCreateEmptyRepo(appConfigRepoName, gitproviders.GitProviderGitHub, private, GITHUB_ORG)
+			appConfigRepoAbsPath := initAndCreateEmptyRepo(appConfigRepoName, gitproviders.GitProviderGitHub, private, githubOrg)
 			gitAddCommitPush(appConfigRepoAbsPath, readmeFilePath)
 		})
 
@@ -693,13 +693,13 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 
 		By("And I create a repo with my app1 workload and run the add app command on it", func() {
-			repoAbsolutePath = initAndCreateEmptyRepo(appRepoName1, gitproviders.GitProviderGitHub, private, GITHUB_ORG)
+			repoAbsolutePath = initAndCreateEmptyRepo(appRepoName1, gitproviders.GitProviderGitHub, private, githubOrg)
 			gitAddCommitPush(repoAbsolutePath, tip1.appManifestFilePath)
 			runWegoAddCommand(repoAbsolutePath, addCommand, WEGO_DEFAULT_NAMESPACE)
 		})
 
 		By("And I create a repo with my app2 workload and run the add app command on it", func() {
-			repoAbsolutePath = initAndCreateEmptyRepo(appRepoName2, gitproviders.GitProviderGitHub, private, GITHUB_ORG)
+			repoAbsolutePath = initAndCreateEmptyRepo(appRepoName2, gitproviders.GitProviderGitHub, private, githubOrg)
 			gitAddCommitPush(repoAbsolutePath, tip2.appManifestFilePath)
 			runWegoAddCommand(repoAbsolutePath, addCommand, WEGO_DEFAULT_NAMESPACE)
 		})
@@ -720,17 +720,17 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		appRepoName := "test-app-" + RandString(8)
 		appName1 := "app1"
 		appName2 := "app2"
-		appRepoRemoteURL := "ssh://git@github.com/" + GITHUB_ORG + "/" + appRepoName + ".git"
+		appRepoRemoteURL := "ssh://git@github.com/" + githubOrg + "/" + appRepoName + ".git"
 
 		addCommand1 := "add app . --path=./" + appName1 + " --name=" + appName1 + " --auto-merge=true"
 		addCommand2 := "add app . --path=./" + appName2 + " --name=" + appName2 + " --auto-merge=true"
 
-		defer deleteRepo(appRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
+		defer deleteRepo(appRepoName, gitproviders.GitProviderGitHub, githubOrg)
 		defer deleteWorkload(tip1.workloadName, tip1.workloadNamespace)
 		defer deleteWorkload(tip2.workloadName, tip2.workloadNamespace)
 
 		By("And application repo does not already exist", func() {
-			deleteRepo(appRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
+			deleteRepo(appRepoName, gitproviders.GitProviderGitHub, githubOrg)
 		})
 
 		By("And application workload is not already deployed to cluster", func() {
@@ -739,7 +739,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 
 		By("And I create a repo", func() {
-			repoAbsolutePath = initAndCreateEmptyRepo(appRepoName, gitproviders.GitProviderGitHub, private, GITHUB_ORG)
+			repoAbsolutePath = initAndCreateEmptyRepo(appRepoName, gitproviders.GitProviderGitHub, private, githubOrg)
 		})
 
 		By("And I install gitops to my active cluster", func() {
@@ -777,7 +777,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		tip := generateTestInputs()
 		appFilesRepoName := tip.appRepoName
 		appConfigRepoName := "config-repo-" + RandString(8)
-		configRepoRemoteURL = "ssh://git@github.com/" + GITHUB_ORG + "/" + appConfigRepoName + ".git"
+		configRepoRemoteURL = "ssh://git@github.com/" + githubOrg + "/" + appConfigRepoName + ".git"
 		helmRepoURL := "https://charts.kube-ops.io"
 		appName1 := appFilesRepoName
 		workloadName1 := tip.workloadName
@@ -792,14 +792,14 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		addCommand2 := "add app . --deployment-type=helm --path=./hello-world --name=" + appName2 + " --config-repo=" + configRepoRemoteURL + " --auto-merge=true"
 		addCommand3 := "add app --url=" + helmRepoURL + " --chart=" + appName3 + " --config-repo=" + configRepoRemoteURL + " --auto-merge=true"
 
-		defer deleteRepo(appFilesRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
-		defer deleteRepo(appConfigRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
+		defer deleteRepo(appFilesRepoName, gitproviders.GitProviderGitHub, githubOrg)
+		defer deleteRepo(appConfigRepoName, gitproviders.GitProviderGitHub, githubOrg)
 		defer deleteWorkload(workloadName1, workloadNamespace1)
 		defer deletePersistingHelmApp(WEGO_DEFAULT_NAMESPACE, workloadName3, EVENTUALLY_DEFAULT_TIMEOUT)
 
 		By("And application repo does not already exist", func() {
-			deleteRepo(appFilesRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
-			deleteRepo(appConfigRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
+			deleteRepo(appFilesRepoName, gitproviders.GitProviderGitHub, githubOrg)
+			deleteRepo(appConfigRepoName, gitproviders.GitProviderGitHub, githubOrg)
 		})
 
 		By("And application workload is not already deployed to cluster", func() {
@@ -808,12 +808,12 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 
 		By("When I create a private repo for gitops app config", func() {
-			appConfigRepoAbsPath := initAndCreateEmptyRepo(appConfigRepoName, gitproviders.GitProviderGitHub, private, GITHUB_ORG)
+			appConfigRepoAbsPath := initAndCreateEmptyRepo(appConfigRepoName, gitproviders.GitProviderGitHub, private, githubOrg)
 			gitAddCommitPush(appConfigRepoAbsPath, readmeFilePath)
 		})
 
 		By("When I create a private repo with app1 workload", func() {
-			repoAbsolutePath = initAndCreateEmptyRepo(appFilesRepoName, gitproviders.GitProviderGitHub, private, GITHUB_ORG)
+			repoAbsolutePath = initAndCreateEmptyRepo(appFilesRepoName, gitproviders.GitProviderGitHub, private, githubOrg)
 			gitAddCommitPush(repoAbsolutePath, appManifestFilePath1)
 		})
 
@@ -854,7 +854,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 
 		By("When I check the app status for app1", func() {
-			appStatus1, _ = runCommandAndReturnStringOutput(WEGO_BIN_PATH + " get app " + appName1)
+			appStatus1, _ = runCommandAndReturnStringOutput(gitopsBinaryPath + " get app " + appName1)
 		})
 
 		By("Then I should see the status for "+appName1, func() {
@@ -864,7 +864,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 
 		By("When I check the app status for app2", func() {
-			appStatus2, _ = runCommandAndReturnStringOutput(WEGO_BIN_PATH + " get app " + appName2)
+			appStatus2, _ = runCommandAndReturnStringOutput(gitopsBinaryPath + " get app " + appName2)
 		})
 
 		By("Then I should see the status for "+appName2, func() {
@@ -874,7 +874,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 
 		By("When I check the app status for app3", func() {
-			appStatus3, _ = runCommandAndReturnStringOutput(WEGO_BIN_PATH + " get app " + appName3)
+			appStatus3, _ = runCommandAndReturnStringOutput(gitopsBinaryPath + " get app " + appName3)
 		})
 
 		By("Then I should see the status for "+appName3, func() {
@@ -884,7 +884,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 
 		By("When I check for apps", func() {
-			listOutput, _ = runCommandAndReturnStringOutput(WEGO_BIN_PATH + " get apps")
+			listOutput, _ = runCommandAndReturnStringOutput(gitopsBinaryPath + " get apps")
 		})
 
 		By("Then I should see appNames for all apps listed", func() {
@@ -905,7 +905,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 
 		By("When I check for list of commits for app1", func() {
-			commitList1, _ = runCommandAndReturnStringOutput(fmt.Sprintf("%s get commits %s", WEGO_BIN_PATH, appName1))
+			commitList1, _ = runCommandAndReturnStringOutput(fmt.Sprintf("%s get commits %s", gitopsBinaryPath, appName1))
 		})
 
 		By("Then I should see the list of commits for app1", func() {
@@ -915,7 +915,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 
 		By("When I check for list of commits for app2", func() {
-			commitList2, _ = runCommandAndReturnStringOutput(fmt.Sprintf("%s get commits %s", WEGO_BIN_PATH, appName2))
+			commitList2, _ = runCommandAndReturnStringOutput(fmt.Sprintf("%s get commits %s", gitopsBinaryPath, appName2))
 		})
 
 		By("Then I should see the list of commits for app2", func() {
@@ -943,19 +943,19 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		private := true
 		public := false
 		replicaSetValue := 3
-		appRepoRemoteURL := "ssh://git@github.com/" + GITHUB_ORG + "/" + tip1.appRepoName + ".git"
+		appRepoRemoteURL := "ssh://git@github.com/" + githubOrg + "/" + tip1.appRepoName + ".git"
 
 		addCommand1 := "add app . --name=" + appName1 + " --auto-merge=true"
 		addCommand2 := "add app . --name=" + appName2 + " --auto-merge=true --config-repo=" + appRepoRemoteURL
 
-		defer deleteRepo(tip1.appRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
-		defer deleteRepo(tip2.appRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
+		defer deleteRepo(tip1.appRepoName, gitproviders.GitProviderGitHub, githubOrg)
+		defer deleteRepo(tip2.appRepoName, gitproviders.GitProviderGitHub, githubOrg)
 		defer deleteWorkload(tip1.workloadName, tip1.workloadNamespace)
 		defer deleteWorkload(tip2.workloadName, tip2.workloadNamespace)
 
 		By("And application repos do not already exist", func() {
-			deleteRepo(tip1.appRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
-			deleteRepo(tip2.appRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
+			deleteRepo(tip1.appRepoName, gitproviders.GitProviderGitHub, githubOrg)
+			deleteRepo(tip2.appRepoName, gitproviders.GitProviderGitHub, githubOrg)
 		})
 
 		By("And application workload is not already deployed to cluster", func() {
@@ -964,11 +964,11 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 
 		By("When I create an empty private repo for app1", func() {
-			repoAbsolutePath1 = initAndCreateEmptyRepo(tip1.appRepoName, gitproviders.GitProviderGitHub, private, GITHUB_ORG)
+			repoAbsolutePath1 = initAndCreateEmptyRepo(tip1.appRepoName, gitproviders.GitProviderGitHub, private, githubOrg)
 		})
 
 		By("When I create an empty public repo for app2", func() {
-			repoAbsolutePath2 = initAndCreateEmptyRepo(tip2.appRepoName, gitproviders.GitProviderGitHub, public, GITHUB_ORG)
+			repoAbsolutePath2 = initAndCreateEmptyRepo(tip2.appRepoName, gitproviders.GitProviderGitHub, public, githubOrg)
 		})
 
 		By("And I git add-commit-push for app1 with workload", func() {
@@ -1008,12 +1008,12 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 
 		By("And repos created have proper visibility", func() {
-			Eventually(getGitRepoVisibility(GITHUB_ORG, tip1.appRepoName, gitproviders.GitProviderGitHub)).Should(ContainSubstring("private"))
-			Eventually(getGitRepoVisibility(GITHUB_ORG, tip2.appRepoName, gitproviders.GitProviderGitHub)).Should(ContainSubstring("public"))
+			Eventually(getGitRepoVisibility(githubOrg, tip1.appRepoName, gitproviders.GitProviderGitHub)).Should(ContainSubstring("private"))
+			Eventually(getGitRepoVisibility(githubOrg, tip2.appRepoName, gitproviders.GitProviderGitHub)).Should(ContainSubstring("public"))
 		})
 
 		By("When I check the app status for "+appName1, func() {
-			appStatus1 = runCommandAndReturnSessionOutput(fmt.Sprintf("%s get app %s", WEGO_BIN_PATH, appName1))
+			appStatus1 = runCommandAndReturnSessionOutput(fmt.Sprintf("%s get app %s", gitopsBinaryPath, appName1))
 		})
 
 		By("Then I should see the status for "+appName1, func() {
@@ -1023,7 +1023,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 
 		By("When I check the app status for "+appName2, func() {
-			appStatus2 = runCommandAndReturnSessionOutput(fmt.Sprintf("%s get app %s", WEGO_BIN_PATH, appName2))
+			appStatus2 = runCommandAndReturnSessionOutput(fmt.Sprintf("%s get app %s", gitopsBinaryPath, appName2))
 		})
 
 		By("Then I should see the status for "+appName2, func() {
@@ -1033,7 +1033,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 
 		By("When I check for apps", func() {
-			listOutput, _ = runCommandAndReturnStringOutput(WEGO_BIN_PATH + " get apps")
+			listOutput, _ = runCommandAndReturnStringOutput(gitopsBinaryPath + " get apps")
 		})
 
 		By("Then I should see appNames for both apps listed", func() {
@@ -1042,7 +1042,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 
 		By("When I suspend an app: "+appName1, func() {
-			pauseOutput, _ = runCommandAndReturnStringOutput(WEGO_BIN_PATH + " suspend app " + appName1)
+			pauseOutput, _ = runCommandAndReturnStringOutput(gitopsBinaryPath + " suspend app " + appName1)
 		})
 
 		By("Then I should see pause message", func() {
@@ -1050,7 +1050,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 
 		By("When I check app status for paused app", func() {
-			appStatus1 = runCommandAndReturnSessionOutput(fmt.Sprintf("%s get app %s", WEGO_BIN_PATH, appName1))
+			appStatus1 = runCommandAndReturnSessionOutput(fmt.Sprintf("%s get app %s", gitopsBinaryPath, appName1))
 		})
 
 		By("Then I should see pause status as suspended=true", func() {
@@ -1071,7 +1071,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 
 		By("When I re-run suspend app command", func() {
-			pauseOutput, _ = runCommandAndReturnStringOutput(WEGO_BIN_PATH + " suspend app " + appName1)
+			pauseOutput, _ = runCommandAndReturnStringOutput(gitopsBinaryPath + " suspend app " + appName1)
 		})
 
 		By("Then I should see a console message without any errors", func() {
@@ -1079,7 +1079,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 
 		By("When I unpause an app: "+appName1, func() {
-			unpauseOutput, _ = runCommandAndReturnStringOutput(WEGO_BIN_PATH + " resume app " + appName1)
+			unpauseOutput, _ = runCommandAndReturnStringOutput(gitopsBinaryPath + " resume app " + appName1)
 		})
 
 		By("Then I should see unpause message", func() {
@@ -1094,7 +1094,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 
 		By("When I re-run resume app command", func() {
-			unpauseOutput, _ = runCommandAndReturnStringOutput(WEGO_BIN_PATH + " resume app " + appName1)
+			unpauseOutput, _ = runCommandAndReturnStringOutput(gitopsBinaryPath + " resume app " + appName1)
 		})
 
 		By("Then I should see unpause message without any errors", func() {
@@ -1102,7 +1102,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 
 		By("When I check app status for unpaused app", func() {
-			appStatus1 = runCommandAndReturnSessionOutput(fmt.Sprintf("%s get app %s", WEGO_BIN_PATH, appName1))
+			appStatus1 = runCommandAndReturnSessionOutput(fmt.Sprintf("%s get app %s", gitopsBinaryPath, appName1))
 		})
 
 		By("Then I should see pause status as suspended=false", func() {
@@ -1110,7 +1110,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 
 		By("When I delete an app", func() {
-			appRemoveOutput, _ = runCommandAndReturnStringOutput(WEGO_BIN_PATH + " delete app " + appName2)
+			appRemoveOutput, _ = runCommandAndReturnStringOutput(gitopsBinaryPath + " delete app " + appName2)
 		})
 
 		By("Then I should see app deleting message", func() {
@@ -1124,7 +1124,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 
 		By("When I check for list of commits for app1", func() {
-			commitList1, _ = runCommandAndReturnStringOutput(fmt.Sprintf("%s get commits %s", WEGO_BIN_PATH, appName1))
+			commitList1, _ = runCommandAndReturnStringOutput(fmt.Sprintf("%s get commits %s", gitopsBinaryPath, appName1))
 		})
 
 		By("Then I should see the list of commits for app1", func() {
@@ -1141,18 +1141,18 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		appName := "my-helm-app"
 		appManifestFilePath := "./data/helm-repo/hello-world"
 		appRepoName := "test-app-" + RandString(8)
-		appRepoRemoteURL := "https://github.com/" + GITHUB_ORG + "/" + appRepoName + ".git"
+		appRepoRemoteURL := "https://github.com/" + githubOrg + "/" + appRepoName + ".git"
 
 		addCommand := "add app . --deployment-type=helm --path=./hello-world --name=" + appName + " --auto-merge=true"
 
-		defer deleteRepo(appRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
+		defer deleteRepo(appRepoName, gitproviders.GitProviderGitHub, githubOrg)
 
 		By("And application repo does not already exist", func() {
-			deleteRepo(appRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
+			deleteRepo(appRepoName, gitproviders.GitProviderGitHub, githubOrg)
 		})
 
 		By("When I create a private repo with my app workload", func() {
-			repoAbsolutePath = initAndCreateEmptyRepo(appRepoName, gitproviders.GitProviderGitHub, public, GITHUB_ORG)
+			repoAbsolutePath = initAndCreateEmptyRepo(appRepoName, gitproviders.GitProviderGitHub, public, githubOrg)
 			gitAddCommitPush(repoAbsolutePath, appManifestFilePath)
 		})
 
@@ -1171,7 +1171,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 
 		By("And repo created has public visibility", func() {
-			Eventually(getGitRepoVisibility(GITHUB_ORG, appRepoName, gitproviders.GitProviderGitHub)).Should(ContainSubstring("public"))
+			Eventually(getGitRepoVisibility(githubOrg, appRepoName, gitproviders.GitProviderGitHub)).Should(ContainSubstring("public"))
 		})
 	})
 
@@ -1184,25 +1184,25 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		appName := "my-helm-app"
 		appRepoName := "test-app-" + RandString(8)
 		configRepoName := "test-config-repo-" + RandString(8)
-		configRepoUrl := fmt.Sprintf("ssh://git@github.com/%s/%s.git", os.Getenv("GITHUB_ORG"), configRepoName)
+		configRepoUrl := fmt.Sprintf("ssh://git@github.com/%s/%s.git", githubOrg, configRepoName)
 
 		addCommand := fmt.Sprintf("add app . --config-repo=%s --deployment-type=helm --path=./hello-world --name=%s --auto-merge=true", configRepoUrl, appName)
 
-		defer deleteRepo(appRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
-		defer deleteRepo(configRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
+		defer deleteRepo(appRepoName, gitproviders.GitProviderGitHub, githubOrg)
+		defer deleteRepo(configRepoName, gitproviders.GitProviderGitHub, githubOrg)
 
 		By("Application and config repo does not already exist", func() {
-			deleteRepo(appRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
-			deleteRepo(configRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
+			deleteRepo(appRepoName, gitproviders.GitProviderGitHub, githubOrg)
+			deleteRepo(configRepoName, gitproviders.GitProviderGitHub, githubOrg)
 		})
 
 		By("When I create a private repo with my app workload", func() {
-			repoAbsolutePath = initAndCreateEmptyRepo(appRepoName, gitproviders.GitProviderGitHub, private, GITHUB_ORG)
+			repoAbsolutePath = initAndCreateEmptyRepo(appRepoName, gitproviders.GitProviderGitHub, private, githubOrg)
 			gitAddCommitPush(repoAbsolutePath, appManifestFilePath)
 		})
 
 		By("When I create a private repo for my config files", func() {
-			configRepoAbsolutePath = initAndCreateEmptyRepo(configRepoName, gitproviders.GitProviderGitHub, private, GITHUB_ORG)
+			configRepoAbsolutePath = initAndCreateEmptyRepo(configRepoName, gitproviders.GitProviderGitHub, private, githubOrg)
 			gitAddCommitPush(configRepoAbsolutePath, configRepoFiles)
 		})
 
@@ -1249,7 +1249,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		workloadName1 := workloadNamespace + "-loki-0"
 		readmeFilePath := "./data/README.md"
 		appRepoName := "test-app-" + RandString(8)
-		appRepoRemoteURL := "ssh://git@github.com/" + GITHUB_ORG + "/" + appRepoName + ".git"
+		appRepoRemoteURL := "ssh://git@github.com/" + githubOrg + "/" + appRepoName + ".git"
 		helmRepoURL := "https://charts.kube-ops.io"
 
 		invalidAddCommand := "add app --url=" + helmRepoURL + " --chart=" + appName1 + " --auto-merge=true"
@@ -1261,10 +1261,10 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		defer deletePersistingHelmApp(WEGO_DEFAULT_NAMESPACE, workloadName1, EVENTUALLY_DEFAULT_TIMEOUT)
 		defer deletePersistingHelmApp(WEGO_DEFAULT_NAMESPACE, workloadName2, EVENTUALLY_DEFAULT_TIMEOUT)
 		defer deletePersistingHelmApp(WEGO_DEFAULT_NAMESPACE, workloadName3, EVENTUALLY_DEFAULT_TIMEOUT)
-		defer deleteRepo(appRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
+		defer deleteRepo(appRepoName, gitproviders.GitProviderGitHub, githubOrg)
 
 		By("And application repo does not already exist", func() {
-			deleteRepo(appRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
+			deleteRepo(appRepoName, gitproviders.GitProviderGitHub, githubOrg)
 		})
 
 		By("And application workload is not already deployed to cluster", func() {
@@ -1272,7 +1272,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 
 		By("When I create a private git repo", func() {
-			repoAbsolutePath = initAndCreateEmptyRepo(appRepoName, gitproviders.GitProviderGitHub, private, GITHUB_ORG)
+			repoAbsolutePath = initAndCreateEmptyRepo(appRepoName, gitproviders.GitProviderGitHub, private, githubOrg)
 			gitAddCommitPush(repoAbsolutePath, readmeFilePath)
 		})
 
@@ -1323,7 +1323,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 
 		By("When I check for apps", func() {
-			listOutput, _ = runCommandAndReturnStringOutput(WEGO_BIN_PATH + " get apps")
+			listOutput, _ = runCommandAndReturnStringOutput(gitopsBinaryPath + " get apps")
 		})
 
 		By("Then I should see appNames for both apps listed", func() {
@@ -1332,7 +1332,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 
 		By("When I check the app status for "+appName1, func() {
-			appStatus1, _ = runCommandAndReturnStringOutput(WEGO_BIN_PATH + " get app " + appName1)
+			appStatus1, _ = runCommandAndReturnStringOutput(gitopsBinaryPath + " get app " + appName1)
 		})
 
 		By("Then I should see the status for app1", func() {
@@ -1342,7 +1342,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 
 		By("When I check the app status for "+appName2, func() {
-			appStatus2, _ = runCommandAndReturnStringOutput(WEGO_BIN_PATH + " get app " + appName2)
+			appStatus2, _ = runCommandAndReturnStringOutput(gitopsBinaryPath + " get app " + appName2)
 		})
 
 		By("Then I should see the status for app2", func() {
@@ -1361,15 +1361,15 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 
 		addCommand := "add app . --auto-merge=true"
 
-		subGroup := GITLAB_ORG + "/" + GITLAB_SUBGROUP
+		subGroup := gitlabOrg + "/" + gitlabSubgroup
 
 		appRepoRemoteURL := "ssh://git@gitlab.com/" + subGroup + "/" + appName + ".git"
 
 		defer deleteRepo(tip.appRepoName, gitproviders.GitProviderGitLab, subGroup)
 		defer deleteWorkload(tip.workloadName, tip.workloadNamespace)
 
-		By("I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
-			setupGitlabSSHKey(DEFAULT_SSH_KEY_PATH)
+		By("I have my default ssh key on path "+sshKeyPath, func() {
+			setupGitlabSSHKey(sshKeyPath)
 		})
 
 		By("And application repo does not already exist", func() {
@@ -1409,7 +1409,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 
 		By("When I remove an app", func() {
-			appRemoveOutput, _ = runCommandAndReturnStringOutput(WEGO_BIN_PATH + " delete app " + appName)
+			appRemoveOutput, _ = runCommandAndReturnStringOutput(gitopsBinaryPath + " delete app " + appName)
 		})
 
 		By("Then I should see app removing message", func() {
@@ -1428,19 +1428,19 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		tip := generateTestInputs()
 		appName := tip.appRepoName
 		prLink := ""
-		appRepoRemoteURL := "ssh://git@github.com/" + GITHUB_ORG + "/" + tip.appRepoName + ".git"
+		appRepoRemoteURL := "ssh://git@github.com/" + githubOrg + "/" + tip.appRepoName + ".git"
 
 		addCommand := "add app . --name=" + appName + " --auto-merge=false"
 
-		defer deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
+		defer deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, githubOrg)
 		defer deleteWorkload(tip.workloadName, tip.workloadNamespace)
 
 		By("And application repo does not already exist", func() {
-			deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
+			deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, githubOrg)
 		})
 
 		By("When I create an empty private repo for app", func() {
-			repoAbsolutePath = initAndCreateEmptyRepo(tip.appRepoName, gitproviders.GitProviderGitHub, true, GITHUB_ORG)
+			repoAbsolutePath = initAndCreateEmptyRepo(tip.appRepoName, gitproviders.GitProviderGitHub, true, githubOrg)
 		})
 
 		By("And I git add-commit-push app manifest", func() {
@@ -1476,23 +1476,23 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		tip := generateTestInputs()
 		appName := tip.appRepoName
 		prLink := ""
-		appRepoRemoteURL := "ssh://git@gitlab.com/" + GITLAB_ORG + "/" + tip.appRepoName + ".git"
+		appRepoRemoteURL := "ssh://git@gitlab.com/" + gitlabOrg + "/" + tip.appRepoName + ".git"
 
 		addCommand := "add app . --name=" + appName + " --auto-merge=false"
 
-		defer deleteRepo(tip.appRepoName, gitproviders.GitProviderGitLab, GITLAB_ORG)
+		defer deleteRepo(tip.appRepoName, gitproviders.GitProviderGitLab, gitlabOrg)
 		defer deleteWorkload(tip.workloadName, tip.workloadNamespace)
 
-		By("I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
-			setupGitlabSSHKey(DEFAULT_SSH_KEY_PATH)
+		By("I have my default ssh key on path "+sshKeyPath, func() {
+			setupGitlabSSHKey(sshKeyPath)
 		})
 
 		By("And application repo does not already exist", func() {
-			deleteRepo(tip.appRepoName, gitproviders.GitProviderGitLab, GITLAB_ORG)
+			deleteRepo(tip.appRepoName, gitproviders.GitProviderGitLab, gitlabOrg)
 		})
 
 		By("When I create an empty private repo for app", func() {
-			repoAbsolutePath = initAndCreateEmptyRepo(tip.appRepoName, gitproviders.GitProviderGitLab, true, GITLAB_ORG)
+			repoAbsolutePath = initAndCreateEmptyRepo(tip.appRepoName, gitproviders.GitProviderGitLab, true, gitlabOrg)
 		})
 
 		By("And I git add-commit-push app manifest", func() {
@@ -1532,26 +1532,26 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		tip := generateTestInputs()
 		appName := tip.appRepoName
 		appConfigRepoName := "config-repo-" + RandString(8)
-		configRepoRemoteURL = "ssh://git@github.com/" + GITHUB_ORG + "/" + appConfigRepoName + ".git"
+		configRepoRemoteURL = "ssh://git@github.com/" + githubOrg + "/" + appConfigRepoName + ".git"
 
 		addCommand := "add app . --config-repo=" + configRepoRemoteURL
 
-		defer deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
-		defer deleteRepo(appConfigRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
+		defer deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, githubOrg)
+		defer deleteRepo(appConfigRepoName, gitproviders.GitProviderGitHub, githubOrg)
 		defer deleteWorkload(tip.workloadName, tip.workloadNamespace)
 
 		By("And application repo does not already exist", func() {
-			deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
-			deleteRepo(appConfigRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
+			deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, githubOrg)
+			deleteRepo(appConfigRepoName, gitproviders.GitProviderGitHub, githubOrg)
 		})
 
 		By("When I create a private repo for gitops app config", func() {
-			appConfigRepoAbsPath = initAndCreateEmptyRepo(appConfigRepoName, gitproviders.GitProviderGitHub, private, GITHUB_ORG)
+			appConfigRepoAbsPath = initAndCreateEmptyRepo(appConfigRepoName, gitproviders.GitProviderGitHub, private, githubOrg)
 			gitAddCommitPush(appConfigRepoAbsPath, tip.appManifestFilePath)
 		})
 
 		By("When I create a private repo with my app workload", func() {
-			repoAbsolutePath = initAndCreateEmptyRepo(tip.appRepoName, gitproviders.GitProviderGitHub, private, GITHUB_ORG)
+			repoAbsolutePath = initAndCreateEmptyRepo(tip.appRepoName, gitproviders.GitProviderGitHub, private, githubOrg)
 			gitAddCommitPush(repoAbsolutePath, tip.appManifestFilePath)
 		})
 
@@ -1585,21 +1585,21 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		tip2 := generateTestInputs()
 		appName := tip.appRepoName
 		appName2 := tip2.appRepoName
-		appRepoRemoteURL := "ssh://git@github.com/" + GITHUB_ORG + "/" + tip.appRepoName + ".git"
-		prLink := "https://github.com/" + GITHUB_ORG + "/" + tip.appRepoName + "/pull/1"
+		appRepoRemoteURL := "ssh://git@github.com/" + githubOrg + "/" + tip.appRepoName + ".git"
+		prLink := "https://github.com/" + githubOrg + "/" + tip.appRepoName + "/pull/1"
 
 		addCommand := "add app . --name=" + appName
 		addCommand2 := "add app . --name=" + appName2
 
-		defer deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
+		defer deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, githubOrg)
 		defer deleteWorkload(tip.workloadName, tip.workloadNamespace)
 
 		By("And application repo does not already exist", func() {
-			deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
+			deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, githubOrg)
 		})
 
 		By("When I create an empty private repo for app", func() {
-			repoAbsolutePath = initAndCreateEmptyRepo(tip.appRepoName, gitproviders.GitProviderGitHub, true, GITHUB_ORG)
+			repoAbsolutePath = initAndCreateEmptyRepo(tip.appRepoName, gitproviders.GitProviderGitHub, true, githubOrg)
 		})
 
 		By("And I git add-commit-push for app with workload", func() {
@@ -1655,7 +1655,7 @@ var _ = Describe("Weave GitOps Add Tests With Long Cluster Name", func() {
 		})
 
 		By("And I have a gitops binary installed on my local machine", func() {
-			Expect(FileExists(WEGO_BIN_PATH)).To(BeTrue())
+			Expect(FileExists(gitopsBinaryPath)).To(BeTrue())
 		})
 	})
 
@@ -1669,7 +1669,7 @@ var _ = Describe("Weave GitOps Add Tests With Long Cluster Name", func() {
 		tip := generateTestInputs()
 		appFilesRepoName := tip.appRepoName + "123456789012345678901234567890"
 		appConfigRepoName := "config-repo-" + RandString(8)
-		configRepoRemoteURL = "ssh://git@github.com/" + GITHUB_ORG + "/" + appConfigRepoName + ".git"
+		configRepoRemoteURL = "ssh://git@github.com/" + githubOrg + "/" + appConfigRepoName + ".git"
 		appName := appFilesRepoName
 		workloadName := tip.workloadName
 		workloadNamespace := tip.workloadNamespace
@@ -1677,13 +1677,13 @@ var _ = Describe("Weave GitOps Add Tests With Long Cluster Name", func() {
 
 		addCommand := "add app . --config-repo=" + configRepoRemoteURL + " --auto-merge=true"
 
-		defer deleteRepo(appFilesRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
-		defer deleteRepo(appConfigRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
+		defer deleteRepo(appFilesRepoName, gitproviders.GitProviderGitHub, githubOrg)
+		defer deleteRepo(appConfigRepoName, gitproviders.GitProviderGitHub, githubOrg)
 		defer deleteWorkload(workloadName, workloadNamespace)
 
 		By("And application repo does not already exist", func() {
-			deleteRepo(appFilesRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
-			deleteRepo(appConfigRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
+			deleteRepo(appFilesRepoName, gitproviders.GitProviderGitHub, githubOrg)
+			deleteRepo(appConfigRepoName, gitproviders.GitProviderGitHub, githubOrg)
 		})
 
 		By("And application workload is not already deployed to cluster", func() {
@@ -1691,12 +1691,12 @@ var _ = Describe("Weave GitOps Add Tests With Long Cluster Name", func() {
 		})
 
 		By("When I create a private repo for gitops app config", func() {
-			appConfigRepoAbsPath := initAndCreateEmptyRepo(appConfigRepoName, gitproviders.GitProviderGitHub, private, GITHUB_ORG)
+			appConfigRepoAbsPath := initAndCreateEmptyRepo(appConfigRepoName, gitproviders.GitProviderGitHub, private, githubOrg)
 			gitAddCommitPush(appConfigRepoAbsPath, readmeFilePath)
 		})
 
 		By("When I create a private repo with app workload", func() {
-			repoAbsolutePath = initAndCreateEmptyRepo(appFilesRepoName, gitproviders.GitProviderGitHub, private, GITHUB_ORG)
+			repoAbsolutePath = initAndCreateEmptyRepo(appFilesRepoName, gitproviders.GitProviderGitHub, private, githubOrg)
 			gitAddCommitPush(repoAbsolutePath, appManifestFilePath)
 		})
 
@@ -1714,7 +1714,7 @@ var _ = Describe("Weave GitOps Add Tests With Long Cluster Name", func() {
 		})
 
 		By("When I check the app status for app", func() {
-			appStatus, _ = runCommandAndReturnStringOutput(WEGO_BIN_PATH + " get app " + appName)
+			appStatus, _ = runCommandAndReturnStringOutput(gitopsBinaryPath + " get app " + appName)
 		})
 
 		By("Then I should see the status for "+appName, func() {
@@ -1724,7 +1724,7 @@ var _ = Describe("Weave GitOps Add Tests With Long Cluster Name", func() {
 		})
 
 		By("When I check for apps", func() {
-			listOutput, _ = runCommandAndReturnStringOutput(WEGO_BIN_PATH + " get apps")
+			listOutput, _ = runCommandAndReturnStringOutput(gitopsBinaryPath + " get apps")
 		})
 
 		By("Then I should see appNames for all apps listed", func() {
@@ -1753,7 +1753,7 @@ var _ = Describe("Weave GitOps Add Tests With Long Cluster Name", func() {
 		tip := generateTestInputs()
 		appFilesRepoName := tip.appRepoName + "123456789012345678901234567890"
 		appConfigRepoName := "config-repo-" + RandString(8)
-		configRepoRemoteURL = "ssh://git@gitlab.com/" + GITLAB_ORG + "/" + appConfigRepoName + ".git"
+		configRepoRemoteURL = "ssh://git@gitlab.com/" + gitlabOrg + "/" + appConfigRepoName + ".git"
 		appName := appFilesRepoName
 		workloadName := tip.workloadName
 		workloadNamespace := tip.workloadNamespace
@@ -1761,17 +1761,17 @@ var _ = Describe("Weave GitOps Add Tests With Long Cluster Name", func() {
 
 		addCommand := "add app . --config-repo=" + configRepoRemoteURL + " --auto-merge=true"
 
-		defer deleteRepo(appFilesRepoName, gitproviders.GitProviderGitLab, GITLAB_ORG)
-		defer deleteRepo(appConfigRepoName, gitproviders.GitProviderGitLab, GITLAB_ORG)
+		defer deleteRepo(appFilesRepoName, gitproviders.GitProviderGitLab, gitlabOrg)
+		defer deleteRepo(appConfigRepoName, gitproviders.GitProviderGitLab, gitlabOrg)
 		defer deleteWorkload(workloadName, workloadNamespace)
 
-		By("I have my default ssh key on path "+DEFAULT_SSH_KEY_PATH, func() {
-			setupGitlabSSHKey(DEFAULT_SSH_KEY_PATH)
+		By("I have my default ssh key on path "+sshKeyPath, func() {
+			setupGitlabSSHKey(sshKeyPath)
 		})
 
 		By("And application repo does not already exist", func() {
-			deleteRepo(appFilesRepoName, gitproviders.GitProviderGitLab, GITLAB_ORG)
-			deleteRepo(appConfigRepoName, gitproviders.GitProviderGitLab, GITLAB_ORG)
+			deleteRepo(appFilesRepoName, gitproviders.GitProviderGitLab, gitlabOrg)
+			deleteRepo(appConfigRepoName, gitproviders.GitProviderGitLab, gitlabOrg)
 		})
 
 		By("And application workload is not already deployed to cluster", func() {
@@ -1779,12 +1779,12 @@ var _ = Describe("Weave GitOps Add Tests With Long Cluster Name", func() {
 		})
 
 		By("When I create a private repo for gitops app config", func() {
-			appConfigRepoAbsPath := initAndCreateEmptyRepo(appConfigRepoName, gitproviders.GitProviderGitLab, private, GITLAB_ORG)
+			appConfigRepoAbsPath := initAndCreateEmptyRepo(appConfigRepoName, gitproviders.GitProviderGitLab, private, gitlabOrg)
 			gitAddCommitPush(appConfigRepoAbsPath, readmeFilePath)
 		})
 
 		By("When I create a private repo with app workload", func() {
-			repoAbsolutePath = initAndCreateEmptyRepo(appFilesRepoName, gitproviders.GitProviderGitLab, private, GITLAB_ORG)
+			repoAbsolutePath = initAndCreateEmptyRepo(appFilesRepoName, gitproviders.GitProviderGitLab, private, gitlabOrg)
 			gitAddCommitPush(repoAbsolutePath, appManifestFilePath)
 		})
 
@@ -1802,7 +1802,7 @@ var _ = Describe("Weave GitOps Add Tests With Long Cluster Name", func() {
 		})
 
 		By("When I check the app status for app", func() {
-			appStatus, _ = runCommandAndReturnStringOutput(WEGO_BIN_PATH + " get app " + appName)
+			appStatus, _ = runCommandAndReturnStringOutput(gitopsBinaryPath + " get app " + appName)
 		})
 
 		By("Then I should see the status for "+appName, func() {
@@ -1812,7 +1812,7 @@ var _ = Describe("Weave GitOps Add Tests With Long Cluster Name", func() {
 		})
 
 		By("When I check for apps", func() {
-			listOutput, _ = runCommandAndReturnStringOutput(WEGO_BIN_PATH + " get apps")
+			listOutput, _ = runCommandAndReturnStringOutput(gitopsBinaryPath + " get apps")
 		})
 
 		By("Then I should see appNames for all apps listed", func() {

--- a/test/acceptance/test/flux_tests.go
+++ b/test/acceptance/test/flux_tests.go
@@ -17,14 +17,14 @@ var _ = Describe("Weave GitOps Flux Tests", func() {
 	BeforeEach(func() {
 
 		By("Given I have a gitops binary installed on my local machine", func() {
-			Expect(FileExists(WEGO_BIN_PATH)).To(BeTrue())
+			Expect(FileExists(gitopsBinaryPath)).To(BeTrue())
 		})
 	})
 
 	It("Verify that gitops-flux displays error message when provided with the wrong flag", func() {
 
 		By("When I run the command 'gitops flux foo'", func() {
-			sessionOutput = runCommandAndReturnSessionOutput(WEGO_BIN_PATH + " flux foo")
+			sessionOutput = runCommandAndReturnSessionOutput(gitopsBinaryPath + " flux foo")
 		})
 
 		By("Then I should see gitops error message", func() {
@@ -35,7 +35,7 @@ var _ = Describe("Weave GitOps Flux Tests", func() {
 	It("Verify that gitops-flux can print out the version of flux", func() {
 
 		By("When I run the command 'gitops flux -v'", func() {
-			sessionOutput = runCommandAndReturnSessionOutput(WEGO_BIN_PATH + " flux -v")
+			sessionOutput = runCommandAndReturnSessionOutput(gitopsBinaryPath + " flux -v")
 		})
 
 		By("Then I should see flux version", func() {

--- a/test/acceptance/test/help_tests.go
+++ b/test/acceptance/test/help_tests.go
@@ -22,14 +22,14 @@ var _ = XDescribe("WEGO Help Tests", func() {
 	BeforeEach(func() {
 
 		By("Given I have a gitops binary installed on my local machine", func() {
-			Expect(FileExists(WEGO_BIN_PATH)).To(BeTrue())
+			Expect(FileExists(gitopsBinaryPath)).To(BeTrue())
 		})
 	})
 
 	It("Verify that gitops displays error message when provided with the wrong flag", func() {
 
 		By("When I run 'gitops foo'", func() {
-			command := exec.Command(WEGO_BIN_PATH, "foo")
+			command := exec.Command(gitopsBinaryPath, "foo")
 			sessionOutput, err = gexec.Start(command, GinkgoWriter, GinkgoWriter)
 			Expect(err).ShouldNot(HaveOccurred())
 		})
@@ -43,7 +43,7 @@ var _ = XDescribe("WEGO Help Tests", func() {
 	It("Verify that gitops help flag prints the help text", func() {
 
 		By("When I run the command 'gitops --help' ", func() {
-			stringOutput, _ = runCommandAndReturnStringOutput(WEGO_BIN_PATH + " --help")
+			stringOutput, _ = runCommandAndReturnStringOutput(gitopsBinaryPath + " --help")
 		})
 
 		By("Then I should see help message printed for gitops", func() {
@@ -60,7 +60,7 @@ var _ = XDescribe("WEGO Help Tests", func() {
 	It("Verify that gitops app help flag prints the help text", func() {
 
 		By("When I run the command 'gitops app -h' ", func() {
-			stringOutput, _ = runCommandAndReturnStringOutput(WEGO_BIN_PATH + " app -h")
+			stringOutput, _ = runCommandAndReturnStringOutput(gitopsBinaryPath + " app -h")
 		})
 
 		By("Then I should see help message printed for gitops app", func() {
@@ -75,7 +75,7 @@ var _ = XDescribe("WEGO Help Tests", func() {
 	It("Verify that gitops add app help flag prints the help text", func() {
 
 		By("When I run the command 'gitops add app -h' ", func() {
-			stringOutput, _ = runCommandAndReturnStringOutput(WEGO_BIN_PATH + " add app -h")
+			stringOutput, _ = runCommandAndReturnStringOutput(gitopsBinaryPath + " add app -h")
 		})
 
 		By("Then I should see help message printed for gitops add app", func() {
@@ -99,7 +99,7 @@ var _ = XDescribe("WEGO Help Tests", func() {
 	It("Verify that gitops get app help flag prints the help text", func() {
 
 		By("When I run the command 'gitops get app -h' ", func() {
-			sessionOutput = runCommandAndReturnSessionOutput(WEGO_BIN_PATH + " get app -h")
+			sessionOutput = runCommandAndReturnSessionOutput(gitopsBinaryPath + " get app -h")
 		})
 
 		By("Then I should see help message printed for gitops get app", func() {
@@ -113,7 +113,7 @@ var _ = XDescribe("WEGO Help Tests", func() {
 	It("Verify that gitops get apps help flag prints the help text", func() {
 
 		By("When I run the command 'gitops get apps -h' ", func() {
-			stringOutput, _ = runCommandAndReturnStringOutput(WEGO_BIN_PATH + " get apps -h")
+			stringOutput, _ = runCommandAndReturnStringOutput(gitopsBinaryPath + " get apps -h")
 		})
 
 		By("Then I should see help message printed for gitops get apps", func() {

--- a/test/acceptance/test/install_tests.go
+++ b/test/acceptance/test/install_tests.go
@@ -28,14 +28,14 @@ var _ = Describe("Weave GitOps Install Tests", func() {
 
 	BeforeEach(func() {
 		By("Given I have a gitops binary installed on my local machine", func() {
-			Expect(FileExists(WEGO_BIN_PATH)).To(BeTrue())
+			Expect(FileExists(gitopsBinaryPath)).To(BeTrue())
 		})
 	})
 
 	It("Validate that gitops displays help text for 'install' command", func() {
 
 		By("When I run the command 'gitops install -h'", func() {
-			sessionOutput = runCommandAndReturnSessionOutput(WEGO_BIN_PATH + " install -h")
+			sessionOutput = runCommandAndReturnSessionOutput(gitopsBinaryPath + " install -h")
 		})
 
 		By("Then I should see gitops help text displayed for 'install' command", func() {
@@ -47,7 +47,7 @@ var _ = Describe("Weave GitOps Install Tests", func() {
 	It("Validate that gitops displays help text for 'uninstall' command", func() {
 
 		By("When I run the command 'gitops uninstall -h'", func() {
-			sessionOutput = runCommandAndReturnSessionOutput(WEGO_BIN_PATH + " uninstall -h")
+			sessionOutput = runCommandAndReturnSessionOutput(gitopsBinaryPath + " uninstall -h")
 		})
 
 		By("Then I should see gitops help text displayed for 'uninstall' command", func() {
@@ -73,7 +73,7 @@ var _ = Describe("Weave GitOps Install Tests", func() {
 		})
 
 		By("And I run 'gitops install' command", func() {
-			_, errOutput = runCommandAndReturnStringOutput(WEGO_BIN_PATH + " install --config-repo=ssh://git@github.com/user/repo.git")
+			_, errOutput = runCommandAndReturnStringOutput(gitopsBinaryPath + " install --config-repo=ssh://git@github.com/user/repo.git")
 		})
 
 		By("Then I should see a quitting message", func() {
@@ -93,20 +93,20 @@ var _ = Describe("Weave GitOps Install Tests", func() {
 
 		private := true
 		tip := generateTestInputs()
-		appRepoRemoteURL := "git@github.com:" + GITHUB_ORG + "/" + tip.appRepoName + ".git"
+		appRepoRemoteURL := "git@github.com:" + githubOrg + "/" + tip.appRepoName + ".git"
 
-		defer deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
+		defer deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, githubOrg)
 
 		By("And application repo does not already exist", func() {
-			deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
+			deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, githubOrg)
 		})
 
-		_ = initAndCreateEmptyRepo(tip.appRepoName, gitproviders.GitProviderGitHub, private, GITHUB_ORG)
+		_ = initAndCreateEmptyRepo(tip.appRepoName, gitproviders.GitProviderGitHub, private, githubOrg)
 
 		installAndVerifyWego(namespace, appRepoRemoteURL)
 
 		By("When I run 'gitops uninstall' command without force flag it asks for confirmation", func() {
-			cmd := fmt.Sprintf("%s uninstall --namespace %s", WEGO_BIN_PATH, namespace)
+			cmd := fmt.Sprintf("%s uninstall --namespace %s", gitopsBinaryPath, namespace)
 			outputStream := gbytes.NewBuffer()
 			inputUser := bytes.NewBuffer([]byte("y\n"))
 
@@ -142,15 +142,15 @@ var _ = Describe("Weave GitOps Install Tests", func() {
 
 		private := true
 		tip := generateTestInputs()
-		appRepoRemoteURL := "ssh://git@github.com/" + GITHUB_ORG + "/" + tip.appRepoName + ".git"
+		appRepoRemoteURL := "ssh://git@github.com/" + githubOrg + "/" + tip.appRepoName + ".git"
 
-		defer deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
+		defer deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, githubOrg)
 
 		By("And application repo does not already exist", func() {
-			deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
+			deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, githubOrg)
 		})
 
-		_ = initAndCreateEmptyRepo(tip.appRepoName, gitproviders.GitProviderGitHub, private, GITHUB_ORG)
+		_ = initAndCreateEmptyRepo(tip.appRepoName, gitproviders.GitProviderGitHub, private, githubOrg)
 
 		installAndVerifyWego(namespace, appRepoRemoteURL)
 
@@ -163,7 +163,7 @@ var _ = Describe("Weave GitOps Install Tests", func() {
 		Expect(crdErr).ShouldNot(HaveOccurred())
 
 		By("When I run 'gitops uninstall' command", func() {
-			runErr := runCommandPassThrough([]string{}, "sh", "-c", fmt.Sprintf("%s uninstall --force --namespace %s", WEGO_BIN_PATH, namespace))
+			runErr := runCommandPassThrough([]string{}, "sh", "-c", fmt.Sprintf("%s uninstall --force --namespace %s", gitopsBinaryPath, namespace))
 			Expect(runErr).ShouldNot(HaveOccurred())
 		})
 
@@ -187,18 +187,18 @@ var _ = Describe("Weave GitOps Install Tests", func() {
 
 		private := true
 		tip := generateTestInputs()
-		appRepoRemoteURL := "ssh://git@github.com/" + GITHUB_ORG + "/" + tip.appRepoName + ".git"
+		appRepoRemoteURL := "ssh://git@github.com/" + githubOrg + "/" + tip.appRepoName + ".git"
 
-		defer deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
+		defer deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, githubOrg)
 
 		By("And application repo does not already exist", func() {
-			deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
+			deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, githubOrg)
 		})
 
-		_ = initAndCreateEmptyRepo(tip.appRepoName, gitproviders.GitProviderGitHub, private, GITHUB_ORG)
+		_ = initAndCreateEmptyRepo(tip.appRepoName, gitproviders.GitProviderGitHub, private, githubOrg)
 
 		By("When I try to install gitops in dry-run mode", func() {
-			installDryRunOutput, _ = runCommandAndReturnStringOutput(WEGO_BIN_PATH + fmt.Sprintf(" install --dry-run --config-repo=%s", appRepoRemoteURL))
+			installDryRunOutput, _ = runCommandAndReturnStringOutput(gitopsBinaryPath + fmt.Sprintf(" install --dry-run --config-repo=%s", appRepoRemoteURL))
 		})
 
 		By("Then I should see install dry-run output in the console", func() {
@@ -215,7 +215,7 @@ var _ = Describe("Weave GitOps Install Tests", func() {
 		installAndVerifyWego(WEGO_DEFAULT_NAMESPACE, appRepoRemoteURL)
 
 		By("When I try to uninstall gitops in dry-run mode", func() {
-			uninstallDryRunOutput, _ = runCommandAndReturnStringOutput(WEGO_BIN_PATH + " uninstall --force --dry-run")
+			uninstallDryRunOutput, _ = runCommandAndReturnStringOutput(gitopsBinaryPath + " uninstall --force --dry-run")
 		})
 
 		By("Then I should see uninstall dry-run output in the console", func() {
@@ -235,7 +235,7 @@ var _ = Describe("Weave GitOps Install Tests", func() {
 		})
 
 		By("When I run 'gitops uninstall' command", func() {
-			_ = runCommandPassThrough([]string{}, "sh", "-c", fmt.Sprintf("%s uninstall --force --namespace %s", WEGO_BIN_PATH, WEGO_DEFAULT_NAMESPACE))
+			_ = runCommandPassThrough([]string{}, "sh", "-c", fmt.Sprintf("%s uninstall --force --namespace %s", gitopsBinaryPath, WEGO_DEFAULT_NAMESPACE))
 		})
 
 		_ = waitForNamespaceToTerminate(WEGO_DEFAULT_NAMESPACE, NAMESPACE_TERMINATE_TIMEOUT)
@@ -256,15 +256,15 @@ var _ = Describe("Weave GitOps Install Tests", func() {
 
 		private := true
 		tip := generateTestInputs()
-		appRepoRemoteURL := "ssh://git@github.com/" + GITHUB_ORG + "/" + tip.appRepoName + ".git"
+		appRepoRemoteURL := "ssh://git@github.com/" + githubOrg + "/" + tip.appRepoName + ".git"
 
-		defer deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
+		defer deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, githubOrg)
 
 		By("And application repo does not already exist", func() {
-			deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
+			deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, githubOrg)
 		})
 
-		_ = initAndCreateEmptyRepo(tip.appRepoName, gitproviders.GitProviderGitHub, private, GITHUB_ORG)
+		_ = initAndCreateEmptyRepo(tip.appRepoName, gitproviders.GitProviderGitHub, private, githubOrg)
 
 		installAndVerifyWego(namespace, appRepoRemoteURL)
 

--- a/test/acceptance/test/profiles_test.go
+++ b/test/acceptance/test/profiles_test.go
@@ -40,26 +40,26 @@ var _ = PDescribe("Weave GitOps Profiles API", func() {
 	)
 
 	BeforeEach(func() {
-		Expect(FileExists(WEGO_BIN_PATH)).To(BeTrue())
-		Expect(GITHUB_ORG).NotTo(BeEmpty())
+		Expect(FileExists(gitopsBinaryPath)).To(BeTrue())
+		Expect(githubOrg).NotTo(BeEmpty())
 
 		_, _, err := ResetOrCreateCluster(namespace, true)
 		Expect(err).NotTo(HaveOccurred())
 
 		private := true
 		tip = generateTestInputs()
-		_ = initAndCreateEmptyRepo(tip.appRepoName, gitproviders.GitProviderGitHub, private, GITHUB_ORG)
+		_ = initAndCreateEmptyRepo(tip.appRepoName, gitproviders.GitProviderGitHub, private, githubOrg)
 
 		clientSet, kClient = buildKubernetesClients()
 	})
 
 	AfterEach(func() {
-		deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
+		deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, githubOrg)
 	})
 
 	It("gets deployed and is accessible via the service", func() {
 		By("Installing the Profiles API and setting up the profile helm repository")
-		appRepoRemoteURL = "git@github.com:" + GITHUB_ORG + "/" + tip.appRepoName + ".git"
+		appRepoRemoteURL = "git@github.com:" + githubOrg + "/" + tip.appRepoName + ".git"
 		installAndVerifyWego(namespace, appRepoRemoteURL)
 		deployProfilesHelmRepository(kClient, namespace)
 		time.Sleep(time.Second * 20)

--- a/test/acceptance/test/testsuite_common_test.go
+++ b/test/acceptance/test/testsuite_common_test.go
@@ -4,6 +4,7 @@
 package acceptance
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -12,6 +13,19 @@ import (
 	"github.com/onsi/gomega"
 	. "github.com/onsi/gomega"
 	log "github.com/sirupsen/logrus"
+)
+
+const (
+	gitlabTokenEnvVar       = "GITLAB_TOKEN"
+	gitlabOrgEnvVar         = "GITLAB_ORG"
+	gitlabPublicGroupEnvVar = "GITLAB_PUBLIC_GROUP"
+	gitlabSubgroupEnvVar    = "GITLAB_SUBGROUP"
+	gitlabKeyEnvVar         = "GITLAB_KEY"
+
+	githubTokenEnvVar = "GITHUB_TOKEN"
+	githubOrgEnvVar   = "GITHUB_ORG"
+
+	gitopsBinaryPathEnvVar = "WEGO_BIN_PATH"
 )
 
 func TestAcceptance(t *testing.T) {
@@ -40,18 +54,31 @@ func TestAcceptance(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	SetDefaultEventuallyTimeout(EVENTUALLY_DEFAULT_TIMEOUT)
-	DEFAULT_SSH_KEY_PATH = os.Getenv("HOME") + "/.ssh/id_rsa"
-	GITHUB_ORG = os.Getenv("GITHUB_ORG")
-	GITLAB_ORG = os.Getenv("GITLAB_ORG")
-	GITLAB_PUBLIC_GROUP = os.Getenv("GITLAB_PUBLIC_GROUP")
-	GITLAB_SUBGROUP = os.Getenv("GITLAB_SUBGROUP")
-	WEGO_BIN_PATH = os.Getenv("WEGO_BIN_PATH")
-	if WEGO_BIN_PATH == "" {
-		WEGO_BIN_PATH = "/usr/local/bin/gitops"
+	sshKeyPath = getEnvVar("HOME") + "/.ssh/id_rsa"
+	gitopsBinaryPath = getEnvVar(gitopsBinaryPathEnvVar)
+
+	githubOrg = getEnvVar(githubOrgEnvVar)
+	githubToken = getEnvVar(githubTokenEnvVar)
+
+	gitlabOrg = getEnvVar(gitlabOrgEnvVar)
+	gitlabToken = getEnvVar(gitlabTokenEnvVar)
+	gitlabKey = getEnvVar(gitlabKeyEnvVar)
+	gitlabPublicGroup = getEnvVar(gitlabPublicGroupEnvVar)
+	gitlabSubgroup = getEnvVar(gitlabSubgroupEnvVar)
+
+	if gitopsBinaryPath == "" {
+		gitopsBinaryPath = "/usr/local/bin/gitops"
 	}
-	log.Infof("GITOPS Binary Path: %s", WEGO_BIN_PATH)
+	log.Infof("GITOPS Binary Path: %s", gitopsBinaryPath)
 })
 
 func GomegaFail(message string, callerSkip ...int) {
 	ginkgo.Fail(message, callerSkip...)
+}
+
+func getEnvVar(envVar string) string {
+	value := os.Getenv(envVar)
+	ExpectWithOffset(1, value).NotTo(BeEmpty(), fmt.Sprintf("Please ensure %s environment variable is set", envVar))
+
+	return value
 }

--- a/test/acceptance/test/ui_tests.go
+++ b/test/acceptance/test/ui_tests.go
@@ -41,11 +41,11 @@ var _ = XDescribe("Weave GitOps UI Test", func() {
 			_, _, err = ResetOrCreateCluster(WEGO_DEFAULT_NAMESPACE, deleteWegoRuntime)
 			Expect(err).ShouldNot(HaveOccurred())
 
-			Expect(FileExists(WEGO_BIN_PATH)).To(BeTrue())
+			Expect(FileExists(gitopsBinaryPath)).To(BeTrue())
 		})
 
 		By("And I run gitops ui", func() {
-			_ = runCommandAndReturnSessionOutput(fmt.Sprintf("%s ui run &", WEGO_BIN_PATH))
+			_ = runCommandAndReturnSessionOutput(fmt.Sprintf("%s ui run &", gitopsBinaryPath))
 		})
 
 		By("And I open up a browser", func() {
@@ -86,12 +86,12 @@ var _ = XDescribe("Weave GitOps UI Test", func() {
 		tip := generateTestInputs()
 		appName := tip.appRepoName
 		private := true
-		appRepoRemoteURL := "https://github.com/" + GITHUB_ORG + "/" + tip.appRepoName + ".git"
+		appRepoRemoteURL := "https://github.com/" + githubOrg + "/" + tip.appRepoName + ".git"
 
 		dashboardPage = pages.GetDashboardPageElements(webDriver)
 		addAppPage = pages.GetAddAppPageElements(webDriver)
 
-		defer deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
+		defer deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, githubOrg)
 		defer deleteWorkload(tip.workloadName, tip.workloadNamespace)
 
 		By("When I navigate to Add Application page", func() {
@@ -103,8 +103,8 @@ var _ = XDescribe("Weave GitOps UI Test", func() {
 		})
 
 		By("When I create an app repo with workload that does not already exist", func() {
-			deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
-			repoAbsolutePath = initAndCreateEmptyRepo(tip.appRepoName, gitproviders.GitProviderGitHub, private, GITHUB_ORG)
+			deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, githubOrg)
+			repoAbsolutePath = initAndCreateEmptyRepo(tip.appRepoName, gitproviders.GitProviderGitHub, private, githubOrg)
 			gitAddCommitPush(repoAbsolutePath, tip.appManifestFilePath)
 		})
 
@@ -146,19 +146,19 @@ var _ = XDescribe("Weave GitOps UI Test", func() {
 		deploymentType1 := "Helm"
 		deploymentType2 := "Kustomize"
 		appManifestFilePath := tip.appManifestFilePath
-		appRepoRemoteURL := "ssh://git@github.com/" + GITHUB_ORG + "/" + tip.appRepoName + ".git"
+		appRepoRemoteURL := "ssh://git@github.com/" + githubOrg + "/" + tip.appRepoName + ".git"
 		helmRepoURL := "https://charts.kube-ops.io"
 		appDetailsPage := pages.GetAppDetailsPageElements(webDriver)
 
 		addCommand1 := "add app --url=" + helmRepoURL + " --chart=" + appName1 + " --config-repo=" + appRepoRemoteURL + " --auto-merge=true"
 		addCommand2 := "add app . --deployment-type=kustomize --auto-merge=true"
 
-		defer deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
+		defer deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, githubOrg)
 		defer deleteWorkload(workloadName2, tip.workloadNamespace)
 		defer deletePersistingHelmApp(WEGO_DEFAULT_NAMESPACE, workloadName1, EVENTUALLY_DEFAULT_TIMEOUT)
 
 		By("And application repo does not already exist", func() {
-			deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
+			deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, githubOrg)
 		})
 
 		By("And application workload is not already deployed to cluster", func() {
@@ -166,7 +166,7 @@ var _ = XDescribe("Weave GitOps UI Test", func() {
 		})
 
 		By("When I create a public repo with my app workload", func() {
-			repoAbsolutePath = initAndCreateEmptyRepo(tip.appRepoName, gitproviders.GitProviderGitHub, public, GITHUB_ORG)
+			repoAbsolutePath = initAndCreateEmptyRepo(tip.appRepoName, gitproviders.GitProviderGitHub, public, githubOrg)
 			gitAddCommitPush(repoAbsolutePath, appManifestFilePath)
 		})
 

--- a/test/acceptance/test/utils.go
+++ b/test/acceptance/test/utils.go
@@ -34,29 +34,36 @@ import (
 	"github.com/weaveworks/weave-gitops/pkg/utils"
 )
 
-const THIRTY_SECOND_TIMEOUT time.Duration = 30 * time.Second
-const EVENTUALLY_DEFAULT_TIMEOUT time.Duration = 60 * time.Second
-const TIMEOUT_TWO_MINUTES time.Duration = 120 * time.Second
-const INSTALL_RESET_TIMEOUT time.Duration = 300 * time.Second
-const NAMESPACE_TERMINATE_TIMEOUT time.Duration = 600 * time.Second
-const INSTALL_SUCCESSFUL_TIMEOUT time.Duration = 3 * time.Minute
-const INSTALL_PODS_READY_TIMEOUT time.Duration = 3 * time.Minute
-const WEGO_DEFAULT_NAMESPACE = wego.DefaultNamespace
-const WEGO_UI_URL = "http://localhost:9001"
-const SELENIUM_SERVICE_URL = "http://localhost:4444/wd/hub"
-const SCREENSHOTS_DIR string = "screenshots/"
-const DEFAULT_BRANCH_NAME = "main"
-const WEGO_DASHBOARD_TITLE string = "Weave GitOps"
-const APP_PAGE_HEADER string = "Applications"
+const (
+	THIRTY_SECOND_TIMEOUT       time.Duration = 30 * time.Second
+	EVENTUALLY_DEFAULT_TIMEOUT  time.Duration = 60 * time.Second
+	TIMEOUT_TWO_MINUTES         time.Duration = 120 * time.Second
+	INSTALL_RESET_TIMEOUT       time.Duration = 300 * time.Second
+	NAMESPACE_TERMINATE_TIMEOUT time.Duration = 600 * time.Second
+	INSTALL_SUCCESSFUL_TIMEOUT  time.Duration = 3 * time.Minute
+	INSTALL_PODS_READY_TIMEOUT  time.Duration = 3 * time.Minute
+	WEGO_DEFAULT_NAMESPACE                    = wego.DefaultNamespace
+	WEGO_UI_URL                               = "http://localhost:9001"
+	SELENIUM_SERVICE_URL                      = "http://localhost:4444/wd/hub"
+	SCREENSHOTS_DIR             string        = "screenshots/"
+	DEFAULT_BRANCH_NAME                       = "main"
+	WEGO_DASHBOARD_TITLE        string        = "Weave GitOps"
+	APP_PAGE_HEADER             string        = "Applications"
+	charset                                   = "abcdefghijklmnopqrstuvwxyz0123456789"
+)
 
-var DEFAULT_SSH_KEY_PATH string
-var GITHUB_ORG string
-var GITLAB_ORG string
-
-// Make sure the subgroup belongs to the GITLAB_ORG
-var GITLAB_SUBGROUP string
-var GITLAB_PUBLIC_GROUP string
-var WEGO_BIN_PATH string
+var (
+	sshKeyPath  string
+	githubOrg   string
+	githubToken string
+	gitlabOrg   string
+	gitlabToken string
+	gitlabKey   string
+	// Make sure the subgroup belongs to the GITLAB_ORG
+	gitlabSubgroup    string
+	gitlabPublicGroup string
+	gitopsBinaryPath  string
+)
 
 type TestInputs struct {
 	appRepoName         string
@@ -64,8 +71,6 @@ type TestInputs struct {
 	workloadName        string
 	workloadNamespace   string
 }
-
-const charset = "abcdefghijklmnopqrstuvwxyz0123456789"
 
 var seededRand *rand.Rand = rand.New(
 	rand.NewSource(time.Now().UnixNano()))
@@ -165,7 +170,7 @@ func setupGitlabSSHKey(sshKeyPath string) {
                            echo "%s" >> %s &&
                            chmod 0600 %s &&
                            ls -la %s &&
-                           ssh-keyscan gitlab.com >> ~/.ssh/known_hosts`, os.Getenv("GITLAB_KEY"), sshKeyPath, sshKeyPath, sshKeyPath))
+                           ssh-keyscan gitlab.com >> ~/.ssh/known_hosts`, gitlabKey, sshKeyPath, sshKeyPath, sshKeyPath))
 		session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 		Expect(err).ShouldNot(HaveOccurred())
 		Eventually(session).Should(gexec.Exit())
@@ -401,7 +406,7 @@ func VerifyControllersInCluster(namespace string) {
 
 func installAndVerifyWego(wegoNamespace, repoURL string) {
 	By("And I run 'gitops install' command with namespace "+wegoNamespace, func() {
-		command := exec.Command("sh", "-c", fmt.Sprintf("%s install --namespace=%s --config-repo=%s", WEGO_BIN_PATH, wegoNamespace, repoURL))
+		command := exec.Command("sh", "-c", fmt.Sprintf("%s install --namespace=%s --config-repo=%s", gitopsBinaryPath, wegoNamespace, repoURL))
 		session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 		Expect(err).ShouldNot(HaveOccurred())
 		Eventually(session, INSTALL_SUCCESSFUL_TIMEOUT).Should(gexec.Exit())
@@ -412,7 +417,7 @@ func installAndVerifyWego(wegoNamespace, repoURL string) {
 
 func uninstallWegoRuntime(namespace string) {
 	log.Infof("About to delete Gitops runtime from namespace: %s", namespace)
-	err := runCommandPassThrough([]string{}, "sh", "-c", fmt.Sprintf("%s flux uninstall --namespace %s --silent", WEGO_BIN_PATH, namespace))
+	err := runCommandPassThrough([]string{}, "sh", "-c", fmt.Sprintf("%s flux uninstall --namespace %s --silent", gitopsBinaryPath, namespace))
 
 	if err != nil {
 		log.Infof("Failed to uninstall the gitops runtime %s", namespace)
@@ -505,7 +510,7 @@ func waitForAppRemoval(appName string, timeout time.Duration) error {
 	pollInterval := time.Second * 5
 
 	_ = utils.WaitUntil(os.Stdout, pollInterval, timeout, func() error {
-		command := exec.Command("sh", "-c", fmt.Sprintf("%s get apps", WEGO_BIN_PATH))
+		command := exec.Command("sh", "-c", fmt.Sprintf("%s get apps", gitopsBinaryPath))
 		session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 		Expect(err).ShouldNot(HaveOccurred())
 		Eventually(session).Should(gexec.Exit())
@@ -564,7 +569,7 @@ func runWegoAddCommand(repoAbsolutePath string, addCommand string, wegoNamespace
 }
 
 func runWegoAddCommandWithOutput(repoAbsolutePath string, addCommand string, wegoNamespace string) (string, string) {
-	command := exec.Command("sh", "-c", fmt.Sprintf("cd %s && %s %s", repoAbsolutePath, WEGO_BIN_PATH, addCommand))
+	command := exec.Command("sh", "-c", fmt.Sprintf("cd %s && %s %s", repoAbsolutePath, gitopsBinaryPath, addCommand))
 	session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 	Expect(err).ShouldNot(HaveOccurred())
 	Eventually(session).Should(gexec.Exit())
@@ -822,17 +827,16 @@ func getGitProvider(org string, repo string, providerName gitproviders.GitProvid
 		orgRef = gitproviders.NewOrgRepositoryRef(github.DefaultDomain, org, repo)
 
 		gitProvider, err = github.NewClient(
-			gitprovider.WithOAuth2Token(os.Getenv("GITHUB_TOKEN")),
+			gitprovider.WithOAuth2Token(githubToken),
 			gitprovider.WithDestructiveAPICalls(true),
 		)
 	case gitproviders.GitProviderGitLab:
 		orgRef = gitproviders.NewOrgRepositoryRef(gitlab.DefaultDomain, org, repo)
 
-		token := os.Getenv("GITLAB_TOKEN")
 		gitProvider, err = gitlab.NewClient(
-			token,
+			gitlabToken,
 			"oauth2",
-			gitprovider.WithOAuth2Token(token),
+			gitprovider.WithOAuth2Token(gitlabToken),
 			gitprovider.WithDestructiveAPICalls(true),
 		)
 	default:

--- a/test/acceptance/test/version_tests.go
+++ b/test/acceptance/test/version_tests.go
@@ -14,14 +14,14 @@ var _ = Describe("Weave GitOps Version Test", func() {
 	BeforeEach(func() {
 
 		By("Given I have a gitops binary installed on my local machine", func() {
-			Expect(FileExists(WEGO_BIN_PATH)).To(BeTrue())
+			Expect(FileExists(gitopsBinaryPath)).To(BeTrue())
 		})
 	})
 
 	It("SmokeTestShort - Verify that command gitops version prints the version information", func() {
 
 		By("When I run the command 'gitops version'", func() {
-			session = runCommandAndReturnSessionOutput(WEGO_BIN_PATH + " version")
+			session = runCommandAndReturnSessionOutput(gitopsBinaryPath + " version")
 		})
 
 		By("Then I should see the gitops version printed with newline character", func() {


### PR DESCRIPTION
Fails faster and more clearly this way

Before:
```
make integration-tests
KUBEBUILDER_ASSETS="/home/jake/weave/weave-gitops/tools/bin/envtest" CGO_ENABLED=0 go test -v ./test/integration/...
=== RUN   TestServerIntegration
Running Suite: Server Integration
=================================
Random Seed: 1638813585
Will run 6 of 6 specs

• Failure [0.008 seconds]
AddApplication
/home/jake/weave/weave-gitops/test/integration/server/add_test.go:33
  GitLab
  /home/jake/weave/weave-gitops/test/integration/server/add_test.go:423
    via merge request
    /home/jake/weave/weave-gitops/test/integration/server/add_test.go:424
      adds with no config repo specified [It]
      /home/jake/weave/weave-gitops/test/integration/server/add_test.go:425

      Unexpected error:
          <*fmt.wrapError | 0xc000df6a80>: {
              msg: "could not create repo: error parsing url: invalid organization, user or repository URL: https://gitlab.com//test-source-repo-xxns9",
              err: <*fmt.wrapError | 0xc000df6a60>{
                  msg: "error parsing url: invalid organization, user or repository URL: https://gitlab.com//test-source-repo-xxns9",
                  err: <*fmt.wrapError | 0xc000df6a40>{
                      msg: "invalid organization, user or repository URL: https://gitlab.com//test-source-repo-xxns9",
                      err: <*errors.errorString | 0xc00011f040>{
                          s: "invalid organization, user or repository URL",
                      },
                  },
              },
          }
          could not create repo: error parsing url: invalid organization, user or repository URL: https://gitlab.com//test-source-repo-xxns9
      occurred

      /home/jake/weave/weave-gitops/test/integration/server/add_test.go:440

```

After:
```
make integration-tests
KUBEBUILDER_ASSETS="/home/jake/weave/weave-gitops/tools/bin/envtest" CGO_ENABLED=0 go test -v ./test/integration/...
=== RUN   TestServerIntegration
Running Suite: Server Integration
=================================
Random Seed: 1638813541
Will run 6 of 6 specs

Failure [0.000 seconds]
[BeforeSuite] BeforeSuite
/home/jake/weave/weave-gitops/test/integration/server/suite_test.go:70

  Please ensure GITLAB_ORG environment variable is set
  Expected
      <string>:
  not to be empty

```