### PR TITLE
Fix uninstall build error

### DIFF
--- a/manifests/manifests.go
+++ b/manifests/manifests.go
@@ -22,9 +22,8 @@ var (
 )
 
 type Params struct {
-	AppVersion      string
-	ProfilesVersion string
-	Namespace       string
+	AppVersion string
+	Namespace  string
 }
 
 // GenerateManifests generates weave-gitops manifests from a template

--- a/manifests/manifests_test.go
+++ b/manifests/manifests_test.go
@@ -8,9 +8,8 @@ import (
 var _ = Describe("Testing GenerateManifests", func() {
 	It("should contain all the manifests for Wego", func() {
 		params := Params{
-			AppVersion:      "latest",
-			ProfilesVersion: "0.1.0",
-			Namespace:       "my-namespace",
+			AppVersion: "latest",
+			Namespace:  "my-namespace",
 		}
 
 		manifestsBytes, err := GenerateManifests(params)

--- a/pkg/services/gitops/install.go
+++ b/pkg/services/gitops/install.go
@@ -76,9 +76,8 @@ func (g *Gitops) Install(params InstallParams) (map[string][]byte, error) {
 		}
 
 		wegoAppManifests, err := manifests.GenerateManifests(manifests.Params{
-			AppVersion:      version,
-			ProfilesVersion: version,
-			Namespace:       params.Namespace,
+			AppVersion: version,
+			Namespace:  params.Namespace,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("error generating wego-app manifests, %w", err)

--- a/pkg/services/gitops/uninstall.go
+++ b/pkg/services/gitops/uninstall.go
@@ -32,7 +32,7 @@ func (g *Gitops) Uninstall(params UninstallParams) error {
 	g.logger.Actionf("Deleting Weave Gitops manifests")
 
 	if !params.DryRun {
-		wegoAppManifests, err := manifests.GenerateWegoAppManifests(manifests.WegoAppParams{Version: version.Version, Namespace: params.Namespace})
+		wegoAppManifests, err := manifests.GenerateManifests(manifests.Params{AppVersion: version.Version, Namespace: params.Namespace})
 		if err != nil {
 			return fmt.Errorf("error generating wego-app manifests, %w", err)
 		}

--- a/pkg/services/gitops/uninstall_test.go
+++ b/pkg/services/gitops/uninstall_test.go
@@ -178,7 +178,7 @@ var _ = Describe("Uninstall", func() {
 		err := gitopsSrv.Uninstall(uninstallParams)
 		Expect(err).ShouldNot(HaveOccurred())
 
-		wegoAppManifests, err := manifests.GenerateWegoAppManifests(manifests.WegoAppParams{Version: version.Version, Namespace: "default"})
+		wegoAppManifests, err := manifests.GenerateManifests(manifests.Params{AppVersion: version.Version, Namespace: "default"})
 		Expect(err).ShouldNot(HaveOccurred())
 
 		Expect(kubeClient.DeleteCallCount()).To(Equal(len(wegoAppManifests)+1), "deletes all wego app manifests plus the app crd")


### PR DESCRIPTION
Failure here: https://github.com/weaveworks/weave-gitops/actions/runs/1572147230

```
pkg/services/gitops/uninstall.go:35:28: undefined: manifests.GenerateWegoAppManifests
pkg/services/gitops/uninstall.go:35:63: undefined: manifests.WegoAppParams
make: *** [Makefile:55: bin] Error 2
```

works now:
```
make bin
go build -ldflags "-X github.com/weaveworks/weave-gitops/cmd/gitops/version.BuildTime=2021-12-13_14:35:09 -X github.com/weaveworks/weave-gitops/cmd/gitops/version.Branch=main -X github.com/weaveworks/weave-gitops/cmd/gitops/version.GitCommit=2aad1a5c -X github.com/weaveworks/weave-gitops/pkg/version.FluxVersion=0.21.0 -X github.com/weavewo
rks/weave-gitops/cmd/gitops/version.Version=v0.5.1-rc3-7-g2aad1a5c" -o bin/gitops cmd/gitops/*.go
```