### PR TITLE
Add support for cluster names with path separators

### DIFF
--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -53,8 +53,8 @@ const WegoClusterDir = "clusters"
 // WegoClusterOSWorkloadDir is where OS workload manifests will live in the GitOps repo
 const WegoClusterOSWorkloadDir = "system"
 
-// WegoClusterUserWorloadDir is where user workload manifests will live in the GitOps repo
-const WegoClusterUserWorloadDir = "user"
+// WegoClusterUserWorkloadDir is where user workload manifests will live in the GitOps repo
+const WegoClusterUserWorkloadDir = "user"
 
 // Git is an interface for basic Git operations on a single branch of a
 // remote repository.

--- a/pkg/services/app/add_test.go
+++ b/pkg/services/app/add_test.go
@@ -329,7 +329,7 @@ var _ = Describe("New directory structure", func() {
 		Expect(manifestsByPath[filepath.Join(git.WegoRoot, git.WegoAppDir, addParams.Name, "kustomization.yaml")]).ToNot(BeNil())
 		cname, err := kubeClient.GetClusterName(context.Background())
 		Expect(err).To(BeNil())
-		clusterKustomizeFile := manifestsByPath[filepath.Join(git.WegoRoot, git.WegoClusterDir, cname, git.WegoClusterUserWorloadDir, "kustomization.yaml")]
+		clusterKustomizeFile := manifestsByPath[filepath.Join(git.WegoRoot, git.WegoClusterDir, cname, git.WegoClusterUserWorkloadDir, "kustomization.yaml")]
 		Expect(clusterKustomizeFile).ToNot(BeNil())
 
 		manifestMap := map[string]interface{}{}
@@ -348,7 +348,7 @@ var _ = Describe("New directory structure", func() {
 		Expect(manifestsByPath[filepath.Join(git.WegoRoot, git.WegoAppDir, addParams.Name, "kustomization.yaml")]).ToNot(BeNil())
 		cname, err := kubeClient.GetClusterName(context.Background())
 		Expect(err).To(BeNil())
-		clusterKustomizeFile := manifestsByPath[filepath.Join(git.WegoRoot, git.WegoClusterDir, cname, git.WegoClusterUserWorloadDir, "kustomization.yaml")]
+		clusterKustomizeFile := manifestsByPath[filepath.Join(git.WegoRoot, git.WegoClusterDir, cname, git.WegoClusterUserWorkloadDir, "kustomization.yaml")]
 		Expect(clusterKustomizeFile).ToNot(BeNil())
 		manifestMap := map[string]interface{}{}
 
@@ -373,7 +373,7 @@ var _ = Describe("New directory structure", func() {
 		Expect(manifestsByPath[filepath.Join(git.WegoRoot, git.WegoAppDir, addParams.Name, "kustomization.yaml")]).ToNot(BeNil())
 		cname, err := kubeClient.GetClusterName(context.Background())
 		Expect(err).To(BeNil())
-		clusterKustomizeFile := manifestsByPath[filepath.Join(git.WegoRoot, git.WegoClusterDir, cname, git.WegoClusterUserWorloadDir, "kustomization.yaml")]
+		clusterKustomizeFile := manifestsByPath[filepath.Join(git.WegoRoot, git.WegoClusterDir, cname, git.WegoClusterUserWorkloadDir, "kustomization.yaml")]
 		Expect(clusterKustomizeFile).ToNot(BeNil())
 		manifestMap := map[string]interface{}{}
 

--- a/pkg/services/app/add_test.go
+++ b/pkg/services/app/add_test.go
@@ -339,6 +339,7 @@ var _ = Describe("New directory structure", func() {
 		Expect(len(r)).To(Equal(1))
 		Expect(r[0].(string)).To(Equal("../../../apps/" + addParams.Name))
 	})
+
 	It("adds second app to the cluster kustomization file", func() {
 		addParams.SourceType = wego.SourceTypeGit
 		origName := addParams.Name
@@ -359,6 +360,7 @@ var _ = Describe("New directory structure", func() {
 		Expect(r[0].(string)).To(Equal("../../../apps/" + origName))
 		Expect(r[1].(string)).To(Equal("../../../apps/" + addParams.Name))
 	})
+
 	It("deals with a cluster dir with additional subdirectories", func() {
 		kubeClient.GetClusterNameReturns("arn:aws:eks:us-west-2:01234567890:cluster/default-my-wego-control-plan", nil)
 		appNames := []string{

--- a/pkg/services/app/add_test.go
+++ b/pkg/services/app/add_test.go
@@ -381,10 +381,10 @@ var _ = Describe("New directory structure", func() {
 
 		Expect(yaml.Unmarshal(clusterKustomizeFile, &manifestMap)).Should(Succeed())
 
-		r := manifestMap["resources"].([]interface{})
-		Expect(len(r)).To(Equal(len(appNames)))
-		for i, a := range appNames {
-			Expect(r[i].(string)).To(Equal("../../../../apps/" + a))
+		resources := manifestMap["resources"].([]interface{})
+		Expect(len(resources)).To(Equal(len(appNames)))
+		for i, name := range appNames {
+			Expect(resources[i].(string)).To(Equal("../../../../apps/" + name))
 		}
 
 	})

--- a/pkg/services/gitops/install.go
+++ b/pkg/services/gitops/install.go
@@ -198,7 +198,7 @@ func (g *Gitops) storeManifests(gitClient git.Git, gitProvider gitproviders.GitP
 	manifests["flux-system-kustomization-resource.yaml"] = system
 
 	user, err := g.genKustomize(automation.ConstrainResourceName(fmt.Sprintf("%s-user", cname)), sourceName,
-		prefixForFlux(filepath.Join(".", clusterPath, git.WegoClusterUserWorloadDir)), params)
+		prefixForFlux(filepath.Join(".", clusterPath, git.WegoClusterUserWorkloadDir)), params)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create user kustomization manifest: %w", err)
 	}

--- a/pkg/services/gitopswriter/gitopswriter.go
+++ b/pkg/services/gitopswriter/gitopswriter.go
@@ -58,7 +58,12 @@ func (dw *gitOpsDirectoryWriterSvc) AddApplication(ctx context.Context, app mode
 
 	defer remover()
 
-	kManifest, err := addKustomizeResources(app, repoDir, clusterName, appKustomizeReference(app))
+	resourceEntry, err := appKustomizeReference(getUserKustomizationRepoPath(clusterName), appPath(app.Name))
+	if err != nil {
+		return err
+	}
+
+	kManifest, err := addKustomizeResources(app, repoDir, clusterName, resourceEntry)
 	if err != nil {
 		return err
 	}
@@ -134,14 +139,19 @@ func (dw *gitOpsDirectoryWriterSvc) RemoveApplication(ctx context.Context, app m
 
 	for _, resourcePath := range resourcePaths {
 		pathStr := filepath.Join(appSubDir, resourcePath.Name())
-
 		if err := dw.RepoWriter.Remove(ctx, pathStr); err != nil {
 			return fmt.Errorf("failed to remove app resource from repository: %w", err)
 		}
 	}
 
 	// Remove reference in kustomization file
-	kManifest, err := removeKustomizeResources(app, repoDir, clusterName, appKustomizeReference(app))
+	resourceEntry, err := appKustomizeReference(getUserKustomizationRepoPath(clusterName), appPath(app.Name))
+	if err != nil {
+		return err
+	}
+
+	kManifest, err := removeKustomizeResources(app, repoDir, clusterName, resourceEntry)
+
 	if err != nil {
 		return fmt.Errorf("failed to remove app reference from user kustomize file: %w", err)
 	}
@@ -239,6 +249,15 @@ func getUserKustomizationRepoPath(clusterName string) string {
 	return filepath.Join(git.WegoRoot, git.WegoClusterDir, clusterName, "user", "kustomization.yaml")
 }
 
-func appKustomizeReference(app models.Application) string {
-	return "../../../apps/" + automation.AppDeployName(app)
+func appPath(appName string) string {
+	return filepath.Join(git.WegoRoot, git.WegoAppDir, appName)
+}
+
+func appKustomizeReference(userKustomizationPath, appPath string) (string, error) {
+	r, err := filepath.Rel(filepath.Dir(userKustomizationPath), appPath)
+	if err != nil {
+		return "", err
+	}
+
+	return r, nil
 }

--- a/pkg/services/gitopswriter/gitopswriter.go
+++ b/pkg/services/gitopswriter/gitopswriter.go
@@ -256,7 +256,8 @@ func appPath(appName string) string {
 func appKustomizeReference(userKustomizationPath, appPath string) (string, error) {
 	r, err := filepath.Rel(filepath.Dir(userKustomizationPath), appPath)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to calculate the relative path between the cluster %q and app %q: %w",
+			userKustomizationPath, appPath, err)
 	}
 
 	return r, nil

--- a/pkg/services/gitopswriter/writer_remove_test.go
+++ b/pkg/services/gitopswriter/writer_remove_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
 	"github.com/weaveworks/weave-gitops/pkg/gitproviders"
-	"gopkg.in/yaml.v2"
+	"sigs.k8s.io/yaml"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/pkg/services/gitopswriter/writer_remove_test.go
+++ b/pkg/services/gitopswriter/writer_remove_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
 	"github.com/weaveworks/weave-gitops/pkg/gitproviders"
+	"gopkg.in/yaml.v2"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -23,10 +24,12 @@ import (
 )
 
 var (
-	application wego.Application
-	realFlux    flux.Flux
-	fluxDir     string
-	goatPaths   map[string]bool
+	application                  wego.Application
+	clusterUserKustomization     []byte
+	clusterUserKustomizationPath string
+	fluxDir                      string
+	goatPaths                    map[string]bool
+	realFlux                     flux.Flux
 )
 
 type dummyDirEntry struct {
@@ -87,11 +90,14 @@ func createRemoveDirWriter() GitOpsDirectoryWriter {
 	return NewGitOpsDirectoryWriter(automationSvc, repoWriter, osysClient, log)
 }
 
-// Run 'gitops add app' and gather the resources we expect to be generated
+// Run 'gitops add app' using cluster name of test-cluster and gathers the resources
+// we expect to be generated
 func runAddAndCollectInfo() error {
-	application = automation.AppToWegoApp(app)
+	return runAddAndCollectInfoWithClusterName("test-cluster")
+}
 
-	if err := gitOpsDirWriter.AddApplication(context.Background(), app, "test-cluster", true); err != nil {
+func runAddAndCollectInfoWithClusterName(clusterName string) error {
+	if err := gitOpsDirWriter.AddApplication(context.Background(), app, clusterName, true); err != nil {
 		return err
 	}
 
@@ -105,6 +111,29 @@ func checkRemoveResults() error {
 	}
 
 	return nil
+}
+
+// See if the cluster kustomization has a reference to the app
+func checkClusterKustomizationForApp(name string) error {
+	if clusterUserKustomization == nil {
+		return errors.New("No cluster user kustomization")
+	}
+
+	manifestMap := map[string]interface{}{}
+
+	Expect(yaml.Unmarshal(clusterUserKustomization, &manifestMap)).Should(Succeed())
+	r := manifestMap["resources"]
+
+	if r != nil {
+		l := manifestMap["resources"].([]interface{})
+		for _, a := range l {
+			if strings.Contains(a.(string), name) {
+				return nil
+			}
+		}
+	}
+
+	return errors.New("Not Found")
 }
 
 var _ = Describe("Remove", func() {
@@ -143,6 +172,10 @@ var _ = Describe("Remove", func() {
 
 			gitClient.WriteStub = func(path string, manifest []byte) error {
 				storeGOATPath(path)
+				if strings.HasSuffix(path, "user/kustomization.yaml") {
+					clusterUserKustomization = manifest
+					clusterUserKustomizationPath = path
+				}
 				return nil
 			}
 
@@ -321,6 +354,27 @@ var _ = Describe("Remove", func() {
 				Expect(runAddAndCollectInfo()).To(Succeed())
 				Expect(gitOpsDirWriter.RemoveApplication(context.Background(), app, "test-cluster", true)).To(Succeed())
 				Expect(checkRemoveResults()).To(Succeed())
+			})
+			It("removes cluster resources for non-helm app with configRepo = <url> and eksctl cluster name", func() {
+
+				app.GitSourceURL = createRepoURL("ssh://git@github.com/user/wego-fork-test.git")
+				app.ConfigRepo = createRepoURL("ssh://git@github.com/user/external.git")
+
+				cname := "arn:aws:eks:us-west-2:01234567890:cluster/default-my-wego-control-plan"
+				Expect(runAddAndCollectInfoWithClusterName(cname)).To(Succeed())
+				// Check that a resource was added
+				Expect(checkClusterKustomizationForApp(app.Name)).To(Succeed())
+				gitClient.CloneStub = func(arg1 context.Context, dir string, arg3 string, arg4 string) (bool, error) {
+					if clusterUserKustomization != nil {
+						p := filepath.Join(dir, filepath.Dir(clusterUserKustomizationPath))
+						Expect(os.MkdirAll(p, 0700)).To(Succeed(), "failed to create git dir")
+						Expect(os.WriteFile(filepath.Join(p, "kustomization.yaml"), clusterUserKustomization, 0666)).To(Succeed())
+					}
+
+					return false, nil
+				}
+				Expect(gitOpsDirWriter.RemoveApplication(context.Background(), app, cname, true)).To(Succeed())
+				Expect(checkClusterKustomizationForApp(app.Name)).ToNot(Succeed())
 			})
 		})
 	})


### PR DESCRIPTION
<!-- Use # to add the issue this pull request is related to -->
Closes: #1213  
* #1213 

<!-- Describe what has changed in this PR -->
**What changed?**
Instead of assuming the relative path between applications and apps, calculate it.

<!-- Tell your future self why have you made these changes -->
**Why?**
EKS clusters sometimes have a path separator in their name and this was causing an issue with Kustomize

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**
Added unit tests and existing tests will validate that existing functionality still works.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
**Release notes**
Yes.

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
No