### PR TITLE
Fix flaky test by disabling Prometheus metrics

### DIFF
--- a/pkg/testutils/testutils.go
+++ b/pkg/testutils/testutils.go
@@ -87,7 +87,8 @@ func StartK8sTestEnvironment(crdPaths []string) (*K8sTestEnv, error) {
 			&sourcev1.GitRepository{},
 			&v1.CustomResourceDefinition{},
 		},
-		Scheme: scheme,
+		Scheme:             scheme,
+		MetricsBindAddress: "0",
 	})
 	if err != nil {
 		return nil, fmt.Errorf("could not create controller manager: %w", err)


### PR DESCRIPTION
The test suites for some of our packages spin up parts of a Kubernetes cluster using the `envtest` library, so that we have something more solid than mocks to test against. One problem this was causing was that running tests for both the `kube` and `server` packages at once would cause one of those test suites to fail.

Side-note: it's possible to reproduce this problem a little more efficiently by spinning up a fake web server to sit on port 8080, for example using Python's built-in web server:

    python3 -m http.server 8080

After some digging, I found out that the reason for this is that both environments were trying to spin up a Prometheus metrics handler listening on port 8080. If they both tried to do this at once, one would fail, causing the entire test suite for that package to fail too (including some nil-pointer panics during the clean up, which might be worth tidying up in a future pull request).

Setting the metrics bind address to the string "0" disables metrics for the test clusters (the documentation for which is buried in [a comment in the Kubernetes docs][1]), which fixes this particular problem. Testing on my local machine, there didn't seem to be any other fixed port assignments cropping up to take its place.

[1]: https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.10.2/pkg/manager

<!-- Use # to add the issue this pull request is related to -->
Closes: #1332 