### PR TITLE
Configure zapr logger to skip the caller

### DIFF
--- a/pkg/server/internal/logger.go
+++ b/pkg/server/internal/logger.go
@@ -14,7 +14,7 @@ type ApiLogger struct {
 }
 
 func NewApiLogger(z *zap.Logger) logger.Logger {
-	logger := zapr.NewLogger(z)
+	logger := zapr.NewLogger(z.WithOptions(zap.AddCallerSkip(1)))
 
 	return ApiLogger{
 		logger: logger,


### PR DESCRIPTION
By skipping the caller, the output shows the calling function instead
of the logging wrapper.

<!-- Use # to add the issue this pull request is related to -->
Closes: #1238 
* #1238 

<!-- Describe what has changed in this PR -->
**What changed?**
Added a skip caller option to the creation of the logger used in the API server.

<!-- Tell your future self why have you made these changes -->
**Why?**
By skipping the caller, the output shows the code making the call to the logger instead of the logger.

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**
I Ran `gitops ui run` and checked the output

Output now looks like - 
>2021-12-15T16:14:18.523-0700    INFO    app/add.go:107  Adding application:
2021-12-15T16:14:18.523-0700    INFO    app/add.go:108  Name: mypdi
2021-12-15T16:14:18.523-0700    INFO    app/add.go:109  URL: ssh://git@github.com/palemtnrider/podinfo-deploy.git
2021-12-15T16:14:18.523-0700    INFO    app/add.go:110  Path: ./
2021-12-15T16:14:18.523-0700    INFO    app/add.go:111  Branch: main
2021-12-15T16:14:18.523-0700    INFO    app/add.go:112  Type: kustomize
2021-12-15T16:14:18.523-0700    INFO    app/add.go:118
2021-12-15T16:14:18.523-0700    INFO    kube/kube.go:70 Checking cluster status
2021-12-15T16:14:18.538-0700    INFO    kube/kube.go:81 GitOps installed
2021-12-15T16:14:18.547-0700    INFO    automation/generator.go:114     Generating application spec manifest
2021-12-15T16:14:18.548-0700    INFO    automation/generator.go:121     Generating GitOps automation manifests
2021-12-15T16:14:20.421-0700    INFO    gitopswriter/gitopswriter.go:73 Adding application "mypdi" to cluster "kind-kind" and repository
2021-12-15T16:14:22.901-0700    INFO    gitrepo/service.go:45   Pull Request created: https://github.com/palemtnrider/kb3/pull/27

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
**Release notes**
yes

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
No