### PR TITLE
Use snyk for js, go & docker, upload results properly

### DIFF
--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - main
+      - v2
   pull_request:
     branches:
       - main
+      - v2
   workflow_dispatch:
 
 jobs:
@@ -36,34 +38,51 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Fake Install flux
-        run: mkdir -p pkg/flux/bin && touch pkg/flux/bin/flux
-      - name: Remove UI deps from Scan
-        run: rm package-lock.json && rm package.json && make cmd/gitops/ui/run/dist/index.html
+      - uses: snyk/actions/setup@master
+      - uses: actions/setup-go@v1
+        with:
+          go-version: '1.17'
+      - name: Generate UI file to embed
+        run: make cmd/gitops/ui/run/dist/index.html
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/golang@master
+        run: snyk test --all-projects --sarif-file-output=snyk.code.sarif
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_API_TOKEN }}
-        with:
-          args: --sarif-file-output=snyk.code.sarif
+        continue-on-error: true
       - name: Upload result to GitHub Code Scanning
         uses: github/codeql-action/upload-sarif@v1
         with:
           sarif_file: snyk.code.sarif
-      - name: Remove fake flux
-        run: rm -rv pkg/flux/bin
+      - name: Upload a report to Snyk to report new vulnerabilities
+        run: snyk monitor --all-projects
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_API_TOKEN }}
+        if: github.event.push
 
-  codeql:
-    name: CodeQL
+  snyk-docker:
+    name: Snyk Docker
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
+      - name: Checkout
         uses: actions/checkout@v2
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v1
+      - name: Build docker image
+        run: make docker
+      - name: Scan docker image
+        uses: snyk/actions/docker@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_API_TOKEN }}
         with:
-          languages: go
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@v1
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v1
+          image: ghcr.io/weaveworks/wego-app:latest
+          args: --file=Dockerfile
+        continue-on-error: true
+      - name: Upload result to GitHub Code Scanning
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: snyk.sarif
+      - name: Upload result to Snyk
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          command: monitor
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_API_TOKEN }}
+        if: github.event.push


### PR DESCRIPTION
Run snyk against javascript, go, and use the CLI directly to scan both                                                    
in one invocation.                                                                                                        
                                                                                                                          
Also run snyk against docker (separately, in parallel). It's a bit                                                        
slow right now, but a) I expect to speed this up later b) we'll have                                                      
to build the docker image anyway, and the scan takes about a second                                                       
extra c) this is still faster than the v2 pipeline.       
                                                                                                                          
Upload the snyk test results to github even if they fail - otherwise                                                      
what's the point.                                                                                                         
                                                                                                                          
Upload main branch updates to snyk directly (this will also trigger                                                       
for v2) - this means they can report newly discovered security                                                            
problems with the main branch. Don't upload PRs though - I can't see                                                      
that snyk is particularly branch aware.

Remove CodeQL - it takes over 20 minutes, which isn't anywhere near                                                       
acceptable for interactive PRs. We can add it back as a nightly job,                                                      
if it does anything snyk doesn't. 