### PR TITLE
Only run tests when PRing to main

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
   pull_request:
+    branches:
+      - main
   workflow_dispatch:
 
 name: run tests


### PR DESCRIPTION
CI running on our `v2` branch was causing issues. We have a separate, simplified CI workflow for that branch.