### PR TITLE
Remove app-config-url references

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -71,7 +71,7 @@ jobs:
         OS_NAME=$(echo "${{matrix.os}}" | tr '[:upper:]' '[:lower:]')
         export CLUSTER_NAME=wego-nightly-cluster-$OS_NAME
         export CLUSTER_VERSION=1.20
-        export CLUSTER_REGION=us-east-1
+        export CLUSTER_REGION=us-east-2
         export CLUSTER_EXISTS=$(eksctl get clusters --region $CLUSTER_REGION | grep -i $CLUSTER_NAME)
         if [ -z $CLUSTER_EXISTS ]
         then

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -56,7 +56,7 @@ jobs:
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws-region: us-east-2
+        aws-region: us-west-1
     - name: Install eksctl
       run: |
         curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -71,7 +71,7 @@ jobs:
         OS_NAME=$(echo "${{matrix.os}}" | tr '[:upper:]' '[:lower:]')
         export CLUSTER_NAME=wego-nightly-cluster-$OS_NAME
         export CLUSTER_VERSION=1.20
-        export CLUSTER_REGION=us-west-1
+        export CLUSTER_REGION=us-east-1
         export CLUSTER_EXISTS=$(eksctl get clusters --region $CLUSTER_REGION | grep -i $CLUSTER_NAME)
         if [ -z $CLUSTER_EXISTS ]
         then

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -56,7 +56,7 @@ jobs:
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws-region: us-west-1
+        aws-region: us-east-2
     - name: Install eksctl
       run: |
         curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
@@ -71,7 +71,7 @@ jobs:
         OS_NAME=$(echo "${{matrix.os}}" | tr '[:upper:]' '[:lower:]')
         export CLUSTER_NAME=wego-nightly-cluster-$OS_NAME
         export CLUSTER_VERSION=1.20
-        export CLUSTER_REGION=us-east-2
+        export CLUSTER_REGION=us-west-1
         export CLUSTER_EXISTS=$(eksctl get clusters --region $CLUSTER_REGION | grep -i $CLUSTER_NAME)
         if [ -z $CLUSTER_EXISTS ]
         then

--- a/api/applications/applications.proto
+++ b/api/applications/applications.proto
@@ -260,13 +260,13 @@ message GetApplicationResponse {
 }
 
 message AddApplicationRequest {
-    string name      = 1;
-    string namespace = 2;
-    string path      = 3;
-    string url       = 4;
-    string branch    = 5;
-    bool   autoMerge = 6;
-    string configUrl = 7;
+    string name       = 1;
+    string namespace  = 2;
+    string path       = 3;
+    string url        = 4;
+    string branch     = 5;
+    bool   autoMerge  = 6;
+    string configRepo = 7;
 }
 
 message AddApplicationResponse {

--- a/api/applications/applications.swagger.json
+++ b/api/applications/applications.swagger.json
@@ -588,7 +588,7 @@
         "autoMerge": {
           "type": "boolean"
         },
-        "configUrl": {
+        "configRepo": {
           "type": "string"
         }
       }

--- a/api/v1alpha1/application_types.go
+++ b/api/v1alpha1/application_types.go
@@ -26,8 +26,8 @@ const ApplicationKind = "Application"
 
 // ApplicationSpec defines the desired state of Application
 type ApplicationSpec struct {
-	// ConfigURL is the address of the git repository containing the automation for this application
-	ConfigURL string `json:"config_url,omitempty"`
+	// ConfigRepo is the address of the git repository containing the automation for this application
+	ConfigRepo string `json:"config_url,omitempty"`
 	// URL is the address of the git repository for this application
 	URL string `json:"url,omitempty"`
 	// Path is the path in the repository where the k8s yaml files for this application are stored.

--- a/cmd/gitops/add/app/cmd.go
+++ b/cmd/gitops/add/app/cmd.go
@@ -59,7 +59,7 @@ func init() {
 	Cmd.Flags().StringVar(&params.Branch, "branch", "", "Branch to watch within git repository")
 	Cmd.Flags().StringVar(&params.DeploymentType, "deployment-type", app.DefaultDeploymentType, "Deployment type [kustomize, helm]")
 	Cmd.Flags().StringVar(&params.Chart, "chart", "", "Specify chart for helm source")
-	Cmd.Flags().StringVar(&params.AppConfigUrl, "app-config-url", "", "URL of external repository (if any) which will hold automation manifests")
+	Cmd.Flags().StringVar(&params.ConfigRepo, "config-repo", "", "URL of external repository (if any) which will hold automation manifests")
 	Cmd.Flags().StringVar(&params.HelmReleaseTargetNamespace, "helm-release-target-namespace", "", "Namespace in which to deploy a helm chart; defaults to the gitops installation namespace")
 	Cmd.Flags().BoolVar(&params.DryRun, "dry-run", false, "If set, 'gitops add app' will not make any changes to the system; it will just display the actions that would have been taken")
 	Cmd.Flags().BoolVar(&params.AutoMerge, "auto-merge", false, "If set, 'gitops add app' will merge automatically into the set --branch")
@@ -114,7 +114,7 @@ func runCmd(cmd *cobra.Command, args []string) error {
 
 	gitClient, gitProvider, err := factory.GetGitClients(ctx, providerClient, services.GitConfigParams{
 		URL:              params.Url,
-		ConfigURL:        params.AppConfigUrl,
+		ConfigRepo:       params.ConfigRepo,
 		Namespace:        params.Namespace,
 		IsHelmRepository: params.IsHelmRepository(),
 		DryRun:           params.DryRun,

--- a/cmd/gitops/beta/cmd/add/app.go
+++ b/cmd/gitops/beta/cmd/add/app.go
@@ -46,9 +46,9 @@ var AppCmd = &cobra.Command{
 
 func init() {
 	AppCmd.Flags().StringVar(&params.Url, "url", "", "Url of remote repository")
-	AppCmd.Flags().StringVar(&params.AppConfigUrl, "app-config-url", "", "Url of external repository (if any) which will hold automation manifests; NONE to store only in the cluster")
+	AppCmd.Flags().StringVar(&params.ConfigRepo, "config-repo", "", "Url of external repository (if any) which will hold automation manifests; NONE to store only in the cluster")
 	AppCmd.Flags().BoolVar(&params.DryRun, "dry-run", false, "If set, 'gitops add app' will not make any changes to the system; it will just display the actions that would have been taken")
-	cobra.CheckErr(AppCmd.MarkFlagRequired("app-config-url"))
+	cobra.CheckErr(AppCmd.MarkFlagRequired("config-repo"))
 
 	// TODO expose support for PRs
 	params.AutoMerge = true
@@ -75,7 +75,7 @@ func runCmd(cmd *cobra.Command, args []string) error {
 
 	gitClient, gitProvider, err := factory.GetGitClients(ctx, providerClient, services.GitConfigParams{
 		URL:              params.Url,
-		ConfigURL:        params.AppConfigUrl,
+		ConfigRepo:       params.ConfigRepo,
 		Namespace:        params.Namespace,
 		IsHelmRepository: params.IsHelmRepository(),
 		DryRun:           params.DryRun,

--- a/cmd/gitops/beta/cmd/install.go
+++ b/cmd/gitops/beta/cmd/install.go
@@ -72,8 +72,8 @@ func installRunCmd(cmd *cobra.Command, args []string) error {
 	gitopsService := gitops.New(log, fluxClient, k)
 
 	gitOpsParams := gitops.InstallParams{
-		Namespace:    namespace,
-		DryRun:       installParams.DryRun,
+		Namespace:  namespace,
+		DryRun:     installParams.DryRun,
 		ConfigRepo: installParams.ConfigRepo,
 	}
 

--- a/cmd/gitops/beta/cmd/install.go
+++ b/cmd/gitops/beta/cmd/install.go
@@ -23,8 +23,8 @@ import (
 )
 
 type params struct {
-	DryRun       bool
-	AppConfigURL string
+	DryRun     bool
+	ConfigRepo string
 }
 
 var (
@@ -39,7 +39,7 @@ var installCmd = &cobra.Command{
 adds a cluster entry to the GitOps repo, and persists the GitOps runtime into the
 repo.`,
 	Example: `  # Install GitOps in the wego-system namespace
-  gitops beta install --app-config-url ssh://git@github.com/me/mygitopsrepo.git`,
+  gitops beta install --config-repo ssh://git@github.com/me/mygitopsrepo.git`,
 	RunE:          installRunCmd,
 	SilenceErrors: true,
 	SilenceUsage:  true,
@@ -51,8 +51,8 @@ repo.`,
 func init() {
 	Cmd.AddCommand(installCmd)
 	installCmd.Flags().BoolVar(&installParams.DryRun, "dry-run", false, "Outputs all the manifests that would be installed")
-	installCmd.Flags().StringVar(&installParams.AppConfigURL, "app-config-url", "", "URL of external repository that will hold automation manifests")
-	cobra.CheckErr(installCmd.MarkFlagRequired("app-config-url"))
+	installCmd.Flags().StringVar(&installParams.ConfigRepo, "config-repo", "", "URL of external repository that will hold automation manifests")
+	cobra.CheckErr(installCmd.MarkFlagRequired("config-repo"))
 }
 
 func installRunCmd(cmd *cobra.Command, args []string) error {
@@ -74,7 +74,7 @@ func installRunCmd(cmd *cobra.Command, args []string) error {
 	gitOpsParams := gitops.InstallParams{
 		Namespace:    namespace,
 		DryRun:       installParams.DryRun,
-		AppConfigURL: installParams.AppConfigURL,
+		ConfigRepo: installParams.ConfigRepo,
 	}
 
 	manifests, err := gitopsService.Install(gitOpsParams)
@@ -83,7 +83,7 @@ func installRunCmd(cmd *cobra.Command, args []string) error {
 	}
 
 	gitClient, gitProvider, err := factory.GetGitClients(context.Background(), providerClient, services.GitConfigParams{
-		URL:       installParams.AppConfigURL,
+		URL:       installParams.ConfigRepo,
 		Namespace: namespace,
 		DryRun:    installParams.DryRun,
 	})

--- a/cmd/gitops/install/cmd.go
+++ b/cmd/gitops/install/cmd.go
@@ -25,8 +25,8 @@ import (
 )
 
 type params struct {
-	DryRun       bool
-	AppConfigURL string
+	DryRun     bool
+	ConfigRepo string
 }
 
 var (
@@ -40,7 +40,7 @@ var Cmd = &cobra.Command{
 adds a cluster entry to the GitOps repo, and persists the GitOps runtime into the
 repo. If a previous version is installed, then an in-place upgrade will be performed.`,
 	Example: fmt.Sprintf(`  # Install GitOps in the %s namespace
-  gitops install --app-config-url=ssh://git@github.com/me/mygitopsrepo.git`, wego.DefaultNamespace),
+  gitops install --config-repo=ssh://git@github.com/me/mygitopsrepo.git`, wego.DefaultNamespace),
 	RunE:          installRunCmd,
 	SilenceErrors: true,
 	SilenceUsage:  true,
@@ -51,8 +51,8 @@ repo. If a previous version is installed, then an in-place upgrade will be perfo
 
 func init() {
 	Cmd.Flags().BoolVar(&installParams.DryRun, "dry-run", false, "Outputs all the manifests that would be installed")
-	Cmd.Flags().StringVar(&installParams.AppConfigURL, "app-config-url", "", "URL of external repository that will hold automation manifests")
-	cobra.CheckErr(Cmd.MarkFlagRequired("app-config-url"))
+	Cmd.Flags().StringVar(&installParams.ConfigRepo, "config-repo", "", "URL of external repository that will hold automation manifests")
+	cobra.CheckErr(Cmd.MarkFlagRequired("config-repo"))
 }
 
 func installRunCmd(cmd *cobra.Command, args []string) error {
@@ -72,7 +72,7 @@ func installRunCmd(cmd *cobra.Command, args []string) error {
 	gitopsParams := gitops.InstallParams{
 		Namespace:    namespace,
 		DryRun:       installParams.DryRun,
-		AppConfigURL: installParams.AppConfigURL,
+		ConfigRepo: installParams.ConfigRepo,
 	}
 
 	manifests, err := gitopsService.Install(gitopsParams)
@@ -89,7 +89,7 @@ func installRunCmd(cmd *cobra.Command, args []string) error {
 		providerClient := internal.NewGitProviderClient(osysClient.Stdout(), osysClient.LookupEnv, auth.NewAuthCLIHandler, log)
 
 		gitClient, gitProvider, err = factory.GetGitClients(context.Background(), providerClient, services.GitConfigParams{
-			URL:       installParams.AppConfigURL,
+			URL:       installParams.ConfigRepo,
 			Namespace: namespace,
 			DryRun:    installParams.DryRun,
 		})

--- a/cmd/gitops/install/cmd.go
+++ b/cmd/gitops/install/cmd.go
@@ -70,8 +70,8 @@ func installRunCmd(cmd *cobra.Command, args []string) error {
 	gitopsService := gitops.New(log, flux, k)
 
 	gitopsParams := gitops.InstallParams{
-		Namespace:    namespace,
-		DryRun:       installParams.DryRun,
+		Namespace:  namespace,
+		DryRun:     installParams.DryRun,
 		ConfigRepo: installParams.ConfigRepo,
 	}
 

--- a/cmd/gitops/upgrade/cmd.go
+++ b/cmd/gitops/upgrade/cmd.go
@@ -19,7 +19,7 @@ import (
 var upgradeCmdFlags upgrade.UpgradeValues
 
 var example = fmt.Sprintf(`  # Upgrade Weave GitOps in the %s namespace
-  gitops upgrade --version 0.0.15 --app-config-url https://github.com/my-org/my-management-cluster.git`,
+  gitops upgrade --version 0.0.15 --config-repo https://github.com/my-org/my-management-cluster.git`,
 	wego.DefaultNamespace)
 
 var Cmd = &cobra.Command{
@@ -32,7 +32,7 @@ var Cmd = &cobra.Command{
 }
 
 func init() {
-	Cmd.PersistentFlags().StringVar(&upgradeCmdFlags.AppConfigURL, "app-config-url", "", "URL of external repository that will hold automation manifests")
+	Cmd.PersistentFlags().StringVar(&upgradeCmdFlags.ConfigRepo, "config-repo", "", "URL of external repository that will hold automation manifests")
 	Cmd.PersistentFlags().StringVar(&upgradeCmdFlags.Version, "version", "", "Version of Weave GitOps Enterprise to be installed")
 	Cmd.PersistentFlags().StringVar(&upgradeCmdFlags.BaseBranch, "base", "main", "The base branch to open the pull request against")
 	Cmd.PersistentFlags().StringVar(&upgradeCmdFlags.HeadBranch, "branch", "tier-upgrade-enterprise", "The branch to create the pull request from")
@@ -40,7 +40,7 @@ func init() {
 	Cmd.PersistentFlags().StringArrayVar(&upgradeCmdFlags.Values, "set", []string{}, "set values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)")
 	Cmd.PersistentFlags().BoolVar(&upgradeCmdFlags.DryRun, "dry-run", false, "Output the generated profile without creating a pull request")
 
-	cobra.CheckErr(Cmd.MarkPersistentFlagRequired("app-config-url"))
+	cobra.CheckErr(Cmd.MarkPersistentFlagRequired("config-repo"))
 	cobra.CheckErr(Cmd.MarkPersistentFlagRequired("version"))
 }
 
@@ -63,7 +63,7 @@ func upgradeCmdRunE() func(*cobra.Command, []string) error {
 		providerClient := internal.NewGitProviderClient(os.Stdout, os.LookupEnv, auth.NewAuthCLIHandler, log)
 
 		gitClient, gitProvider, err := factory.GetGitClients(ctx, providerClient, services.GitConfigParams{
-			URL:       upgradeCmdFlags.AppConfigURL,
+			URL:       upgradeCmdFlags.ConfigRepo,
 			Namespace: upgradeCmdFlags.Namespace,
 			DryRun:    upgradeCmdFlags.DryRun,
 		})

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/google/go-github/v32 v32.1.0
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/uuid v1.3.0 // indirect
-	github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0
+	github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.1
 	github.com/grpc-ecosystem/protoc-gen-grpc-gateway-ts v1.1.1
 	github.com/helm/helm v2.17.0+incompatible
 	github.com/jandelgado/gcov2lcov v1.0.5
@@ -53,7 +53,7 @@ require (
 	go.uber.org/zap v1.19.0
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8
 	golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b // indirect
-	google.golang.org/genproto v0.0.0-20211118181313-81c1377c94b1
+	google.golang.org/genproto v0.0.0-20211129164237-f09f9a12af12
 	google.golang.org/grpc v1.42.0
 	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0
 	google.golang.org/protobuf v1.27.1

--- a/go.sum
+++ b/go.sum
@@ -590,8 +590,8 @@ github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t
 github.com/grpc-ecosystem/grpc-gateway v1.15.2/go.mod h1:vO11I9oWA+KsxmfFQPhLnnIb1VDE24M+pdxZFiuZcA8=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0 h1:gmcG1KaJ57LophUzW0Hy8NmPhnMZb4M0+kPpLofRdBo=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
-github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0 h1:BZHcxBETFHIdVyhyEfOvn/RdU/QGdLI4y34qQGjGWO0=
-github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0/go.mod h1:hgWBS7lorOAVIJEQMi4ZsPv9hVvWI6+ch50m39Pf2Ks=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.1 h1:p5m7GOEGXyoq6QWl4/RRMsQ6tWbTpbQmAnkxXgWSprY=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.1/go.mod h1:8ZeZajTed/blCOHBbj8Fss8bPHiFKcmJJzuIbUtFCAo=
 github.com/grpc-ecosystem/protoc-gen-grpc-gateway-ts v1.1.1 h1:arwcA21RFb6T+jDlx8webgjG5mxVOVUk/L4/sxRLisY=
 github.com/grpc-ecosystem/protoc-gen-grpc-gateway-ts v1.1.1/go.mod h1:eirF820XKj2zKB4hFfdsOqlAVq45EpWH2WzR2WxBua4=
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
@@ -1617,8 +1617,8 @@ google.golang.org/genproto v0.0.0-20210805201207-89edb61ffb67/go.mod h1:ob2IJxKr
 google.golang.org/genproto v0.0.0-20210813162853-db860fec028c/go.mod h1:cFeNkxwySK631ADgubI+/XFU/xp8FD5KIVV4rj8UC5w=
 google.golang.org/genproto v0.0.0-20210821163610-241b8fcbd6c8/go.mod h1:eFjDcFEctNawg4eG61bRv87N7iHBWyVhJu7u1kqDUXY=
 google.golang.org/genproto v0.0.0-20210828152312-66f60bf46e71/go.mod h1:eFjDcFEctNawg4eG61bRv87N7iHBWyVhJu7u1kqDUXY=
-google.golang.org/genproto v0.0.0-20211118181313-81c1377c94b1 h1:b9mVrqYfq3P4bCdaLg1qtBnPzUYgglsIdjZkL/fQVOE=
-google.golang.org/genproto v0.0.0-20211118181313-81c1377c94b1/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
+google.golang.org/genproto v0.0.0-20211129164237-f09f9a12af12 h1:DN5b3HU13J4sMd/QjDx34U6afpaexKTDdop+26pdjdk=
+google.golang.org/genproto v0.0.0-20211129164237-f09f9a12af12/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
 google.golang.org/grpc v0.0.0-20160317175043-d3ddb4469d5a/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.17.0/go.mod h1:6QZJwpn2B+Zp71q/5VxRsJ6NXXVCE5NRUHRo+f3cWCs=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=

--- a/manifests/crds/wego.weave.works_apps.yaml
+++ b/manifests/crds/wego.weave.works_apps.yaml
@@ -41,7 +41,7 @@ spec:
                   yaml files for this application are stored.
                 type: string
               config_url:
-                description: ConfigURL is the address of the git repository containing
+                description: ConfigRepo is the address of the git repository containing
                   the automation for this application
                 type: string
               deployment_type:

--- a/pkg/api/applications/applications.pb.go
+++ b/pkg/api/applications/applications.pb.go
@@ -1047,13 +1047,13 @@ type AddApplicationRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Name      string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
-	Namespace string `protobuf:"bytes,2,opt,name=namespace,proto3" json:"namespace,omitempty"`
-	Path      string `protobuf:"bytes,3,opt,name=path,proto3" json:"path,omitempty"`
-	Url       string `protobuf:"bytes,4,opt,name=url,proto3" json:"url,omitempty"`
-	Branch    string `protobuf:"bytes,5,opt,name=branch,proto3" json:"branch,omitempty"`
-	AutoMerge bool   `protobuf:"varint,6,opt,name=autoMerge,proto3" json:"autoMerge,omitempty"`
-	ConfigUrl string `protobuf:"bytes,7,opt,name=configUrl,proto3" json:"configUrl,omitempty"`
+	Name       string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Namespace  string `protobuf:"bytes,2,opt,name=namespace,proto3" json:"namespace,omitempty"`
+	Path       string `protobuf:"bytes,3,opt,name=path,proto3" json:"path,omitempty"`
+	Url        string `protobuf:"bytes,4,opt,name=url,proto3" json:"url,omitempty"`
+	Branch     string `protobuf:"bytes,5,opt,name=branch,proto3" json:"branch,omitempty"`
+	AutoMerge  bool   `protobuf:"varint,6,opt,name=autoMerge,proto3" json:"autoMerge,omitempty"`
+	ConfigRepo string `protobuf:"bytes,7,opt,name=configRepo,proto3" json:"configRepo,omitempty"`
 }
 
 func (x *AddApplicationRequest) Reset() {
@@ -1130,9 +1130,9 @@ func (x *AddApplicationRequest) GetAutoMerge() bool {
 	return false
 }
 
-func (x *AddApplicationRequest) GetConfigUrl() string {
+func (x *AddApplicationRequest) GetConfigRepo() string {
 	if x != nil {
-		return x.ConfigUrl
+		return x.ConfigRepo
 	}
 	return ""
 }

--- a/pkg/models/application.go
+++ b/pkg/models/application.go
@@ -21,7 +21,7 @@ type Application struct {
 	Namespace           string
 	HelmSourceURL       string
 	GitSourceURL        gitproviders.RepoURL
-	ConfigURL           gitproviders.RepoURL
+	ConfigRepo          gitproviders.RepoURL
 	Branch              string
 	Path                string
 	AutomationType      AutomationType
@@ -29,6 +29,6 @@ type Application struct {
 	HelmTargetNamespace string
 }
 
-func IsExternalConfigUrl(url string) bool {
+func IsExternalConfigRepo(url string) bool {
 	return url != ""
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -261,11 +261,11 @@ func (s *applicationServer) AddApplication(ctx context.Context, msg *pb.AddAppli
 		return nil, grpcStatus.Errorf(codes.InvalidArgument, "unable to parse app url %q: %s", msg.Url, err)
 	}
 
-	var configUrl gitproviders.RepoURL
-	if msg.ConfigUrl != "" {
-		configUrl, err = gitproviders.NewRepoURL(msg.ConfigUrl)
+	var configRepo gitproviders.RepoURL
+	if msg.ConfigRepo != "" {
+		configRepo, err = gitproviders.NewRepoURL(msg.ConfigRepo)
 		if err != nil {
-			return nil, grpcStatus.Errorf(codes.InvalidArgument, "unable to parse config url %q: %s", msg.ConfigUrl, err)
+			return nil, grpcStatus.Errorf(codes.InvalidArgument, "unable to parse config url %q: %s", msg.ConfigRepo, err)
 		}
 	}
 
@@ -282,15 +282,15 @@ func (s *applicationServer) AddApplication(ctx context.Context, msg *pb.AddAppli
 		GitProviderToken: token.AccessToken,
 		Branch:           msg.Branch,
 		AutoMerge:        msg.AutoMerge,
-		AppConfigUrl:     configUrl.String(),
+		ConfigRepo:       configRepo.String(),
 	}
 
 	client := internal.NewGitProviderClient(token.AccessToken)
 
 	gitClient, gitProvider, err := s.factory.GetGitClients(ctx, client, services.GitConfigParams{
-		URL:       msg.Url,
-		ConfigURL: msg.ConfigUrl,
-		Namespace: msg.Namespace,
+		URL:        msg.Url,
+		ConfigRepo: msg.ConfigRepo,
+		Namespace:  msg.Namespace,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get git clients: %w", err)
@@ -333,9 +333,9 @@ func (s *applicationServer) RemoveApplication(ctx context.Context, msg *pb.Remov
 	client := internal.NewGitProviderClient(token.AccessToken)
 
 	gitClient, gitProvider, err := s.factory.GetGitClients(ctx, client, services.GitConfigParams{
-		URL:       application.Spec.URL,
-		ConfigURL: application.Spec.ConfigURL,
-		Namespace: msg.Namespace,
+		URL:        application.Spec.URL,
+		ConfigRepo: application.Spec.ConfigRepo,
+		Namespace:  msg.Namespace,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get git clients: %w", err)
@@ -411,9 +411,9 @@ func (s *applicationServer) ListCommits(ctx context.Context, msg *pb.ListCommits
 	client := internal.NewGitProviderClient(providerToken.AccessToken)
 
 	_, gitProvider, err := s.factory.GetGitClients(ctx, client, services.GitConfigParams{
-		URL:       application.Spec.URL,
-		ConfigURL: application.Spec.ConfigURL,
-		Namespace: msg.Namespace,
+		URL:        application.Spec.URL,
+		ConfigRepo: application.Spec.ConfigRepo,
+		Namespace:  msg.Namespace,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get git clients: %w", err)

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -562,12 +562,12 @@ var _ = Describe("ApplicationsServer", func() {
 			ctx := context.Background()
 			name := "my-app"
 			appRequest := &pb.AddApplicationRequest{
-				Name:      name,
-				Namespace: namespace.Name,
-				Url:       "ssh://git@github.com/some-org/somerepo.git",
-				Path:      "./k8s/mydir",
-				Branch:    "main",
-				ConfigUrl: "ssh://git@github.com/some-org/my-config-url.git",
+				Name:       name,
+				Namespace:  namespace.Name,
+				Url:        "ssh://git@github.com/some-org/somerepo.git",
+				Path:       "./k8s/mydir",
+				Branch:     "main",
+				ConfigRepo: "ssh://git@github.com/some-org/my-config-url.git",
 			}
 
 			gitProvider.GetRepoVisibilityReturns(gitprovider.RepositoryVisibilityVar(gitprovider.RepositoryVisibilityInternal), nil)
@@ -671,7 +671,7 @@ var _ = Describe("ApplicationsServer", func() {
 			"Remove applications",
 			func(
 				url,
-				configurl string,
+				configRepo string,
 				sourceType wego.SourceType,
 				deploymentType wego.DeploymentType,
 				autoMerge bool,
@@ -686,7 +686,7 @@ var _ = Describe("ApplicationsServer", func() {
 						Branch:         "main",
 						Path:           "./k8s",
 						URL:            url,
-						ConfigURL:      configurl,
+						ConfigRepo:     configRepo,
 						SourceType:     sourceType,
 						DeploymentType: deploymentType,
 					},

--- a/pkg/services/app/add_test.go
+++ b/pkg/services/app/add_test.go
@@ -36,7 +36,7 @@ var _ = Describe("Add", func() {
 			DeploymentType: "kustomize",
 			SourceType:     wego.SourceTypeGit,
 			Namespace:      wego.DefaultNamespace,
-			AppConfigUrl:   "",
+			ConfigRepo:     "",
 			AutoMerge:      true,
 		}
 
@@ -67,13 +67,13 @@ var _ = Describe("Add", func() {
 		Expect(kubeClient.GetClusterNameCallCount()).To(Equal(1))
 	})
 
-	It("validates app-config-url is set when source is helm", func() {
+	It("validates config-repo is set when source is helm", func() {
 		addParams.Chart = "my-chart"
 		addParams.Url = "https://my-chart.com"
-		addParams.AppConfigUrl = ""
+		addParams.ConfigRepo = ""
 
 		err := appSrv.Add(gitClient, gitProviders, addParams)
-		Expect(err.Error()).Should(HaveSuffix("--app-config-url should be provided"))
+		Expect(err.Error()).Should(HaveSuffix("--config-repo should be provided"))
 	})
 
 	Context("Looking up repo default branch", func() {
@@ -106,7 +106,7 @@ var _ = Describe("Add", func() {
 	Context("add app with config in app repo", func() {
 		BeforeEach(func() {
 			addParams.Url = "ssh://git@github.com/foo/bar.git"
-			addParams.AppConfigUrl = ""
+			addParams.ConfigRepo = ""
 
 			gitClient.OpenStub = func(s string) (*gogit.Repository, error) {
 				r, err := gogit.Init(memory.NewStorage(), memfs.New())
@@ -126,7 +126,7 @@ var _ = Describe("Add", func() {
 				addParams.Url = "https://charts.kube-ops.io"
 				addParams.Chart = "loki"
 				addParams.HelmReleaseTargetNamespace = "sock-shop"
-				addParams.AppConfigUrl = "ssh://git@github.com/owner/config-repo.git"
+				addParams.ConfigRepo = "ssh://git@github.com/owner/config-repo.git"
 
 				goodNamespaceErr := appSrv.Add(gitClient, gitProviders, addParams)
 				Expect(goodNamespaceErr).ShouldNot(HaveOccurred())
@@ -141,7 +141,7 @@ var _ = Describe("Add", func() {
 				addParams.Url = "https://charts.kube-ops.io"
 				addParams.Chart = "loki"
 				addParams.HelmReleaseTargetNamespace = "sock-shop"
-				addParams.AppConfigUrl = "ssh://git@github.com/owner/config-repo.git"
+				addParams.ConfigRepo = "ssh://git@github.com/owner/config-repo.git"
 
 				goodNamespaceErr := appSrv.Add(gitClient, gitProviders, addParams)
 				Expect(goodNamespaceErr).ShouldNot(HaveOccurred())
@@ -229,7 +229,7 @@ var _ = Describe("Add Gitlab", func() {
 			Dir:            ".",
 			DeploymentType: "kustomize",
 			Namespace:      wego.DefaultNamespace,
-			AppConfigUrl:   "",
+			ConfigRepo:     "",
 			AutoMerge:      true,
 		}
 
@@ -241,7 +241,7 @@ var _ = Describe("Add Gitlab", func() {
 	Context("add app with config in app repo", func() {
 		BeforeEach(func() {
 			addParams.Url = "ssh://git@gitlab.com/foo/bar.git"
-			addParams.AppConfigUrl = ""
+			addParams.ConfigRepo = ""
 
 			gitClient.OpenStub = func(s string) (*gogit.Repository, error) {
 				r, err := gogit.Init(memory.NewStorage(), memfs.New())
@@ -285,7 +285,7 @@ var _ = Describe("New directory structure", func() {
 			Dir:                      ".",
 			DeploymentType:           "kustomize",
 			Namespace:                "wego-system",
-			AppConfigUrl:             "https://github.com/foo/bar",
+			ConfigRepo:               "https://github.com/foo/bar",
 			SourceType:               wego.SourceTypeGit,
 			AutoMerge:                true,
 			MigrateToNewDirStructure: utils.MigrateToNewDirStructure,

--- a/pkg/services/app/remove.go
+++ b/pkg/services/app/remove.go
@@ -47,7 +47,7 @@ func (a *AppSvc) Remove(configGit git.Git, gitProvider gitproviders.GitProvider,
 }
 
 func (a *AppSvc) removeApp(ctx context.Context, configGit git.Git, gitProvider gitproviders.GitProvider, app models.Application, clusterName string, autoMerge bool) error {
-	repoWriter := gitrepo.NewRepoWriter(app.ConfigURL, gitProvider, configGit, a.Logger)
+	repoWriter := gitrepo.NewRepoWriter(app.ConfigRepo, gitProvider, configGit, a.Logger)
 	automationGen := automation.NewAutomationGenerator(gitProvider, a.Flux, a.Logger)
 	gitOpsDirWriter := gitopswriter.NewGitOpsDirectoryWriter(automationGen, repoWriter, a.Osys, a.Logger)
 

--- a/pkg/services/applicationv2/fetcher.go
+++ b/pkg/services/applicationv2/fetcher.go
@@ -91,8 +91,8 @@ func translateApp(app wego.Application) (models.Application, error) {
 		helmSourceURL = app.Spec.URL
 	}
 
-	if models.IsExternalConfigUrl(app.Spec.ConfigURL) {
-		configRepoUrl, err = gitproviders.NewRepoURL(app.Spec.ConfigURL)
+	if models.IsExternalConfigRepo(app.Spec.ConfigRepo) {
+		configRepoUrl, err = gitproviders.NewRepoURL(app.Spec.ConfigRepo)
 		if err != nil {
 			return models.Application{}, err
 		}
@@ -103,7 +103,7 @@ func translateApp(app wego.Application) (models.Application, error) {
 		Namespace:           app.Namespace,
 		HelmSourceURL:       helmSourceURL,
 		GitSourceURL:        appRepoUrl,
-		ConfigURL:           configRepoUrl,
+		ConfigRepo:          configRepoUrl,
 		Branch:              app.Spec.Branch,
 		Path:                app.Spec.Path,
 		HelmTargetNamespace: app.Spec.HelmTargetNamespace,

--- a/pkg/services/automation/automation_test.go
+++ b/pkg/services/automation/automation_test.go
@@ -76,7 +76,7 @@ var _ = Describe("Generate manifests", func() {
 	Context("add app with config in app repo", func() {
 		BeforeEach(func() {
 			app.GitSourceURL = createRepoURL("ssh://git@github.com/foo/bar.git")
-			app.ConfigURL = emptyRepoURL
+			app.ConfigRepo = emptyRepoURL
 		})
 
 		Describe("generates source manifest", func() {
@@ -119,7 +119,7 @@ var _ = Describe("Generate manifests", func() {
 				app.Path = "loki"
 				app.Name = "loki"
 				app.SourceType = models.SourceTypeHelm
-				app.ConfigURL = createRepoURL("ssh://git@github.com/owner/config-repo.git")
+				app.ConfigRepo = createRepoURL("ssh://git@github.com/owner/config-repo.git")
 
 				results, err := automationGen.GenerateAutomation(ctx, app, "test-cluster")
 				Expect(err).ShouldNot(HaveOccurred())
@@ -170,7 +170,7 @@ var _ = Describe("Generate manifests", func() {
 				app.AutomationType = models.AutomationTypeHelm
 				app.Path = "loki"
 				app.Name = "bar"
-				app.ConfigURL = createRepoURL("ssh://github.com/owner/repo")
+				app.ConfigRepo = createRepoURL("ssh://github.com/owner/repo")
 
 				app.Path = "./charts/my-chart"
 				app.AutomationType = models.AutomationTypeHelm
@@ -210,7 +210,7 @@ var _ = Describe("Generate manifests", func() {
 		Context("add app with external config repo", func() {
 			BeforeEach(func() {
 				app.GitSourceURL = createRepoURL("https://github.com/user/repo")
-				app.ConfigURL = createRepoURL("https://github.com/foo/bar")
+				app.ConfigRepo = createRepoURL("https://github.com/foo/bar")
 			})
 
 			Describe("generates source manifest", func() {
@@ -342,7 +342,7 @@ var _ = Describe("Generate manifests", func() {
 					app.AutomationType = models.AutomationTypeHelm
 					app.Path = "loki"
 					app.Name = "loki"
-					app.ConfigURL = createRepoURL("ssh://github.com/owner/repo")
+					app.ConfigRepo = createRepoURL("ssh://github.com/owner/repo")
 
 					_, err := automationGen.GenerateAutomation(ctx, app, "test-cluster")
 					Expect(err).ShouldNot(HaveOccurred())
@@ -360,7 +360,7 @@ var _ = Describe("Generate manifests", func() {
 					app.AutomationType = models.AutomationTypeHelm
 					app.Path = "loki"
 					app.Name = "bar"
-					app.ConfigURL = createRepoURL("ssh://github.com/owner/repo")
+					app.ConfigRepo = createRepoURL("ssh://github.com/owner/repo")
 
 					app.Path = "./charts/my-chart"
 					app.AutomationType = models.AutomationTypeHelm
@@ -385,7 +385,7 @@ var _ = Describe("Generate manifests", func() {
 					app.Name = "loki"
 					app.HelmTargetNamespace = "sock-shop"
 					app.AutomationType = models.AutomationTypeHelm
-					app.ConfigURL = createRepoURL("ssh://git@github.com/owner/config-repo.git")
+					app.ConfigRepo = createRepoURL("ssh://git@github.com/owner/config-repo.git")
 
 					_, err := automationGen.GenerateAutomation(ctx, app, "test-cluster")
 					Expect(err).ShouldNot(HaveOccurred())

--- a/pkg/services/automation/generator.go
+++ b/pkg/services/automation/generator.go
@@ -306,8 +306,8 @@ func WegoAppToApp(app wego.Application) (models.Application, error) {
 		helmRepoUrl = app.Spec.URL
 	}
 
-	if models.IsExternalConfigUrl(app.Spec.ConfigURL) {
-		configRepoUrl, err = gitproviders.NewRepoURL(app.Spec.ConfigURL)
+	if models.IsExternalConfigRepo(app.Spec.ConfigRepo) {
+		configRepoUrl, err = gitproviders.NewRepoURL(app.Spec.ConfigRepo)
 		if err != nil {
 			return models.Application{}, err
 		}
@@ -318,7 +318,7 @@ func WegoAppToApp(app wego.Application) (models.Application, error) {
 		Namespace:           app.Namespace,
 		GitSourceURL:        appRepoUrl,
 		HelmSourceURL:       helmRepoUrl,
-		ConfigURL:           configRepoUrl,
+		ConfigRepo:          configRepoUrl,
 		Branch:              app.Spec.Branch,
 		Path:                app.Spec.Path,
 		HelmTargetNamespace: app.Spec.HelmTargetNamespace,
@@ -345,7 +345,7 @@ func AppToWegoApp(app models.Application) wego.Application {
 			Namespace: app.Namespace,
 		},
 		Spec: wego.ApplicationSpec{
-			ConfigURL:           app.ConfigURL.String(),
+			ConfigRepo:          app.ConfigRepo.String(),
 			Branch:              app.Branch,
 			URL:                 sourceUrl,
 			Path:                app.Path,

--- a/pkg/services/factory.go
+++ b/pkg/services/factory.go
@@ -31,7 +31,7 @@ type Factory interface {
 
 type GitConfigParams struct {
 	URL              string
-	ConfigURL        string
+	ConfigRepo       string
 	Namespace        string
 	IsHelmRepository bool
 	DryRun           bool
@@ -42,7 +42,7 @@ func NewGitConfigParamsFromApp(app *wego.Application, dryRun bool) GitConfigPara
 
 	return GitConfigParams{
 		URL:              app.Spec.URL,
-		ConfigURL:        app.Spec.ConfigURL,
+		ConfigRepo:       app.Spec.ConfigRepo,
 		Namespace:        app.Namespace,
 		IsHelmRepository: isHelmRepository,
 		DryRun:           dryRun,
@@ -104,7 +104,7 @@ func (f *defaultFactory) GetKubeService() (kube.Kube, error) {
 }
 
 func (f *defaultFactory) GetGitClients(ctx context.Context, gpClient gitproviders.Client, params GitConfigParams) (git.Git, gitproviders.GitProvider, error) {
-	isExternalConfig := models.IsExternalConfigUrl(params.ConfigURL)
+	isExternalConfig := models.IsExternalConfigRepo(params.ConfigRepo)
 
 	var providerUrl string
 
@@ -112,7 +112,7 @@ func (f *defaultFactory) GetGitClients(ctx context.Context, gpClient gitprovider
 	case !params.IsHelmRepository:
 		providerUrl = params.URL
 	case isExternalConfig:
-		providerUrl = params.ConfigURL
+		providerUrl = params.ConfigRepo
 	default:
 		return nil, nil, nil
 	}
@@ -150,12 +150,12 @@ func (f *defaultFactory) GetGitClients(ctx context.Context, gpClient gitprovider
 	}
 
 	if isExternalConfig {
-		normalizedConfigUrl, err := gitproviders.NewRepoURL(params.ConfigURL)
+		normalizedConfigRepo, err := gitproviders.NewRepoURL(params.ConfigRepo)
 		if err != nil {
 			return nil, nil, fmt.Errorf("error normalizing url: %w", err)
 		}
 
-		configRepoClient, configRepoErr := authSvc.CreateGitClient(ctx, normalizedConfigUrl, targetName, params.Namespace, params.DryRun)
+		configRepoClient, configRepoErr := authSvc.CreateGitClient(ctx, normalizedConfigRepo, targetName, params.Namespace, params.DryRun)
 		if configRepoErr != nil {
 			return nil, nil, configRepoErr
 		}

--- a/pkg/services/factory_test.go
+++ b/pkg/services/factory_test.go
@@ -59,7 +59,7 @@ var _ = Describe("Services factory", func() {
 
 		It("config type user repo and empty url return error", func() {
 			gitClient, gitProvider, err := factory.GetGitClients(ctx, fakeClient, GitConfigParams{
-				ConfigURL:        "",
+				ConfigRepo:       "",
 				IsHelmRepository: false,
 			})
 

--- a/pkg/services/gitops/install.go
+++ b/pkg/services/gitops/install.go
@@ -19,8 +19,8 @@ import (
 )
 
 type InstallParams struct {
-	Namespace    string
-	DryRun       bool
+	Namespace  string
+	DryRun     bool
 	ConfigRepo string
 }
 

--- a/pkg/services/gitops/install.go
+++ b/pkg/services/gitops/install.go
@@ -21,7 +21,7 @@ import (
 type InstallParams struct {
 	Namespace    string
 	DryRun       bool
-	AppConfigURL string
+	ConfigRepo string
 }
 
 func (g *Gitops) Install(params InstallParams) (map[string][]byte, error) {
@@ -40,7 +40,7 @@ func (g *Gitops) Install(params InstallParams) (map[string][]byte, error) {
 
 	var err error
 
-	if params.AppConfigURL != "" || params.DryRun {
+	if params.ConfigRepo != "" || params.DryRun {
 		// We need to get the manifests to persist in the repo and
 		// non-dry run install doesn't return them
 		fluxManifests, err = g.flux.Install(params.Namespace, true)
@@ -91,7 +91,7 @@ func (g *Gitops) Install(params InstallParams) (map[string][]byte, error) {
 func (g *Gitops) StoreManifests(gitClient git.Git, gitProvider gitproviders.GitProvider, params InstallParams, systemManifests map[string][]byte) (map[string][]byte, error) {
 	ctx := context.Background()
 
-	if !params.DryRun && params.AppConfigURL != "" {
+	if !params.DryRun && params.ConfigRepo != "" {
 		cname, err := g.kube.GetClusterName(ctx)
 		if err != nil {
 			g.logger.Warningf("Cluster name not found, using default : %v", err)
@@ -117,14 +117,14 @@ func (g *Gitops) StoreManifests(gitClient git.Git, gitProvider gitproviders.GitP
 func (g *Gitops) storeManifests(gitClient git.Git, gitProvider gitproviders.GitProvider, params InstallParams, systemManifests map[string][]byte, cname string) (map[string][]byte, error) {
 	ctx := context.Background()
 
-	normalizedURL, err := gitproviders.NewRepoURL(params.AppConfigURL)
+	normalizedURL, err := gitproviders.NewRepoURL(params.ConfigRepo)
 	if err != nil {
-		return nil, fmt.Errorf("failed to convert app config repo %q : %w", params.AppConfigURL, err)
+		return nil, fmt.Errorf("failed to convert app config repo %q : %w", params.ConfigRepo, err)
 	}
 
 	configBranch, err := gitProvider.GetDefaultBranch(ctx, normalizedURL)
 	if err != nil {
-		return nil, fmt.Errorf("could not determine default branch for config repository: %q %w", params.AppConfigURL, err)
+		return nil, fmt.Errorf("could not determine default branch for config repository: %q %w", params.ConfigRepo, err)
 	}
 
 	remover, _, err := gitrepo.CloneRepo(ctx, gitClient, normalizedURL, configBranch)
@@ -165,7 +165,7 @@ func (g *Gitops) storeManifests(gitClient git.Git, gitProvider gitproviders.GitP
 
 	//TODO add handling for PRs
 	// if !params.AutoMerge {
-	//  if err := a.createPullRequestToRepo(info, info.Spec.ConfigURL, appHash, appSpec, appGoat, appSource); err != nil {
+	//  if err := a.createPullRequestToRepo(info, info.Spec.ConfigRepo, appHash, appSpec, appGoat, appSource); err != nil {
 	//      return err
 	//  }
 	// } else {

--- a/pkg/services/gitops/install_test.go
+++ b/pkg/services/gitops/install_test.go
@@ -170,7 +170,7 @@ var _ = Describe("Install", func() {
 	})
 	Context("when app url specified", func() {
 		BeforeEach(func() {
-			installParams.AppConfigURL = "ssh://git@github.com/foo/somevalidrepo.git"
+			installParams.ConfigRepo = "ssh://git@github.com/foo/somevalidrepo.git"
 			fluxClient.InstallReturns(fakeFluxManifests, nil)
 			manifestsByPath = map[string][]byte{}
 
@@ -208,25 +208,25 @@ var _ = Describe("Install", func() {
 	})
 	Context("when app url specified && dry-run", func() {
 		BeforeEach(func() {
-			installParams.AppConfigURL = "ssh://git@github.com/foo/somevalidrepo.git"
+			installParams.ConfigRepo = "ssh://git@github.com/foo/somevalidrepo.git"
 			installParams.DryRun = true
 			fluxClient.InstallReturns(fakeFluxManifests, nil)
 		})
 		It("skips flux install", func() {
 			_, err := gitopsSrv.Install(installParams)
 			Expect(err).ShouldNot(HaveOccurred())
-			Expect(kubeClient.ApplyCallCount()).Should(Equal(0), "With dry-run and app-config-url nothing should be sent to k8s")
+			Expect(kubeClient.ApplyCallCount()).Should(Equal(0), "With dry-run and config-repo nothing should be sent to k8s")
 		})
 		It("writes no manifests to the repo", func() {
 			_, err := gitopsSrv.Install(installParams)
 			Expect(err).ShouldNot(HaveOccurred())
-			Expect(fakeGit.WriteCallCount()).Should(Equal(0), "With dry-run and app-config-url nothing should be written to git")
+			Expect(fakeGit.WriteCallCount()).Should(Equal(0), "With dry-run and config-repo nothing should be written to git")
 		})
 		It("flux manifests are returned", func() {
 			manifests, err := gitopsSrv.Install(installParams)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(manifests["gitops-runtime.yaml"]).To(ContainSubstring(string(fakeFluxManifests)))
-			Expect(fakeGit.WriteCallCount()).Should(Equal(0), "With dry-run and app-config-url nothing should be written to git")
+			Expect(fakeGit.WriteCallCount()).Should(Equal(0), "With dry-run and config-repo nothing should be written to git")
 		})
 	})
 

--- a/pkg/services/gitopswriter/writer_add_test.go
+++ b/pkg/services/gitopswriter/writer_add_test.go
@@ -30,7 +30,7 @@ func createRepoURL(url string) gitproviders.RepoURL {
 }
 
 func createDirWriter() GitOpsDirectoryWriter {
-	repoWriter := gitrepo.NewRepoWriter(app.ConfigURL, gitProviders, gitClient, log)
+	repoWriter := gitrepo.NewRepoWriter(app.ConfigRepo, gitProviders, gitClient, log)
 	automationGen := automation.NewAutomationGenerator(gitProviders, fluxClient, log)
 
 	return NewGitOpsDirectoryWriter(automationGen, repoWriter, osysClient, log)
@@ -92,7 +92,7 @@ var _ = Describe("Add", func() {
 	Context("add app with config in app repo", func() {
 		BeforeEach(func() {
 			app.GitSourceURL = createRepoURL("ssh://git@github.com/foo/bar.git")
-			app.ConfigURL = app.GitSourceURL
+			app.ConfigRepo = app.GitSourceURL
 			gitOpsDirWriter = createDirWriter()
 
 			gitClient.OpenStub = func(s string) (*gogit.Repository, error) {
@@ -172,7 +172,7 @@ var _ = Describe("Add", func() {
 	Context("add app with external config repo", func() {
 		BeforeEach(func() {
 			app.GitSourceURL = createRepoURL("https://github.com/user/repo")
-			app.ConfigURL = createRepoURL("https://github.com/foo/bar")
+			app.ConfigRepo = createRepoURL("https://github.com/foo/bar")
 			gitOpsDirWriter = createDirWriter()
 		})
 
@@ -253,7 +253,7 @@ var _ = Describe("Add", func() {
 
 		Context("uses the default app branch for config in app repository", func() {
 			BeforeEach(func() {
-				app.ConfigURL = app.GitSourceURL
+				app.ConfigRepo = app.GitSourceURL
 				gitOpsDirWriter = createDirWriter()
 			})
 
@@ -268,7 +268,7 @@ var _ = Describe("Add", func() {
 
 		Context("uses the default config branch for external config", func() {
 			BeforeEach(func() {
-				app.ConfigURL = createRepoURL("https://github.com/foo/bar")
+				app.ConfigRepo = createRepoURL("https://github.com/foo/bar")
 				gitOpsDirWriter = createDirWriter()
 			})
 
@@ -300,7 +300,7 @@ var _ = Describe("Add", func() {
 
 		Context("uses the default app branch for config in app repository", func() {
 			BeforeEach(func() {
-				app.ConfigURL = app.GitSourceURL
+				app.ConfigRepo = app.GitSourceURL
 				gitOpsDirWriter = createDirWriter()
 			})
 
@@ -315,7 +315,7 @@ var _ = Describe("Add", func() {
 
 		Context("uses the default config branch for external config", func() {
 			BeforeEach(func() {
-				app.ConfigURL = createRepoURL("https://github.com/foo/bar")
+				app.ConfigRepo = createRepoURL("https://github.com/foo/bar")
 				gitOpsDirWriter = createDirWriter()
 			})
 

--- a/pkg/services/gitopswriter/writer_remove_test.go
+++ b/pkg/services/gitopswriter/writer_remove_test.go
@@ -77,7 +77,7 @@ func removeGOATPath(path string) error {
 }
 
 func createRemoveDirWriter() GitOpsDirectoryWriter {
-	repoWriter := gitrepo.NewRepoWriter(app.ConfigURL, gitProviders, gitClient, log)
+	repoWriter := gitrepo.NewRepoWriter(app.ConfigRepo, gitProviders, gitClient, log)
 	automationSvc := automation.NewAutomationGenerator(gitProviders, realFlux, log)
 
 	return NewGitOpsDirectoryWriter(automationSvc, repoWriter, osysClient, log)
@@ -169,8 +169,8 @@ var _ = Describe("Remove", func() {
 				goatPaths = map[string]bool{}
 			})
 
-			It("removes cluster resources for helm chart from helm repo with configURL = <url>", func() {
-				app.ConfigURL = createRepoURL("ssh://git@github.com/user/external.git")
+			It("removes cluster resources for helm chart from helm repo with configRepo = <url>", func() {
+				app.ConfigRepo = createRepoURL("ssh://git@github.com/user/external.git")
 				app.Path = "loki"
 
 				Expect(runAddAndCollectInfo()).To(Succeed())
@@ -178,9 +178,9 @@ var _ = Describe("Remove", func() {
 				Expect(checkRemoveResults()).To(Succeed())
 			})
 
-			It("removes cluster resources for helm chart from git repo with configURL = <url>", func() {
+			It("removes cluster resources for helm chart from git repo with configRepo = <url>", func() {
 				app.GitSourceURL = createRepoURL("ssh://git@github.com/user/wego-fork-test.git")
-				app.ConfigURL = createRepoURL("ssh://git@github.com/user/external.git")
+				app.ConfigRepo = createRepoURL("ssh://git@github.com/user/external.git")
 				app.Path = "./"
 
 				Expect(runAddAndCollectInfo()).To(Succeed())
@@ -196,7 +196,7 @@ var _ = Describe("Remove", func() {
 						Name:           "wego-fork-test",
 						Namespace:      wego.DefaultNamespace,
 						GitSourceURL:   sourceURL,
-						ConfigURL:      sourceURL,
+						ConfigRepo:     sourceURL,
 						Branch:         "main",
 						Path:           "./",
 						AutomationType: models.AutomationTypeKustomize,
@@ -206,7 +206,7 @@ var _ = Describe("Remove", func() {
 					goatPaths = map[string]bool{}
 				})
 
-				It("removes cluster resources for non-helm app configURL = ''", func() {
+				It("removes cluster resources for non-helm app configRepo = ''", func() {
 					Expect(runAddAndCollectInfo()).To(Succeed())
 					Expect(gitOpsDirWriter.RemoveApplication(context.Background(), app, "test-cluster", true)).To(Succeed())
 					Expect(checkRemoveResults()).To(Succeed())
@@ -221,9 +221,9 @@ var _ = Describe("Remove", func() {
 					Expect(commit.Message).To(Equal(RemoveCommitMessage))
 				})
 
-				It("removes cluster resources for non-helm app with configURL = <url>", func() {
+				It("removes cluster resources for non-helm app with configRepo = <url>", func() {
 					app.GitSourceURL = createRepoURL("ssh://git@github.com/user/wego-fork-test.git")
-					app.ConfigURL = createRepoURL("ssh://git@github.com/user/external.git")
+					app.ConfigRepo = createRepoURL("ssh://git@github.com/user/external.git")
 
 					Expect(runAddAndCollectInfo()).To(Succeed())
 					Expect(gitOpsDirWriter.RemoveApplication(context.Background(), app, "test-cluster", true)).To(Succeed())

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -32,7 +32,7 @@ import (
 )
 
 type UpgradeValues struct {
-	AppConfigURL  string
+	ConfigRepo    string
 	Version       string
 	BaseBranch    string
 	HeadBranch    string
@@ -61,12 +61,12 @@ func upgrade(ctx context.Context, uv UpgradeValues, kube kube.Kube, gitClient gi
 		return fmt.Errorf("failed to get cluster name: %w", err)
 	}
 
-	resources, err := makeHelmResources(uv.Namespace, uv.Version, cname, uv.AppConfigURL, uv.Values)
+	resources, err := makeHelmResources(uv.Namespace, uv.Version, cname, uv.ConfigRepo, uv.Values)
 	if err != nil {
 		return fmt.Errorf("error creating helm resources: %w", err)
 	}
 
-	appResources, err := makeAppsCapiKustomization(uv.Namespace, uv.AppConfigURL)
+	appResources, err := makeAppsCapiKustomization(uv.Namespace, uv.ConfigRepo)
 	if err != nil {
 		return fmt.Errorf("error creating app resources: %w", err)
 	}
@@ -90,9 +90,9 @@ func upgrade(ctx context.Context, uv UpgradeValues, kube kube.Kube, gitClient gi
 		return fmt.Errorf("failed to load credentials for profiles repo from cluster: %v", err)
 	}
 
-	normalizedURL, err := gitproviders.NewRepoURL(uv.AppConfigURL)
+	normalizedURL, err := gitproviders.NewRepoURL(uv.ConfigRepo)
 	if err != nil {
-		return fmt.Errorf("failed to normalize URL %q: %w", uv.AppConfigURL, err)
+		return fmt.Errorf("failed to normalize URL %q: %w", uv.ConfigRepo, err)
 	}
 
 	// Create pull request

--- a/pkg/upgrade/upgrade_test.go
+++ b/pkg/upgrade/upgrade_test.go
@@ -77,7 +77,7 @@ func TestUpgrade(t *testing.T) {
 
 	// Run upgrade!
 	err := upgrade(context.TODO(), UpgradeValues{
-		ConfigRepo:  "https://github.com/test/example.git",
+		ConfigRepo:    "https://github.com/test/example.git",
 		HeadBranch:    "upgrade-to-wge",
 		BaseBranch:    "main",
 		CommitMessage: "Upgrade to wge",

--- a/pkg/upgrade/upgrade_test.go
+++ b/pkg/upgrade/upgrade_test.go
@@ -36,7 +36,7 @@ func TestUpgradeDryRun(t *testing.T) {
 
 	// Run upgrade!
 	err := upgrade(context.TODO(), UpgradeValues{
-		AppConfigURL:  "ssh://git@github.com/my-org/my-management-cluster.git",
+		ConfigRepo:    "ssh://git@github.com/my-org/my-management-cluster.git",
 		HeadBranch:    "upgrade-to-wge",
 		BaseBranch:    "main",
 		CommitMessage: "Upgrade to wge",
@@ -77,7 +77,7 @@ func TestUpgrade(t *testing.T) {
 
 	// Run upgrade!
 	err := upgrade(context.TODO(), UpgradeValues{
-		AppConfigURL:  "https://github.com/test/example.git",
+		ConfigRepo:  "https://github.com/test/example.git",
 		HeadBranch:    "upgrade-to-wge",
 		BaseBranch:    "main",
 		CommitMessage: "Upgrade to wge",

--- a/test/acceptance/test/add_tests.go
+++ b/test/acceptance/test/add_tests.go
@@ -149,11 +149,11 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 
 		By("Then I should see error message", func() {
-			Eventually(errOutput).Should(ContainSubstring("required flag(s) \"app-config-url\", \"version\" not set"))
+			Eventually(errOutput).Should(ContainSubstring("required flag(s) \"config-repo\", \"version\" not set"))
 		})
 
 		By("When I try to upgrade gitops core to enterprise with config-repo & version provided", func() {
-			_, errOutput = runCommandAndReturnStringOutput(WEGO_BIN_PATH + " upgrade --app-config-url=" + appRepoRemoteURL + " --version=0.0.1")
+			_, errOutput = runCommandAndReturnStringOutput(WEGO_BIN_PATH + " upgrade --config-repo=" + appRepoRemoteURL + " --version=0.0.1")
 		})
 
 		By("Then I should see error message", func() {
@@ -332,7 +332,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 
 	})
 
-	It("Test1 - Verify that gitops can deploy an app with specified config-url and app-config-url set to <url>", func() {
+	It("Test1 - Verify that gitops can deploy an app with specified config-url and config-repo set to <url>", func() {
 		var repoAbsolutePath string
 		var configRepoRemoteURL string
 		private := true
@@ -342,7 +342,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		appRepoRemoteURL := "https://github.com/" + GITHUB_ORG + "/" + tip.appRepoName + ".git"
 		configRepoRemoteURL = "https://github.com/" + GITHUB_ORG + "/" + appConfigRepoName + ".git"
 
-		addCommand := "add app --url=" + appRepoRemoteURL + " --app-config-url=" + configRepoRemoteURL + " --auto-merge=true"
+		addCommand := "add app --url=" + appRepoRemoteURL + " --config-repo=" + configRepoRemoteURL + " --auto-merge=true"
 
 		defer deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
 		defer deleteRepo(appConfigRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
@@ -371,7 +371,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 			installAndVerifyWego(WEGO_DEFAULT_NAMESPACE, configRepoRemoteURL)
 		})
 
-		By("And I run gitops add command with --url and --app-config-url params", func() {
+		By("And I run gitops add command with --url and --config-repo params", func() {
 			runWegoAddCommand(repoAbsolutePath+"/../", addCommand, WEGO_DEFAULT_NAMESPACE)
 		})
 
@@ -381,7 +381,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 	})
 
-	It("Test2 - Verify that gitops can deploy and remove a gitlab app with specified config-url and app-config-url set to <url>", func() {
+	It("Test2 - Verify that gitops can deploy and remove a gitlab app with specified config-url and config-repo set to <url>", func() {
 		var repoAbsolutePath string
 		var configRepoRemoteURL string
 		var appRemoveOutput string
@@ -392,7 +392,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		appRepoRemoteURL := "ssh://git@gitlab.com/" + GITLAB_ORG + "/" + tip.appRepoName + ".git"
 		configRepoRemoteURL = "ssh://git@gitlab.com/" + GITLAB_ORG + "/" + appConfigRepoName + ".git"
 
-		addCommand := "add app --url=" + appRepoRemoteURL + " --app-config-url=" + configRepoRemoteURL + " --auto-merge=true"
+		addCommand := "add app --url=" + appRepoRemoteURL + " --config-repo=" + configRepoRemoteURL + " --auto-merge=true"
 
 		defer deleteRepo(tip.appRepoName, gitproviders.GitProviderGitLab, GITLAB_ORG)
 		defer deleteRepo(appConfigRepoName, gitproviders.GitProviderGitHub, GITLAB_ORG)
@@ -425,7 +425,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 			installAndVerifyWego(WEGO_DEFAULT_NAMESPACE, configRepoRemoteURL)
 		})
 
-		By("And I run gitops add command with --url and --app-config-url params", func() {
+		By("And I run gitops add command with --url and --config-repo params", func() {
 			runWegoAddCommand(repoAbsolutePath+"/../", addCommand, WEGO_DEFAULT_NAMESPACE)
 		})
 
@@ -449,7 +449,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 	})
 
-	It("Test1 - Verify that gitops can deploy an app with specified config-url and app-config-url set to default", func() {
+	It("Test1 - Verify that gitops can deploy an app with specified config-url and config-repo set to default", func() {
 		var repoAbsolutePath string
 		private := false
 		tip := generateTestInputs()
@@ -664,7 +664,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		appName1 := appRepoName1
 		appName2 := appRepoName2
 
-		addCommand := "add app . --app-config-url=" + configRepoRemoteURL + " --auto-merge=true"
+		addCommand := "add app . --config-repo=" + configRepoRemoteURL + " --auto-merge=true"
 
 		defer deleteRepo(appRepoName1, gitproviders.GitProviderGitHub, GITHUB_ORG)
 		defer deleteRepo(appRepoName2, gitproviders.GitProviderGitHub, GITHUB_ORG)
@@ -763,7 +763,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 	})
 
-	It("Test3 - Verify that gitops can deploy an app with app-config-url set to <url>", func() {
+	It("Test3 - Verify that gitops can deploy an app with config-repo set to <url>", func() {
 		var repoAbsolutePath string
 		var configRepoRemoteURL string
 		var listOutput string
@@ -788,9 +788,9 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		appName3 := "loki"
 		workloadName3 := "loki-0"
 
-		addCommand1 := "add app . --app-config-url=" + configRepoRemoteURL + " --auto-merge=true"
-		addCommand2 := "add app . --deployment-type=helm --path=./hello-world --name=" + appName2 + " --app-config-url=" + configRepoRemoteURL + " --auto-merge=true"
-		addCommand3 := "add app --url=" + helmRepoURL + " --chart=" + appName3 + " --app-config-url=" + configRepoRemoteURL + " --auto-merge=true"
+		addCommand1 := "add app . --config-repo=" + configRepoRemoteURL + " --auto-merge=true"
+		addCommand2 := "add app . --deployment-type=helm --path=./hello-world --name=" + appName2 + " --config-repo=" + configRepoRemoteURL + " --auto-merge=true"
+		addCommand3 := "add app --url=" + helmRepoURL + " --chart=" + appName3 + " --config-repo=" + configRepoRemoteURL + " --auto-merge=true"
 
 		defer deleteRepo(appFilesRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
 		defer deleteRepo(appConfigRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
@@ -946,7 +946,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		appRepoRemoteURL := "ssh://git@github.com/" + GITHUB_ORG + "/" + tip1.appRepoName + ".git"
 
 		addCommand1 := "add app . --name=" + appName1 + " --auto-merge=true"
-		addCommand2 := "add app . --name=" + appName2 + " --auto-merge=true --app-config-url=" + appRepoRemoteURL
+		addCommand2 := "add app . --name=" + appName2 + " --auto-merge=true --config-repo=" + appRepoRemoteURL
 
 		defer deleteRepo(tip1.appRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
 		defer deleteRepo(tip2.appRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
@@ -1135,7 +1135,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 	})
 
-	It("Verify that gitops can deploy a helm app from a git repo with app-config-url set to default", func() {
+	It("Verify that gitops can deploy a helm app from a git repo with config-repo set to default", func() {
 		var repoAbsolutePath string
 		public := false
 		appName := "my-helm-app"
@@ -1175,7 +1175,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 	})
 
-	It("Test3 - Verify that gitops can deploy a helm app from a git repo with app-config-url set to <url>", func() {
+	It("Test3 - Verify that gitops can deploy a helm app from a git repo with config-repo set to <url>", func() {
 		var repoAbsolutePath string
 		var configRepoAbsolutePath string
 		private := true
@@ -1186,7 +1186,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		configRepoName := "wego-test-config-repo-" + RandString(8)
 		configRepoUrl := fmt.Sprintf("ssh://git@github.com/%s/%s.git", os.Getenv("GITHUB_ORG"), configRepoName)
 
-		addCommand := fmt.Sprintf("add app . --app-config-url=%s --deployment-type=helm --path=./hello-world --name=%s --auto-merge=true", configRepoUrl, appName)
+		addCommand := fmt.Sprintf("add app . --config-repo=%s --deployment-type=helm --path=./hello-world --name=%s --auto-merge=true", configRepoUrl, appName)
 
 		defer deleteRepo(appRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
 		defer deleteRepo(configRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
@@ -1235,7 +1235,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 
 	})
 
-	It("Test3 - Verify that gitops can deploy multiple helm apps from a helm repo with app-config-url set to <url>", func() {
+	It("Test3 - Verify that gitops can deploy multiple helm apps from a helm repo with config-repo set to <url>", func() {
 		var repoAbsolutePath string
 		var listOutput string
 		var appStatus1 string
@@ -1254,8 +1254,8 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 
 		invalidAddCommand := "add app --url=" + helmRepoURL + " --chart=" + appName1 + " --auto-merge=true"
 
-		addCommand1 := "add app --url=" + helmRepoURL + " --chart=" + appName1 + " --app-config-url=" + appRepoRemoteURL + " --auto-merge=true --helm-release-target-namespace=" + workloadNamespace
-		addCommand2 := "add app --url=" + helmRepoURL + " --chart=" + appName2 + " --app-config-url=" + appRepoRemoteURL + " --auto-merge=true --helm-release-target-namespace=" + workloadNamespace
+		addCommand1 := "add app --url=" + helmRepoURL + " --chart=" + appName1 + " --config-repo=" + appRepoRemoteURL + " --auto-merge=true --helm-release-target-namespace=" + workloadNamespace
+		addCommand2 := "add app --url=" + helmRepoURL + " --chart=" + appName2 + " --config-repo=" + appRepoRemoteURL + " --auto-merge=true --helm-release-target-namespace=" + workloadNamespace
 
 		defer deleteNamespace(workloadNamespace)
 		defer deletePersistingHelmApp(WEGO_DEFAULT_NAMESPACE, workloadName1, EVENTUALLY_DEFAULT_TIMEOUT)
@@ -1285,9 +1285,9 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 			Eventually(out).Should(ContainSubstring("namespace/" + workloadNamespace + " created"))
 		})
 
-		By("And I add an invalid entry without --app-config-url set", func() {
+		By("And I add an invalid entry without --config-repo set", func() {
 			_, err := runWegoAddCommandWithOutput(repoAbsolutePath, invalidAddCommand, WEGO_DEFAULT_NAMESPACE)
-			Eventually(err).Should(ContainSubstring("--app-config-url should be provided"))
+			Eventually(err).Should(ContainSubstring("--config-repo should be provided"))
 		})
 
 		By("And I run gitops add app command for 1st app", func() {
@@ -1523,7 +1523,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 	})
 
-	It("Test2 - Verify that a PR can be raised against an external repo with app-config-url set to <url>", func() {
+	It("Test2 - Verify that a PR can be raised against an external repo with config-repo set to <url>", func() {
 		var repoAbsolutePath string
 		var configRepoRemoteURL string
 		var appConfigRepoAbsPath string
@@ -1534,7 +1534,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		appConfigRepoName := "wego-config-repo-" + RandString(8)
 		configRepoRemoteURL = "ssh://git@github.com/" + GITHUB_ORG + "/" + appConfigRepoName + ".git"
 
-		addCommand := "add app . --app-config-url=" + configRepoRemoteURL
+		addCommand := "add app . --config-repo=" + configRepoRemoteURL
 
 		defer deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
 		defer deleteRepo(appConfigRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
@@ -1559,7 +1559,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 			installAndVerifyWego(WEGO_DEFAULT_NAMESPACE, configRepoRemoteURL)
 		})
 
-		By("And I run gitops add command with --app-config-url param", func() {
+		By("And I run gitops add command with --config-repo param", func() {
 			output, _ := runWegoAddCommandWithOutput(repoAbsolutePath, addCommand, WEGO_DEFAULT_NAMESPACE)
 			re := regexp.MustCompile(`(http|https):\/\/([\w\-_]+(?:(?:\.[\w\-_]+)+))([\w\-\.,@?^=%&amp;:/~\+#]*[\w\-\@?^=%&amp;/~\+#])?`)
 			prLink = re.FindAllString(output, 1)[0]
@@ -1659,7 +1659,7 @@ var _ = Describe("Weave GitOps Add Tests With Long Cluster Name", func() {
 		})
 	})
 
-	It("SmokeTestLong - Verify that gitops can deploy an app with app-config-url set to <url>", func() {
+	It("SmokeTestLong - Verify that gitops can deploy an app with config-repo set to <url>", func() {
 		var repoAbsolutePath string
 		var configRepoRemoteURL string
 		var listOutput string
@@ -1675,7 +1675,7 @@ var _ = Describe("Weave GitOps Add Tests With Long Cluster Name", func() {
 		workloadNamespace := tip.workloadNamespace
 		appManifestFilePath := tip.appManifestFilePath
 
-		addCommand := "add app . --app-config-url=" + configRepoRemoteURL + " --auto-merge=true"
+		addCommand := "add app . --config-repo=" + configRepoRemoteURL + " --auto-merge=true"
 
 		defer deleteRepo(appFilesRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
 		defer deleteRepo(appConfigRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)
@@ -1743,7 +1743,7 @@ var _ = Describe("Weave GitOps Add Tests With Long Cluster Name", func() {
 		})
 	})
 
-	It("SmokeTestShort - Verify that gitops can deploy an app with app-config-url set to a gitlab <url>", func() {
+	It("SmokeTestShort - Verify that gitops can deploy an app with config-repo set to a gitlab <url>", func() {
 		var repoAbsolutePath string
 		var configRepoRemoteURL string
 		var listOutput string
@@ -1759,7 +1759,7 @@ var _ = Describe("Weave GitOps Add Tests With Long Cluster Name", func() {
 		workloadNamespace := tip.workloadNamespace
 		appManifestFilePath := tip.appManifestFilePath
 
-		addCommand := "add app . --app-config-url=" + configRepoRemoteURL + " --auto-merge=true"
+		addCommand := "add app . --config-repo=" + configRepoRemoteURL + " --auto-merge=true"
 
 		defer deleteRepo(appFilesRepoName, gitproviders.GitProviderGitLab, GITLAB_ORG)
 		defer deleteRepo(appConfigRepoName, gitproviders.GitProviderGitLab, GITLAB_ORG)

--- a/test/acceptance/test/help_tests.go
+++ b/test/acceptance/test/help_tests.go
@@ -82,7 +82,7 @@ var _ = XDescribe("WEGO Help Tests", func() {
 			Eventually(stringOutput).Should(MatchRegexp(`Associates an additional application in a git repository with a gitops cluster so that its contents may be managed via GitOps\n*Usage:`))
 			Eventually(stringOutput).Should(MatchRegexp(`gitops add app \[--name <name>] \[--url <url>] \[--branch <branch>] \[--path <path within repository>] \ <repository directory> \[flags]`))
 			Eventually(stringOutput).Should(MatchRegexp(`Examples:\ngitops add app .\n*Flags:`))
-			Eventually(stringOutput).Should(MatchRegexp(`--app-config-url string\s*URL of external repository \(if any\) which will hold automation manifests`))
+			Eventually(stringOutput).Should(MatchRegexp(`--config-repo string\s*URL of external repository \(if any\) which will hold automation manifests`))
 			Eventually(stringOutput).Should(MatchRegexp(`--auto-merge\s*If set, 'gitops add app' will merge automatically into the set`))
 			Eventually(stringOutput).Should(MatchRegexp(`--branch\n\s*--branch string\s*Branch to watch within git repository \(default "main"\)`))
 			Eventually(stringOutput).Should(MatchRegexp(`--chart string\s*Specify chart for helm source`))

--- a/test/acceptance/test/install_tests.go
+++ b/test/acceptance/test/install_tests.go
@@ -40,7 +40,7 @@ var _ = Describe("Weave GitOps Install Tests", func() {
 
 		By("Then I should see gitops help text displayed for 'install' command", func() {
 			Eventually(string(sessionOutput.Wait().Out.Contents())).Should(MatchRegexp(
-				fmt.Sprintf(`The install command deploys GitOps in the specified namespace,\nadds a cluster entry to the GitOps repo, and persists the GitOps runtime into the\nrepo. If a previous version is installed, then an in-place upgrade will be performed.\n*Usage:\n\s*gitops install \[flags]\n*Examples:\n\s*# Install GitOps in the %s namespace\n\s*gitops install --app-config-url=ssh://git@github.com/me/mygitopsrepo.git\n*Flags:\n\s*--app-config-url string\s*URL of external repository that will hold automation manifests\n\s*--dry-run\s*Outputs all the manifests that would be installed\n\s*-h, --help\s*help for install\n*Global Flags:\n\s*-e, --endpoint string\s*The Weave GitOps Enterprise HTTP API endpoint\n\s*--namespace string\s*The namespace scope for this operation \(default "%s"\)\n\s*-v, --verbose\s*Enable verbose output`, wego.DefaultNamespace, wego.DefaultNamespace)))
+				fmt.Sprintf(`The install command deploys GitOps in the specified namespace,\nadds a cluster entry to the GitOps repo, and persists the GitOps runtime into the\nrepo. If a previous version is installed, then an in-place upgrade will be performed.\n*Usage:\n\s*gitops install \[flags]\n*Examples:\n\s*# Install GitOps in the %s namespace\n\s*gitops install --config-repo=ssh://git@github.com/me/mygitopsrepo.git\n*Flags:\n\s*--config-repo string\s*URL of external repository that will hold automation manifests\n\s*--dry-run\s*Outputs all the manifests that would be installed\n\s*-h, --help\s*help for install\n*Global Flags:\n\s*-e, --endpoint string\s*The Weave GitOps Enterprise HTTP API endpoint\n\s*--namespace string\s*The namespace scope for this operation \(default "%s"\)\n\s*-v, --verbose\s*Enable verbose output`, wego.DefaultNamespace, wego.DefaultNamespace)))
 		})
 	})
 
@@ -73,7 +73,7 @@ var _ = Describe("Weave GitOps Install Tests", func() {
 		})
 
 		By("And I run 'gitops install' command", func() {
-			_, errOutput = runCommandAndReturnStringOutput(WEGO_BIN_PATH + " install --app-config-url=ssh://git@github.com/user/repo.git")
+			_, errOutput = runCommandAndReturnStringOutput(WEGO_BIN_PATH + " install --config-repo=ssh://git@github.com/user/repo.git")
 		})
 
 		By("Then I should see a quitting message", func() {
@@ -198,7 +198,7 @@ var _ = Describe("Weave GitOps Install Tests", func() {
 		_ = initAndCreateEmptyRepo(tip.appRepoName, gitproviders.GitProviderGitHub, private, GITHUB_ORG)
 
 		By("When I try to install gitops in dry-run mode", func() {
-			installDryRunOutput, _ = runCommandAndReturnStringOutput(WEGO_BIN_PATH + fmt.Sprintf(" install --dry-run --app-config-url=%s", appRepoRemoteURL))
+			installDryRunOutput, _ = runCommandAndReturnStringOutput(WEGO_BIN_PATH + fmt.Sprintf(" install --dry-run --config-repo=%s", appRepoRemoteURL))
 		})
 
 		By("Then I should see install dry-run output in the console", func() {

--- a/test/acceptance/test/pages/add_application_page.go
+++ b/test/acceptance/test/pages/add_application_page.go
@@ -23,7 +23,7 @@ func GetAddAppPageElements(webDriver *agouti.Page) *AddAppPageElements {
 		AppName:              webDriver.FindByID("name"),
 		AppNamespace:         webDriver.FindByID("namespace"),
 		AppRepoURL:           webDriver.FindByID("url"),
-		ConfigRepoURL:        webDriver.FindByID("configUrl"),
+		ConfigRepoURL:        webDriver.FindByID("configRepo"),
 		PathToManifests:      webDriver.FindByID("path"),
 		Branch:               webDriver.FindByID("branch"),
 		AutoMergeCheck:       webDriver.FindByXPath(`//input[@type="checkbox" and contains(@class, 'MuiSwitch-input')]`),

--- a/test/acceptance/test/ui_tests.go
+++ b/test/acceptance/test/ui_tests.go
@@ -150,7 +150,7 @@ var _ = XDescribe("Weave GitOps UI Test", func() {
 		helmRepoURL := "https://charts.kube-ops.io"
 		appDetailsPage := pages.GetAppDetailsPageElements(webDriver)
 
-		addCommand1 := "add app --url=" + helmRepoURL + " --chart=" + appName1 + " --app-config-url=" + appRepoRemoteURL + " --auto-merge=true"
+		addCommand1 := "add app --url=" + helmRepoURL + " --chart=" + appName1 + " --config-repo=" + appRepoRemoteURL + " --auto-merge=true"
 		addCommand2 := "add app . --deployment-type=kustomize --auto-merge=true"
 
 		defer deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, GITHUB_ORG)

--- a/test/acceptance/test/utils.go
+++ b/test/acceptance/test/utils.go
@@ -400,7 +400,7 @@ func VerifyControllersInCluster(namespace string) {
 
 func installAndVerifyWego(wegoNamespace, repoURL string) {
 	By("And I run 'gitops install' command with namespace "+wegoNamespace, func() {
-		command := exec.Command("sh", "-c", fmt.Sprintf("%s install --namespace=%s --app-config-url=%s", WEGO_BIN_PATH, wegoNamespace, repoURL))
+		command := exec.Command("sh", "-c", fmt.Sprintf("%s install --namespace=%s --config-repo=%s", WEGO_BIN_PATH, wegoNamespace, repoURL))
 		session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 		Expect(err).ShouldNot(HaveOccurred())
 		Eventually(session, INSTALL_SUCCESSFUL_TIMEOUT).Should(gexec.Exit())

--- a/test/integration/server/add_test.go
+++ b/test/integration/server/add_test.go
@@ -126,7 +126,7 @@ var _ = Describe("AddApplication", func() {
 					URL:            req.Url,
 					Branch:         req.Branch,
 					Path:           req.Path,
-					ConfigURL:      req.Url,
+					ConfigRepo:     req.Url,
 					DeploymentType: wego.DeploymentTypeKustomize,
 					SourceType:     wego.SourceTypeGit,
 				}
@@ -154,12 +154,12 @@ var _ = Describe("AddApplication", func() {
 				defer func() { Expect(sourceRepo.Delete(ctx)).To(Succeed()) }()
 
 				req := &pb.AddApplicationRequest{
-					Name:      "my-app",
-					Namespace: namespace.Name,
-					Url:       sourceRef.GetCloneURL(gitprovider.TransportTypeSSH) + ".git",
-					Branch:    "main",
-					Path:      "k8s/overlays/development",
-					ConfigUrl: configRef.GetCloneURL(gitprovider.TransportTypeSSH) + ".git",
+					Name:       "my-app",
+					Namespace:  namespace.Name,
+					Url:        sourceRef.GetCloneURL(gitprovider.TransportTypeSSH) + ".git",
+					Branch:     "main",
+					Path:       "k8s/overlays/development",
+					ConfigRepo: configRef.GetCloneURL(gitprovider.TransportTypeSSH) + ".git",
 				}
 
 				res, err := client.AddApplication(ctx, req)
@@ -189,7 +189,7 @@ var _ = Describe("AddApplication", func() {
 					URL:            normalizedUrl.String(),
 					Branch:         req.Branch,
 					Path:           req.Path,
-					ConfigURL:      req.ConfigUrl,
+					ConfigRepo:     req.ConfigRepo,
 					DeploymentType: wego.DeploymentTypeKustomize,
 					SourceType:     wego.SourceTypeGit,
 				}
@@ -279,7 +279,7 @@ var _ = Describe("AddApplication", func() {
 					URL:            req.Url,
 					Branch:         req.Branch,
 					Path:           req.Path,
-					ConfigURL:      ref.GetCloneURL(gitprovider.TransportTypeSSH) + ".git",
+					ConfigRepo:     ref.GetCloneURL(gitprovider.TransportTypeSSH) + ".git",
 					DeploymentType: wego.DeploymentTypeKustomize,
 					SourceType:     wego.SourceTypeGit,
 				}
@@ -335,13 +335,13 @@ var _ = Describe("AddApplication", func() {
 				defer func() { Expect(sourceRepo.Delete(ctx)).To(Succeed()) }()
 
 				req := &pb.AddApplicationRequest{
-					Name:      "my-app",
-					Namespace: namespace.Name,
-					Url:       sourceRef.GetCloneURL(gitprovider.TransportTypeSSH) + ".git",
-					Branch:    "main",
-					Path:      "k8s/overlays/development",
-					ConfigUrl: configRef.GetCloneURL(gitprovider.TransportTypeSSH) + ".git",
-					AutoMerge: true,
+					Name:       "my-app",
+					Namespace:  namespace.Name,
+					Url:        sourceRef.GetCloneURL(gitprovider.TransportTypeSSH) + ".git",
+					Branch:     "main",
+					Path:       "k8s/overlays/development",
+					ConfigRepo: configRef.GetCloneURL(gitprovider.TransportTypeSSH) + ".git",
+					AutoMerge:  true,
 				}
 
 				res, err := client.AddApplication(ctx, req)
@@ -376,7 +376,7 @@ var _ = Describe("AddApplication", func() {
 					URL:            req.Url,
 					Branch:         req.Branch,
 					Path:           req.Path,
-					ConfigURL:      req.ConfigUrl,
+					ConfigRepo:     req.ConfigRepo,
 					DeploymentType: wego.DeploymentTypeKustomize,
 					SourceType:     wego.SourceTypeGit,
 				}
@@ -507,7 +507,7 @@ var _ = Describe("AddApplication", func() {
 					URL:            req.Url,
 					Branch:         req.Branch,
 					Path:           req.Path,
-					ConfigURL:      req.Url,
+					ConfigRepo:     req.Url,
 					DeploymentType: wego.DeploymentTypeKustomize,
 					SourceType:     wego.SourceTypeGit,
 				}
@@ -545,12 +545,12 @@ var _ = Describe("AddApplication", func() {
 				defer func() { Expect(sourceRepo.Delete(ctx)).To(Succeed()) }()
 
 				req := &pb.AddApplicationRequest{
-					Name:      "my-app",
-					Namespace: namespace.Name,
-					Url:       sourceRef.GetCloneURL(gitprovider.TransportTypeSSH) + ".git",
-					Branch:    "main",
-					Path:      "k8s/overlays/development",
-					ConfigUrl: configRef.GetCloneURL(gitprovider.TransportTypeSSH) + ".git",
+					Name:       "my-app",
+					Namespace:  namespace.Name,
+					Url:        sourceRef.GetCloneURL(gitprovider.TransportTypeSSH) + ".git",
+					Branch:     "main",
+					Path:       "k8s/overlays/development",
+					ConfigRepo: configRef.GetCloneURL(gitprovider.TransportTypeSSH) + ".git",
 				}
 
 				res, err := client.AddApplication(ctx, req)
@@ -580,7 +580,7 @@ var _ = Describe("AddApplication", func() {
 					URL:            normalizedUrl.String(),
 					Branch:         req.Branch,
 					Path:           req.Path,
-					ConfigURL:      req.ConfigUrl,
+					ConfigRepo:     req.ConfigRepo,
 					DeploymentType: wego.DeploymentTypeKustomize,
 					SourceType:     wego.SourceTypeGit,
 				}

--- a/ui/lib/api/applications/applications.pb.ts
+++ b/ui/lib/api/applications/applications.pb.ts
@@ -125,7 +125,7 @@ export type AddApplicationRequest = {
   url?: string
   branch?: string
   autoMerge?: boolean
-  configUrl?: string
+  configRepo?: string
 }
 
 export type AddApplicationResponse = {

--- a/ui/pages/ApplicationAdd.tsx
+++ b/ui/pages/ApplicationAdd.tsx
@@ -133,7 +133,7 @@ function AddApplication({ className }: Props) {
     path: "./",
     branch: "main",
     url: "",
-    configUrl: "",
+    configRepo: "",
     autoMerge: false,
     provider: null,
   };
@@ -172,7 +172,7 @@ function AddApplication({ className }: Props) {
       return;
     }
     const repoURL = convertGitURLToGitProvider(
-      formState.configUrl || formState.url
+      formState.configRepo || formState.url
     );
 
     setPrLink(`${repoURL.replace(".git", "")}/pulls`);
@@ -276,13 +276,13 @@ function AddApplication({ className }: Props) {
                 onChange={(e) => {
                   setFormState({
                     ...formState,
-                    configUrl: e.currentTarget.value,
+                    configRepo: e.currentTarget.value,
                   });
                 }}
-                id="configUrl"
+                id="configRepo"
                 label="Config Repo URL"
                 variant="standard"
-                value={formState.configUrl}
+                value={formState.configRepo}
               />
               <FormHelperText>
                 The git repository URL to which Weave GitOps will write the


### PR DESCRIPTION
<!-- Use # to add the issue this pull request is related to -->
Closes: #1095 

<!-- Describe what has changed in this PR -->
**What changed?**

Any references to `--app-config-url` or `AppConfigURL` have been replaced with `config-repo` or `ConfigRepo`

<!-- Tell your future self why have you made these changes -->
**Why?**

For better user experience

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**
- Locally
- CI

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
**Release notes**

The flag change should be notified to teams that will be testing/using it

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**

Weave GitOps docs need to be updated