### PR TITLE
Remove merge conflict marker after bad rebase and remove label job

### DIFF
--- a/.github/workflows/label.yaml
+++ b/.github/workflows/label.yaml
@@ -1,6 +1,8 @@
-on: 
+on:
   pull_request:
     types: [opened, labeled, unlabeled, synchronize]
+    branches:
+      - main
 name: label
 jobs:
   labelCheck:

--- a/core/server/sources.go
+++ b/core/server/sources.go
@@ -25,7 +25,7 @@ func (as *appServer) AddGitRepository(ctx context.Context, msg *pb.AddGitReposit
 		return nil, status.Error(codes.InvalidArgument, "missing 'reference' field")
 	}
 
-	u, err := gitproviders.NewRepoURL(msg.Url, false)
+	u, err := gitproviders.NewRepoURL(msg.Url)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "invalid url: %s", err.Error())
 	}

--- a/tools/download-deps.sh
+++ b/tools/download-deps.sh
@@ -122,18 +122,4 @@ for tool in $tools; do
 done
 
 echo "Installing golangci-lint"
-<<<<<<< HEAD
 curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$(go env GOPATH)"/bin v1.44.0
-=======
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.44.0
-
-if ! command -v tilt
-then
-    echo "Installing Tilt for local development"
-    curl -fsSL https://raw.githubusercontent.com/tilt-dev/tilt/v0.23.8/scripts/install.sh | bash
-else
-    echo "Local tilt binary found, skipping install"
-fi
-
-
->>>>>>> Add tilt.dev support for local development (#1348)


### PR DESCRIPTION
Left over from a v2 rebase. We use the `depdencies.toml` file to handle install `tilt` now.

Also removes the label check from CI for the `v2` branch.