### PR TITLE
Fixes version reported by the `gitops` binary in the `wego-app` docker image in a tagged release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -84,8 +84,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-         with:
-           fetch-depth: 0
+        with:
+          fetch-depth: 0
       - name: Log in to the Container registry
         uses: docker/login-action@v1
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -84,10 +84,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-      - name: Unshallow
-        run: |
-          git fetch --prune --unshallow
-          git fetch --tags -f
+         with:
+           fetch-depth: 0
       - name: Log in to the Container registry
         uses: docker/login-action@v1
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -84,6 +84,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+      - name: Unshallow
+        run: |
+          git fetch --prune --unshallow
+          git fetch --tags -f
       - name: Log in to the Container registry
         uses: docker/login-action@v1
         with:


### PR DESCRIPTION
- E.g. `docker run wego-app install` will create a deployment for
  wego-app with an image tag of a git hash instead of the tagged release
  version.
- Github doesn't checkout tags by default so can only report the hash.

<!-- Tell your future self why have you made these changes -->
**Why?**

So we can run `docker run wego-app install` and not end up with an ImagePullError in the wego-app deployment:

```
  Normal  BackOff  3m26s (x4039 over 15h)  kubelet  Back-off pulling image "ghcr.io/weaveworks/wego-app:15349f1"
```

e.g. this is caused by version being wrong

```
$ docker run ghcr.io/weaveworks/wego-app:v0.6.0 version
Current Version: 15349f1
GitCommit: 15349f1
BuildTime: 2021-12-16_19:24:51
Branch: HEAD
Flux Version: v0.21.0
```


<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**

Have not tested this, but assume it works similarly to the go-releaser task, in that we need to pull all the git tag meta down before calling :

`VERSION=$(shell git describe --always --match "v*")` via `make bin`

