### PR TITLE
Tilt install fix

### DIFF
--- a/tools/dependencies.toml
+++ b/tools/dependencies.toml
@@ -7,3 +7,8 @@ bindir="../pkg/flux/bin"
 [envtest]
 version="1.19.2"
 special_tarpath="https://storage.googleapis.com/kubebuilder-tools/kubebuilder-tools-${version}-${goos}-${goarch}.tar.gz;kubebuilder/bin"
+
+[tilt]
+version="0.23.8"
+special_tarpath="https://github.com/tilt-dev/tilt/releases/download/v${version}/tilt.${version}.${goos}.${arch}.tar.gz;tilt"
+bindir="/usr/local/bin"

--- a/tools/download-deps.sh
+++ b/tools/download-deps.sh
@@ -119,14 +119,3 @@ done
 
 echo "Installing golangci-lint"
 curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.44.0
-
-if ! command -v tilt
-then
-    echo "Installing Tilt for local development"
-    TILT_VERSION="0.23.8"
-    # Tilt uses a mixture of Golang and uname style naming in releases
-    TILT_SOURCE="https://github.com/tilt-dev/tilt/releases/download/v${TILT_VERSION}/tilt.${TILT_VERSION}.$(goos).$(uname -m).tar.gz"
-    curl -fsSL "${TILT_SOURCE}" | tar -C /usr/local/bin -xz tilt
-else
-    echo "Local tilt binary found, skipping install"
-fi

--- a/tools/download-deps.sh
+++ b/tools/download-deps.sh
@@ -130,5 +130,3 @@ then
 else
     echo "Local tilt binary found, skipping install"
 fi
-
-

--- a/tools/download-deps.sh
+++ b/tools/download-deps.sh
@@ -123,7 +123,10 @@ curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/insta
 if ! command -v tilt
 then
     echo "Installing Tilt for local development"
-    curl -fsSL https://raw.githubusercontent.com/tilt-dev/tilt/v0.23.8/scripts/install.sh | bash
+    TILT_VERSION="0.23.8"
+    # Tilt uses a mixture of Golang and uname style naming in releases
+    TILT_SOURCE="https://github.com/tilt-dev/tilt/releases/download/v${TILT_VERSION}/tilt.${TILT_VERSION}.$(goos).$(uname -m).tar.gz"
+    curl -fsSL "${TILT_SOURCE}" | tar -C /usr/local/bin -xz tilt
 else
     echo "Local tilt binary found, skipping install"
 fi


### PR DESCRIPTION
<!-- Use # to add the issue this pull request is related to -->
Closes: #1369

<!-- Describe what has changed in this PR -->
**What changed?**

Install tilt directly, rather than using `curl | bash`

<!-- Tell your future self why have you made these changes -->
**Why?**

`docker build` fails otherwise as it uses (not installed or configured) `sudo`.

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**

Tested locally with `docker build` on Arch Linux & Mac OS, x86_64. I can't test the `make` targets directly as they refuse to build in a clean chroot, and I don't currently have time to figure out which dependencies are missing.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
**Release notes**

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**

**Other**

I am not familiar enough with your build env to determine which fix is correct: caa497548c5fd1db9eb6493e2f175c550903604c or 0acba92265176c8ccd8ea9870caf52c20a2c673d.