### PR TITLE
Restructure GitHub auth test to remove flakiness

### DIFF
--- a/pkg/services/auth/github_test.go
+++ b/pkg/services/auth/github_test.go
@@ -8,11 +8,10 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"runtime"
 	"strings"
+	"sync"
 	"time"
 
-	"github.com/benbjohnson/clock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	fakehttp "github.com/weaveworks/weave-gitops/pkg/vendorfakes/http"
@@ -36,6 +35,32 @@ func (t *testServerTransport) RoundTrip(r *http.Request) (*http.Response, error)
 	r.URL = tsUrl
 
 	return t.roundTripper.RoundTrip(r)
+}
+
+type outcome struct {
+	string
+	error
+}
+
+// sleeper is a very lightweight fake sleep timer. Instead of faking out the system
+// clock, we can accept `sleep` calls and keep track of how long we've slept.
+type sleeper struct {
+	mutex sync.Mutex
+	time  time.Time
+}
+
+func (t *sleeper) sleep(d time.Duration) {
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+
+	t.time = t.time.Add(d)
+}
+
+func (t *sleeper) now() time.Time {
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+
+	return t.time
 }
 
 var _ = Describe("Github Device Flow", func() {
@@ -91,57 +116,101 @@ var _ = Describe("Github Device Flow", func() {
 		Expect(cliOutput.String()).To(ContainSubstring(verificationUri))
 	})
 
-	// These auth flow tests are failing intermittently, so bypass them for now
-	XDescribe("pollAuthStatus", func() {
-		It("retries after a slow_down response from github", func() {
-			rt := newMockRoundTripper(3, token)
-			client.Transport = &testServerTransport{testServeUrl: ts.URL, roundTripper: rt}
-			interval := 5 * time.Second
+	Describe("pollAuthStatus", func() {
+		var rt *mockAuthRoundTripper
+		var s *sleeper
+		outcomeChan := make(chan outcome)
 
-			c := clock.NewMock()
+		// pollTimes is a convenience function to convert from a series of polling intervals
+		// to their respective polling timestamps, relative to the sleeper type's starting time
+		pollTimes := func(intervals []time.Duration) []time.Time {
+			zero := time.Time{}
+			times := make([]time.Time, len(intervals))
+			for index, interval := range intervals {
+				switch index {
+				case 0:
+					times[index] = zero.Add(interval)
+				default:
+					times[index] = times[index-1].Add(interval)
+				}
+			}
+			return times
+		}
 
-			go func() {
-				_, err := pollAuthStatus(c.Sleep, interval, client, "somedevicecode")
-				Expect(err).NotTo(HaveOccurred())
-			}()
-			runtime.Gosched()
+		drainPollTimes := func(pollChan <-chan time.Time) (result []time.Time) {
+			for pollTime := range pollChan {
+				result = append(result, pollTime)
+			}
+			return
+		}
 
-			// check one second after interval
-			c.Add(interval + 1*time.Second)
-			Expect(rt.calls).To(Equal(1), "should have tried the first time")
+		Context("after a slow_down response from GitHub", func() {
+			BeforeEach(func() {
+				s = &sleeper{}
+				rt = newMockRoundTripper(1, token, s.now)
+				client.Transport = &testServerTransport{testServeUrl: ts.URL, roundTripper: rt}
+			})
 
-			// check during back off
-			c.Add(interval)
-			Expect(rt.calls).To(Equal(1), "should NOT have retried early")
+			It("retries with a longer interval", func() {
+				interval := 5 * time.Second
 
-			// check one second after back off ended
-			c.Add(interval + 6*time.Second)
-			Expect(rt.calls).To(Equal(2), "should have backed off 10 seconds")
+				go func() {
+					resultToken, err := pollAuthStatus(s.sleep, interval, client, "somedevicecode")
+					outcomeChan <- outcome{resultToken, err}
+				}()
+
+				<-outcomeChan
+
+				expectedPollTimes := pollTimes([]time.Duration{
+					interval,
+					interval + 5*time.Second,
+				})
+				Expect(drainPollTimes(rt.callChan)).To(Equal(expectedPollTimes))
+			})
+
+			It("returns a token", func() {
+				interval := 5 * time.Second
+
+				go func() {
+					resultToken, err := pollAuthStatus(s.sleep, interval, client, "somedevicecode")
+					outcomeChan <- outcome{resultToken, err}
+				}()
+
+				outcome := <-outcomeChan
+
+				Expect(outcome.string).To(Equal(token))
+				Expect(outcome.error).NotTo(HaveOccurred())
+			})
 		})
-		It("returns a token after a slow_down", func() {
-			rt := newMockRoundTripper(1, token)
-			client.Transport = &testServerTransport{testServeUrl: ts.URL, roundTripper: rt}
-			interval := 5 * time.Second
-			c := clock.NewMock()
 
-			var resultToken string
-			var err error
-			go func() {
-				resultToken, err = pollAuthStatus(c.Sleep, interval, client, "somedevicecode")
-				Expect(err).NotTo(HaveOccurred())
-			}()
-			runtime.Gosched()
+		Context("after several slow_down responses from GitHub", func() {
+			var s *sleeper
+			outcomeChan := make(chan outcome)
 
-			// check 1 second after interval
-			c.Add(interval + 1*time.Second)
-			Expect(rt.calls).To(Equal(1), "should have tried the first time")
+			BeforeEach(func() {
+				s = &sleeper{}
+				rt = newMockRoundTripper(3, token, s.now)
+				client.Transport = &testServerTransport{testServeUrl: ts.URL, roundTripper: rt}
+			})
 
-			// check 1 second after back off ended
-			c.Add(interval + 6*time.Second)
-			Expect(rt.calls).To(Equal(2), "should have tried again after back off")
+			It("keeps slowing down", func() {
+				interval := 5 * time.Second
 
-			Expect(resultToken).To(Equal(token))
+				go func() {
+					resultToken, err := pollAuthStatus(s.sleep, interval, client, "somedevicecode")
+					outcomeChan <- outcome{resultToken, err}
+				}()
+
+				expectedPollTimes := pollTimes([]time.Duration{
+					interval,
+					interval + 5*time.Second,
+					interval + 10*time.Second,
+					interval + 15*time.Second,
+				})
+				Expect(drainPollTimes(rt.callChan)).To(Equal(expectedPollTimes))
+			})
 		})
+
 	})
 })
 
@@ -164,8 +233,9 @@ var _ = Describe("ValidateToken", func() {
 })
 
 type mockAuthRoundTripper struct {
-	fn    func(r *http.Request) (*http.Response, error)
-	calls int
+	fn       func(r *http.Request) (*http.Response, error)
+	calls    int
+	callChan chan time.Time
 }
 
 func (rt *mockAuthRoundTripper) MockRoundTrip(fn func(r *http.Request) (*http.Response, error)) {
@@ -176,15 +246,24 @@ func (rt *mockAuthRoundTripper) RoundTrip(r *http.Request) (*http.Response, erro
 	return rt.fn(r)
 }
 
-func newMockRoundTripper(pollCount int, token string) *mockAuthRoundTripper {
-	rt := &mockAuthRoundTripper{calls: 0}
+func newMockRoundTripper(pollCount int, token string, now func() time.Time) *mockAuthRoundTripper {
+	rt := &mockAuthRoundTripper{calls: 0, callChan: make(chan time.Time, pollCount+1)}
 
 	rt.MockRoundTrip(func(r *http.Request) (*http.Response, error) {
 		b := bytes.NewBuffer(nil)
 
-		data := githubAuthResponse{Error: "slow_down"}
-		if rt.calls == pollCount {
-			data = githubAuthResponse{Error: "", AccessToken: token}
+		var data githubAuthResponse
+
+		switch {
+		case rt.calls > pollCount:
+			panic("mock API called after successful request")
+		case rt.calls == pollCount:
+			data = githubAuthResponse{AccessToken: token}
+			rt.callChan <- now()
+			close(rt.callChan)
+		default:
+			data = githubAuthResponse{Error: "slow_down"}
+			rt.callChan <- now()
 		}
 
 		if err := json.NewEncoder(b).Encode(data); err != nil {


### PR DESCRIPTION
<!-- Use # to add the issue this pull request is related to -->
Closes: #1199

As best as I can tell, the flakiness here was coming from two places:

1. Plain ol' data races, where we were sharing a variable between threads, updating it one thread and reading it in another. Sometimes these wouldn't happen in the right order, causing failures.
2. Race conditions when interacting with the `clock` library, where (for example) we would kick off a piece of code that we knew would call `Sleep`, call `runtime.Gosched` to give it a chance to execute, and then tell the `clock` library to advance time. It looks like these, again, weren't always happening in order.

A bunch of the complexity here stems from the fact that we're poking our clock from one end with the `Sleep` function, then poking it from the other end to tell it time has advanced. Since all we're relying on in our non-test code is a `sleep` function, we can fake this out with a small `struct`, then use the `mockRoundTripper` to keep track of what the "current time" is when it receives requests.

Another change is using a channel to communicate when `pollAuthStatus` has completed, so that we can wait for this (and know nothing else is going to change) before testing the state of the system.

Finally, I took the opportunity to restructure the tests a little bit to take advantage of Ginkgo's `Context`s, providing a slightly clearer separation between what scenario we're testing and what behavior we want to see.

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**

I mostly tested this manually (and repeatedly), but also with a bit of help from [Go’s race detector](https://go.dev/doc/articles/race_detector).