### PR TITLE
Upgrades to a ggp w/ the on-prem-gitlab fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/benbjohnson/clock v1.1.0
 	github.com/coreos/go-oidc/v3 v3.1.0
 	github.com/deepmap/oapi-codegen v1.8.1
-	github.com/fluxcd/go-git-providers v0.5.2-0.20220111143741-04eef9791373
+	github.com/fluxcd/go-git-providers v0.5.3-0.20220117132246-2e907fbf3e15
 	github.com/fluxcd/helm-controller/api v0.14.1
 	github.com/fluxcd/kustomize-controller/api v0.18.2
 	github.com/fluxcd/pkg/apis/meta v0.10.1

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/benbjohnson/clock v1.1.0
 	github.com/coreos/go-oidc/v3 v3.1.0
 	github.com/deepmap/oapi-codegen v1.8.1
-	github.com/fluxcd/go-git-providers v0.5.3-0.20220117132246-2e907fbf3e15
+	github.com/fluxcd/go-git-providers v0.5.2
 	github.com/fluxcd/helm-controller/api v0.14.1
 	github.com/fluxcd/kustomize-controller/api v0.18.2
 	github.com/fluxcd/pkg/apis/meta v0.10.1

--- a/go.sum
+++ b/go.sum
@@ -372,6 +372,8 @@ github.com/felixge/httpsnoop v1.0.1 h1:lvB5Jl89CsZtGIWuTcDM1E/vkVs49/Ml7JJe07l8S
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fluxcd/go-git-providers v0.5.2-0.20220111143741-04eef9791373 h1:d2RHYaFZrWQy3KKobyqkwToLxH8kgujnqf8/BGo8cj8=
 github.com/fluxcd/go-git-providers v0.5.2-0.20220111143741-04eef9791373/go.mod h1:4jTHTmSx3rFGnG78KUVgFYeG6vWFnKwUSr2mi31tvp8=
+github.com/fluxcd/go-git-providers v0.5.2 h1:TA+1q6w2KgSugaZ9VXODQcYbtZyn6JH+V7g2MZtzTPA=
+github.com/fluxcd/go-git-providers v0.5.2/go.mod h1:4jTHTmSx3rFGnG78KUVgFYeG6vWFnKwUSr2mi31tvp8=
 github.com/fluxcd/go-git-providers v0.5.3-0.20220117132246-2e907fbf3e15 h1:JYVfAsOcfymUmBNgfCBGlza7/jKPtwi0KBnQHbh6JjM=
 github.com/fluxcd/go-git-providers v0.5.3-0.20220117132246-2e907fbf3e15/go.mod h1:4jTHTmSx3rFGnG78KUVgFYeG6vWFnKwUSr2mi31tvp8=
 github.com/fluxcd/helm-controller/api v0.14.1 h1:aAWaYZxTI68SD1R2SpNJh8+hm9oBeIOa9nW4YX5qYjM=

--- a/go.sum
+++ b/go.sum
@@ -372,6 +372,8 @@ github.com/felixge/httpsnoop v1.0.1 h1:lvB5Jl89CsZtGIWuTcDM1E/vkVs49/Ml7JJe07l8S
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fluxcd/go-git-providers v0.5.2-0.20220111143741-04eef9791373 h1:d2RHYaFZrWQy3KKobyqkwToLxH8kgujnqf8/BGo8cj8=
 github.com/fluxcd/go-git-providers v0.5.2-0.20220111143741-04eef9791373/go.mod h1:4jTHTmSx3rFGnG78KUVgFYeG6vWFnKwUSr2mi31tvp8=
+github.com/fluxcd/go-git-providers v0.5.3-0.20220117132246-2e907fbf3e15 h1:JYVfAsOcfymUmBNgfCBGlza7/jKPtwi0KBnQHbh6JjM=
+github.com/fluxcd/go-git-providers v0.5.3-0.20220117132246-2e907fbf3e15/go.mod h1:4jTHTmSx3rFGnG78KUVgFYeG6vWFnKwUSr2mi31tvp8=
 github.com/fluxcd/helm-controller/api v0.14.1 h1:aAWaYZxTI68SD1R2SpNJh8+hm9oBeIOa9nW4YX5qYjM=
 github.com/fluxcd/helm-controller/api v0.14.1/go.mod h1:NkfZ5ugs9EUUPSGHfAnNs295mf8sVKG0842aL6cFzMM=
 github.com/fluxcd/kustomize-controller/api v0.18.2 h1:rGu9R6PMFw3x0S6tVj/ZS54sJWW6/cdWe0Gga09e1AY=

--- a/pkg/services/automation/cluster_generator.go
+++ b/pkg/services/automation/cluster_generator.go
@@ -46,10 +46,12 @@ const (
 	WegoConfigMapName = "weave-gitops-config"
 )
 
+// The cluster source name and the app source name need to remain distinct to prevent https://github.com/weaveworks/weave-gitops/issues/1075 from coming back.
+// (hence the `-auto-` addition)
 func CreateClusterSourceName(gitSourceURL gitproviders.RepoURL) string {
 	provider := string(gitSourceURL.Provider())
 	cleanRepoName := replaceUnderscores(gitSourceURL.RepositoryName())
-	qualifiedName := fmt.Sprintf("wego-%s-%s", provider, cleanRepoName)
+	qualifiedName := fmt.Sprintf("wego-auto-%s-%s", provider, cleanRepoName)
 	lengthConstrainedName := hashNameIfTooLong(qualifiedName)
 
 	return lengthConstrainedName

--- a/pkg/services/automation/cluster_generator.go
+++ b/pkg/services/automation/cluster_generator.go
@@ -49,7 +49,7 @@ const (
 func CreateClusterSourceName(gitSourceURL gitproviders.RepoURL) string {
 	provider := string(gitSourceURL.Provider())
 	cleanRepoName := replaceUnderscores(gitSourceURL.RepositoryName())
-	qualifiedName := fmt.Sprintf("wego-auto-%s-%s", provider, cleanRepoName)
+	qualifiedName := fmt.Sprintf("wego-%s-%s", provider, cleanRepoName)
 	lengthConstrainedName := hashNameIfTooLong(qualifiedName)
 
 	return lengthConstrainedName


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

- #1297 introduced a version of ggp that breaks on-prem support
- This PR upgrades to ggp that includes https://github.com/fluxcd/go-git-providers/pull/141 which fixes on-prem-gitlab support. 
- It also adds support for older wg installations that might not have a kustomization.yaml file present

<!-- Tell your future self why have you made these changes -->
**Why?**

For on-prem things!

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**

`gitops upgrade` before:

```
Error: failed to get git clients: error setting up deploy keys: failed check for existing deploy key: error getting user repo reference for owner XXXX, repo demo-01, error getting user repository domai
n "https://XXXX" not supported by this client: the client doesn't support handling requests for this domain
```
