### PR TITLE
Revert field name from config_repo to config_url in wego app CRD

### DIFF
--- a/api/v1alpha1/application_types.go
+++ b/api/v1alpha1/application_types.go
@@ -27,7 +27,7 @@ const ApplicationKind = "Application"
 // ApplicationSpec defines the desired state of Application
 type ApplicationSpec struct {
 	// ConfigRepo is the address of the git repository containing the automation for this application
-	ConfigRepo string `json:"config_repo,omitempty"`
+	ConfigRepo string `json:"config_url,omitempty"`
 	// URL is the address of the git repository for this application
 	URL string `json:"url,omitempty"`
 	// Path is the path in the repository where the k8s yaml files for this application are stored.

--- a/manifests/crds/wego.weave.works_apps.yaml
+++ b/manifests/crds/wego.weave.works_apps.yaml
@@ -40,7 +40,7 @@ spec:
                 description: Branch is the branch in the repository where the k8s
                   yaml files for this application are stored.
                 type: string
-              config_repo:
+              config_url:
                 description: ConfigRepo is the address of the git repository containing
                   the automation for this application
                 type: string


### PR DESCRIPTION
<!-- Use # to add the issue this pull request is related to -->
Closes: 

<!-- Describe what has changed in this PR -->
**What changed?**
- Revert field name from config_repo to config_url in wego app CRD


<!-- Tell your future self why have you made these changes -->
**Why?**
- Avoid breaking changes


<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**
- I used `gitops` version 0.5.0 to create a config repo and then I used that repo in install with this branch changes.
- I added an app using the UI with a config repo.
Both scenarios result in app deployments.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
**Release notes**

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**