### PR TITLE
Links to commits open new tab

### DIFF
--- a/ui/components/CommitsTable.tsx
+++ b/ui/components/CommitsTable.tsx
@@ -85,7 +85,11 @@ function CommitsTable({
         fields={[
           {
             label: "SHA",
-            value: (row: Commit) => <Link href={row.url}>{row.hash}</Link>,
+            value: (row: Commit) => (
+              <Link newTab href={row.url}>
+                {row.hash}
+              </Link>
+            ),
           },
           {
             label: "Date",

--- a/ui/components/Link.tsx
+++ b/ui/components/Link.tsx
@@ -9,14 +9,15 @@ type Props = {
   innerRef?: any;
   children?: any;
   href?: any;
+  newTab?: boolean;
 };
 
-function Link({ children, href, className, to = "", ...props }: Props) {
+function Link({ children, href, className, to = "", newTab, ...props }: Props) {
   const txt = <Text color="primary">{children}</Text>;
 
   if (href) {
     return (
-      <a className={className} href={href}>
+      <a className={className} href={href} target={newTab ? "_blank" : ""}>
         {txt}
       </a>
     );

--- a/ui/components/Link.tsx
+++ b/ui/components/Link.tsx
@@ -17,7 +17,12 @@ function Link({ children, href, className, to = "", newTab, ...props }: Props) {
 
   if (href) {
     return (
-      <a className={className} href={href} target={newTab ? "_blank" : ""}>
+      <a
+        className={className}
+        href={href}
+        target={newTab ? "_blank" : ""}
+        rel="noreferrer"
+      >
         {txt}
       </a>
     );


### PR DESCRIPTION
Closes: #1210

Added `newTab` prop to the Link component which allows toggling of the` target='_blank'` attribute of the <a> element

