### PR TITLE
Only add deploy key when needed

### DIFF
--- a/cmd/gitops/add/app/cmd.go
+++ b/cmd/gitops/add/app/cmd.go
@@ -60,7 +60,6 @@ func init() {
 	Cmd.Flags().StringVar(&params.Branch, "branch", "", "Branch to watch within git repository")
 	Cmd.Flags().StringVar(&params.DeploymentType, "deployment-type", app.DefaultDeploymentType, "Deployment type [kustomize, helm]")
 	Cmd.Flags().StringVar(&params.Chart, "chart", "", "Specify chart for helm source")
-	Cmd.Flags().StringVar(&params.ConfigRepo, "config-repo", "", "URL of external repository (if any) which will hold automation manifests")
 	Cmd.Flags().StringVar(&params.HelmReleaseTargetNamespace, "helm-release-target-namespace", "", "Namespace in which to deploy a helm chart; defaults to the gitops installation namespace")
 	Cmd.Flags().BoolVar(&params.DryRun, "dry-run", false, "If set, 'gitops add app' will not make any changes to the system; it will just display the actions that would have been taken")
 	Cmd.Flags().BoolVar(&params.AutoMerge, "auto-merge", false, "If set, 'gitops add app' will merge automatically into the set --branch")
@@ -123,9 +122,11 @@ func runCmd(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed getting wego config")
 	}
 
+	params.ConfigRepo = wegoConfig.ConfigRepo
+
 	gitClient, gitProvider, err := factory.GetGitClients(ctx, kubeClient, providerClient, services.GitConfigParams{
 		URL:              params.Url,
-		ConfigRepo:       wegoConfig.ConfigRepo,
+		ConfigRepo:       params.ConfigRepo,
 		Namespace:        params.Namespace,
 		IsHelmRepository: params.IsHelmRepository(),
 		DryRun:           params.DryRun,

--- a/cmd/gitops/add/app/cmd.go
+++ b/cmd/gitops/add/app/cmd.go
@@ -89,10 +89,6 @@ func runCmd(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("you should choose either --url or the app directory")
 	}
 
-	if params.ConfigRepo == "" {
-		return errors.New("--config-repo should be provided")
-	}
-
 	if len(args) > 0 {
 		path, err := filepath.Abs(args[0])
 		if err != nil {

--- a/cmd/gitops/add/app/cmd.go
+++ b/cmd/gitops/add/app/cmd.go
@@ -89,6 +89,10 @@ func runCmd(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("you should choose either --url or the app directory")
 	}
 
+	if params.ConfigRepo == "" {
+		return errors.New("--config-repo should be provided")
+	}
+
 	if len(args) > 0 {
 		path, err := filepath.Abs(args[0])
 		if err != nil {

--- a/cmd/gitops/add/clusters/cmd.go
+++ b/cmd/gitops/add/clusters/cmd.go
@@ -117,7 +117,7 @@ func getClusterCmdRunE(endpoint *string, client *resty.Client) func(*cobra.Comma
 			return cmderrors.ErrNoURL
 		}
 
-		url, err := gitproviders.NewRepoURL(flags.RepositoryURL, true)
+		url, err := gitproviders.NewRepoURL(flags.RepositoryURL)
 		if err != nil {
 			return fmt.Errorf("cannot parse url: %w", err)
 		}

--- a/cmd/gitops/beta/cmd/install.go
+++ b/cmd/gitops/beta/cmd/install.go
@@ -83,9 +83,9 @@ func installRunCmd(cmd *cobra.Command, args []string) error {
 	}
 
 	gitClient, gitProvider, err := factory.GetGitClients(context.Background(), k, providerClient, services.GitConfigParams{
-		URL:       installParams.ConfigRepo,
-		Namespace: namespace,
-		DryRun:    installParams.DryRun,
+		ConfigRepo: installParams.ConfigRepo,
+		Namespace:  namespace,
+		DryRun:     installParams.DryRun,
 	})
 	if err != nil {
 		return fmt.Errorf("error creating git clients: %w", err)

--- a/cmd/gitops/delete/clusters/cmd.go
+++ b/cmd/gitops/delete/clusters/cmd.go
@@ -73,7 +73,7 @@ func getClusterCmdRunE(endpoint *string, client *resty.Client) func(*cobra.Comma
 			return cmderrors.ErrNoURL
 		}
 
-		url, err := gitproviders.NewRepoURL(flags.RepositoryURL, true)
+		url, err := gitproviders.NewRepoURL(flags.RepositoryURL)
 		if err != nil {
 			return fmt.Errorf("cannot parse url: %w", err)
 		}

--- a/cmd/gitops/install/cmd.go
+++ b/cmd/gitops/install/cmd.go
@@ -64,7 +64,7 @@ func installRunCmd(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
 	namespace, _ := cmd.Parent().Flags().GetString("namespace")
 
-	configURL, err := gitproviders.NewRepoURL(installParams.ConfigRepo, true)
+	configURL, err := gitproviders.NewRepoURL(installParams.ConfigRepo)
 	if err != nil {
 		return err
 	}
@@ -119,8 +119,6 @@ func installRunCmd(cmd *cobra.Command, args []string) error {
 	// This is going to be broken up to reduce complexity
 	// and then generates the source yaml of the config repo when using dry-run option
 	gitClient, gitProvider, err := factory.GetGitClients(context.Background(), kubeClient, providerClient, services.GitConfigParams{
-		// We need to set URL and ConfigRepo to the same value so a deploy key is created for public config repos
-		URL:        installParams.ConfigRepo,
 		ConfigRepo: installParams.ConfigRepo,
 		Namespace:  namespace,
 		DryRun:     installParams.DryRun,

--- a/cmd/gitops/upgrade/cmd.go
+++ b/cmd/gitops/upgrade/cmd.go
@@ -78,9 +78,9 @@ func upgradeCmdRunE() func(*cobra.Command, []string) error {
 		providerClient := internal.NewGitProviderClient(os.Stdout, os.LookupEnv, auth.NewAuthCLIHandler, log)
 
 		gitClient, gitProvider, err := factory.GetGitClients(ctx, kubeClient, providerClient, services.GitConfigParams{
-			URL:       upgradeCmdFlags.ConfigRepo,
-			Namespace: upgradeCmdFlags.Namespace,
-			DryRun:    upgradeCmdFlags.DryRun,
+			ConfigRepo: upgradeCmdFlags.ConfigRepo,
+			Namespace:  upgradeCmdFlags.Namespace,
+			DryRun:     upgradeCmdFlags.DryRun,
 		})
 		if err != nil {
 			return fmt.Errorf("failed to get git clients: %w", err)

--- a/cmd/internal/provider_test.go
+++ b/cmd/internal/provider_test.go
@@ -72,7 +72,7 @@ var _ = Describe("Get git provider", func() {
 		It("invalid token key returns an error", func() {
 			fakeLogger = &loggerfakes.FakeLogger{}
 			client = NewGitProviderClient(os.Stdout, fakeEnvLookupExists, fakeAuthHandlerFuncError, fakeLogger)
-			repoUrl, _ = gitproviders.NewRepoURL("ssh://git@some-bucket.com/weaveworks/weave-gitops.git", false)
+			repoUrl, _ = gitproviders.NewRepoURL("ssh://git@some-bucket.com/weaveworks/weave-gitops.git")
 
 			provider, err := client.GetProvider(repoUrl, fakeAccountGetterSuccess)
 			Expect(provider).To(BeNil())
@@ -87,7 +87,7 @@ var _ = Describe("Get git provider", func() {
 			BeforeEach(func() {
 				fakeLogger = &loggerfakes.FakeLogger{}
 				client = NewGitProviderClient(os.Stdout, fakeEnvLookupExists, fakeAuthHandlerFuncError, fakeLogger)
-				repoUrl, _ = gitproviders.NewRepoURL("ssh://git@github.com/weaveworks/weave-gitops.git", false)
+				repoUrl, _ = gitproviders.NewRepoURL("ssh://git@github.com/weaveworks/weave-gitops.git")
 			})
 
 			It("gitproviders.New returns an error", func() {
@@ -111,7 +111,7 @@ var _ = Describe("Get git provider", func() {
 			BeforeEach(func() {
 				fakeLogger = &loggerfakes.FakeLogger{}
 				client = NewGitProviderClient(os.Stdout, fakeEnvLookupExists, fakeAuthHandlerFuncError, fakeLogger)
-				repoUrl, _ = gitproviders.NewRepoURL("ssh://git@gitlab.com/weaveworks/weave-gitops.git", false)
+				repoUrl, _ = gitproviders.NewRepoURL("ssh://git@gitlab.com/weaveworks/weave-gitops.git")
 			})
 
 			It("gitproviders.New returns an error", func() {
@@ -135,7 +135,7 @@ var _ = Describe("Get git provider", func() {
 			fakeLogger = &loggerfakes.FakeLogger{
 				WarningfStub: func(fmtArg string, restArgs ...interface{}) {},
 			}
-			repoUrl, _ = gitproviders.NewRepoURL("ssh://git@github.com/weaveworks/weave-gitops.git", false)
+			repoUrl, _ = gitproviders.NewRepoURL("ssh://git@github.com/weaveworks/weave-gitops.git")
 		})
 
 		AfterEach(func() {

--- a/pkg/flux/flux_test.go
+++ b/pkg/flux/flux_test.go
@@ -84,7 +84,7 @@ var _ = Describe("CreateSourceGit", func() {
 			return []byte("out"), nil
 		}
 
-		repoUrl, err := gitproviders.NewRepoURL("https://github.com/foo/my-name", false)
+		repoUrl, err := gitproviders.NewRepoURL("https://github.com/foo/my-name")
 		Expect(err).ShouldNot(HaveOccurred())
 		out, err := fluxClient.CreateSourceGit("my-name", repoUrl, "main", "my-secret", wego.DefaultNamespace)
 		Expect(err).ShouldNot(HaveOccurred())
@@ -100,7 +100,7 @@ var _ = Describe("CreateSourceGit", func() {
 		runner.RunStub = func(s1 string, s2 ...string) ([]byte, error) {
 			return []byte("out"), nil
 		}
-		repoUrl, err := gitproviders.NewRepoURL("ssh://git@github.com/foo/my-name", false)
+		repoUrl, err := gitproviders.NewRepoURL("ssh://git@github.com/foo/my-name")
 		Expect(err).ShouldNot(HaveOccurred())
 		out, err := fluxClient.CreateSourceGit("my-name", repoUrl, "main", "", wego.DefaultNamespace)
 		Expect(err).ShouldNot(HaveOccurred())
@@ -119,7 +119,7 @@ var _ = Describe("CreateSourceGit", func() {
 			return []byte("out"), nil
 		}
 
-		repoUrl, err := gitproviders.NewRepoURL("ssh://git@gitlab.com/foo/my-name", false)
+		repoUrl, err := gitproviders.NewRepoURL("ssh://git@gitlab.com/foo/my-name")
 		Expect(err).ShouldNot(HaveOccurred())
 		out, err := fluxClient.CreateSourceGit("my-name", repoUrl, "main", "", wego.DefaultNamespace)
 		Expect(err).ShouldNot(HaveOccurred())
@@ -244,7 +244,7 @@ var _ = Describe("CreateSecretGit", func() {
 			return []byte(`ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCh...`), nil
 		}
 
-		repoUrl, err := gitproviders.NewRepoURL("ssh://git@github.com/foo/bar.git", false)
+		repoUrl, err := gitproviders.NewRepoURL("ssh://git@github.com/foo/bar.git")
 		Expect(err).ShouldNot(HaveOccurred())
 		out, err := fluxClient.CreateSecretGit("my-secret", repoUrl, wego.DefaultNamespace)
 		Expect(err).ShouldNot(HaveOccurred())

--- a/pkg/gitproviders/provider_org_test.go
+++ b/pkg/gitproviders/provider_org_test.go
@@ -48,7 +48,7 @@ var _ = Describe("Org Provider", func() {
 		}
 
 		var err error
-		repoUrl, err = NewRepoURL("http://github.com/owner/repo-name", false)
+		repoUrl, err = NewRepoURL("http://github.com/owner/repo-name")
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/pkg/gitproviders/provider_user_test.go
+++ b/pkg/gitproviders/provider_user_test.go
@@ -46,7 +46,7 @@ var _ = Describe("User Provider", func() {
 		}
 
 		var err error
-		repoUrl, err = NewRepoURL("http://github.com/owner/repo-name", false)
+		repoUrl, err = NewRepoURL("http://github.com/owner/repo-name")
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/pkg/gitproviders/repo_url.go
+++ b/pkg/gitproviders/repo_url.go
@@ -17,16 +17,15 @@ const RepositoryURLProtocolHTTPS RepositoryURLProtocol = "https"
 const RepositoryURLProtocolSSH RepositoryURLProtocol = "ssh"
 
 type RepoURL struct {
-	repoName     string
-	owner        string
-	url          *url.URL
-	normalized   string
-	provider     GitProviderName
-	protocol     RepositoryURLProtocol
-	isConfigRepo bool
+	repoName   string
+	owner      string
+	url        *url.URL
+	normalized string
+	provider   GitProviderName
+	protocol   RepositoryURLProtocol
 }
 
-func NewRepoURL(uri string, isConfigRepo bool) (RepoURL, error) {
+func NewRepoURL(uri string) (RepoURL, error) {
 	providerName, err := detectGitProviderFromUrl(uri, ViperGetStringMapString("git-host-types"))
 	if err != nil {
 		return RepoURL{}, fmt.Errorf("could not get provider name from URL %s: %w", uri, err)
@@ -53,13 +52,12 @@ func NewRepoURL(uri string, isConfigRepo bool) (RepoURL, error) {
 	}
 
 	return RepoURL{
-		repoName:     utils.UrlToRepoName(uri),
-		owner:        owner,
-		url:          u,
-		normalized:   normalized,
-		provider:     providerName,
-		protocol:     protocol,
-		isConfigRepo: isConfigRepo,
+		repoName:   utils.UrlToRepoName(uri),
+		owner:      owner,
+		url:        u,
+		normalized: normalized,
+		provider:   providerName,
+		protocol:   protocol,
 	}, nil
 }
 
@@ -85,10 +83,6 @@ func (n RepoURL) Provider() GitProviderName {
 
 func (n RepoURL) Protocol() RepositoryURLProtocol {
 	return n.protocol
-}
-
-func (n RepoURL) IsConfigRepo() bool {
-	return n.isConfigRepo
 }
 
 func getOwnerFromUrl(url url.URL, providerName GitProviderName) (string, error) {

--- a/pkg/gitproviders/repo_url_test.go
+++ b/pkg/gitproviders/repo_url_test.go
@@ -71,7 +71,7 @@ var _ = DescribeTable("NewRepoURL", func(input, gitProviderEnv string, expected 
 	if gitProviderEnv != "" {
 		viper.Set("git-host-types", gitProviderEnv)
 	}
-	result, err := NewRepoURL(input, false)
+	result, err := NewRepoURL(input)
 	Expect(err).NotTo(HaveOccurred())
 
 	Expect(result.String()).To(Equal(expected.s))

--- a/pkg/models/manifest_test.go
+++ b/pkg/models/manifest_test.go
@@ -145,7 +145,7 @@ var _ = Describe("Installer", func() {
 
 				boostrapManifests = []Manifest{}
 
-				configRepo, err := gitproviders.NewRepoURL("ssh://git@github.com/test-user/test-repo", true)
+				configRepo, err := gitproviders.NewRepoURL("ssh://git@github.com/test-user/test-repo")
 				Expect(err).ShouldNot(HaveOccurred())
 
 				params = GitopsManifestsParams{

--- a/pkg/models/manifest_test.go
+++ b/pkg/models/manifest_test.go
@@ -34,7 +34,7 @@ var _ = Describe("Installer", func() {
 	}
 	var err error
 	var _ = BeforeEach(func() {
-		params.ConfigRepo, err = gitproviders.NewRepoURL("ssh://git@github.com/test-user/test-repo", true)
+		params.ConfigRepo, err = gitproviders.NewRepoURL("ssh://git@github.com/test-user/test-repo")
 
 		fakeFluxClient = &fluxfakes.FakeFlux{}
 		fakeKubeClient = &kubefakes.FakeKube{}

--- a/pkg/server/internal/provider_test.go
+++ b/pkg/server/internal/provider_test.go
@@ -24,7 +24,7 @@ var _ = Describe("Get git provider", func() {
 	var repoUrl gitproviders.RepoURL
 	BeforeEach(func() {
 		client = NewGitProviderClient(fakeToken)
-		repoUrl, _ = gitproviders.NewRepoURL("ssh://git@github.com/weaveworks/weave-gitops.git", false)
+		repoUrl, _ = gitproviders.NewRepoURL("ssh://git@github.com/weaveworks/weave-gitops.git")
 	})
 
 	It("gitproviders.New throws an error", func() {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -304,7 +304,7 @@ func (s *applicationServer) AddApplication(ctx context.Context, msg *pb.AddAppli
 		return nil, fmt.Errorf("failed to create kube service: %w", err)
 	}
 
-	appUrl, err := gitproviders.NewRepoURL(msg.Url, false)
+	appUrl, err := gitproviders.NewRepoURL(msg.Url)
 	if err != nil {
 		return nil, grpcStatus.Errorf(codes.InvalidArgument, "unable to parse app url %q: %s", msg.Url, err)
 	}
@@ -314,7 +314,7 @@ func (s *applicationServer) AddApplication(ctx context.Context, msg *pb.AddAppli
 		return nil, fmt.Errorf("failed getting wego config")
 	}
 
-	configRepo, err := gitproviders.NewRepoURL(wegoConfig.ConfigRepo, true)
+	configRepo, err := gitproviders.NewRepoURL(wegoConfig.ConfigRepo)
 	if err != nil {
 		return nil, grpcStatus.Errorf(codes.InvalidArgument, "unable to parse config url %q: %s", wegoConfig.ConfigRepo, err)
 	}
@@ -677,7 +677,7 @@ func (s *applicationServer) Authenticate(_ context.Context, msg *pb.Authenticate
 }
 
 func (s *applicationServer) ParseRepoURL(ctx context.Context, msg *pb.ParseRepoURLRequest) (*pb.ParseRepoURLResponse, error) {
-	u, err := gitproviders.NewRepoURL(msg.Url, false)
+	u, err := gitproviders.NewRepoURL(msg.Url)
 	if err != nil {
 		return nil, grpcStatus.Errorf(codes.InvalidArgument, "could not parse url: %s", err.Error())
 	}

--- a/pkg/services/app/add.go
+++ b/pkg/services/app/add.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -141,6 +142,9 @@ func (a *AppSvc) updateParametersIfNecessary(ctx context.Context, gitProvider gi
 			return params, fmt.Errorf("--url must be specified for helm repositories")
 		}
 
+		if params.ConfigRepo == "" {
+			return params, errors.New("--config-repo should be provided")
+		}
 	default:
 		var err error
 

--- a/pkg/services/app/add.go
+++ b/pkg/services/app/add.go
@@ -144,7 +144,7 @@ func (a *AppSvc) updateParametersIfNecessary(ctx context.Context, gitProvider gi
 	default:
 		var err error
 
-		appRepoUrl, err = gitproviders.NewRepoURL(params.Url, false)
+		appRepoUrl, err = gitproviders.NewRepoURL(params.Url)
 		if err != nil {
 			return params, fmt.Errorf("error normalizing url: %w", err)
 		}
@@ -157,7 +157,7 @@ func (a *AppSvc) updateParametersIfNecessary(ctx context.Context, gitProvider gi
 
 	// making sure the config url is in good format
 	if models.IsExternalConfigRepo(params.ConfigRepo) {
-		configRepoUrl, err := gitproviders.NewRepoURL(params.ConfigRepo, true)
+		configRepoUrl, err := gitproviders.NewRepoURL(params.ConfigRepo)
 		if err != nil {
 			return params, fmt.Errorf("error normalizing url: %w", err)
 		}
@@ -231,7 +231,7 @@ func makeApplication(params AddParams) (models.Application, error) {
 	if models.SourceType(params.SourceType) == models.SourceTypeHelm {
 		helmSourceURL = params.Url
 	} else {
-		gitSourceURL, err = gitproviders.NewRepoURL(params.Url, false)
+		gitSourceURL, err = gitproviders.NewRepoURL(params.Url)
 		if err != nil {
 			return models.Application{}, err
 		}
@@ -240,7 +240,7 @@ func makeApplication(params AddParams) (models.Application, error) {
 	configRepo := gitSourceURL
 
 	if params.ConfigRepo != "" {
-		curl, err := gitproviders.NewRepoURL(params.ConfigRepo, true)
+		curl, err := gitproviders.NewRepoURL(params.ConfigRepo)
 		if err != nil {
 			return models.Application{}, err
 		}

--- a/pkg/services/app/commit.go
+++ b/pkg/services/app/commit.go
@@ -22,7 +22,7 @@ func (a *AppSvc) GetCommits(gitProvider gitproviders.GitProvider, params CommitP
 		return nil, fmt.Errorf("unable to get commits for a helm chart")
 	}
 
-	repoUrl, err := gitproviders.NewRepoURL(application.Spec.URL, false)
+	repoUrl, err := gitproviders.NewRepoURL(application.Spec.URL)
 	if err != nil {
 		return nil, fmt.Errorf("error creating normalized url: %w", err)
 	}

--- a/pkg/services/applicationv2/fetcher.go
+++ b/pkg/services/applicationv2/fetcher.go
@@ -81,7 +81,7 @@ func translateApp(app wego.Application) (models.Application, error) {
 	)
 
 	if wego.DeploymentType(app.Spec.SourceType) == wego.DeploymentType(wego.SourceTypeGit) {
-		appRepoUrl, err = gitproviders.NewRepoURL(app.Spec.URL, false)
+		appRepoUrl, err = gitproviders.NewRepoURL(app.Spec.URL)
 		if err != nil {
 			return models.Application{}, err
 		}
@@ -92,7 +92,7 @@ func translateApp(app wego.Application) (models.Application, error) {
 	}
 
 	if models.IsExternalConfigRepo(app.Spec.ConfigRepo) {
-		configRepoUrl, err = gitproviders.NewRepoURL(app.Spec.ConfigRepo, true)
+		configRepoUrl, err = gitproviders.NewRepoURL(app.Spec.ConfigRepo)
 		if err != nil {
 			return models.Application{}, err
 		}

--- a/pkg/services/auth/auth.go
+++ b/pkg/services/auth/auth.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/fluxcd/go-git-providers/gitprovider"
 	"github.com/weaveworks/weave-gitops/pkg/models"
 	"github.com/weaveworks/weave-gitops/pkg/services/auth/internal"
 
@@ -161,15 +160,6 @@ func (a *authSvc) setupDeployKey(ctx context.Context, name SecretName, targetNam
 }
 
 func (a *authSvc) provisionDeployKey(ctx context.Context, targetName string, name SecretName, repo gitproviders.RepoURL) (*ssh.PublicKeys, error) {
-	visibility, err := a.gitProvider.GetRepoVisibility(ctx, repo)
-	if err != nil {
-		return nil, fmt.Errorf("error getting repo visibility: %w", err)
-	}
-
-	if *visibility == gitprovider.RepositoryVisibilityPublic && !repo.IsConfigRepo() {
-		return nil, nil
-	}
-
 	deployKey, secret, err := a.generateDeployKey(targetName, name, repo)
 	if err != nil {
 		return nil, fmt.Errorf("error generating deploy key: %w", err)

--- a/pkg/services/auth/auth_test.go
+++ b/pkg/services/auth/auth_test.go
@@ -32,9 +32,9 @@ var _ = Describe("auth", func() {
 	var namespace *corev1.Namespace
 	testClustername := "test-cluster"
 	repoUrlString := "ssh://git@github.com/my-org/my-repo.git"
-	configRepoUrl, err := gitproviders.NewRepoURL(repoUrlString, true)
+	configRepoUrl, err := gitproviders.NewRepoURL(repoUrlString)
 	Expect(err).NotTo(HaveOccurred())
-	repoUrl, err := gitproviders.NewRepoURL(repoUrlString, false)
+	repoUrl, err := gitproviders.NewRepoURL(repoUrlString)
 	Expect(err).NotTo(HaveOccurred())
 
 	BeforeEach(func() {

--- a/pkg/services/auth/auth_test.go
+++ b/pkg/services/auth/auth_test.go
@@ -108,14 +108,5 @@ var _ = Describe("auth", func() {
 			Expect(k8sClient.Get(ctx, sn.NamespacedName(), newSecret)).To(Succeed())
 			Expect(gp.UploadDeployKeyCallCount()).To(Equal(1))
 		})
-
-		It("avoids deploying key for non config repos", func() {
-			gp.GetRepoVisibilityReturns(gitprovider.RepositoryVisibilityVar(gitprovider.RepositoryVisibilityPublic), nil)
-
-			_, err = as.CreateGitClient(ctx, repoUrl, testClustername, namespace.Name, false)
-			Expect(err).NotTo(HaveOccurred())
-
-			Expect(gp.UploadDeployKeyCallCount()).To(Equal(0))
-		})
 	})
 })

--- a/pkg/services/automation/automation_test.go
+++ b/pkg/services/automation/automation_test.go
@@ -21,7 +21,7 @@ var (
 )
 
 func createRepoURL(url string) gitproviders.RepoURL {
-	repoURL, err := gitproviders.NewRepoURL(url, false)
+	repoURL, err := gitproviders.NewRepoURL(url)
 	Expect(err).NotTo(HaveOccurred())
 
 	return repoURL

--- a/pkg/services/automation/generator.go
+++ b/pkg/services/automation/generator.go
@@ -277,7 +277,7 @@ func WegoAppToApp(app wego.Application) (models.Application, error) {
 	)
 
 	if wego.SourceType(app.Spec.SourceType) == wego.SourceType(wego.SourceTypeGit) {
-		appRepoUrl, err = gitproviders.NewRepoURL(app.Spec.URL, false)
+		appRepoUrl, err = gitproviders.NewRepoURL(app.Spec.URL)
 		if err != nil {
 			return models.Application{}, err
 		}
@@ -286,7 +286,7 @@ func WegoAppToApp(app wego.Application) (models.Application, error) {
 	}
 
 	if models.IsExternalConfigRepo(app.Spec.ConfigRepo) {
-		configRepoUrl, err = gitproviders.NewRepoURL(app.Spec.ConfigRepo, true)
+		configRepoUrl, err = gitproviders.NewRepoURL(app.Spec.ConfigRepo)
 		if err != nil {
 			return models.Application{}, err
 		}

--- a/pkg/services/factory.go
+++ b/pkg/services/factory.go
@@ -63,10 +63,6 @@ func (f *defaultFactory) GetAppService(ctx context.Context, kubeClient kube.Kube
 }
 
 func (f *defaultFactory) GetGitClients(ctx context.Context, kubeClient kube.Kube, gpClient gitproviders.Client, params GitConfigParams) (git.Git, gitproviders.GitProvider, error) {
-	if params.DryRun {
-		return nil, nil, nil
-	}
-
 	configNormalizedUrl, err := gitproviders.NewRepoURL(params.ConfigRepo)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error normalizing config url: %w", err)

--- a/pkg/services/factory.go
+++ b/pkg/services/factory.go
@@ -89,6 +89,7 @@ func (f *defaultFactory) GetGitClients(ctx context.Context, kubeClient kube.Kube
 	}
 
 	provider := authSvc.GetGitProvider()
+
 	repoVisibility, err := provider.GetRepoVisibility(ctx, normalizedUrl)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error getting repo visibility: %w", err)
@@ -99,6 +100,7 @@ func (f *defaultFactory) GetGitClients(ctx context.Context, kubeClient kube.Kube
 			Name:      automation.CreateRepoSecretName(normalizedUrl),
 			Namespace: params.Namespace,
 		}
+
 		_, err = authSvc.SetupDeployKey(ctx, secretName, targetName, normalizedUrl)
 		if err != nil {
 			return nil, nil, fmt.Errorf("error setting up deploy key: %w", err)

--- a/pkg/services/factory.go
+++ b/pkg/services/factory.go
@@ -97,6 +97,7 @@ func (f *defaultFactory) GetGitClients(ctx context.Context, kubeClient kube.Kube
 			return nil, nil, fmt.Errorf("error getting repo visibility: %w", err)
 		}
 
+		// Only add deploy key for private repo
 		if *repoVisibility == gitprovider.RepositoryVisibilityPrivate {
 			secretName := auth.SecretName{
 				Name:      models.CreateRepoSecretName(normalizedUrl),

--- a/pkg/services/factory.go
+++ b/pkg/services/factory.go
@@ -63,11 +63,6 @@ func (f *defaultFactory) GetAppService(ctx context.Context, kubeClient kube.Kube
 }
 
 func (f *defaultFactory) GetGitClients(ctx context.Context, kubeClient kube.Kube, gpClient gitproviders.Client, params GitConfigParams) (git.Git, gitproviders.GitProvider, error) {
-	// This is temporary. When config repo is always present in the config map this can be removed.
-	if params.ConfigRepo == "" && !params.IsHelmRepository {
-		params.ConfigRepo = params.URL
-	}
-
 	configNormalizedUrl, err := gitproviders.NewRepoURL(params.ConfigRepo)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error normalizing config url: %w", err)

--- a/pkg/services/factory.go
+++ b/pkg/services/factory.go
@@ -11,10 +11,10 @@ import (
 	"github.com/weaveworks/weave-gitops/pkg/gitproviders"
 	"github.com/weaveworks/weave-gitops/pkg/kube"
 	"github.com/weaveworks/weave-gitops/pkg/logger"
+	"github.com/weaveworks/weave-gitops/pkg/models"
 	"github.com/weaveworks/weave-gitops/pkg/osys"
 	"github.com/weaveworks/weave-gitops/pkg/services/app"
 	"github.com/weaveworks/weave-gitops/pkg/services/auth"
-	"github.com/weaveworks/weave-gitops/pkg/services/automation"
 )
 
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
@@ -99,7 +99,7 @@ func (f *defaultFactory) GetGitClients(ctx context.Context, kubeClient kube.Kube
 
 		if *repoVisibility == gitprovider.RepositoryVisibilityPrivate {
 			secretName := auth.SecretName{
-				Name:      automation.CreateRepoSecretName(normalizedUrl),
+				Name:      models.CreateRepoSecretName(normalizedUrl),
 				Namespace: params.Namespace,
 			}
 

--- a/pkg/services/factory.go
+++ b/pkg/services/factory.go
@@ -97,7 +97,7 @@ func (f *defaultFactory) GetGitClients(ctx context.Context, kubeClient kube.Kube
 			return nil, nil, fmt.Errorf("error getting repo visibility: %w", err)
 		}
 
-		// Only add deploy key for private repo
+		// Do not add deploy key for public repo. Issue https://github.com/weaveworks/weave-gitops/issues/1111
 		if *repoVisibility == gitprovider.RepositoryVisibilityPrivate {
 			secretName := auth.SecretName{
 				Name:      models.CreateRepoSecretName(normalizedUrl),

--- a/pkg/services/factory.go
+++ b/pkg/services/factory.go
@@ -70,7 +70,7 @@ func (f *defaultFactory) GetGitClients(ctx context.Context, kubeClient kube.Kube
 
 	configNormalizedUrl, err := gitproviders.NewRepoURL(params.ConfigRepo)
 	if err != nil {
-		return nil, nil, fmt.Errorf("error normalizing url: %w", err)
+		return nil, nil, fmt.Errorf("error normalizing config url: %w", err)
 	}
 
 	targetName, err := kubeClient.GetClusterName(ctx)
@@ -84,7 +84,7 @@ func (f *defaultFactory) GetGitClients(ctx context.Context, kubeClient kube.Kube
 	}
 
 	// Do not add deploy key for helm repo, empty url or if its gonna be added below
-	if !params.IsHelmRepository || params.URL != "" || params.URL != params.ConfigRepo {
+	if !params.IsHelmRepository && params.URL != "" && params.URL != params.ConfigRepo {
 		normalizedUrl, err := gitproviders.NewRepoURL(params.URL)
 		if err != nil {
 			return nil, nil, fmt.Errorf("error normalizing url: %w", err)

--- a/pkg/services/factory.go
+++ b/pkg/services/factory.go
@@ -63,6 +63,10 @@ func (f *defaultFactory) GetAppService(ctx context.Context, kubeClient kube.Kube
 }
 
 func (f *defaultFactory) GetGitClients(ctx context.Context, kubeClient kube.Kube, gpClient gitproviders.Client, params GitConfigParams) (git.Git, gitproviders.GitProvider, error) {
+	if params.DryRun {
+		return nil, nil, nil
+	}
+
 	configNormalizedUrl, err := gitproviders.NewRepoURL(params.ConfigRepo)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error normalizing config url: %w", err)

--- a/pkg/services/factory_test.go
+++ b/pkg/services/factory_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/weaveworks/weave-gitops/pkg/gitproviders/gitprovidersfakes"
 	"github.com/weaveworks/weave-gitops/pkg/kube/kubefakes"
 	"github.com/weaveworks/weave-gitops/pkg/logger/loggerfakes"
-	"github.com/weaveworks/weave-gitops/pkg/services/app"
 )
 
 var _ = Describe("Services factory", func() {
@@ -37,27 +36,6 @@ var _ = Describe("Services factory", func() {
 			Expect(gitClient).To(BeNil())
 			Expect(gitProvider).To(BeNil())
 			Expect(err.Error()).To(MatchRegexp("error normalizing url*."))
-		})
-
-		It("config is for a helm repository", func() {
-			gitClient, gitProvider, err := factory.GetGitClients(ctx, fakeKube, fakeClient, GitConfigParams{
-				IsHelmRepository: true,
-			})
-
-			Expect(gitClient).To(BeNil())
-			Expect(gitProvider).To(BeNil())
-			Expect(err).To(BeNil())
-		})
-
-		It("app add params is helm chart", func() {
-			params := app.AddParams{Chart: "this-chart"}
-			gitClient, gitProvider, err := factory.GetGitClients(ctx, fakeKube, fakeClient, GitConfigParams{
-				IsHelmRepository: params.IsHelmRepository(),
-			})
-
-			Expect(gitClient).To(BeNil())
-			Expect(gitProvider).To(BeNil())
-			Expect(err).To(BeNil())
 		})
 
 		It("config type user repo and empty url return error", func() {

--- a/pkg/services/factory_test.go
+++ b/pkg/services/factory_test.go
@@ -35,7 +35,7 @@ var _ = Describe("Services factory", func() {
 
 			Expect(gitClient).To(BeNil())
 			Expect(gitProvider).To(BeNil())
-			Expect(err.Error()).To(MatchRegexp("error normalizing url*."))
+			Expect(err.Error()).To(MatchRegexp("error normalizing config url*."))
 		})
 
 		It("config type user repo and empty url return error", func() {
@@ -46,7 +46,7 @@ var _ = Describe("Services factory", func() {
 
 			Expect(gitClient).To(BeNil())
 			Expect(gitProvider).To(BeNil())
-			Expect(err.Error()).To(MatchRegexp("error normalizing url*."))
+			Expect(err.Error()).To(MatchRegexp("error config normalizing url*."))
 		})
 	})
 })

--- a/pkg/services/factory_test.go
+++ b/pkg/services/factory_test.go
@@ -46,7 +46,7 @@ var _ = Describe("Services factory", func() {
 
 			Expect(gitClient).To(BeNil())
 			Expect(gitProvider).To(BeNil())
-			Expect(err.Error()).To(MatchRegexp("error config normalizing url*."))
+			Expect(err.Error()).To(MatchRegexp("error normalizing config url*."))
 		})
 	})
 })

--- a/pkg/services/gitops/install.go
+++ b/pkg/services/gitops/install.go
@@ -160,7 +160,7 @@ func (g *Gitops) validateWegoInstall(ctx context.Context, params InstallParams) 
 func (g *Gitops) storeManifests(gitClient git.Git, gitProvider gitproviders.GitProvider, params InstallParams, systemManifests map[string][]byte, cname string) (map[string][]byte, error) {
 	ctx := context.Background()
 
-	normalizedURL, err := gitproviders.NewRepoURL(params.ConfigRepo, true)
+	normalizedURL, err := gitproviders.NewRepoURL(params.ConfigRepo)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert app config repo %q : %w", params.ConfigRepo, err)
 	}

--- a/pkg/services/gitopswriter/writer_add_test.go
+++ b/pkg/services/gitopswriter/writer_add_test.go
@@ -23,7 +23,7 @@ var (
 )
 
 func createRepoURL(url string) gitproviders.RepoURL {
-	repoURL, err := gitproviders.NewRepoURL(url, false)
+	repoURL, err := gitproviders.NewRepoURL(url)
 	Expect(err).NotTo(HaveOccurred())
 
 	return repoURL

--- a/pkg/services/install/install_test.go
+++ b/pkg/services/install/install_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Installer", func() {
 	const clusterName = "test-cluster"
 	var _ = BeforeEach(func() {
 		testNamespace = "test-namespace"
-		configRepo, err = gitproviders.NewRepoURL("ssh://git@github.com/test-user/test-repo", true)
+		configRepo, err = gitproviders.NewRepoURL("ssh://git@github.com/test-user/test-repo")
 		Expect(err).ShouldNot(HaveOccurred())
 		fakeFluxClient = &fluxfakes.FakeFlux{}
 		fakeKubeClient = &kubefakes.FakeKube{}

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -91,7 +91,7 @@ func upgrade(ctx context.Context, uv UpgradeValues, kube kube.Kube, gitClient gi
 		return fmt.Errorf("failed to load credentials for profiles repo from cluster: %v", err)
 	}
 
-	normalizedURL, err := gitproviders.NewRepoURL(uv.ConfigRepo, true)
+	normalizedURL, err := gitproviders.NewRepoURL(uv.ConfigRepo)
 	if err != nil {
 		return fmt.Errorf("failed to normalize URL %q: %w", uv.ConfigRepo, err)
 	}
@@ -160,7 +160,7 @@ func marshalToYamlStream(objects []runtime.Object) ([]byte, error) {
 }
 
 func makeAppsCapiKustomization(namespace, repoURL string) ([]runtime.Object, error) {
-	normalizedURL, err := gitproviders.NewRepoURL(repoURL, false)
+	normalizedURL, err := gitproviders.NewRepoURL(repoURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to normalize URL %q: %w", repoURL, err)
 	}

--- a/test/acceptance/test/add_tests.go
+++ b/test/acceptance/test/add_tests.go
@@ -341,7 +341,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 
 	})
 
-	It("Test1 - Verify that gitops can deploy an app with specified config-url and config-repo set to <url>", func() {
+	It("Test1 - Verify that gitops can deploy an app with different config-repo and add repo", func() {
 		var repoAbsolutePath string
 		var configRepoRemoteURL string
 		private := true
@@ -390,7 +390,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		})
 	})
 
-	It("Test2 - Verify that gitops can deploy and remove a gitlab app with specified config-url and config-repo set to <url>", func() {
+	It("Test2 - Verify that gitops can deploy and remove a gitlab app with different config-repo and add repo", func() {
 		var repoAbsolutePath string
 		var appConfigRepoAbsPath string
 		var appRemoveOutput string

--- a/test/acceptance/test/add_tests.go
+++ b/test/acceptance/test/add_tests.go
@@ -1000,7 +1000,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		replicaSetValue := 3
 		appRepoRemoteURL := "ssh://git@" + gitProviderName + ".com/" + gitOrg + "/" + tip1.appRepoName + ".git"
 
-		addCommand1 := "add app . --name=" + appName1 + " --auto-merge=true"
+		addCommand1 := "add app . --name=" + appName1 + " --auto-merge=true --config-repo=" + appRepoRemoteURL
 		addCommand2 := "add app . --name=" + appName2 + " --auto-merge=true --config-repo=" + appRepoRemoteURL
 
 		defer deleteRepo(tip1.appRepoName, gitProvider, gitOrg)

--- a/test/acceptance/test/add_tests.go
+++ b/test/acceptance/test/add_tests.go
@@ -289,7 +289,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 
 		configRepoURL := "ssh://git@gitlab.com/" + gitlabPublicGroup + "/" + configRepoName + ".git"
 
-		addCommand := "add app . --auto-merge=true --config-repo " + configRepoURL
+		addCommand := "add app . --auto-merge=true"
 
 		defer deleteRepo(tip.appRepoName, gitproviders.GitProviderGitLab, gitlabPublicGroup)
 		defer deleteRepo(configRepoName, gitproviders.GitProviderGitLab, gitlabPublicGroup)
@@ -351,7 +351,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		appRepoRemoteURL := "https://github.com/" + githubOrg + "/" + tip.appRepoName + ".git"
 		configRepoRemoteURL = "https://github.com/" + githubOrg + "/" + appConfigRepoName + ".git"
 
-		addCommand := "add app --url=" + appRepoRemoteURL + " --config-repo=" + configRepoRemoteURL + " --auto-merge=true"
+		addCommand := "add app --url=" + appRepoRemoteURL + " --auto-merge=true"
 
 		defer deleteRepo(tip.appRepoName, gitproviders.GitProviderGitHub, githubOrg)
 		defer deleteRepo(appConfigRepoName, gitproviders.GitProviderGitHub, githubOrg)
@@ -380,7 +380,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 			installAndVerifyWego(WEGO_DEFAULT_NAMESPACE, configRepoRemoteURL)
 		})
 
-		By("And I run gitops add command with --url and --config-repo params", func() {
+		By("And I run gitops add command with --url", func() {
 			runWegoAddCommand(repoAbsolutePath+"/../", addCommand, WEGO_DEFAULT_NAMESPACE)
 		})
 
@@ -402,7 +402,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		appRepoRemoteURL := "https://" + gitProviderName + ".com/" + gitOrg + "/" + tip.appRepoName + ".git"
 		configRepoRemoteURL := "https://" + gitProviderName + ".com/" + gitOrg + "/" + appConfigRepoName + ".git"
 
-		addCommand := "add app --url=" + appRepoRemoteURL + " --config-repo=" + configRepoRemoteURL + " --auto-merge=true"
+		addCommand := "add app --url=" + appRepoRemoteURL + " --auto-merge=true"
 
 		defer deleteRepo(tip.appRepoName, gitProvider, gitOrg)
 		defer deleteRepo(appConfigRepoName, gitProvider, gitOrg)
@@ -431,7 +431,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 			installAndVerifyWego(WEGO_DEFAULT_NAMESPACE, configRepoRemoteURL)
 		})
 
-		By("And I run gitops add command with --url and --config-repo params", func() {
+		By("And I run gitops add command with --url", func() {
 			runWegoAddCommand(repoAbsolutePath+"/../", addCommand, WEGO_DEFAULT_NAMESPACE)
 		})
 
@@ -719,7 +719,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		appName1 := appRepoName1
 		appName2 := appRepoName2
 
-		addCommand := "add app . --config-repo=" + configRepoRemoteURL + " --auto-merge=true"
+		addCommand := "add app . --auto-merge=true"
 
 		defer deleteRepo(appRepoName1, gitProvider, gitOrg)
 		defer deleteRepo(appRepoName2, gitProvider, gitOrg)
@@ -843,9 +843,9 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		appName3 := "loki"
 		workloadName3 := "loki-0"
 
-		addCommand1 := "add app . --config-repo=" + configRepoRemoteURL + " --auto-merge=true"
-		addCommand2 := "add app . --deployment-type=helm --path=./hello-world --name=" + appName2 + " --config-repo=" + configRepoRemoteURL + " --auto-merge=true"
-		addCommand3 := "add app --url=" + helmRepoURL + " --chart=" + appName3 + " --config-repo=" + configRepoRemoteURL + " --auto-merge=true"
+		addCommand1 := "add app . --auto-merge=true"
+		addCommand2 := "add app . --deployment-type=helm --path=./hello-world --name=" + appName2 + " --auto-merge=true"
+		addCommand3 := "add app --url=" + helmRepoURL + " --chart=" + appName3 + " --auto-merge=true"
 
 		defer deleteRepo(appFilesRepoName, gitProvider, gitOrg)
 		defer deleteRepo(appConfigRepoName, gitProvider, gitOrg)
@@ -1000,8 +1000,8 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		replicaSetValue := 3
 		appRepoRemoteURL := "ssh://git@" + gitProviderName + ".com/" + gitOrg + "/" + tip1.appRepoName + ".git"
 
-		addCommand1 := "add app . --name=" + appName1 + " --auto-merge=true --config-repo=" + appRepoRemoteURL
-		addCommand2 := "add app . --name=" + appName2 + " --auto-merge=true --config-repo=" + appRepoRemoteURL
+		addCommand1 := "add app . --name=" + appName1 + " --auto-merge=true"
+		addCommand2 := "add app . --name=" + appName2 + " --auto-merge=true"
 
 		defer deleteRepo(tip1.appRepoName, gitProvider, gitOrg)
 		defer deleteRepo(tip2.appRepoName, gitProvider, gitOrg)
@@ -1238,7 +1238,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		configRepoName := "test-config-repo-" + RandString(8)
 		configRepoUrl := fmt.Sprintf("ssh://git@"+gitProviderName+".com/%s/%s.git", gitOrg, configRepoName)
 
-		addCommand := fmt.Sprintf("add app . --config-repo=%s --deployment-type=helm --path=./hello-world --name=%s --auto-merge=true", configRepoUrl, appName)
+		addCommand := fmt.Sprintf("add app . --deployment-type=helm --path=./hello-world --name=%s --auto-merge=true", appName)
 
 		defer deleteRepo(appRepoName, gitProvider, gitOrg)
 		defer deleteRepo(configRepoName, gitProvider, gitOrg)
@@ -1304,8 +1304,8 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		appRepoRemoteURL := "ssh://git@" + gitProviderName + ".com/" + gitOrg + "/" + appRepoName + ".git"
 		helmRepoURL := "https://charts.kube-ops.io"
 
-		addCommand1 := "add app --url=" + helmRepoURL + " --chart=" + appName1 + " --config-repo=" + appRepoRemoteURL + " --auto-merge=true --helm-release-target-namespace=" + workloadNamespace
-		addCommand2 := "add app --url=" + helmRepoURL + " --chart=" + appName2 + " --config-repo=" + appRepoRemoteURL + " --auto-merge=true --helm-release-target-namespace=" + workloadNamespace
+		addCommand1 := "add app --url=" + helmRepoURL + " --chart=" + appName1 + " --auto-merge=true --helm-release-target-namespace=" + workloadNamespace
+		addCommand2 := "add app --url=" + helmRepoURL + " --chart=" + appName2 + " --auto-merge=true --helm-release-target-namespace=" + workloadNamespace
 
 		defer deleteNamespace(workloadNamespace)
 		defer deletePersistingHelmApp(WEGO_DEFAULT_NAMESPACE, workloadName1, EVENTUALLY_DEFAULT_TIMEOUT)
@@ -1632,7 +1632,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 		appConfigRepoName := "config-repo-" + RandString(8)
 		configRepoRemoteURL = "ssh://git@" + gitProviderName + ".com/" + gitOrg + "/" + appConfigRepoName + ".git"
 
-		addCommand := "add app . --config-repo=" + configRepoRemoteURL
+		addCommand := "add app ."
 
 		defer deleteRepo(tip.appRepoName, gitProvider, gitOrg)
 		defer deleteRepo(appConfigRepoName, gitProvider, gitOrg)
@@ -1657,7 +1657,7 @@ var _ = Describe("Weave GitOps Add App Tests", func() {
 			installAndVerifyWego(WEGO_DEFAULT_NAMESPACE, configRepoRemoteURL)
 		})
 
-		By("And I run gitops add command with --config-repo param", func() {
+		By("And I run gitops add command", func() {
 			output, _ := runWegoAddCommandWithOutput(repoAbsolutePath, addCommand, WEGO_DEFAULT_NAMESPACE)
 			re := regexp.MustCompile(`(http|https):\/\/([\w\-_]+(?:(?:\.[\w\-_]+)+))([\w\-\.,@?^=%&amp;:/~\+#]*[\w\-\@?^=%&amp;/~\+#])?`)
 			prLink = re.FindAllString(output, 1)[0]
@@ -1778,7 +1778,7 @@ var _ = Describe("Weave GitOps Add Tests With Long Cluster Name", func() {
 		workloadNamespace := tip.workloadNamespace
 		appManifestFilePath := tip.appManifestFilePath
 
-		addCommand := "add app . --config-repo=" + configRepoRemoteURL + " --auto-merge=true"
+		addCommand := "add app . --auto-merge=true"
 
 		defer deleteRepo(appFilesRepoName, gitProvider, gitOrg)
 		defer deleteRepo(appConfigRepoName, gitProvider, gitOrg)
@@ -1862,7 +1862,7 @@ var _ = Describe("Weave GitOps Add Tests With Long Cluster Name", func() {
 		workloadNamespace := tip.workloadNamespace
 		appManifestFilePath := tip.appManifestFilePath
 
-		addCommand := "add app . --config-repo=" + configRepoRemoteURL + " --auto-merge=true"
+		addCommand := "add app . --auto-merge=true"
 
 		defer deleteRepo(appFilesRepoName, gitProvider, gitOrg)
 		defer deleteRepo(appConfigRepoName, gitProvider, gitOrg)

--- a/test/acceptance/test/utils.go
+++ b/test/acceptance/test/utils.go
@@ -720,7 +720,7 @@ func mergePR(repoAbsolutePath, prLink string, providerName gitproviders.GitProvi
 }
 
 func extractOrgAndRepo(url string) (string, string) {
-	normalized, normErr := gitproviders.NewRepoURL(url, false)
+	normalized, normErr := gitproviders.NewRepoURL(url)
 	Expect(normErr).ShouldNot(HaveOccurred())
 
 	re := regexp.MustCompile("^[^/]+//[^/]+/([^/]+)/([^/]+).*$")

--- a/test/integration/server/add_test.go
+++ b/test/integration/server/add_test.go
@@ -133,7 +133,7 @@ var _ = XDescribe("AddApplication", func() {
 					Force: false,
 				}
 
-				repoURL, err := gitproviders.NewRepoURL(sourceRepoURL, true)
+				repoURL, err := gitproviders.NewRepoURL(sourceRepoURL)
 				Expect(err).NotTo(HaveOccurred())
 
 				expectedSource := sourcev1.GitRepositorySpec{
@@ -199,7 +199,7 @@ var _ = XDescribe("AddApplication", func() {
 				actual, err := fetcher.GetFilesForPullRequest(ctx, 1, githubOrg, configRepoName, fs)
 				Expect(err).NotTo(HaveOccurred())
 
-				normalizedUrl, err := gitproviders.NewRepoURL(addAppRequest.Url, false)
+				normalizedUrl, err := gitproviders.NewRepoURL(addAppRequest.Url)
 				Expect(err).NotTo(HaveOccurred())
 
 				expectedApp := wego.ApplicationSpec{
@@ -222,7 +222,7 @@ var _ = XDescribe("AddApplication", func() {
 					Force: false,
 				}
 
-				repoURL, err := gitproviders.NewRepoURL(sourceRepoURL, true)
+				repoURL, err := gitproviders.NewRepoURL(sourceRepoURL)
 				Expect(err).NotTo(HaveOccurred())
 
 				expectedSource := sourcev1.GitRepositorySpec{
@@ -313,7 +313,7 @@ var _ = XDescribe("AddApplication", func() {
 					Force: false,
 				}
 
-				repoURL, err := gitproviders.NewRepoURL(sourceRepoURL, true)
+				repoURL, err := gitproviders.NewRepoURL(sourceRepoURL)
 				Expect(err).NotTo(HaveOccurred())
 
 				expectedSrc := sourcev1.GitRepositorySpec{
@@ -445,7 +445,7 @@ var _ = XDescribe("AddApplication", func() {
 					Force: false,
 				}
 
-				repoURL, err := gitproviders.NewRepoURL(sourceRepoURL, true)
+				repoURL, err := gitproviders.NewRepoURL(sourceRepoURL)
 				Expect(err).NotTo(HaveOccurred())
 
 				expectedSrc := sourcev1.GitRepositorySpec{
@@ -554,7 +554,7 @@ var _ = XDescribe("AddApplication", func() {
 					Force: false,
 				}
 
-				repoURL, err := gitproviders.NewRepoURL(sourceRepoURL, true)
+				repoURL, err := gitproviders.NewRepoURL(sourceRepoURL)
 				Expect(err).NotTo(HaveOccurred())
 
 				expectedSource := sourcev1.GitRepositorySpec{
@@ -620,7 +620,7 @@ var _ = XDescribe("AddApplication", func() {
 				actual, err := fetcher.GetFilesForPullRequest(ctx, 1, gitlabOrg, configRepoName, fs)
 				Expect(err).NotTo(HaveOccurred())
 
-				normalizedUrl, err := gitproviders.NewRepoURL(addAppRequest.Url, false)
+				normalizedUrl, err := gitproviders.NewRepoURL(addAppRequest.Url)
 				Expect(err).NotTo(HaveOccurred())
 
 				expectedApp := wego.ApplicationSpec{
@@ -643,7 +643,7 @@ var _ = XDescribe("AddApplication", func() {
 					Force: false,
 				}
 
-				repoURL, err := gitproviders.NewRepoURL(sourceRepoURL, true)
+				repoURL, err := gitproviders.NewRepoURL(sourceRepoURL)
 				Expect(err).NotTo(HaveOccurred())
 
 				expectedSource := sourcev1.GitRepositorySpec{
@@ -740,7 +740,7 @@ var _ = XDescribe("AddApplication", func() {
 					Force: false,
 				}
 
-				repoURL, err := gitproviders.NewRepoURL(sourceRepoURL, true)
+				repoURL, err := gitproviders.NewRepoURL(sourceRepoURL)
 				Expect(err).NotTo(HaveOccurred())
 
 				expectedSrc := sourcev1.GitRepositorySpec{


### PR DESCRIPTION
<!-- Use # to add the issue this pull request is related to -->
Closes: #1323 

<!-- Describe what has changed in this PR -->
**What changed?**
Refactored deploy key code and removed quick fix. This adds a deploy key on install for a config repo and then on add it only adds a deploy key if the repo is private.

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**
Manually and current tests cover it

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
**Release notes**

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**