### PR TITLE
Fixes system kustomization reconciling if no profiles installed

### DIFF
--- a/pkg/models/manifest.go
+++ b/pkg/models/manifest.go
@@ -168,6 +168,10 @@ func NoClusterApplicableManifests(params ManifestsParams) ([]Manifest, error) {
 			Content: systemKustomizationManifest,
 		},
 		{
+			Path:    git.GetSystemQualifiedPath(params.ClusterName, WegoProfilesPath),
+			Content: []byte(""),
+		},
+		{
 			Path:    filepath.Join(git.GetUserPath(params.ClusterName), ".keep"),
 			Content: strconv.AppendQuote(nil, "# keep"),
 		},

--- a/pkg/models/manifest.go
+++ b/pkg/models/manifest.go
@@ -167,10 +167,10 @@ func NoClusterApplicableManifests(params ManifestsParams) ([]Manifest, error) {
 			Path:    git.GetSystemQualifiedPath(params.ClusterName, SystemKustomizationPath),
 			Content: systemKustomizationManifest,
 		},
-		// {
-		// 	Path:    git.GetSystemQualifiedPath(params.ClusterName, WegoProfilesPath),
-		// 	Content: []byte(""),
-		// },
+		{
+			Path:    git.GetSystemQualifiedPath(params.ClusterName, WegoProfilesPath),
+			Content: []byte(""),
+		},
 		{
 			Path:    filepath.Join(git.GetUserPath(params.ClusterName), ".keep"),
 			Content: strconv.AppendQuote(nil, "# keep"),

--- a/pkg/models/manifest.go
+++ b/pkg/models/manifest.go
@@ -167,10 +167,10 @@ func NoClusterApplicableManifests(params ManifestsParams) ([]Manifest, error) {
 			Path:    git.GetSystemQualifiedPath(params.ClusterName, SystemKustomizationPath),
 			Content: systemKustomizationManifest,
 		},
-		{
-			Path:    git.GetSystemQualifiedPath(params.ClusterName, WegoProfilesPath),
-			Content: []byte(""),
-		},
+		// {
+		// 	Path:    git.GetSystemQualifiedPath(params.ClusterName, WegoProfilesPath),
+		// 	Content: []byte(""),
+		// },
 		{
 			Path:    filepath.Join(git.GetUserPath(params.ClusterName), ".keep"),
 			Content: strconv.AppendQuote(nil, "# keep"),

--- a/pkg/models/manifest_test.go
+++ b/pkg/models/manifest_test.go
@@ -178,12 +178,16 @@ var _ = Describe("Installer", func() {
 				noClusterApplicableManifests, err := NoClusterApplicableManifests(params)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				Expect(len(noClusterApplicableManifests)).Should(Equal(2))
+				Expect(len(noClusterApplicableManifests)).Should(Equal(3))
 
 				expectedManifests := []Manifest{
 					{
 						Path:    git.GetSystemQualifiedPath(params.ClusterName, SystemKustomizationPath),
 						Content: systemKustomizationManifest,
+					},
+					{
+						Path:    git.GetSystemQualifiedPath(params.ClusterName, WegoProfilesPath),
+						Content: []byte(""),
 					},
 					{
 						Path:    filepath.Join(git.GetUserPath(params.ClusterName), ".keep"),

--- a/pkg/services/gitops/install.go
+++ b/pkg/services/gitops/install.go
@@ -89,9 +89,7 @@ func (g *Gitops) Install(params InstallParams) (map[string][]byte, error) {
 			}
 		}
 
-		systemManifests[models.WegoAppPath] = bytes.Join(wegoAppManifests, []byte("---\n"))
-		// Empty file until we add some profiles, kustomize.yaml will reference this and fail if its missing.
-		systemManifests[models.WegoProfilesPath] = []byte("")
+		systemManifests["wego-app.yaml"] = bytes.Join(wegoAppManifests, []byte("---\n"))
 	}
 
 	wegoConfigCM, err := g.saveWegoConfig(ctx, params)

--- a/pkg/services/gitops/install.go
+++ b/pkg/services/gitops/install.go
@@ -89,7 +89,9 @@ func (g *Gitops) Install(params InstallParams) (map[string][]byte, error) {
 			}
 		}
 
-		systemManifests["wego-app.yaml"] = bytes.Join(wegoAppManifests, []byte("---\n"))
+		systemManifests[models.WegoAppPath] = bytes.Join(wegoAppManifests, []byte("---\n"))
+		// Empty file until we add some profiles, kustomize.yaml will reference this and fail if its missing.
+		systemManifests[models.WegoProfilesPath] = []byte("")
 	}
 
 	wegoConfigCM, err := g.saveWegoConfig(ctx, params)

--- a/pkg/services/install/install_test.go
+++ b/pkg/services/install/install_test.go
@@ -240,6 +240,10 @@ var _ = Describe("Installer", func() {
 					Content: systemKustomizationManifest,
 				},
 				{
+					Path:    git.GetSystemQualifiedPath(clusterName, models.WegoProfilesPath),
+					Content: []byte(""),
+				},
+				{
 					Path:    filepath.Join(git.GetUserPath(clusterName), ".keep"),
 					Content: strconv.AppendQuote(nil, "# keep"),
 				},
@@ -312,6 +316,10 @@ var _ = Describe("Installer", func() {
 				{
 					Path:    git.GetSystemQualifiedPath(clusterName, models.SystemKustomizationPath),
 					Content: systemKustomizationManifest,
+				},
+				{
+					Path:    git.GetSystemQualifiedPath(clusterName, models.WegoProfilesPath),
+					Content: []byte(""),
 				},
 				{
 					Path:    filepath.Join(git.GetUserPath(clusterName), ".keep"),

--- a/test/acceptance/test/add_tests.go
+++ b/test/acceptance/test/add_tests.go
@@ -1807,6 +1807,10 @@ var _ = Describe("Weave GitOps Add Tests With Long Cluster Name", func() {
 			installAndVerifyWego(WEGO_DEFAULT_NAMESPACE, configRepoRemoteURL)
 		})
 
+		By("And the kustomizations should not have any errors", func() {
+			VerifyKustomizations(clusterName, WEGO_DEFAULT_NAMESPACE)
+		})
+
 		By("And I run gitops add app command for app: "+appName, func() {
 			runWegoAddCommand(repoAbsolutePath, addCommand, WEGO_DEFAULT_NAMESPACE)
 		})

--- a/test/acceptance/test/add_tests.go
+++ b/test/acceptance/test/add_tests.go
@@ -1753,7 +1753,7 @@ var _ = Describe("Weave GitOps Add Tests With Long Cluster Name", func() {
 			var err error
 
 			clusterName = "kind-123456789012345678901234567890"
-			_, _, err = ResetOrCreateClusterWithName(WEGO_DEFAULT_NAMESPACE, deleteWegoRuntime, clusterName, false)
+			_, clusterContext, err = ResetOrCreateClusterWithName(WEGO_DEFAULT_NAMESPACE, deleteWegoRuntime, clusterName, false)
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 
@@ -1808,7 +1808,7 @@ var _ = Describe("Weave GitOps Add Tests With Long Cluster Name", func() {
 		})
 
 		By("And the kustomizations should not have any errors", func() {
-			VerifyKustomizations(clusterName, WEGO_DEFAULT_NAMESPACE)
+			VerifyKustomizations(clusterContext, WEGO_DEFAULT_NAMESPACE)
 		})
 
 		By("And I run gitops add app command for app: "+appName, func() {

--- a/test/acceptance/test/utils.go
+++ b/test/acceptance/test/utils.go
@@ -433,7 +433,8 @@ func VerifyKustomizations(clusterName, namespace string) {
 
 	for _, kustomizationName := range []string{userResourceName, systemResourceName} {
 		cmd := fmt.Sprintf("kubectl wait --for=condition=Ready --timeout=120s kustomization -n %s %s", namespace, kustomizationName)
-		Expect(runCommandPassThroughWithoutOutput([]string{}, "sh", "-c", cmd)).To(Succeed())
+		out, err := runCommandAndReturnStringOutput(cmd)
+		Expect(err).Should(BeEmpty(), fmt.Sprintf("Failed to wait for kustomizations, out: %s, err: %s", out, err))
 	}
 }
 

--- a/test/acceptance/test/utils.go
+++ b/test/acceptance/test/utils.go
@@ -38,21 +38,22 @@ import (
 )
 
 const (
-	THIRTY_SECOND_TIMEOUT       time.Duration = 30 * time.Second
-	EVENTUALLY_DEFAULT_TIMEOUT  time.Duration = 60 * time.Second
-	INSTALL_RESET_TIMEOUT       time.Duration = 300 * time.Second
-	NAMESPACE_TERMINATE_TIMEOUT time.Duration = 600 * time.Second
-	INSTALL_SUCCESSFUL_TIMEOUT  time.Duration = 3 * time.Minute
-	INSTALL_PODS_READY_TIMEOUT  time.Duration = 3 * time.Minute
-	WEGO_DEFAULT_NAMESPACE                    = wego.DefaultNamespace
-	WEGO_UI_URL                               = "http://localhost:9001"
-	SELENIUM_SERVICE_URL                      = "http://localhost:4444/wd/hub"
-	SCREENSHOTS_DIR             string        = "screenshots/"
-	DEFAULT_BRANCH_NAME                       = "main"
-	WEGO_DASHBOARD_TITLE        string        = "Weave GitOps"
-	APP_PAGE_HEADER             string        = "Applications"
-	charset                                   = "abcdefghijklmnopqrstuvwxyz0123456789"
-	DEFAULT_K8S_VERSION         string        = "1.21.1"
+	THIRTY_SECOND_TIMEOUT        time.Duration = 30 * time.Second
+	EVENTUALLY_DEFAULT_TIMEOUT   time.Duration = 60 * time.Second
+	INSTALL_RESET_TIMEOUT        time.Duration = 300 * time.Second
+	NAMESPACE_TERMINATE_TIMEOUT  time.Duration = 600 * time.Second
+	INSTALL_SUCCESSFUL_TIMEOUT   time.Duration = 3 * time.Minute
+	INSTALL_PODS_READY_TIMEOUT   time.Duration = 3 * time.Minute
+	KUSTOMIZATIONS_READY_TIMEOUT time.Duration = 2 * time.Minute
+	WEGO_DEFAULT_NAMESPACE                     = wego.DefaultNamespace
+	WEGO_UI_URL                                = "http://localhost:9001"
+	SELENIUM_SERVICE_URL                       = "http://localhost:4444/wd/hub"
+	SCREENSHOTS_DIR              string        = "screenshots/"
+	DEFAULT_BRANCH_NAME                        = "main"
+	WEGO_DASHBOARD_TITLE         string        = "Weave GitOps"
+	APP_PAGE_HEADER              string        = "Applications"
+	charset                                    = "abcdefghijklmnopqrstuvwxyz0123456789"
+	DEFAULT_K8S_VERSION          string        = "1.21.1"
 )
 
 var (
@@ -432,7 +433,7 @@ func VerifyKustomizations(clusterName, namespace string) {
 	systemResourceName := models.ConstrainResourceName(fmt.Sprintf("%s-system", clusterName))
 
 	for _, kustomizationName := range []string{userResourceName, systemResourceName} {
-		cmd := fmt.Sprintf("kubectl wait --for=condition=Ready --timeout=120s kustomization -n %s %s", namespace, kustomizationName)
+		cmd := fmt.Sprintf("kubectl wait --for=condition=Ready --timeout=110s kustomization -n %s %s", namespace, kustomizationName)
 		out, err := runCommandAndReturnStringOutput(cmd)
 		Expect(err).Should(BeEmpty(), fmt.Sprintf("Failed to wait for kustomizations, out: %s, err: %s", out, err))
 	}

--- a/test/acceptance/test/utils.go
+++ b/test/acceptance/test/utils.go
@@ -33,6 +33,7 @@ import (
 	"github.com/weaveworks/weave-gitops/pkg/git"
 	"github.com/weaveworks/weave-gitops/pkg/git/wrapper"
 	"github.com/weaveworks/weave-gitops/pkg/gitproviders"
+	"github.com/weaveworks/weave-gitops/pkg/models"
 	"github.com/weaveworks/weave-gitops/pkg/utils"
 )
 
@@ -424,6 +425,16 @@ func VerifyControllersInCluster(namespace string) {
 		Expect(err).ShouldNot(HaveOccurred())
 		Eventually(session, INSTALL_PODS_READY_TIMEOUT).Should(gexec.Exit())
 	})
+}
+
+func VerifyKustomizations(clusterName, namespace string) {
+	userResourceName := models.ConstrainResourceName(fmt.Sprintf("%s-user", clusterName))
+	systemResourceName := models.ConstrainResourceName(fmt.Sprintf("%s-system", clusterName))
+
+	for _, kustomizationName := range []string{userResourceName, systemResourceName} {
+		cmd := fmt.Sprintf("kubectl wait --for=condition=Ready --timeout=120s kustomization -n %s %s", namespace, kustomizationName)
+		Expect(runCommandPassThroughWithoutOutput([]string{}, "sh", "-c", cmd)).To(Succeed())
+	}
 }
 
 func installAndVerifyWego(wegoNamespace, repoURL string) {


### PR DESCRIPTION
- Kustomization controller complains about a missing profiles.yaml

<!-- Describe what has changed in this PR -->
**What changed?**

Add an empty `profiles.yaml` file so that the system kustomzation can reconcile.

```json
{
  "level": "error",
  "ts": "2022-02-07T11:10:21.828Z",
  "logger": "controller.kustomization",
  "msg": "Reconciliation failed after 31.707953ms, next try in 1m0s",
  "reconciler group": "kustomize.toolkit.fluxcd.io",
  "reconciler kind": "Kustomization",
  "name": "kind-test-upgrade-system",
  "namespace": "wego-system",
  "revision": "main/ae43a6151d0f4c368a3abc352f6349837b91561e",
  "error": "kustomize build failed: accumulating resources: accumulation err='accumulating resources from 'profiles.yaml': open /tmp/kind-test-upgrade-system4030199120/.weave-gitops/clusters/kind-test-upgrade/system/profiles.yaml: no such file or directory': evalsymlink failure on '/tmp/kind-test-upgrade-system4030199120/.weave-gitops/clusters/kind-test-upgrade/system/profiles.yaml' : lstat /tmp/kind-test-upgrade-system4030199120/.weave-gitops/clusters/kind-test-upgrade/system/profiles.yaml: no such file or directory",
}

```

<!-- Tell your future self why have you made these changes -->
**Why?**

Easier to add a `profiles.yaml` than to add it into the kustomization.yaml dynamically.


<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**

Locally.

