### PR TITLE
Extends Nav height to match Content

### DIFF
--- a/ui/components/Layout.tsx
+++ b/ui/components/Layout.tsx
@@ -76,6 +76,7 @@ const ContentContainer = styled.div`
   padding-top: ${(props) => props.theme.spacing.medium};
   padding-bottom: ${(props) => props.theme.spacing.medium};
   padding-right: ${(props) => props.theme.spacing.medium};
+  padding-left: ${(props) => props.theme.spacing.medium};
 `;
 
 const Main = styled(Flex)`

--- a/ui/components/Layout.tsx
+++ b/ui/components/Layout.tsx
@@ -45,15 +45,14 @@ const AppContainer = styled.div`
 
 const NavContainer = styled.div`
   width: 240px;
-  background-color: ${(props) => props.theme.colors.white};
-  padding-top: ${(props) => props.theme.spacing.medium};
+  min-height: 100%;
+  margin-top: ${(props) => props.theme.spacing.medium};
   padding-right: ${(props) => props.theme.spacing.small};
-  background-color: ${negativeSpaceColor};
+  background-color: ${(props) => props.theme.colors.white};
 `;
 
 const NavContent = styled.div`
-  background-color: white;
-  height: 100vh;
+  min-height: 100%;
   padding-top: ${(props) => props.theme.spacing.medium};
   padding-left: ${(props) => props.theme.spacing.xs};
   padding-right: ${(props) => props.theme.spacing.xl};
@@ -79,6 +78,7 @@ const ContentContainer = styled.div`
 `;
 
 const Main = styled(Flex)`
+  height: 100%;
   flex: 1 1 auto;
 `;
 

--- a/ui/components/Layout.tsx
+++ b/ui/components/Layout.tsx
@@ -72,6 +72,7 @@ const NavContent = styled.div`
 
 const ContentContainer = styled.div`
   width: 100%;
+  min-height: 100vh;
   padding-top: ${(props) => props.theme.spacing.medium};
   padding-bottom: ${(props) => props.theme.spacing.medium};
   padding-right: ${(props) => props.theme.spacing.medium};

--- a/ui/components/Page.tsx
+++ b/ui/components/Page.tsx
@@ -21,6 +21,7 @@ export type PageProps = {
 };
 
 const Content = styled.div`
+  min-height: 80vh;
   max-width: 1400px;
   margin: 0 auto;
   width: 100%;

--- a/ui/components/__tests__/__snapshots__/Page.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/Page.test.tsx.snap
@@ -49,6 +49,7 @@ exports[`Page snapshots default 1`] = `
 }
 
 .c1 {
+  min-height: 80vh;
   max-width: 1400px;
   margin: 0 auto;
   width: 100%;


### PR DESCRIPTION
Closes: #1256 

Specifying the height of `<Main />` to be 100% allows `<NavContainer />` to extend through the whole page. Also had to change the background color to white <|:^}

Screenshot shows it extending past the Commits in App Detail - which is where it used to stop.

![image](https://user-images.githubusercontent.com/65822698/148463226-0c086a38-d450-4ad7-8201-a2e6139b816b.png)
 