### PR TITLE
Include weave-gitops in resources managed by weave-gitops

### DIFF
--- a/pkg/services/automation/automation_test.go
+++ b/pkg/services/automation/automation_test.go
@@ -442,7 +442,7 @@ var _ = Describe("Generate cluster manifests", func() {
 		Expect(clusterAutomation.UserKustResourceManifest.Content).To(Equal(userKustResourceManifest))
 		Expect(clusterAutomation.UserKustResourceManifest.Path).To(Equal(systemQualifiedPath(userKustResourcePath)))
 
-		systemKust := CreateKustomize(cluster.Name, namespace, runtimePath, sourcePath, systemKustResourcePath, userKustResourcePath)
+		systemKust := CreateKustomize(cluster.Name, namespace, runtimePath, sourcePath, systemKustResourcePath, userKustResourcePath, WegoAppPath)
 		systemKustManifest, err := yaml.Marshal(systemKust)
 		Expect(err).ShouldNot(HaveOccurred())
 

--- a/pkg/services/automation/cluster_generator.go
+++ b/pkg/services/automation/cluster_generator.go
@@ -106,7 +106,7 @@ func (a *AutomationGen) GenerateClusterAutomation(ctx context.Context, cluster m
 		return ClusterAutomation{}, err
 	}
 
-	systemKustomization := CreateKustomize(cluster.Name, namespace, RuntimePath, SourcePath, SystemKustResourcePath, UserKustResourcePath)
+	systemKustomization := CreateKustomize(cluster.Name, namespace, RuntimePath, SourcePath, SystemKustResourcePath, UserKustResourcePath, WegoAppPath)
 
 	systemKustomizationManifest, err := yaml.Marshal(systemKustomization)
 	if err != nil {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Put the file `wego-app.yaml` into `kustomization.yaml`

<!-- Tell your future self why have you made these changes -->
**Why?**
While the wego-app resources were installed at cluster creation time,
they wouldn't be upgraded by changing the manifest. I found this unexpected.

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**
I made a PR before: https://github.com/ozamosi/gitops-config/pull/6/files
and after: https://github.com/ozamosi/gitops-config/pull/5/files

The difference is in  `.weave-gitops/clusters/kind-regression-test-cluster-{0,1}/system/kustomization.yaml` where `wego-app.yaml` is only included in the "after" PR.

I'm not really familiar with the code in this repo, so if there's anywhere I should put an automated test, please advise.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
**Release notes**
The code I'm changing seems to have originated in #1141 - assuming this wasn't a problem in 0.6.0, this doesn't need release notes.

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
No.