### PR TITLE
Remove Polling Message on Applications Page

### DIFF
--- a/ui/components/PollingIndicator.tsx
+++ b/ui/components/PollingIndicator.tsx
@@ -1,55 +1,37 @@
-import { CircularProgress, Tooltip } from "@material-ui/core";
+import { CircularProgress } from "@material-ui/core";
 import * as React from "react";
 import styled from "styled-components";
 import { theme } from "..";
-import { muiTheme } from "../lib/theme";
 import Flex from "./Flex";
-import Spacer from "./Spacer";
 
 type Props = {
   /** whether `<CircularProgress />` should be shown */
   loading: boolean;
-  interval: string;
   className?: string;
 };
 
-function PollingIndicator({ className, loading, interval }: Props) {
-  const date = new Date();
-  const [updated, setUpdated] = React.useState(date.toTimeString().slice(0, 8));
+function PollingIndicator({ className, loading }: Props) {
   const [visible, setVisible] = React.useState(false);
 
   React.useEffect(() => {
     loading
       ? setVisible(true)
       : setTimeout(() => {
-          const date = new Date();
-          setUpdated(date.toTimeString().slice(0, 8));
           setVisible(false);
         }, 1000);
   }, [loading]);
 
   return (
     <Flex align className={className}>
-      <Tooltip title={updated} arrow placement="top">
-        <p className="timestamp-p">last updated {interval} seconds ago</p>
-      </Tooltip>
-      <Spacer padding="base">
-        <Flex>
-          <CircularProgress
-            size={theme.spacing.base}
-            className={visible ? "in" : "out"}
-          />
-        </Flex>
-      </Spacer>
+      <CircularProgress
+        size={theme.spacing.base}
+        className={visible ? "in" : "out"}
+      />
     </Flex>
   );
 }
 
 export default styled(PollingIndicator)`
-  .timestamp-p {
-    color: ${muiTheme.palette.text.secondary};
-    margin-bottom: 12px;
-  }
   .MuiCircularProgress-root {
     transition: opacity 2s;
     margin-bottom: 0;

--- a/ui/pages/Applications.tsx
+++ b/ui/pages/Applications.tsx
@@ -44,8 +44,8 @@ function Applications({ className }: Props) {
     <Page className={className}>
       <Flex align start>
         <h2>Applications</h2>
-        <Spacer padding="small" />
-        <PollingIndicator loading={loading} interval="30" />
+        <Spacer padding="xs" />
+        <PollingIndicator loading={loading} />
       </Flex>
       <ActionBar>
         <Link to={PageRoute.ApplicationAdd} className="title-bar-button">


### PR DESCRIPTION
Closes: #1246

The "last updated 30 seconds ago" was too prominent and was more trouble than it was worth - removed in favor of just having the spinner appear every thirty seconds.