### PR TITLE
Improve Graph Zoom Functionality

### DIFF
--- a/ui/components/DirectedGraph.tsx
+++ b/ui/components/DirectedGraph.tsx
@@ -1,3 +1,4 @@
+import { Slider } from "@material-ui/core";
 import * as d3 from "d3";
 import dagreD3 from "dagre-d3";
 import _ from "lodash";
@@ -15,6 +16,17 @@ type Props<N> = {
   labelShape: "rect" | "ellipse";
 };
 
+const GraphSlider = styled(Slider)`
+  &.MuiSlider-root {
+    &.MuiSlider-vertical {
+      position: relative;
+      height: 150px;
+      left: 95%;
+      top: 5vh;
+    }
+  }
+`;
+
 function DirectedGraph<T>({
   className,
   nodes,
@@ -26,6 +38,8 @@ function DirectedGraph<T>({
   labelShape,
 }: Props<T>) {
   const svgRef = React.useRef();
+
+  const [zoomPercent, setZoomPercent] = React.useState(0);
 
   React.useEffect(() => {
     if (!svgRef.current) {
@@ -74,16 +88,26 @@ function DirectedGraph<T>({
 
     // Set up zoom support
     const zoom = d3.zoom().on("zoom", (e) => {
+      e.transform.k = zoomPercent / 100;
       svg.select("g").attr("transform", e.transform);
     });
 
-    svg.call(zoom).call(zoom.transform, d3.zoomIdentity.scale(scale));
+    svg
+      .call(zoom)
+      .call(zoom.transform, d3.zoomIdentity.scale(scale))
+      .on("wheel.zoom", null);
 
     // Run the renderer. This is what draws the final graph.
     render(d3.select("svg g"), graph);
-  }, [svgRef.current, nodes, edges]);
+  }, [svgRef.current, nodes, edges, zoomPercent]);
   return (
     <div className={className}>
+      <GraphSlider
+        onChange={(e, value: number) => setZoomPercent(value)}
+        defaultValue={0}
+        orientation="vertical"
+        aria-label="zoom"
+      />
       <svg width={width} height={height} ref={svgRef} />
     </div>
   );

--- a/ui/components/DirectedGraph.tsx
+++ b/ui/components/DirectedGraph.tsx
@@ -20,12 +20,11 @@ type Props<N> = {
 };
 
 const SliderFlex = styled(Flex)`
-  position: absolute;
+  position: relative;
   min-height: 200px;
   height: 15vh;
   width: 5%;
-  left: 90%;
-  top: 25vh;
+  top: 150px;
 `;
 
 const PercentFlex = styled(Flex)`
@@ -109,7 +108,8 @@ function DirectedGraph<T>({
     render(d3.select("svg g"), graph);
   }, [svgRef.current, nodes, edges, zoomPercent]);
   return (
-    <div className={className}>
+    <Flex className={className}>
+      <svg width={width} height={height} ref={svgRef} />
       <SliderFlex column align>
         <Slider
           onChange={(e, value: number) => setZoomPercent(value)}
@@ -120,8 +120,7 @@ function DirectedGraph<T>({
         <Spacer padding="base" />
         <PercentFlex>{zoomPercent}%</PercentFlex>
       </SliderFlex>
-      <svg width={width} height={height} ref={svgRef} />
-    </div>
+    </Flex>
   );
 }
 

--- a/ui/components/DirectedGraph.tsx
+++ b/ui/components/DirectedGraph.tsx
@@ -1,9 +1,12 @@
-import { Slider } from "@material-ui/core";
+import Slider from "@material-ui/core/Slider";
 import * as d3 from "d3";
 import dagreD3 from "dagre-d3";
 import _ from "lodash";
 import * as React from "react";
 import styled from "styled-components";
+import { muiTheme } from "../lib/theme";
+import Flex from "./Flex";
+import Spacer from "./Spacer";
 
 type Props<N> = {
   className?: string;
@@ -16,15 +19,20 @@ type Props<N> = {
   labelShape: "rect" | "ellipse";
 };
 
-const GraphSlider = styled(Slider)`
-  &.MuiSlider-root {
-    &.MuiSlider-vertical {
-      position: relative;
-      height: 150px;
-      left: 95%;
-      top: 5vh;
-    }
-  }
+const SliderFlex = styled(Flex)`
+  position: absolute;
+  min-height: 200px;
+  height: 15vh;
+  width: 5%;
+  left: 90%;
+  top: 25vh;
+`;
+
+const PercentFlex = styled(Flex)`
+  color: ${muiTheme.palette.primary.main};
+  padding: 10px;
+  background: rgba(0, 179, 236, 0.1);
+  border-radius: 2px;
 `;
 
 function DirectedGraph<T>({
@@ -39,7 +47,7 @@ function DirectedGraph<T>({
 }: Props<T>) {
   const svgRef = React.useRef();
 
-  const [zoomPercent, setZoomPercent] = React.useState(0);
+  const [zoomPercent, setZoomPercent] = React.useState(30);
 
   React.useEffect(() => {
     if (!svgRef.current) {
@@ -88,7 +96,7 @@ function DirectedGraph<T>({
 
     // Set up zoom support
     const zoom = d3.zoom().on("zoom", (e) => {
-      e.transform.k = zoomPercent / 100;
+      e.transform.k = (zoomPercent + 30) / 100;
       svg.select("g").attr("transform", e.transform);
     });
 
@@ -102,12 +110,16 @@ function DirectedGraph<T>({
   }, [svgRef.current, nodes, edges, zoomPercent]);
   return (
     <div className={className}>
-      <GraphSlider
-        onChange={(e, value: number) => setZoomPercent(value)}
-        defaultValue={0}
-        orientation="vertical"
-        aria-label="zoom"
-      />
+      <SliderFlex column align>
+        <Slider
+          onChange={(e, value: number) => setZoomPercent(value)}
+          defaultValue={30}
+          orientation="vertical"
+          aria-label="zoom"
+        />
+        <Spacer padding="base" />
+        <PercentFlex>{zoomPercent}%</PercentFlex>
+      </SliderFlex>
       <svg width={width} height={height} ref={svgRef} />
     </div>
   );
@@ -115,18 +127,15 @@ function DirectedGraph<T>({
 
 export default styled(DirectedGraph)`
   overflow: hidden;
-
   text {
     font-weight: 300;
     font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
     font-size: 12px;
   }
-
   .edgePath path {
     stroke: #333;
     stroke-width: 1.5px;
   }
-
   foreignObject {
     display: flex;
     flex-direction: column;

--- a/ui/components/DirectedGraph.tsx
+++ b/ui/components/DirectedGraph.tsx
@@ -128,6 +128,10 @@ export default styled(DirectedGraph)`
   }
 
   foreignObject {
+    display: flex;
+    flex-direction: column;
+    width: 125px;
+    height: 125px;
     overflow: visible;
   }
 `;

--- a/ui/components/Input.tsx
+++ b/ui/components/Input.tsx
@@ -8,7 +8,7 @@ import styled from "styled-components";
 
 export type InputProps = TextFieldProps;
 
-function Input(props: InputProps) {
+function Input({ ...props }: InputProps) {
   return <TextField {...props} />;
 }
 

--- a/ui/components/ReconciliationGraph.tsx
+++ b/ui/components/ReconciliationGraph.tsx
@@ -99,7 +99,7 @@ function ReconciliationGraph({
     <div className={className}>
       <DirectedGraph
         width="100%"
-        height={540}
+        height={640}
         scale={1}
         nodes={nodes}
         edges={edges}

--- a/ui/components/ReconciliationGraph.tsx
+++ b/ui/components/ReconciliationGraph.tsx
@@ -116,7 +116,6 @@ export default styled(ReconciliationGraph)`
   }
 
   .node {
-    position: relative;
     font-size: 16px;
     /* background-color: white; */
     width: 125px;

--- a/ui/lib/theme.ts
+++ b/ui/lib/theme.ts
@@ -98,4 +98,11 @@ export const muiTheme = createTheme({
       disabled: theme.colors.neutral30,
     },
   },
+  overrides: {
+    MuiSlider: {
+      root: {
+        color: "#00B3EC",
+      },
+    },
+  },
 });

--- a/ui/lib/theme.ts
+++ b/ui/lib/theme.ts
@@ -67,8 +67,8 @@ export const GlobalStyle = createGlobalStyle`
   
   body {
     font-family: ${(props) => props.theme.fontFamilies.regular};
-    font-size: ${theme.fontSizes.normal};
-    color: ${theme.colors.black};
+    font-size: ${(props) => props.theme.fontSizes.normal};
+    color: ${(props) => props.theme.colors.black};
     padding: 0;
     margin: 0;
     min-width: fit-content;
@@ -101,7 +101,7 @@ export const muiTheme = createTheme({
   overrides: {
     MuiSlider: {
       root: {
-        color: "#00B3EC",
+        color: theme.colors.primary,
       },
     },
   },


### PR DESCRIPTION
Closes: #1189 
Mouse wheel scroll on ApplicationDetail graph is disabled. Instead, a slider allows the user to zoom in and out, with the percentage displayed below. The graph also now starts in the center!!

![image](https://user-images.githubusercontent.com/65822698/145291282-c6cfe5d2-b65a-4732-bbfd-d4d4befefb94.png)