### PR TITLE
Notify Slack when the `main` branch build fails

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -262,12 +262,13 @@ jobs:
           echo "::set-output name=sha::$sha"
       - id: commit-subject
         name: Escape the first line of the commit message
+        if: ${{ github.event_name == 'push' }}
         run: |
           subject=$(jq -r '.head_commit.message | split("\n")[0]|@json' <${{ github.event_path }})
           echo "::set-output name=subject::$subject"
       - name: Send team Slack notification
         uses: actions-ecosystem/action-slack-notifier@fc778468d09c43a6f4d1b8cccaca59766656996a
-        if: ${{ github.ref == 'refs/heads/main' }}
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         with:
           slack_token: ${{ secrets.SLACK_TOKEN_BLUETONIUM }}
           channel: team-bluetonium

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -241,6 +241,83 @@ jobs:
         gitlab-org: ${{ secrets.GITLAB_ORG }}
         artifacts-base-dir: "/tmp/gitops-test"
 
+  notify-failure:
+    name: Send failure notifications
+    runs-on: ubuntu-latest
+    needs:
+      - test
+      - smoke-tests
+      - smoke-tests-long
+      - acceptance-tests-0
+      - acceptance-tests-1
+      - acceptance-tests-2
+      - acceptance-tests-3
+      - ui-tests
+    if: ${{ failure() }}
+    steps:
+      - id: short-sha
+        name: Get short commit SHA
+        run: |
+          sha=$(echo ${{ github.event.head_commit.id }} | cut -b -7)
+          echo "::set-output name=sha::$sha"
+      - id: commit-subject
+        name: Escape the first line of the commit message
+        run: |
+          subject=$(jq -r '.head_commit.message | split("\n")[0]|@json' <${{ github.event_path }})
+          echo "::set-output name=subject::$subject"
+      - name: Send team Slack notification
+        uses: actions-ecosystem/action-slack-notifier@fc778468d09c43a6f4d1b8cccaca59766656996a
+        if: ${{ github.ref == 'refs/heads/main' }}
+        with:
+          slack_token: ${{ secrets.SLACK_TOKEN_BLUETONIUM }}
+          channel: team-bluetonium
+          custom_payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":red_circle: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Weave GitOps tests failed on `${{ github.ref_name }}`>"
+                  }
+                },
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": ":memo: Commit information"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": ${{ steps.commit-subject.outputs.subject }}
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "<${{ github.event.head_commit.url }}|:github: View on GitHub>"
+                  }
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": ":bust_in_silhouette: ${{ github.event.head_commit.author.name }}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": ":pushpin: `${{ steps.short-sha.outputs.sha }}`"
+                    }
+                  ]
+                }
+              ]
+            }
+
   # Commenting while the library code is unused
   # library-integration-test:
   #   runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -258,7 +258,7 @@ jobs:
       - id: short-sha
         name: Get short commit SHA
         run: |
-          sha=$(echo ${{ github.event.head_commit.id }} | cut -b -7)
+          sha=$(echo ${{ github.sha }} | cut -b -7)
           echo "::set-output name=sha::$sha"
       - id: commit-subject
         name: Escape the first line of the commit message


### PR DESCRIPTION
<img width="472" alt="Example build failure notification" src="https://user-images.githubusercontent.com/32775/152409090-891cc9eb-f518-4f38-9b5e-f347382cd096.png">

This is largely based on [similar work in other Weaveworks projects][1], but with a bit of extra information that will hopefully be useful to folks who want to investigate the failure.

[1]: https://github.com/search?q=org%3Aweaveworks+action-slack-notifier&type=code

There are a few bits of this workflow that I don't love: the `jq` hackery to extract the first line of the commit message isn't particularly pleasant, but I couldn't see anything exposed by GitHub that gives us just the commit's subject line. Telling `jq` to JSON-encode the commit subject also feels like a bit of a hack, but these are the perils of telling GitHub how to write YAML that writes JSON that writes Slack's custom `mrkdwn` syntax.

If we want to add any more context to these messages (for instance, which bits of the run failed and how long they took), I would strongly recommend taking the functionality here and re-implementing it in a scripting language of choice (Python seems like a good fit, but anything else that has JSON support in its standard library and comes bundled with Ubuntu would probably work just as well).

I've tentatively left the job open to the prospect of adding other build failure notifications (Slack or otherwise). Normally, I'd think of this as a premature generalization, but it plays nicely into GitHub's way of evaluating whether to run a job at all.

## Reviewer notes

This is one instance where a reviewer is going to get a better impression by looking at the individual commits:
* The first commit is where the actual work is. Look at this one.
* The second commit changes a few settings to allow for testing without messing up the `main` branch or spamming the team.
* The third commit artificially breaks a bunch of steps in the build, so that I can get feedback in seconds, rather than minutes.

I’m also open to feedback on the information we’re presenting in the notifications. Is there something missing that would be really useful? Is there something there that isn’t helpful? We’re a little limited in what GitHub makes available without checking out the source code or running more advanced scripting, but suggestions are always welcome.