### PR TITLE
Support HTTPS installations

### DIFF
--- a/pkg/gitproviders/repo_url.go
+++ b/pkg/gitproviders/repo_url.go
@@ -52,7 +52,7 @@ func NewRepoURL(uri string) (RepoURL, error) {
 	}
 
 	return RepoURL{
-		repoName:   utils.UrlToRepoName(uri),
+		repoName:   utils.URLToRepoName(uri),
 		owner:      owner,
 		url:        u,
 		normalized: normalized,
@@ -145,7 +145,6 @@ func normalizeRepoURLString(url string) (string, error) {
 	// https://github.com/weaveworks/weave-gitops/issues/878
 	// A trailing slash causes problems when naming secrets.
 	url = strings.TrimSuffix(url, "/")
-
 	if !strings.HasSuffix(url, ".git") {
 		url = url + ".git"
 	}
@@ -153,6 +152,9 @@ func normalizeRepoURLString(url string) (string, error) {
 	u, err := parseGitURL(url)
 	if err != nil {
 		return "", fmt.Errorf("could not parse git repo url while normalizing %q: %w", url, err)
+	}
+	if u.Scheme == "https" {
+		return u.String(), nil
 	}
 
 	return fmt.Sprintf("ssh://git@%s%s", u.Host, u.Path), nil

--- a/pkg/gitproviders/repo_url_test.go
+++ b/pkg/gitproviders/repo_url_test.go
@@ -97,11 +97,11 @@ var _ = DescribeTable("NewRepoURL", func(input, gitProviderEnv string, expected 
 		protocol: RepositoryURLProtocolSSH,
 	}),
 	Entry("github https", "https://github.com/someuser/podinfo.git", "", expectedRepoURL{
-		s:        "ssh://git@github.com/someuser/podinfo.git",
+		s:        "https://github.com/someuser/podinfo.git",
 		owner:    "someuser",
 		name:     "podinfo",
 		provider: GitProviderGitHub,
-		protocol: RepositoryURLProtocolSSH,
+		protocol: RepositoryURLProtocolHTTPS,
 	}),
 	Entry("gitlab git clone style", "git@gitlab.com:someuser/podinfo.git", "", expectedRepoURL{
 		s:        "ssh://git@gitlab.com/someuser/podinfo.git",
@@ -111,18 +111,18 @@ var _ = DescribeTable("NewRepoURL", func(input, gitProviderEnv string, expected 
 		protocol: RepositoryURLProtocolSSH,
 	}),
 	Entry("gitlab https", "https://gitlab.com/someuser/podinfo.git", "", expectedRepoURL{
-		s:        "ssh://git@gitlab.com/someuser/podinfo.git",
+		s:        "https://gitlab.com/someuser/podinfo.git",
 		owner:    "someuser",
 		name:     "podinfo",
 		provider: GitProviderGitLab,
-		protocol: RepositoryURLProtocolSSH,
+		protocol: RepositoryURLProtocolHTTPS,
 	}),
 	Entry("trailing slash in url", "https://github.com/sympatheticmoose/podinfo-deploy/", "", expectedRepoURL{
-		s:        "ssh://git@github.com/sympatheticmoose/podinfo-deploy.git",
+		s:        "https://github.com/sympatheticmoose/podinfo-deploy.git",
 		owner:    "sympatheticmoose",
 		name:     "podinfo-deploy",
 		provider: GitProviderGitHub,
-		protocol: RepositoryURLProtocolSSH,
+		protocol: RepositoryURLProtocolHTTPS,
 	}),
 	Entry(
 		"custom domain",

--- a/pkg/services/app/add.go
+++ b/pkg/services/app/add.go
@@ -170,7 +170,7 @@ func (a *AppSvc) updateParametersIfNecessary(ctx context.Context, gitProvider gi
 	}
 
 	if params.Name == "" {
-		repoName := utils.UrlToRepoName(params.Url)
+		repoName := utils.URLToRepoName(params.Url)
 		if automation.ApplicationNameTooLong(repoName) {
 			return params, fmt.Errorf("url base name %q is too long to use as application name (must be <= %d characters); please specify name with '--name'",
 				repoName, automation.MaxKubernetesResourceNameLength)

--- a/pkg/services/auth/auth.go
+++ b/pkg/services/auth/auth.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/weaveworks/weave-gitops/pkg/services/auth/internal"
 
+	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/go-git/go-git/v5/plumbing/transport/ssh"
 	"github.com/weaveworks/weave-gitops/pkg/flux"
 	"github.com/weaveworks/weave-gitops/pkg/git"
@@ -63,7 +64,7 @@ func (sn SecretName) NamespacedName() types.NamespacedName {
 }
 
 type AuthService interface {
-	CreateGitClient(ctx context.Context, repoUrl gitproviders.RepoURL, targetName string, namespace string, dryRun bool) (git.Git, error)
+	CreateGitClient(ctx context.Context, repoUrl gitproviders.RepoURL, targetName, namespace string, dryRun bool, creds *flux.HTTPSCreds) (git.Git, error)
 	GetGitProvider() gitproviders.GitProvider
 }
 
@@ -93,7 +94,7 @@ func (a *authSvc) GetGitProvider() gitproviders.GitProvider {
 
 // CreateGitClient creates a git.Git client instrumented with existing or generated deploy keys.
 // This ensures that git operations are done with stored deploy keys instead of a user's local ssh-agent or equivalent.
-func (a *authSvc) CreateGitClient(ctx context.Context, repoUrl gitproviders.RepoURL, targetName string, namespace string, dryRun bool) (git.Git, error) {
+func (a *authSvc) CreateGitClient(ctx context.Context, repoUrl gitproviders.RepoURL, targetName, namespace string, dryRun bool, creds *flux.HTTPSCreds) (git.Git, error) {
 	if dryRun {
 		d, _ := makePublicKey([]byte(""))
 		return git.New(d, wrapper.NewGoGit()), nil
@@ -104,7 +105,7 @@ func (a *authSvc) CreateGitClient(ctx context.Context, repoUrl gitproviders.Repo
 		Namespace: namespace,
 	}
 
-	pubKey, keyErr := a.setupDeployKey(ctx, secretName, targetName, repoUrl)
+	pubKey, keyErr := a.setupDeployKey(ctx, secretName, targetName, repoUrl, creds)
 	if keyErr != nil {
 		return nil, fmt.Errorf("error setting up deploy keys: %w", keyErr)
 	}
@@ -112,6 +113,12 @@ func (a *authSvc) CreateGitClient(ctx context.Context, repoUrl gitproviders.Repo
 	if pubKey == nil {
 		// Don't return git.New(pubkey, wrapper.NewGoGit()), nil here. It will fail
 		// "nil" of type *ssh.PublicKeys does not behave correctly
+		if creds != nil {
+			return git.New(&githttp.BasicAuth{
+				Username: creds.Username,
+				Password: creds.Password,
+			}, wrapper.NewGoGit()), nil
+		}
 		return git.New(nil, wrapper.NewGoGit()), nil
 	}
 
@@ -121,7 +128,7 @@ func (a *authSvc) CreateGitClient(ctx context.Context, repoUrl gitproviders.Repo
 
 // setupDeployKey creates a git.Git client instrumented with existing or generated deploy keys.
 // This ensures that git operations are done with stored deploy keys instead of a user's local ssh-agent or equivalent.
-func (a *authSvc) setupDeployKey(ctx context.Context, name SecretName, targetName string, repo gitproviders.RepoURL) (*ssh.PublicKeys, error) {
+func (a *authSvc) setupDeployKey(ctx context.Context, name SecretName, targetName string, repo gitproviders.RepoURL, creds *flux.HTTPSCreds) (*ssh.PublicKeys, error) {
 	deployKeyExists, err := a.gitProvider.DeployKeyExists(ctx, repo)
 	if err != nil {
 		return nil, fmt.Errorf("failed check for existing deploy key: %w", err)
@@ -136,8 +143,9 @@ func (a *authSvc) setupDeployKey(ctx context.Context, name SecretName, targetNam
 			// or if a cluster was destroyed during development work.
 			// Create and upload a new deploy key.
 			a.logger.Warningf("A deploy key named %s was found on the git provider, but not in the cluster.", name.Name)
-			return a.provisionDeployKey(ctx, targetName, name, repo)
-		} else if err != nil {
+			return a.provisionDeployKey(ctx, targetName, name, repo, creds)
+		}
+		if err != nil {
 			return nil, fmt.Errorf("error retrieving deploy key: %w", err)
 		}
 
@@ -152,49 +160,52 @@ func (a *authSvc) setupDeployKey(ctx context.Context, name SecretName, targetNam
 		return pubKey, nil
 	}
 
-	return a.provisionDeployKey(ctx, targetName, name, repo)
+	return a.provisionDeployKey(ctx, targetName, name, repo, creds)
 }
 
-func (a *authSvc) provisionDeployKey(ctx context.Context, targetName string, name SecretName, repo gitproviders.RepoURL) (*ssh.PublicKeys, error) {
-	deployKey, secret, err := a.generateDeployKey(targetName, name, repo)
+func (a *authSvc) provisionDeployKey(ctx context.Context, targetName string, name SecretName, repo gitproviders.RepoURL, creds *flux.HTTPSCreds) (*ssh.PublicKeys, error) {
+	deployKey, secret, err := a.generateRepoAuthSecret(targetName, name, repo, creds)
 	if err != nil {
-		return nil, fmt.Errorf("error generating deploy key: %w", err)
+		return nil, fmt.Errorf("error generating repo auth secret: %w", err)
+	}
+	// KEVIN!!!! this needs to be tested.
+	if deployKey != nil {
+		publicKeyBytes := extractPublicKey(secret)
+		if err := a.gitProvider.UploadDeployKey(ctx, repo, publicKeyBytes); err != nil {
+			return nil, fmt.Errorf("error uploading deploy key: %w", err)
+		}
 	}
 
-	publicKeyBytes := extractPublicKey(secret)
-
-	if err := a.gitProvider.UploadDeployKey(ctx, repo, publicKeyBytes); err != nil {
-		return nil, fmt.Errorf("error uploading deploy key: %w", err)
+	if err := a.storeRepoAuthSecret(ctx, secret); err != nil {
+		return nil, fmt.Errorf("error storing repo authentication secret: %w", err)
 	}
 
-	if err := a.storeDeployKey(ctx, secret); err != nil {
-		return nil, fmt.Errorf("error storing deploy key: %w", err)
+	if creds == nil {
+		a.logger.Println("Deploy key generated and uploaded to git provider")
 	}
-
-	a.logger.Println("Deploy key generated and uploaded to git provider")
-
 	return deployKey, nil
 }
 
 // Generates an ssh keypair for upload to the Git Provider and for use in a git.Git client.
-func (a *authSvc) generateDeployKey(targetName string, secretName SecretName, repo gitproviders.RepoURL) (*ssh.PublicKeys, *corev1.Secret, error) {
-	secret, err := a.createKeyPairSecret(secretName, repo)
+func (a *authSvc) generateRepoAuthSecret(targetName string, secretName SecretName, repo gitproviders.RepoURL, creds *flux.HTTPSCreds) (*ssh.PublicKeys, *corev1.Secret, error) {
+	secret, err := a.createRepoAuthSecret(secretName, repo, creds)
 	if err != nil {
 		return nil, nil, fmt.Errorf("could not create key-pair secret: %w", err)
 	}
+	if creds != nil {
+		return nil, secret, nil
+	}
 
 	privKeyBytes := extractPrivateKey(secret)
-
 	deployKey, err := makePublicKey(privKeyBytes)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error creating new public keys: %w", err)
 	}
-
 	return deployKey, secret, nil
 }
 
 // Wrapper to abstract how the key is stored in case we want to change this later.
-func (a *authSvc) storeDeployKey(ctx context.Context, secret *corev1.Secret) error {
+func (a *authSvc) storeRepoAuthSecret(ctx context.Context, secret *corev1.Secret) error {
 	if err := a.k8sClient.Create(ctx, secret); err != nil {
 		return fmt.Errorf("could not store secret: %w", err)
 	}
@@ -213,14 +224,13 @@ func (a *authSvc) retrieveDeployKey(ctx context.Context, name SecretName) (*core
 }
 
 // Uses flux to create a ssh key pair secret.
-func (a *authSvc) createKeyPairSecret(name SecretName, repo gitproviders.RepoURL) (*corev1.Secret, error) {
-	secretData, err := a.fluxClient.CreateSecretGit(name.Name.String(), repo, name.Namespace)
+func (a *authSvc) createRepoAuthSecret(name SecretName, repo gitproviders.RepoURL, creds *flux.HTTPSCreds) (*corev1.Secret, error) {
+	secretData, err := a.fluxClient.CreateSecretGit(name.Name.String(), repo, name.Namespace, creds)
 	if err != nil {
-		return nil, fmt.Errorf("could not create git secret: %w", err)
+		return nil, fmt.Errorf("could not create git authentication secret: %w", err)
 	}
 
 	var secret corev1.Secret
-
 	err = yaml.Unmarshal(secretData, &secret)
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal created secret: %w", err)
@@ -235,18 +245,13 @@ func makePublicKey(pemBytes []byte) (*ssh.PublicKeys, error) {
 
 // Helper to standardize how we extract data from a ssh key pair secret.
 func extractSecretPart(secret *corev1.Secret, key string) []byte {
-	var data []byte
-
-	var ok bool
-
-	data, ok = secret.Data[string(key)]
+	data, ok := secret.Data[string(key)]
 	if !ok {
 		// StringData is a write-only field, flux generates secrets on disk with StringData
 		// Once they get applied on the cluster, Kubernetes populates Data and removes StringData.
 		// Handle this case here to be able to extract data no matter the "state" of the object.
 		data = []byte(secret.StringData[string(key)])
 	}
-
 	return data
 }
 

--- a/pkg/services/automation/generator.go
+++ b/pkg/services/automation/generator.go
@@ -141,7 +141,8 @@ func (a *AutomationGen) generateAppSource(ctx context.Context, app models.Applic
 
 	switch app.SourceType {
 	case models.SourceTypeGit:
-		source, err = a.Flux.CreateSourceGit(app.Name, app.GitSourceURL, app.Branch, appSecretRef.String(), app.Namespace)
+		// Passes nil in as the credentials as we don't have anything.
+		source, err = a.Flux.CreateSourceGit(app.Name, app.GitSourceURL, app.Branch, appSecretRef.String(), app.Namespace, nil)
 		if err == nil {
 			source, err = AddWegoIgnore(source)
 		}

--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -111,7 +111,7 @@ func CaptureStdout(c callback) string {
 	return string(stdout)
 }
 
-func UrlToRepoName(url string) string {
+func URLToRepoName(url string) string {
 	return strings.TrimSuffix(filepath.Base(url), ".git")
 }
 
@@ -167,7 +167,7 @@ func ConvertCommitURLToShort(url string) string {
 }
 
 func CreateRepoSecretName(targetName string, repoURL string) string {
-	return fmt.Sprintf("wego-%s-%s", targetName, UrlToRepoName(repoURL))
+	return fmt.Sprintf("wego-%s-%s", targetName, URLToRepoName(repoURL))
 }
 
 func StartK8sTestEnvironment() (client.Client, func(), error) {


### PR DESCRIPTION
<!-- Use # to add the issue this pull request is related to -->
Closes: #1204 

<!-- Describe what has changed in this PR -->
**What changed?**
This adds support for using an HTTPS URL when running install.

$ gitops install --config-repo https://github.com/org/repo.git --flux-https-password=$GITHUB_TOKEN will pass through the provided password to flux.

https://fluxcd.io/docs/installation/#generic-git-server

<!-- Tell your future self why have you made these changes -->
**Why?**
To support https installations

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**

See the command-line above

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
**Release notes**

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**