### PR TITLE
Get kube client during HTTP request

### DIFF
--- a/cmd/gitops/add/app/cmd.go
+++ b/cmd/gitops/add/app/cmd.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/weaveworks/weave-gitops/cmd/internal"
 	"github.com/weaveworks/weave-gitops/pkg/flux"
+	"github.com/weaveworks/weave-gitops/pkg/kube"
 	"github.com/weaveworks/weave-gitops/pkg/osys"
 	"github.com/weaveworks/weave-gitops/pkg/runner"
 	"github.com/weaveworks/weave-gitops/pkg/services"
@@ -107,12 +108,17 @@ func runCmd(cmd *cobra.Command, args []string) error {
 
 	providerClient := internal.NewGitProviderClient(os.Stdout, os.LookupEnv, auth.NewAuthCLIHandler, log)
 
-	appService, err := factory.GetAppService(ctx)
+	kubeClient, _, err := kube.NewKubeHTTPClient()
+	if err != nil {
+		return fmt.Errorf("failed to create kube client: %w", err)
+	}
+
+	appService, err := factory.GetAppService(ctx, kubeClient)
 	if err != nil {
 		return fmt.Errorf("failed to create app service: %w", err)
 	}
 
-	gitClient, gitProvider, err := factory.GetGitClients(ctx, providerClient, services.GitConfigParams{
+	gitClient, gitProvider, err := factory.GetGitClients(ctx, kubeClient, providerClient, services.GitConfigParams{
 		URL:              params.Url,
 		ConfigRepo:       params.ConfigRepo,
 		Namespace:        params.Namespace,

--- a/cmd/gitops/app/status/cmd.go
+++ b/cmd/gitops/app/status/cmd.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/weaveworks/weave-gitops/cmd/internal"
 	"github.com/weaveworks/weave-gitops/pkg/flux"
+	"github.com/weaveworks/weave-gitops/pkg/kube"
 	"github.com/weaveworks/weave-gitops/pkg/osys"
 	"github.com/weaveworks/weave-gitops/pkg/runner"
 	"github.com/weaveworks/weave-gitops/pkg/services"
@@ -33,7 +34,12 @@ var Cmd = &cobra.Command{
 		log := internal.NewCLILogger(os.Stdout)
 		fluxClient := flux.New(osys.New(), &runner.CLIRunner{})
 		appFactory := services.NewFactory(fluxClient, log)
-		appService, err := appFactory.GetAppService(ctx)
+
+		kubeClient, _, err := kube.NewKubeHTTPClient()
+		if err != nil {
+			return fmt.Errorf("failed to create kube client: %w", err)
+		}
+		appService, err := appFactory.GetAppService(ctx, kubeClient)
 		if err != nil {
 			return fmt.Errorf("failed to create app service: %w", err)
 		}

--- a/cmd/gitops/beta/cmd/install.go
+++ b/cmd/gitops/beta/cmd/install.go
@@ -82,7 +82,7 @@ func installRunCmd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	gitClient, gitProvider, err := factory.GetGitClients(context.Background(), providerClient, services.GitConfigParams{
+	gitClient, gitProvider, err := factory.GetGitClients(context.Background(), k, providerClient, services.GitConfigParams{
 		URL:       installParams.ConfigRepo,
 		Namespace: namespace,
 		DryRun:    installParams.DryRun,

--- a/cmd/gitops/delete/app/cmd.go
+++ b/cmd/gitops/delete/app/cmd.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/weaveworks/weave-gitops/cmd/internal"
 	"github.com/weaveworks/weave-gitops/pkg/flux"
+	"github.com/weaveworks/weave-gitops/pkg/kube"
 	"github.com/weaveworks/weave-gitops/pkg/osys"
 	"github.com/weaveworks/weave-gitops/pkg/runner"
 	"github.com/weaveworks/weave-gitops/pkg/services"
@@ -58,7 +59,12 @@ func runCmd(cmd *cobra.Command, args []string) error {
 	log := internal.NewCLILogger(os.Stdout)
 	factory := services.NewFactory(flux.New(osys.New(), &runner.CLIRunner{}), log)
 
-	appService, err := factory.GetAppService(ctx)
+	kubeClient, _, err := kube.NewKubeHTTPClient()
+	if err != nil {
+		return fmt.Errorf("failed to create kube client: %w", err)
+	}
+
+	appService, err := factory.GetAppService(ctx, kubeClient)
 	if err != nil {
 		return fmt.Errorf("failed to create app service: %w", err)
 	}
@@ -70,7 +76,7 @@ func runCmd(cmd *cobra.Command, args []string) error {
 
 	providerClient := internal.NewGitProviderClient(os.Stdout, os.LookupEnv, auth.NewAuthCLIHandler, log)
 
-	gitClient, gitProvider, err := factory.GetGitClients(ctx, providerClient, services.NewGitConfigParamsFromApp(appContent, params.DryRun))
+	gitClient, gitProvider, err := factory.GetGitClients(ctx, kubeClient, providerClient, services.NewGitConfigParamsFromApp(appContent, params.DryRun))
 	if err != nil {
 		return fmt.Errorf("failed to get git clients: %w", err)
 	}

--- a/cmd/gitops/get/app/cmd.go
+++ b/cmd/gitops/get/app/cmd.go
@@ -53,7 +53,12 @@ func getApplicationStatus(cmd *cobra.Command, args []string) error {
 	fluxClient := flux.New(osys.New(), &runner.CLIRunner{})
 	factory := services.NewFactory(fluxClient, log)
 
-	appService, err := factory.GetAppService(ctx)
+	kubeClient, _, err := kube.NewKubeHTTPClient()
+	if err != nil {
+		return fmt.Errorf("failed to create kube client: %w", err)
+	}
+
+	appService, err := factory.GetAppService(ctx, kubeClient)
 	if err != nil {
 		return fmt.Errorf("failed to create app service: %w", err)
 	}

--- a/cmd/gitops/install/cmd.go
+++ b/cmd/gitops/install/cmd.go
@@ -115,7 +115,7 @@ func installRunCmd(cmd *cobra.Command, args []string) error {
 	// This is creating the secret, uploads it and applies it to the cluster
 	// This is going to be broken up to reduce complexity
 	// and then generates the source yaml of the config repo when using dry-run option
-	gitClient, gitProvider, err := factory.GetGitClients(context.Background(), providerClient, services.GitConfigParams{
+	gitClient, gitProvider, err := factory.GetGitClients(context.Background(), kubeClient, providerClient, services.GitConfigParams{
 		// We need to set URL and ConfigRepo to the same value so a deploy key is created for public config repos
 		URL:        installParams.ConfigRepo,
 		ConfigRepo: installParams.ConfigRepo,

--- a/cmd/gitops/resume/app/cmd.go
+++ b/cmd/gitops/resume/app/cmd.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/weaveworks/weave-gitops/pkg/flux"
+	"github.com/weaveworks/weave-gitops/pkg/kube"
 	"github.com/weaveworks/weave-gitops/pkg/osys"
 	"github.com/weaveworks/weave-gitops/pkg/runner"
 	"github.com/weaveworks/weave-gitops/pkg/services"
@@ -40,7 +41,12 @@ func runCmd(cmd *cobra.Command, args []string) error {
 
 	appFactory := services.NewFactory(flux.New(osys.New(), &runner.CLIRunner{}), internal.NewCLILogger(os.Stdout))
 
-	appService, err := appFactory.GetAppService(ctx)
+	kubeClient, _, err := kube.NewKubeHTTPClient()
+	if err != nil {
+		return fmt.Errorf("failed to create kube client: %w", err)
+	}
+
+	appService, err := appFactory.GetAppService(ctx, kubeClient)
 	if err != nil {
 		return fmt.Errorf("failed to create app service: %w", err)
 	}

--- a/cmd/gitops/suspend/app/cmd.go
+++ b/cmd/gitops/suspend/app/cmd.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/weaveworks/weave-gitops/pkg/flux"
+	"github.com/weaveworks/weave-gitops/pkg/kube"
 	"github.com/weaveworks/weave-gitops/pkg/osys"
 	"github.com/weaveworks/weave-gitops/pkg/runner"
 	"github.com/weaveworks/weave-gitops/pkg/services"
@@ -41,7 +42,12 @@ func runCmd(cmd *cobra.Command, args []string) error {
 	fluxClient := flux.New(osys.New(), &runner.CLIRunner{})
 	factory := services.NewFactory(fluxClient, internal.NewCLILogger(os.Stdout))
 
-	appService, err := factory.GetAppService(ctx)
+	kubeClient, _, err := kube.NewKubeHTTPClient()
+	if err != nil {
+		return fmt.Errorf("failed to create kube client: %w", err)
+	}
+
+	appService, err := factory.GetAppService(ctx, kubeClient)
 	if err != nil {
 		return fmt.Errorf("failed to create app service: %w", err)
 	}

--- a/go.sum
+++ b/go.sum
@@ -260,7 +260,6 @@ github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-iptables v0.5.0/go.mod h1:/mVI274lEDI2ns62jHCDnCyBF9Iwsmekav8Dbxlm1MU=
-github.com/coreos/go-oidc v2.1.0+incompatible h1:sdJrfw8akMnCuUlaZU3tE/uYXFgfqom8DBE9so9EBsM=
 github.com/coreos/go-oidc v2.1.0+incompatible/go.mod h1:CgnwVTmzoESiwO9qyAFEMiHoZ1nMCKZlZ9V6mm3/LKc=
 github.com/coreos/go-oidc/v3 v3.1.0 h1:6avEvcdvTa1qYsOZ6I5PRkSYHzpTNWgKYmaJfaYbrRw=
 github.com/coreos/go-oidc/v3 v3.1.0/go.mod h1:rEJ/idjfUyfkBit1eI1fvyr+64/g9dcKpAm8MJMesvo=
@@ -273,7 +272,6 @@ github.com/coreos/go-systemd/v22 v22.1.0/go.mod h1:xO0FLkIi5MaZafQlIrOotqXZ90ih+
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
-github.com/cpuguy83/go-md2man v1.0.10 h1:BSKMNlYxDvnunlTymqtgONjNnaRV1sTpcovwwjF22jk=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0 h1:EoUDS0afbrsXAZ9YQ9jdu/mZ2sXgT1/2yyNng4PGlyM=
@@ -567,7 +565,6 @@ github.com/golang/mock v1.4.3/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt
 github.com/golang/mock v1.4.4/go.mod h1:l3mdAwkq5BuhzHwde/uurv3sEJeZMXNpwsxVWU71h+4=
 github.com/golang/mock v1.5.0/go.mod h1:CWnOUgYIOo4TcNZ0wHX3YZCqsaM1I1Jvs6v3mP3KVu8=
 github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
-github.com/golang/protobuf v1.0.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -679,7 +676,6 @@ github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgf
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-gateway v1.15.2/go.mod h1:vO11I9oWA+KsxmfFQPhLnnIb1VDE24M+pdxZFiuZcA8=
-github.com/grpc-ecosystem/grpc-gateway v1.16.0 h1:gmcG1KaJ57LophUzW0Hy8NmPhnMZb4M0+kPpLofRdBo=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.1 h1:p5m7GOEGXyoq6QWl4/RRMsQ6tWbTpbQmAnkxXgWSprY=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.1/go.mod h1:8ZeZajTed/blCOHBbj8Fss8bPHiFKcmJJzuIbUtFCAo=
@@ -701,7 +697,6 @@ github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjh
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-multierror v1.1.0/go.mod h1:spPvp8C1qA32ftKqdAHm4hHTbPw+vmowP0z+KUhOZdA=
-github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-retryablehttp v0.6.8/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
 github.com/hashicorp/go-retryablehttp v0.7.0 h1:eu1EI/mbirUgP5C8hVsTNaGZreBDlYiwC1FZWkvQPQ4=
 github.com/hashicorp/go-retryablehttp v0.7.0/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
@@ -775,8 +770,6 @@ github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/X
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
-github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88/go.mod h1:3w7q1U84EfirKl04SVQ/s7nPm1ZPhiXd34z40TNz36k=
-github.com/k0kubun/pp v2.3.0+incompatible/go.mod h1:GWse8YhT0p8pT4ir3ZgBbfZild3tgzSScAn6HmfYukg=
 github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0 h1:iQTw/8FWTuc7uiaSepXwyf3o52HaUYcV+Tu66S3F5GA=
 github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0/go.mod h1:1NbS8ALrpOvjt0rHPNLyCIeMtbizbir8U//inJ+zuB8=
 github.com/karrick/godirwalk v1.15.8 h1:7+rWAZPn9zuRxaIqqT8Ohs2Q2Ac0msBqwRdxNCr2VVs=
@@ -807,7 +800,6 @@ github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
-github.com/ktrysmt/go-bitbucket v0.9.34/go.mod h1:FWxy2UK7GlK5b0NSJGc5hPqnssVlkNnsChvyuOf/Xno=
 github.com/labstack/echo/v4 v4.2.1 h1:LF5Iq7t/jrtUuSutNuiEWtB5eiHfZ5gSe2pcu5exjQw=
 github.com/labstack/echo/v4 v4.2.1/go.mod h1:AA49e0DZ8kk5jTOOCKNuPR6oTnBS0dYiM4FW1e6jwpg=
 github.com/labstack/gommon v0.3.0 h1:JEeO0bvc78PKdyHxloTKiF8BD5iGrH8T6MSeGvSgob0=
@@ -905,7 +897,6 @@ github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUb
 github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS42BGNg=
 github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
-github.com/mitchellh/mapstructure v0.0.0-20180220230111-00c29f56e238/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.3.2/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
@@ -1352,7 +1343,6 @@ golang.org/x/mod v0.4.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.1/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.2 h1:Gz96sIWK3OalVv/I/qNygP42zyoKp3xptRVCWRFEBvo=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/net v0.0.0-20180218175443-cbe0f9307d01/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -1417,9 +1407,7 @@ golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20210825183410-e898025ed96a/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2 h1:CIJ76btIcR3eFI5EgSo6k1qKw9KJexJuRLI9G7Hp5wE=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/oauth2 v0.0.0-20180227000427-d7d64896b5ff/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
-golang.org/x/oauth2 v0.0.0-20181106182150-f42d05182288/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -1450,7 +1438,6 @@ golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sys v0.0.0-20180224232135-f6cff0780e54/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -1691,10 +1678,8 @@ google.golang.org/api v0.50.0/go.mod h1:4bNT5pAuq5ji4SRZm+5QIkjny9JAyVD/3gaSihNe
 google.golang.org/api v0.51.0/go.mod h1:t4HdrdoNgyN5cbEfm7Lum0lcLDLiise1F8qDKX00sOU=
 google.golang.org/api v0.54.0/go.mod h1:7C4bFFOvVDGXjfDTAsgGwDgAxRDeQ4X8NvUedIt6z3k=
 google.golang.org/api v0.56.0/go.mod h1:38yMfeP1kfjsl8isn0tliTjIb1rJXcQi4UXlbqivdVE=
-google.golang.org/appengine v1.0.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.2.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
-google.golang.org/appengine v1.3.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.6.1/go.mod h1:i06prIuMbXzDqacNJfV5OdTW448YApPu5ww/cMBSeb0=

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -72,6 +72,7 @@ type applicationServer struct {
 	fetcherFactory FetcherFactory
 	glAuthClient   auth.GitlabAuthClient
 	clientGetter   ClientGetter
+	kubeGetter     KubeGetter
 }
 
 // An ApplicationsConfig allows for the customization of an ApplicationsServer.
@@ -115,9 +116,14 @@ type ClusterConfig struct {
 
 // NewApplicationsServer creates a grpc Applications server
 func NewApplicationsServer(cfg *ApplicationsConfig, setters ...ApplicationsOption) pb.ApplicationsServer {
+	configGetter := NewImpersonatingConfigGetter(cfg.ClusterConfig.DefaultConfig, false)
 	args := &ApplicationsOptions{
 		ClientGetter: &DefaultClientGetter{
-			configGetter: NewImpersonatingConfigGetter(cfg.ClusterConfig.DefaultConfig, false),
+			configGetter: configGetter,
+			clusterName:  cfg.ClusterConfig.ClusterName,
+		},
+		KubeGetter: &DefaultKubeGetter{
+			configGetter: configGetter,
 			clusterName:  cfg.ClusterConfig.ClusterName,
 		},
 	}
@@ -134,6 +140,7 @@ func NewApplicationsServer(cfg *ApplicationsConfig, setters ...ApplicationsOptio
 		fetcherFactory: cfg.FetcherFactory,
 		glAuthClient:   cfg.GitlabAuthClient,
 		clientGetter:   args.ClientGetter,
+		kubeGetter:     args.KubeGetter,
 	}
 }
 
@@ -165,7 +172,7 @@ func DefaultApplicationsConfig() (*ApplicationsConfig, error) {
 
 	return &ApplicationsConfig{
 		Logger:           logr,
-		Factory:          services.NewServerFactory(fluxClient, internal.NewApiLogger(zapLog), nil, ""),
+		Factory:          services.NewFactory(fluxClient, internal.NewApiLogger(zapLog)),
 		JwtClient:        jwtClient,
 		FetcherFactory:   NewDefaultFetcherFactory(),
 		GithubAuthClient: auth.NewGithubAuthClient(http.DefaultClient),
@@ -207,9 +214,9 @@ func (s *applicationServer) ListApplications(ctx context.Context, msg *pb.ListAp
 }
 
 func (s *applicationServer) GetApplication(ctx context.Context, msg *pb.GetApplicationRequest) (*pb.GetApplicationResponse, error) {
-	kubeClient, kubeErr := s.factory.GetKubeService()
-	if kubeErr != nil {
-		return nil, fmt.Errorf("failed to create kube service: %w", kubeErr)
+	kubeClient, err := s.kubeGetter.Kube(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create kube service: %w", err)
 	}
 
 	app, err := kubeClient.GetApplication(ctx, types.NamespacedName{Name: msg.Name, Namespace: msg.Namespace})
@@ -292,6 +299,11 @@ func (s *applicationServer) AddApplication(ctx context.Context, msg *pb.AddAppli
 		return nil, grpcStatus.Errorf(codes.Unauthenticated, "token error: %s", err.Error())
 	}
 
+	kubeClient, err := s.kubeGetter.Kube(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create kube service: %w", err)
+	}
+
 	appUrl, err := gitproviders.NewRepoURL(msg.Url, false)
 	if err != nil {
 		return nil, grpcStatus.Errorf(codes.InvalidArgument, "unable to parse app url %q: %s", msg.Url, err)
@@ -305,7 +317,7 @@ func (s *applicationServer) AddApplication(ctx context.Context, msg *pb.AddAppli
 		}
 	}
 
-	appSrv, err := s.factory.GetAppService(ctx)
+	appSrv, err := s.factory.GetAppService(ctx, kubeClient)
 	if err != nil {
 		return nil, fmt.Errorf("could not create app service: %w", err)
 	}
@@ -323,7 +335,7 @@ func (s *applicationServer) AddApplication(ctx context.Context, msg *pb.AddAppli
 
 	client := internal.NewGitProviderClient(token.AccessToken)
 
-	gitClient, gitProvider, err := s.factory.GetGitClients(ctx, client, services.GitConfigParams{
+	gitClient, gitProvider, err := s.factory.GetGitClients(ctx, kubeClient, client, services.GitConfigParams{
 		URL:        msg.Url,
 		ConfigRepo: msg.ConfigRepo,
 		Namespace:  msg.Namespace,
@@ -351,7 +363,7 @@ func (s *applicationServer) RemoveApplication(ctx context.Context, msg *pb.Remov
 		return nil, grpcStatus.Errorf(codes.Unauthenticated, "token error: %s", err.Error())
 	}
 
-	kubeClient, err := s.factory.GetKubeService()
+	kubeClient, err := s.kubeGetter.Kube(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create kube service: %w", err)
 	}
@@ -361,14 +373,14 @@ func (s *applicationServer) RemoveApplication(ctx context.Context, msg *pb.Remov
 		return nil, fmt.Errorf("could not get application %q: %w", msg.Name, err)
 	}
 
-	appSrv, err := s.factory.GetAppService(ctx)
+	appSrv, err := s.factory.GetAppService(ctx, kubeClient)
 	if err != nil {
 		return nil, fmt.Errorf("could not create app service: %w", err)
 	}
 
 	client := internal.NewGitProviderClient(token.AccessToken)
 
-	gitClient, gitProvider, err := s.factory.GetGitClients(ctx, client, services.GitConfigParams{
+	gitClient, gitProvider, err := s.factory.GetGitClients(ctx, kubeClient, client, services.GitConfigParams{
 		URL:        application.Spec.URL,
 		ConfigRepo: application.Spec.ConfigRepo,
 		Namespace:  msg.Namespace,
@@ -393,7 +405,7 @@ func (s *applicationServer) RemoveApplication(ctx context.Context, msg *pb.Remov
 }
 
 func (s *applicationServer) SyncApplication(ctx context.Context, msg *pb.SyncApplicationRequest) (*pb.SyncApplicationResponse, error) {
-	kube, err := s.factory.GetKubeService()
+	kubeClient, err := s.kubeGetter.Kube(ctx)
 	if err != nil {
 		return &pb.SyncApplicationResponse{
 			Success: false,
@@ -401,7 +413,7 @@ func (s *applicationServer) SyncApplication(ctx context.Context, msg *pb.SyncApp
 	}
 
 	appSrv := &app.AppSvc{
-		Kube:  kube,
+		Kube:  kubeClient,
 		Clock: clock.New(),
 	}
 	if err := appSrv.Sync(app.SyncParams{Name: msg.Name, Namespace: msg.Namespace}); err != nil {
@@ -427,6 +439,11 @@ func (s *applicationServer) ListCommits(ctx context.Context, msg *pb.ListCommits
 		return nil, err
 	}
 
+	kubeClient, err := s.kubeGetter.Kube(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create kube service: %w", err)
+	}
+
 	pageToken := 0
 	if msg.PageToken != nil {
 		pageToken = int(*msg.PageToken)
@@ -445,14 +462,14 @@ func (s *applicationServer) ListCommits(ctx context.Context, msg *pb.ListCommits
 		return nil, fmt.Errorf("could not get app %q in namespace %q: %w", msg.Name, msg.Namespace, err)
 	}
 
-	appService, err := s.factory.GetAppService(ctx)
+	appService, err := s.factory.GetAppService(ctx, kubeClient)
 	if err != nil {
 		return nil, grpcStatus.Errorf(codes.Unauthenticated, "failed to create app service: %s", err.Error())
 	}
 
 	client := internal.NewGitProviderClient(providerToken.AccessToken)
 
-	_, gitProvider, err := s.factory.GetGitClients(ctx, client, services.GitConfigParams{
+	_, gitProvider, err := s.factory.GetGitClients(ctx, kubeClient, client, services.GitConfigParams{
 		URL:        application.Spec.URL,
 		ConfigRepo: application.Spec.ConfigRepo,
 		Namespace:  msg.Namespace,

--- a/pkg/server/server_options.go
+++ b/pkg/server/server_options.go
@@ -4,6 +4,7 @@ package server
 // ApplicationsServer.
 type ApplicationsOptions struct {
 	ClientGetter ClientGetter
+	KubeGetter   KubeGetter
 }
 
 // ApplicationsOption defines the signature of a function that can be used
@@ -14,5 +15,12 @@ type ApplicationsOption func(*ApplicationsOptions)
 func WithClientGetter(clientGetter ClientGetter) ApplicationsOption {
 	return func(args *ApplicationsOptions) {
 		args.ClientGetter = clientGetter
+	}
+}
+
+// WithKubeGetter allows for setting a KubeGetter.
+func WithKubeGetter(kubeGetter KubeGetter) ApplicationsOption {
+	return func(args *ApplicationsOptions) {
+		args.KubeGetter = kubeGetter
 	}
 }

--- a/pkg/server/suite_test.go
+++ b/pkg/server/suite_test.go
@@ -117,10 +117,6 @@ var _ = BeforeEach(func() {
 
 	fakeFactory.GetGitClientsReturns(configGit, gitProvider, nil)
 
-	fakeFactory.GetKubeServiceStub = func() (kube.Kube, error) {
-		return k, nil
-	}
-
 	ghAuthClient = &authfakes.FakeGithubAuthClient{}
 	glAuthClient = &authfakes.FakeGitlabAuthClient{}
 	jwtClient = auth.NewJwtClient(secretKey)
@@ -133,7 +129,8 @@ var _ = BeforeEach(func() {
 		GitlabAuthClient: glAuthClient,
 		ClusterConfig:    ClusterConfig{},
 	}
-	apps = NewApplicationsServer(&cfg, WithClientGetter(NewFakeClientGetter(k8sClient)))
+	apps = NewApplicationsServer(&cfg,
+		WithClientGetter(NewFakeClientGetter(k8sClient)), WithKubeGetter(NewFakeKubeGetter(k)))
 	pb.RegisterApplicationsServer(s, apps)
 
 	go func() {

--- a/pkg/services/factory.go
+++ b/pkg/services/factory.go
@@ -4,9 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"k8s.io/client-go/rest"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
 	wego "github.com/weaveworks/weave-gitops/api/v1alpha1"
 	"github.com/weaveworks/weave-gitops/pkg/flux"
 	"github.com/weaveworks/weave-gitops/pkg/git"
@@ -24,9 +21,8 @@ import (
 
 // Factory provides helpers for generating various WeGO service objects at runtime.
 type Factory interface {
-	GetKubeService() (kube.Kube, error)
-	GetAppService(ctx context.Context) (app.AppService, error)
-	GetGitClients(ctx context.Context, gpClient gitproviders.Client, params GitConfigParams) (git.Git, gitproviders.GitProvider, error)
+	GetAppService(ctx context.Context, kubeClient kube.Kube) (app.AppService, error)
+	GetGitClients(ctx context.Context, kubeClient kube.Kube, gpClient gitproviders.Client, params GitConfigParams) (git.Git, gitproviders.GitProvider, error)
 }
 
 type GitConfigParams struct {
@@ -50,10 +46,8 @@ func NewGitConfigParamsFromApp(app *wego.Application, dryRun bool) GitConfigPara
 }
 
 type defaultFactory struct {
-	fluxClient  flux.Flux
-	log         logger.Logger
-	rest        *rest.Config
-	clusterName string
+	fluxClient flux.Flux
+	log        logger.Logger
 }
 
 func NewFactory(fluxClient flux.Flux, log logger.Logger) Factory {
@@ -63,47 +57,11 @@ func NewFactory(fluxClient flux.Flux, log logger.Logger) Factory {
 	}
 }
 
-func NewServerFactory(fluxClient flux.Flux, log logger.Logger, rest *rest.Config, clusterName string) Factory {
-	return &defaultFactory{
-		fluxClient:  fluxClient,
-		log:         log,
-		rest:        rest,
-		clusterName: clusterName,
-	}
-}
-
-func (f *defaultFactory) GetAppService(ctx context.Context) (app.AppService, error) {
-	kubeClient, err := f.GetKubeService()
-	if err != nil {
-		return nil, fmt.Errorf("error initializing clients: %w", err)
-	}
-
+func (f *defaultFactory) GetAppService(ctx context.Context, kubeClient kube.Kube) (app.AppService, error) {
 	return app.New(ctx, f.log, f.fluxClient, kubeClient, osys.New()), nil
 }
 
-func (f *defaultFactory) GetKubeService() (kube.Kube, error) {
-	var mainKubeClient kube.Kube
-
-	if f.rest == nil {
-		kubeClient, _, err := kube.NewKubeHTTPClient()
-		if err != nil {
-			return nil, fmt.Errorf("error creating k8s http client: %w", err)
-		}
-
-		mainKubeClient = kubeClient
-	} else {
-		kubeClient, _, err := kube.NewKubeHTTPClientWithConfig(f.rest, f.clusterName)
-		if err != nil {
-			return nil, err
-		}
-
-		mainKubeClient = kubeClient
-	}
-
-	return mainKubeClient, nil
-}
-
-func (f *defaultFactory) GetGitClients(ctx context.Context, gpClient gitproviders.Client, params GitConfigParams) (git.Git, gitproviders.GitProvider, error) {
+func (f *defaultFactory) GetGitClients(ctx context.Context, kubeClient kube.Kube, gpClient gitproviders.Client, params GitConfigParams) (git.Git, gitproviders.GitProvider, error) {
 	isExternalConfig := models.IsExternalConfigRepo(params.ConfigRepo)
 
 	var providerUrl string
@@ -122,17 +80,12 @@ func (f *defaultFactory) GetGitClients(ctx context.Context, gpClient gitprovider
 		return nil, nil, fmt.Errorf("error normalizing url: %w", err)
 	}
 
-	kube, err := f.GetKubeService()
-	if err != nil {
-		return nil, nil, fmt.Errorf("error creating k8s http client: %w", err)
-	}
-
-	targetName, err := kube.GetClusterName(ctx)
+	targetName, err := kubeClient.GetClusterName(ctx)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error getting target name: %w", err)
 	}
 
-	authSvc, err := f.getAuthService(normalizedUrl, gpClient, params.DryRun)
+	authSvc, err := f.getAuthService(kubeClient, normalizedUrl, gpClient, params.DryRun)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error creating auth service: %w", err)
 	}
@@ -168,7 +121,7 @@ func (f *defaultFactory) GetGitClients(ctx context.Context, gpClient gitprovider
 	return configClient, authSvc.GetGitProvider(), nil
 }
 
-func (f *defaultFactory) getAuthService(normalizedUrl gitproviders.RepoURL, gpClient gitproviders.Client, dryRun bool) (auth.AuthService, error) {
+func (f *defaultFactory) getAuthService(kubeClient kube.Kube, normalizedUrl gitproviders.RepoURL, gpClient gitproviders.Client, dryRun bool) (auth.AuthService, error) {
 	var (
 		gitProvider gitproviders.GitProvider
 		err         error
@@ -184,18 +137,5 @@ func (f *defaultFactory) getAuthService(normalizedUrl gitproviders.RepoURL, gpCl
 		}
 	}
 
-	var rawClient client.Client
-	if f.rest == nil {
-		_, rawClient, err = kube.NewKubeHTTPClient()
-		if err != nil {
-			return nil, fmt.Errorf("error creating k8s http client: %w", err)
-		}
-	} else {
-		_, rawClient, err = kube.NewKubeHTTPClientWithConfig(f.rest, f.clusterName)
-		if err != nil {
-			return nil, fmt.Errorf("error creating k8s http client: %w", err)
-		}
-	}
-
-	return auth.NewAuthService(f.fluxClient, rawClient, gitProvider, f.log)
+	return auth.NewAuthService(f.fluxClient, kubeClient.Raw(), gitProvider, f.log)
 }

--- a/pkg/services/factory_test.go
+++ b/pkg/services/factory_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/weaveworks/weave-gitops/pkg/flux/fluxfakes"
 	"github.com/weaveworks/weave-gitops/pkg/gitproviders/gitprovidersfakes"
+	"github.com/weaveworks/weave-gitops/pkg/kube/kubefakes"
 	"github.com/weaveworks/weave-gitops/pkg/logger/loggerfakes"
 	"github.com/weaveworks/weave-gitops/pkg/services/app"
 )
@@ -16,6 +17,7 @@ var _ = Describe("Services factory", func() {
 	var fakeFlux *fluxfakes.FakeFlux
 	var fakeLog *loggerfakes.FakeLogger
 	var fakeClient *gitprovidersfakes.FakeClient
+	var fakeKube *kubefakes.FakeKube
 	var factory Factory
 
 	BeforeEach(func() {
@@ -23,13 +25,14 @@ var _ = Describe("Services factory", func() {
 		fakeFlux = &fluxfakes.FakeFlux{}
 		fakeClient = &gitprovidersfakes.FakeClient{}
 		fakeLog = &loggerfakes.FakeLogger{}
+		fakeKube = &kubefakes.FakeKube{}
 
 		factory = NewFactory(fakeFlux, fakeLog)
 	})
 
 	Describe("get git clients", func() {
 		It("all parameter fields are empty throws error", func() {
-			gitClient, gitProvider, err := factory.GetGitClients(ctx, fakeClient, GitConfigParams{})
+			gitClient, gitProvider, err := factory.GetGitClients(ctx, fakeKube, fakeClient, GitConfigParams{})
 
 			Expect(gitClient).To(BeNil())
 			Expect(gitProvider).To(BeNil())
@@ -37,7 +40,7 @@ var _ = Describe("Services factory", func() {
 		})
 
 		It("config is for a helm repository", func() {
-			gitClient, gitProvider, err := factory.GetGitClients(ctx, fakeClient, GitConfigParams{
+			gitClient, gitProvider, err := factory.GetGitClients(ctx, fakeKube, fakeClient, GitConfigParams{
 				IsHelmRepository: true,
 			})
 
@@ -48,7 +51,7 @@ var _ = Describe("Services factory", func() {
 
 		It("app add params is helm chart", func() {
 			params := app.AddParams{Chart: "this-chart"}
-			gitClient, gitProvider, err := factory.GetGitClients(ctx, fakeClient, GitConfigParams{
+			gitClient, gitProvider, err := factory.GetGitClients(ctx, fakeKube, fakeClient, GitConfigParams{
 				IsHelmRepository: params.IsHelmRepository(),
 			})
 
@@ -58,7 +61,7 @@ var _ = Describe("Services factory", func() {
 		})
 
 		It("config type user repo and empty url return error", func() {
-			gitClient, gitProvider, err := factory.GetGitClients(ctx, fakeClient, GitConfigParams{
+			gitClient, gitProvider, err := factory.GetGitClients(ctx, fakeKube, fakeClient, GitConfigParams{
 				ConfigRepo:       "",
 				IsHelmRepository: false,
 			})

--- a/pkg/services/servicesfakes/fake_factory.go
+++ b/pkg/services/servicesfakes/fake_factory.go
@@ -13,10 +13,11 @@ import (
 )
 
 type FakeFactory struct {
-	GetAppServiceStub        func(context.Context) (app.AppService, error)
+	GetAppServiceStub        func(context.Context, kube.Kube) (app.AppService, error)
 	getAppServiceMutex       sync.RWMutex
 	getAppServiceArgsForCall []struct {
 		arg1 context.Context
+		arg2 kube.Kube
 	}
 	getAppServiceReturns struct {
 		result1 app.AppService
@@ -26,12 +27,13 @@ type FakeFactory struct {
 		result1 app.AppService
 		result2 error
 	}
-	GetGitClientsStub        func(context.Context, gitproviders.Client, services.GitConfigParams) (git.Git, gitproviders.GitProvider, error)
+	GetGitClientsStub        func(context.Context, kube.Kube, gitproviders.Client, services.GitConfigParams) (git.Git, gitproviders.GitProvider, error)
 	getGitClientsMutex       sync.RWMutex
 	getGitClientsArgsForCall []struct {
 		arg1 context.Context
-		arg2 gitproviders.Client
-		arg3 services.GitConfigParams
+		arg2 kube.Kube
+		arg3 gitproviders.Client
+		arg4 services.GitConfigParams
 	}
 	getGitClientsReturns struct {
 		result1 git.Git
@@ -43,34 +45,23 @@ type FakeFactory struct {
 		result2 gitproviders.GitProvider
 		result3 error
 	}
-	GetKubeServiceStub        func() (kube.Kube, error)
-	getKubeServiceMutex       sync.RWMutex
-	getKubeServiceArgsForCall []struct {
-	}
-	getKubeServiceReturns struct {
-		result1 kube.Kube
-		result2 error
-	}
-	getKubeServiceReturnsOnCall map[int]struct {
-		result1 kube.Kube
-		result2 error
-	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeFactory) GetAppService(arg1 context.Context) (app.AppService, error) {
+func (fake *FakeFactory) GetAppService(arg1 context.Context, arg2 kube.Kube) (app.AppService, error) {
 	fake.getAppServiceMutex.Lock()
 	ret, specificReturn := fake.getAppServiceReturnsOnCall[len(fake.getAppServiceArgsForCall)]
 	fake.getAppServiceArgsForCall = append(fake.getAppServiceArgsForCall, struct {
 		arg1 context.Context
-	}{arg1})
+		arg2 kube.Kube
+	}{arg1, arg2})
 	stub := fake.GetAppServiceStub
 	fakeReturns := fake.getAppServiceReturns
-	fake.recordInvocation("GetAppService", []interface{}{arg1})
+	fake.recordInvocation("GetAppService", []interface{}{arg1, arg2})
 	fake.getAppServiceMutex.Unlock()
 	if stub != nil {
-		return stub(arg1)
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -84,17 +75,17 @@ func (fake *FakeFactory) GetAppServiceCallCount() int {
 	return len(fake.getAppServiceArgsForCall)
 }
 
-func (fake *FakeFactory) GetAppServiceCalls(stub func(context.Context) (app.AppService, error)) {
+func (fake *FakeFactory) GetAppServiceCalls(stub func(context.Context, kube.Kube) (app.AppService, error)) {
 	fake.getAppServiceMutex.Lock()
 	defer fake.getAppServiceMutex.Unlock()
 	fake.GetAppServiceStub = stub
 }
 
-func (fake *FakeFactory) GetAppServiceArgsForCall(i int) context.Context {
+func (fake *FakeFactory) GetAppServiceArgsForCall(i int) (context.Context, kube.Kube) {
 	fake.getAppServiceMutex.RLock()
 	defer fake.getAppServiceMutex.RUnlock()
 	argsForCall := fake.getAppServiceArgsForCall[i]
-	return argsForCall.arg1
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakeFactory) GetAppServiceReturns(result1 app.AppService, result2 error) {
@@ -123,20 +114,21 @@ func (fake *FakeFactory) GetAppServiceReturnsOnCall(i int, result1 app.AppServic
 	}{result1, result2}
 }
 
-func (fake *FakeFactory) GetGitClients(arg1 context.Context, arg2 gitproviders.Client, arg3 services.GitConfigParams) (git.Git, gitproviders.GitProvider, error) {
+func (fake *FakeFactory) GetGitClients(arg1 context.Context, arg2 kube.Kube, arg3 gitproviders.Client, arg4 services.GitConfigParams) (git.Git, gitproviders.GitProvider, error) {
 	fake.getGitClientsMutex.Lock()
 	ret, specificReturn := fake.getGitClientsReturnsOnCall[len(fake.getGitClientsArgsForCall)]
 	fake.getGitClientsArgsForCall = append(fake.getGitClientsArgsForCall, struct {
 		arg1 context.Context
-		arg2 gitproviders.Client
-		arg3 services.GitConfigParams
-	}{arg1, arg2, arg3})
+		arg2 kube.Kube
+		arg3 gitproviders.Client
+		arg4 services.GitConfigParams
+	}{arg1, arg2, arg3, arg4})
 	stub := fake.GetGitClientsStub
 	fakeReturns := fake.getGitClientsReturns
-	fake.recordInvocation("GetGitClients", []interface{}{arg1, arg2, arg3})
+	fake.recordInvocation("GetGitClients", []interface{}{arg1, arg2, arg3, arg4})
 	fake.getGitClientsMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3)
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
@@ -150,17 +142,17 @@ func (fake *FakeFactory) GetGitClientsCallCount() int {
 	return len(fake.getGitClientsArgsForCall)
 }
 
-func (fake *FakeFactory) GetGitClientsCalls(stub func(context.Context, gitproviders.Client, services.GitConfigParams) (git.Git, gitproviders.GitProvider, error)) {
+func (fake *FakeFactory) GetGitClientsCalls(stub func(context.Context, kube.Kube, gitproviders.Client, services.GitConfigParams) (git.Git, gitproviders.GitProvider, error)) {
 	fake.getGitClientsMutex.Lock()
 	defer fake.getGitClientsMutex.Unlock()
 	fake.GetGitClientsStub = stub
 }
 
-func (fake *FakeFactory) GetGitClientsArgsForCall(i int) (context.Context, gitproviders.Client, services.GitConfigParams) {
+func (fake *FakeFactory) GetGitClientsArgsForCall(i int) (context.Context, kube.Kube, gitproviders.Client, services.GitConfigParams) {
 	fake.getGitClientsMutex.RLock()
 	defer fake.getGitClientsMutex.RUnlock()
 	argsForCall := fake.getGitClientsArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
 }
 
 func (fake *FakeFactory) GetGitClientsReturns(result1 git.Git, result2 gitproviders.GitProvider, result3 error) {
@@ -192,62 +184,6 @@ func (fake *FakeFactory) GetGitClientsReturnsOnCall(i int, result1 git.Git, resu
 	}{result1, result2, result3}
 }
 
-func (fake *FakeFactory) GetKubeService() (kube.Kube, error) {
-	fake.getKubeServiceMutex.Lock()
-	ret, specificReturn := fake.getKubeServiceReturnsOnCall[len(fake.getKubeServiceArgsForCall)]
-	fake.getKubeServiceArgsForCall = append(fake.getKubeServiceArgsForCall, struct {
-	}{})
-	stub := fake.GetKubeServiceStub
-	fakeReturns := fake.getKubeServiceReturns
-	fake.recordInvocation("GetKubeService", []interface{}{})
-	fake.getKubeServiceMutex.Unlock()
-	if stub != nil {
-		return stub()
-	}
-	if specificReturn {
-		return ret.result1, ret.result2
-	}
-	return fakeReturns.result1, fakeReturns.result2
-}
-
-func (fake *FakeFactory) GetKubeServiceCallCount() int {
-	fake.getKubeServiceMutex.RLock()
-	defer fake.getKubeServiceMutex.RUnlock()
-	return len(fake.getKubeServiceArgsForCall)
-}
-
-func (fake *FakeFactory) GetKubeServiceCalls(stub func() (kube.Kube, error)) {
-	fake.getKubeServiceMutex.Lock()
-	defer fake.getKubeServiceMutex.Unlock()
-	fake.GetKubeServiceStub = stub
-}
-
-func (fake *FakeFactory) GetKubeServiceReturns(result1 kube.Kube, result2 error) {
-	fake.getKubeServiceMutex.Lock()
-	defer fake.getKubeServiceMutex.Unlock()
-	fake.GetKubeServiceStub = nil
-	fake.getKubeServiceReturns = struct {
-		result1 kube.Kube
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeFactory) GetKubeServiceReturnsOnCall(i int, result1 kube.Kube, result2 error) {
-	fake.getKubeServiceMutex.Lock()
-	defer fake.getKubeServiceMutex.Unlock()
-	fake.GetKubeServiceStub = nil
-	if fake.getKubeServiceReturnsOnCall == nil {
-		fake.getKubeServiceReturnsOnCall = make(map[int]struct {
-			result1 kube.Kube
-			result2 error
-		})
-	}
-	fake.getKubeServiceReturnsOnCall[i] = struct {
-		result1 kube.Kube
-		result2 error
-	}{result1, result2}
-}
-
 func (fake *FakeFactory) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -255,8 +191,6 @@ func (fake *FakeFactory) Invocations() map[string][][]interface{} {
 	defer fake.getAppServiceMutex.RUnlock()
 	fake.getGitClientsMutex.RLock()
 	defer fake.getGitClientsMutex.RUnlock()
-	fake.getKubeServiceMutex.RLock()
-	defer fake.getKubeServiceMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/test/integration/server/remove_test.go
+++ b/test/integration/server/remove_test.go
@@ -48,7 +48,7 @@ var _ = XDescribe("RemoveApplication", func() {
 	Context("Github", func() {
 		var gh *ghAPI.Client
 		var gp gitprovider.Client
-		var githubOrg = "weaveworks-gitops-test"
+		var githubOrg = os.Getenv("GITHUB_ORG")
 		var githubToken = os.Getenv("GITHUB_TOKEN")
 		var sourceRepoURL string
 		var sourceRepo gitprovider.OrgRepository

--- a/test/integration/server/suite_test.go
+++ b/test/integration/server/suite_test.go
@@ -87,7 +87,7 @@ var _ = BeforeSuite(func() {
 	fluxClient := flux.New(osys.New(), &runner.CLIRunner{})
 	fluxClient.SetupBin()
 
-	factory := services.NewServerFactory(fluxClient, &loggerfakes.FakeLogger{}, env.Rest, clusterName)
+	factory := services.NewFactory(fluxClient, &loggerfakes.FakeLogger{})
 	Expect(err).NotTo(HaveOccurred())
 
 	cfg := &server.ApplicationsConfig{


### PR DESCRIPTION
<!-- Use # to add the issue this pull request is related to -->
Part of: #1092 

<!-- Describe what has changed in this PR -->
**What changed?**
To get an instance of `kube.Kube` a `Factory` was used that was initialised during application startup with a `*rest.Config`. The responsibility of getting a `kube.Kube` instance now lies with the `KubeGetter` which reads the `*rest.Config` during an HTTP request and uses it to impersonate the call to the Kubernetes API.

<!-- Tell your future self why have you made these changes -->
**Why?**
The end goal is to execute calls to the Kubernetes API on behalf of the authenticated user.

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**
Updated existing unit tests + manually

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
**Release notes**
Not yet, still behind a feature flag.

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
Not yet, still behind a feature flag.