### PR TITLE
Refactor application endpoints to get `client` at the time of the request

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -66,7 +66,6 @@ type applicationServer struct {
 	factory        services.Factory
 	jwtClient      auth.JWTClient
 	log            logr.Logger
-	kube           client.Client
 	ghAuthClient   auth.GithubAuthClient
 	fetcherFactory FetcherFactory
 	glAuthClient   auth.GitlabAuthClient
@@ -79,7 +78,6 @@ type ApplicationsConfig struct {
 	Logger           logr.Logger
 	Factory          services.Factory
 	JwtClient        auth.JWTClient
-	KubeClient       client.Client
 	GithubAuthClient auth.GithubAuthClient
 	FetcherFactory   FetcherFactory
 	GitlabAuthClient auth.GitlabAuthClient
@@ -130,7 +128,6 @@ func NewApplicationsServer(cfg *ApplicationsConfig, setters ...ApplicationsOptio
 		jwtClient:      cfg.JwtClient,
 		log:            cfg.Logger,
 		factory:        cfg.Factory,
-		kube:           cfg.KubeClient,
 		ghAuthClient:   cfg.GithubAuthClient,
 		fetcherFactory: cfg.FetcherFactory,
 		glAuthClient:   cfg.GitlabAuthClient,
@@ -162,18 +159,12 @@ func DefaultApplicationsConfig() (*ApplicationsConfig, error) {
 		return nil, fmt.Errorf("could not create client config: %w", err)
 	}
 
-	_, rawClient, err := kube.NewKubeHTTPClientWithConfig(rest, clusterName)
-	if err != nil {
-		return nil, fmt.Errorf("could not create kube http client: %w", err)
-	}
-
 	fluxClient := flux.New(osys.New(), &runner.CLIRunner{})
 
 	return &ApplicationsConfig{
 		Logger:           logr,
 		Factory:          services.NewServerFactory(fluxClient, internal.NewApiLogger(zapLog), nil, ""),
 		JwtClient:        jwtClient,
-		KubeClient:       rawClient,
 		FetcherFactory:   NewDefaultFetcherFactory(),
 		GithubAuthClient: auth.NewGithubAuthClient(http.DefaultClient),
 		GitlabAuthClient: auth.NewGitlabAuthClient(http.DefaultClient),
@@ -429,6 +420,11 @@ func (s *applicationServer) ListCommits(ctx context.Context, msg *pb.ListCommits
 		return nil, grpcStatus.Errorf(codes.Unauthenticated, "error listing commits: %s", err.Error())
 	}
 
+	cl, err := s.clientGetter.Client(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	pageToken := 0
 	if msg.PageToken != nil {
 		pageToken = int(*msg.PageToken)
@@ -443,7 +439,7 @@ func (s *applicationServer) ListCommits(ctx context.Context, msg *pb.ListCommits
 	}
 
 	application := &wego.Application{}
-	if err := s.kube.Get(ctx, types.NamespacedName{Name: msg.Name, Namespace: msg.Namespace}, application); err != nil {
+	if err := cl.Get(ctx, types.NamespacedName{Name: msg.Name, Namespace: msg.Namespace}, application); err != nil {
 		return nil, fmt.Errorf("could not get app %q in namespace %q: %w", msg.Name, msg.Namespace, err)
 	}
 
@@ -491,6 +487,11 @@ func (s *applicationServer) ListCommits(ctx context.Context, msg *pb.ListCommits
 }
 
 func (s *applicationServer) GetReconciledObjects(ctx context.Context, msg *pb.GetReconciledObjectsReq) (*pb.GetReconciledObjectsRes, error) {
+	cl, err := s.clientGetter.Client(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	var opts client.MatchingLabels
 
 	switch msg.AutomationKind {
@@ -519,7 +520,7 @@ func (s *applicationServer) GetReconciledObjects(ctx context.Context, msg *pb.Ge
 			Version: gvk.Version,
 		})
 
-		if err := s.kube.List(ctx, &list, opts); err != nil {
+		if err := cl.List(ctx, &list, opts); err != nil {
 			return nil, fmt.Errorf("could not get unstructured list: %s", err)
 		}
 
@@ -552,6 +553,11 @@ func (s *applicationServer) GetReconciledObjects(ctx context.Context, msg *pb.Ge
 }
 
 func (s *applicationServer) GetChildObjects(ctx context.Context, msg *pb.GetChildObjectsReq) (*pb.GetChildObjectsRes, error) {
+	cl, err := s.clientGetter.Client(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	list := unstructured.UnstructuredList{}
 
 	list.SetGroupVersionKind(schema.GroupVersionKind{
@@ -560,7 +566,7 @@ func (s *applicationServer) GetChildObjects(ctx context.Context, msg *pb.GetChil
 		Kind:    msg.GroupVersionKind.Kind,
 	})
 
-	if err := s.kube.List(ctx, &list); err != nil {
+	if err := cl.List(ctx, &list); err != nil {
 		return nil, fmt.Errorf("could not get unstructured object: %s", err)
 	}
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1037,7 +1037,6 @@ var _ = Describe("ApplicationsServer", func() {
 
 				cfg := ApplicationsConfig{
 					Logger:         log,
-					KubeClient:     k8s,
 					JwtClient:      auth.NewJwtClient(secretKey),
 					FetcherFactory: NewFakeFetcherFactory(applicationv2.NewFetcher(k8s)),
 					Factory:        fakeFactory,
@@ -1209,7 +1208,6 @@ var _ = Describe("Applications handler", func() {
 
 		cfg := ApplicationsConfig{
 			Logger:         log,
-			KubeClient:     k8s,
 			FetcherFactory: NewFakeFetcherFactory(applicationv2.NewFetcher(k8s)),
 			Factory:        factory,
 			ClusterConfig:  ClusterConfig{},

--- a/pkg/server/suite_test.go
+++ b/pkg/server/suite_test.go
@@ -127,7 +127,6 @@ var _ = BeforeEach(func() {
 	cfg := ApplicationsConfig{
 		Factory:          fakeFactory,
 		JwtClient:        jwtClient,
-		KubeClient:       k8sClient,
 		GithubAuthClient: ghAuthClient,
 		FetcherFactory:   NewFakeFetcherFactory(applicationv2.NewFetcher(k8sClient)),
 		GitlabAuthClient: glAuthClient,

--- a/test/integration/server/suite_test.go
+++ b/test/integration/server/suite_test.go
@@ -94,7 +94,6 @@ var _ = BeforeSuite(func() {
 		Logger:           zapr.NewLogger(zap.NewNop()),
 		JwtClient:        auth.NewJwtClient("somekey"),
 		GithubAuthClient: auth.NewGithubAuthClient(http.DefaultClient),
-		KubeClient:       env.Client,
 		FetcherFactory:   server.NewDefaultFetcherFactory(),
 		ClusterConfig: server.ClusterConfig{
 			DefaultConfig: env.Rest,


### PR DESCRIPTION
<!-- Use # to add the issue this pull request is related to -->
Part of: #1092  

<!-- Describe what has changed in this PR -->
**What changed?**
Instead of creating a Kubernetes `client.Client` when an `applicationsServer` is created, we create it when the HTTP request is handled so that we can use existing middleware to determine the identity of the user making the request. Following that, we can assume the identity of that user when making calls to the Kubernetes API.

<!-- Tell your future self why have you made these changes -->
**Why?**
The end goal is to execute calls to the Kubernetes API on behalf of the authenticated user.

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**
Updated existing unit tests + manually

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
**Release notes**
Not yet, still behind a feature flag.

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
Not yet, still behind a feature flag.