### PR TITLE
Fixes Polling Errors on Remove Page

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -161,6 +161,10 @@ func (s *applicationServer) GetApplication(ctx context.Context, msg *pb.GetAppli
 
 	app, err := kubeClient.GetApplication(ctx, types.NamespacedName{Name: msg.Name, Namespace: msg.Namespace})
 	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, grpcStatus.Errorf(codes.NotFound, "not found: %s", err.Error())
+		}
+		
 		return nil, fmt.Errorf("could not get application %q: %w", msg.Name, err)
 	}
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -164,7 +164,7 @@ func (s *applicationServer) GetApplication(ctx context.Context, msg *pb.GetAppli
 		if apierrors.IsNotFound(err) {
 			return nil, grpcStatus.Errorf(codes.NotFound, "not found: %s", err.Error())
 		}
-		
+
 		return nil, fmt.Errorf("could not get application %q: %w", msg.Name, err)
 	}
 

--- a/ui/lib/types.ts
+++ b/ui/lib/types.ts
@@ -7,6 +7,8 @@ export enum PageRoute {
 }
 
 export enum GrpcErrorCodes {
+  Unknown = 2,
+  NotFound = 5,
   Unauthenticated = 16,
 }
 

--- a/ui/pages/ApplicationRemove.tsx
+++ b/ui/pages/ApplicationRemove.tsx
@@ -154,16 +154,19 @@ function ApplicationRemove({ className, name }: Props) {
           state: { authSuccess: false },
         }}
       >
-        {error &&
-          (error.code === GrpcErrorCodes.Unauthenticated ? (
+        {!authSuccess &&
+          error &&
+          error.code === GrpcErrorCodes.Unauthenticated && (
             <AuthAlert
               title="Error"
               provider={repoInfo.provider}
               onClick={() => setAuthOpen(true)}
             />
-          ) : (
-            <Alert title="Error" severity="error" message={error?.message} />
-          ))}
+          )}
+        {error && error.code !== GrpcErrorCodes.Unauthenticated && (
+          <Alert title="Error" severity="error" message={error?.message} />
+        )}
+
         {repoRemoving && (
           <Flex wide center align>
             <CircularProgress />


### PR DESCRIPTION
Closes: #1190
Closes: #1191 

Fixes display of 500 errors in `RemoveApplication` and only initiates polling on remove request instead of on page load. 
