### PR TITLE
Refactor ListApplications to create fetcher at the time of the request

### DIFF
--- a/pkg/server/auth/auth.go
+++ b/pkg/server/auth/auth.go
@@ -33,6 +33,16 @@ func RegisterAuthServer(mux *http.ServeMux, prefix string, srv *AuthServer) {
 
 type principalCtxKey struct{}
 
+// Principal gets the principal from the context.
+func Principal(ctx context.Context) *UserPrincipal {
+	principal, ok := ctx.Value(principalCtxKey{}).(*UserPrincipal)
+	if ok {
+		return principal
+	}
+
+	return nil
+}
+
 // UserPrincipal is a simple model for the user, including their ID and Groups.
 type UserPrincipal struct {
 	ID     string   `json:"id"`

--- a/pkg/server/config_getter.go
+++ b/pkg/server/config_getter.go
@@ -1,0 +1,78 @@
+package server
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/weaveworks/weave-gitops/pkg/kube"
+	"github.com/weaveworks/weave-gitops/pkg/server/auth"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ConfigGetter implementations should extract the details from a context and
+// create a *rest.Config for use in clients.
+type ConfigGetter interface {
+	Config(ctx context.Context) *rest.Config
+}
+
+// ImpersonatingConfigGetter is an implementation of the ConfigGetter interface
+// that returns configs based on a base one. It inspects the context for a
+// principal and if it finds one, it configures the *rest.Config to impersonate
+// that principal. Otherwise it returns a copy of the base config.
+type ImpersonatingConfigGetter struct {
+	insecure bool
+	cfg      *rest.Config
+}
+
+// NewImpersonatingConfigGetter creates and returns a ConfigGetter with a known
+// config.
+func NewImpersonatingConfigGetter(cfg *rest.Config, insecure bool) *ImpersonatingConfigGetter {
+	return &ImpersonatingConfigGetter{cfg: cfg, insecure: insecure}
+}
+
+// Config returns a *rest.Config configured to impersonate a user or
+// use the default service account credentials.
+func (r *ImpersonatingConfigGetter) Config(ctx context.Context) *rest.Config {
+	shallowCopy := *r.cfg
+
+	if p := auth.Principal(ctx); p != nil {
+		shallowCopy.Impersonate = rest.ImpersonationConfig{
+			UserName: p.ID,
+			Groups:   p.Groups,
+		}
+	}
+
+	if r.insecure {
+		shallowCopy.TLSClientConfig = rest.TLSClientConfig{
+			Insecure: r.insecure,
+		}
+	}
+
+	return &shallowCopy
+}
+
+// ClientGetter implementations should create a Kubernetes client from a context.
+type ClientGetter interface {
+	Client(ctx context.Context) (client.Client, error)
+}
+
+// DefaultClientGetter implements the ClientGetter interface and uses a ConfigGetter
+// to get a *rest.Config and create a Kubernetes client.
+type DefaultClientGetter struct {
+	configGetter ConfigGetter
+	clusterName  string
+}
+
+// Client creates a new Kubernetes client using the *rest.Config returned from its
+// ConfigGetter.
+func (g *DefaultClientGetter) Client(ctx context.Context) (client.Client, error) {
+	config := g.configGetter.Config(ctx)
+
+	_, rawClient, err := kube.NewKubeHTTPClientWithConfig(config, g.clusterName)
+	if err != nil {
+		return nil, fmt.Errorf("could not create kube http client: %w", err)
+	}
+
+	return rawClient, nil
+}

--- a/pkg/server/config_gettter_test.go
+++ b/pkg/server/config_gettter_test.go
@@ -1,0 +1,80 @@
+package server_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/weaveworks/weave-gitops/pkg/server"
+	"github.com/weaveworks/weave-gitops/pkg/server/auth"
+	"k8s.io/client-go/rest"
+)
+
+var _ server.ConfigGetter = (*server.ImpersonatingConfigGetter)(nil)
+
+func TestImpersonatingConfigGetterPrincipalInContext(t *testing.T) {
+	g := server.NewImpersonatingConfigGetter(&rest.Config{}, false)
+	ctx := auth.WithPrincipal(context.TODO(), &auth.UserPrincipal{ID: "user@example.com"})
+
+	cfg := g.Config(ctx)
+
+	want := &rest.Config{
+		Impersonate: rest.ImpersonationConfig{
+			UserName: "user@example.com",
+		},
+	}
+	if diff := cmp.Diff(want, cfg); diff != "" {
+		t.Fatalf("incorrect client config:\n%s", diff)
+	}
+}
+
+func TestImpersonatingConfigGetterPrincipalInContextWithGroups(t *testing.T) {
+	g := server.NewImpersonatingConfigGetter(&rest.Config{}, false)
+	ctx := auth.WithPrincipal(context.TODO(), &auth.UserPrincipal{ID: "user@example.com", Groups: []string{"test-group"}})
+
+	cfg := g.Config(ctx)
+
+	want := &rest.Config{
+		Impersonate: rest.ImpersonationConfig{
+			UserName: "user@example.com",
+			Groups:   []string{"test-group"},
+		},
+	}
+	if diff := cmp.Diff(want, cfg); diff != "" {
+		t.Fatalf("incorrect client config:\n%s", diff)
+	}
+}
+
+func TestImpersonatingConfigGetterInsecureClient(t *testing.T) {
+	g := server.NewImpersonatingConfigGetter(&rest.Config{}, true)
+	ctx := auth.WithPrincipal(context.TODO(), &auth.UserPrincipal{ID: "user@example.com"})
+
+	cfg := g.Config(ctx)
+
+	want := &rest.Config{
+		Impersonate: rest.ImpersonationConfig{
+			UserName: "user@example.com",
+		},
+		TLSClientConfig: rest.TLSClientConfig{
+			Insecure: true,
+		},
+	}
+	if diff := cmp.Diff(want, cfg); diff != "" {
+		t.Fatalf("incorrect client config:\n%s", diff)
+	}
+}
+
+func TestImpersonatingConfigGetterNoPrincipalInContext(t *testing.T) {
+	g := server.NewImpersonatingConfigGetter(&rest.Config{}, true)
+
+	cfg := g.Config(context.TODO())
+
+	want := &rest.Config{
+		TLSClientConfig: rest.TLSClientConfig{
+			Insecure: true,
+		},
+	}
+	if diff := cmp.Diff(want, cfg); diff != "" {
+		t.Fatalf("incorrect client config:\n%s", diff)
+	}
+}

--- a/pkg/server/handler.go
+++ b/pkg/server/handler.go
@@ -23,6 +23,7 @@ func AuthEnabled() bool {
 
 type Config struct {
 	AppConfig      *ApplicationsConfig
+	AppOptions     []ApplicationsOption
 	ProfilesConfig ProfilesConfig
 	AuthServer     *auth.AuthServer
 }
@@ -36,7 +37,7 @@ func NewHandlers(ctx context.Context, cfg *Config) (http.Handler, error) {
 		httpHandler = auth.WithAPIAuth(httpHandler, cfg.AuthServer)
 	}
 
-	appsSrv := NewApplicationsServer(cfg.AppConfig)
+	appsSrv := NewApplicationsServer(cfg.AppConfig, cfg.AppOptions...)
 	if err := pbapp.RegisterApplicationsHandlerServer(ctx, mux, appsSrv); err != nil {
 		return nil, fmt.Errorf("could not register application: %w", err)
 	}

--- a/pkg/server/server_options.go
+++ b/pkg/server/server_options.go
@@ -1,0 +1,18 @@
+package server
+
+// ApplicationsOptions includes all the options that can be set for an
+// ApplicationsServer.
+type ApplicationsOptions struct {
+	ClientGetter ClientGetter
+}
+
+// ApplicationsOption defines the signature of a function that can be used
+// to set an option for an ApplicationsServer.
+type ApplicationsOption func(*ApplicationsOptions)
+
+// WithClientGetter allows for setting a ClientGetter.
+func WithClientGetter(clientGetter ClientGetter) ApplicationsOption {
+	return func(args *ApplicationsOptions) {
+		args.ClientGetter = clientGetter
+	}
+}

--- a/pkg/server/suite_test.go
+++ b/pkg/server/suite_test.go
@@ -129,10 +129,11 @@ var _ = BeforeEach(func() {
 		JwtClient:        jwtClient,
 		KubeClient:       k8sClient,
 		GithubAuthClient: ghAuthClient,
-		Fetcher:          applicationv2.NewFetcher(k8sClient),
+		FetcherFactory:   NewFakeFetcherFactory(applicationv2.NewFetcher(k8sClient)),
 		GitlabAuthClient: glAuthClient,
+		ClusterConfig:    ClusterConfig{},
 	}
-	apps = NewApplicationsServer(&cfg)
+	apps = NewApplicationsServer(&cfg, WithClientGetter(NewFakeClientGetter(k8sClient)))
 	pb.RegisterApplicationsServer(s, apps)
 
 	go func() {

--- a/test/integration/server/suite_test.go
+++ b/test/integration/server/suite_test.go
@@ -11,10 +11,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/weaveworks/weave-gitops/pkg/kube"
-
-	"github.com/weaveworks/weave-gitops/pkg/services/applicationv2"
-
 	"github.com/go-logr/zapr"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -93,16 +89,17 @@ var _ = BeforeSuite(func() {
 	factory := services.NewServerFactory(fluxClient, &loggerfakes.FakeLogger{}, env.Rest, clusterName)
 	Expect(err).NotTo(HaveOccurred())
 
-	_, k, err := kube.NewKubeHTTPClientWithConfig(env.Rest, clusterName)
-	Expect(err).NotTo(HaveOccurred())
-
 	cfg := &server.ApplicationsConfig{
 		Factory:          factory,
 		Logger:           zapr.NewLogger(zap.NewNop()),
 		JwtClient:        auth.NewJwtClient("somekey"),
 		GithubAuthClient: auth.NewGithubAuthClient(http.DefaultClient),
 		KubeClient:       env.Client,
-		Fetcher:          applicationv2.NewFetcher(k),
+		FetcherFactory:   server.NewDefaultFetcherFactory(),
+		ClusterConfig: server.ClusterConfig{
+			DefaultConfig: env.Rest,
+			ClusterName:   clusterName,
+		},
 	}
 
 	s = grpc.NewServer()


### PR DESCRIPTION
<!-- Use # to add the issue this pull request is related to -->
Part of: #1092  

<!-- Describe what has changed in this PR -->
**What changed?**
Instead of creating a fetcher initially when an `ApplicationsServer` is created, we create it when the HTTP request is handled so that we can use existing middleware to determine the identity of the user making the request. Following that, we can assume the identity of that user when making calls to the Kubernetes API.

There are three abstractions on interest that are introduced in this PR: `ConfigGetter`, `ClientGetter` and `FetcherFactory`:
- `ConfigGetter`: this is a low level abstraction that can be used to create a `*rest.Config` after inspecting the `context.Context`.
- `ClientGetter`: this is used to create a `client.Client` from a `*rest.Config`. It complements `ConfigGetter` and it allows for using a fake Kubernetes client in tests.
- `FetcherFactory`: there is already a `FakeFetcher` object being used in tests so this interface allows for substituting fetcher objects with fakes in unit tests, without the need to fake its dependencies (i.e. `client.Client`)

If you try running this, you should get an error similar to this:
```
apps.wego.weave.works is forbidden: User <your-email-address> cannot list resource "apps" in API group "wego.weave.works" in the namespace "wego-system"
```
You need to apply the corrent RBAC permissions to view the list of applications:
```yaml
---
apiVersion: rbac.authorization.k8s.io/v1
kind: Role
metadata:
  namespace: wego-system
  name: apps-reader
rules:
- apiGroups: ["wego.weave.works"]
  resources: ["apps"]
  verbs: ["get", "watch", "list"]
---
apiVersion: rbac.authorization.k8s.io/v1
kind: RoleBinding
metadata:
  name: read-apps
  namespace: wego-system
subjects:
- kind: User
  name: <your-email-address>
  apiGroup: rbac.authorization.k8s.io
roleRef:
  kind: Role
  name: apps-reader
  apiGroup: rbac.authorization.k8s.io
```

<!-- Tell your future self why have you made these changes -->
**Why?**
The end goal is to execute calls to the Kubernetes API on behalf of the authenticated user.

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**
Unit tests and manually.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
**Release notes**
Not yet, still behind a feature flag.

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
Not yet, still behind a feature flag.