### PR TITLE
Report correct version when building docker image on-release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -84,8 +84,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
+      - name: Unshallow
+        run: |
+          git fetch --prune --unshallow
+          git fetch --tags -f
       - name: Log in to the Container registry
         uses: docker/login-action@v1
         with:


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

We use the 
```
      - name: Unshallow
        run: |
          git fetch --prune --unshallow
          git fetch --tags -f
```

trick instead of the `depth: 0` trick to get the git `HEAD` at the correct tag reference so that `git describe` works

<!-- Tell your future self why have you made these changes -->
**Why?**

We tried to fix this in https://github.com/weaveworks/weave-gitops/pull/1293 but it didn't work

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**

In another repo: https://github.com/foot/github-actions-examples

on tagging and pushing `v0.0.2`:
- `checkout` with no args: `9361784`
- `checkout` with `depth: 0`: `v0.0.1-1-g9361784`
- `checkout` with `git fetch --prune --unshallow && git fetch --tags -f` : `v0.0.2`

---
The new bug: 0.6.1 is completely missing a version:

```
$ docker run ghcr.io/weaveworks/wego-app:v0.6.1 version
Current Version:
GitCommit:
BuildTime: 2022-01-20_20:14:33
Branch:
Flux Version: v0.24.1
```

0.6.0 was reporting the wrong version:

```
$ docker run ghcr.io/weaveworks/wego-app:v0.6.0 version
Current Version: 15349f1
GitCommit: 15349f1
BuildTime: 2021-12-16_19:24:51
Branch: HEAD
Flux Version: v0.21.0
```

Running install w/ 0.6.1 gives a broken wego-app manifest:

```
$ docker run -e KUBECONFIG=/tmp/wg/demokubeconfig.txt -v `pwd`:/tmp/wg ghcr.io/weaveworks/wego-app:0.6.1 install --dry-run --config-repo https://github.com/org/repo --override-in-cluster | grep "image:.*wego"
          image: ghcr.io/weaveworks/wego-app:
```