### PR TITLE
Fix broken validation output from dry-run

### DIFF
--- a/pkg/services/gitops/install.go
+++ b/pkg/services/gitops/install.go
@@ -9,6 +9,12 @@ import (
 	"strconv"
 
 	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	kyaml "sigs.k8s.io/yaml"
+
 	"github.com/weaveworks/weave-gitops/cmd/gitops/version"
 	"github.com/weaveworks/weave-gitops/manifests"
 	"github.com/weaveworks/weave-gitops/pkg/git"
@@ -16,11 +22,6 @@ import (
 	"github.com/weaveworks/weave-gitops/pkg/kube"
 	"github.com/weaveworks/weave-gitops/pkg/services/automation"
 	"github.com/weaveworks/weave-gitops/pkg/services/gitrepo"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/selection"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	kyaml "sigs.k8s.io/yaml"
 )
 
 type InstallParams struct {
@@ -32,8 +33,9 @@ type InstallParams struct {
 func (g *Gitops) Install(params InstallParams) (map[string][]byte, error) {
 	ctx := context.Background()
 
-	g.logger.Actionf("Validating Weave Gitops installation")
-
+	// Avoid outputting anything before this line as it will mess up the
+	// output from validate in case of a dry-run.
+	// If you must, output something to Debug which can be disabled.
 	if err := g.validateWegoInstall(ctx, params); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This Log message here, breaks the output of validateWegoInstall.

https://github.com/weaveworks/aws-marketplace/runs/4500418327?check_suite_focus=true

Results in a generated output in case dry run is used such as this:

```
► Validating Weave Gitops installation
---
# Flux version: v0.21.0
# Components: source-controller,kustomize-controller,helm-controller,notification-controller,image-reflector-controller,image-automation-controller
apiVersion: v1
kind: Namespace
metadata:
  labels:
    app.kubernetes.io/instance: wego-system
    app.kubernetes.io/part-of: flux
    app.kubernetes.io/version: v0.21.0
  name: wego-system
---
```