### PR TITLE
Make docker builds faster

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,8 @@
 node_modules
 .parcel-cache
+.deps
+.git
+dist
+bin
+pkg/flux/bin/flux
+cmd/gitops/ui/run/dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,21 +7,11 @@ USER node
 COPY --chown=node:node package*.json /home/app/
 COPY --chown=node:node Makefile /home/app/
 RUN make node_modules
-COPY --chown=node:node . /home/app/
+COPY --chown=node:node ui /home/app/ui
 RUN make ui
 
 # Go build
 FROM golang:1.17 AS go-build
-COPY . /app
-WORKDIR /app
-# Remove flux to ensure the correct version is installed
-RUN make clean
-COPY --from=ui /home/app/cmd/gitops/ui/run/dist/ /app/cmd/gitops/ui/run/dist/
-RUN make dependencies && make bin
-# Add known_hosts entries for GitHub and GitLab
-RUN mkdir ~/.ssh
-RUN ssh-keyscan github.com >> ~/.ssh/known_hosts
-RUN ssh-keyscan gitlab.com >> ~/.ssh/known_hosts
 # Add a kubectl
 RUN apt-get install -y apt-transport-https ca-certificates curl openssh-client && \
     curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg \
@@ -30,6 +20,20 @@ RUN apt-get install -y apt-transport-https ca-certificates curl openssh-client &
     https://apt.kubernetes.io/ kubernetes-xenial main" | tee /etc/apt/sources.list.d/kubernetes.list && \
     apt-get update && \
     apt-get install -y kubectl
+# Add known_hosts entries for GitHub and GitLab
+RUN mkdir ~/.ssh
+RUN ssh-keyscan github.com >> ~/.ssh/known_hosts
+RUN ssh-keyscan gitlab.com >> ~/.ssh/known_hosts
+
+COPY Makefile /app/
+COPY tools /app/tools
+WORKDIR /app
+RUN make dependencies
+COPY go.* /app/
+RUN go mod download
+COPY --from=ui /home/app/cmd/gitops/ui/run/dist/ /app/cmd/gitops/ui/run/dist/
+COPY . /app
+RUN make bin
 
 # Distroless
 FROM gcr.io/distroless/base

--- a/tools/download-deps.sh
+++ b/tools/download-deps.sh
@@ -10,8 +10,7 @@ cd "${SCRIPT_DIR}" || exit 1
 . "${SCRIPT_DIR}/functions.sh"
 
 DEP_FILE=${1}
-TAG=${2:-$(${SCRIPT_DIR}/image-tag)}
-BIN_DIR=${3:-${SCRIPT_DIR}/bin}
+BIN_DIR=${2:-${SCRIPT_DIR}/bin}
 RELEASE_GOOS=${RELEASE_GOOS:-$(go env GOOS)}
 SKIP_FETCH_TOOLS=${SKIP_FETCH_TOOLS:-""}
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Change download-deps to not interact with git - it doesn't need git,
and docker builds shouldn't contain git.

Add a bunch more entries to dockerignore - this cuts out hundreds of megs
of build context.

Remove `make clean` from the Dockerfile. We shouldn't copy cleanable
state into the docker image in the first place. In this case, it seems
we run make clean to run git clean to remove the flux binary - so I
just added the flux binary to the dockerignore instead.

Reorder the Dockerfile and be more explicit, in order to cache more -
go changes now only makes the go code recompile.

<!-- Tell your future self why have you made these changes -->
**Why?**
Before this change, almost every change caused `make docker` to run
for 90-100s on my machine, because almost all caches were always
invalidated.

After this change, go changes only take 30s to re-build, whereas
javascript changes takes 40s (because they still trigger a go build),
and only initial builds or dependency changes take longer.

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**
Local, manual testing