### PR TITLE
Modify the local build to install and configure tilt for first runners

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,8 +61,15 @@ install: bin ## Install binaries to GOPATH
 api-dev: ## Server and watch gitops-server, will reload automatically on change
 	reflex -r '.go' -R 'node_modules' -s -- sh -c 'go run -ldflags $(LDFLAGS) cmd/gitops-server/main.go'
 
-cluster-dev: ## Start tilt to do development with wego-app running on the cluster
+cluster-dev: check-config-repo bin local-kind-cluster-with-registry local-docker-image ## Start tilt to do development with wego-app running on the cluster
+	IS_TEST_ENV=true IS_LOCAL_REGISTRY=true bin/$(BINARY_NAME) install --config-repo=${TEST_CONFIG_REPO} --auto-merge true
 	tilt up
+
+check-config-repo:
+	@test $${TEST_CONFIG_REPO?Please set TEST_CONFIG_REPO to use a dev cluster.}
+
+clean-dev-cluster:
+	kind delete cluster --name kind && docker rm -f kind-registry
 
 debug: ## Compile binary with optimisations and inlining disabled
 	go build -ldflags $(LDFLAGS) -o bin/$(BINARY_NAME) -gcflags='all=-N -l' cmd/gitops/*.go
@@ -179,7 +186,7 @@ unittest.out: dependencies
 integrationtest.out: dependencies
 	go get github.com/ory/go-acc
 	go-acc --ignore fakes,acceptance,pkg/api,api -o integrationtest.out ./test/integration/... -- -v --timeout=496s -tags test
-	@go mod tidy	
+	@go mod tidy
 
 coverage:
 	@mkdir -p coverage
@@ -190,7 +197,7 @@ coverage/unittest.info: coverage unittest.out
 	gcov2lcov -infile=unittest.out -outfile=coverage/unittest.info
 
 coverage/integrationtest.info: coverage integrationtest.out
-	gcov2lcov -infile=integrationtest.out -outfile=coverage/integrationtest.info	
+	gcov2lcov -infile=integrationtest.out -outfile=coverage/integrationtest.info
 
 # Concat the JS and Go coverage files for the coveralls report/
 # Note: you need to install `lcov` to run this locally.

--- a/README.md
+++ b/README.md
@@ -67,13 +67,22 @@ For more information please see the [docs](https://docs.gitops.weave.works/docs/
 
 To set up a development environment for the CLI
 
+### To use an existing environment
+
 1. Install go v1.17
 2. Install [buf](https://github.com/bufbuild/buf)
 3. Run `make all` to install dependencies and build binaries and assets
 4. Start a `kind` cluster like so: `KIND_CLUSTER_NAME=<some name> ./tools/kind-with-registry.sh`
 5. Run `./bin/gitops install --config-repo=<repo url>`
-6. Start the in-cluster API replacement job (powered by [http://tilt.dev](tilt.dev)) with `make cluster-dev`
+6. Start the in-cluster API replacement job (powered by [http://tilt.dev](tilt.dev)) with `tilt up`
 7. make or make unit-tests to ensure everything built correctly.
+
+### To use a bootstrapped, ready made environment
+
+1. Install go v1.17
+2. Install [buf](https://github.com/bufbuild/buf)
+3. Run `make all` to install dependencies and build binaries and assets
+4. Run `make cluster-dev` which should install and bring up everything and then start `tilt` to take over monitoring
 
 ### Cluster Dev Tips
 

--- a/Tiltfile
+++ b/Tiltfile
@@ -1,16 +1,16 @@
 load('ext://restart_process', 'docker_build_with_restart')
 
 local_resource(
-    'gitops-bin', 
-    'GOOS=linux GOARCH=amd64 make bin', 
+    'gitops-bin',
+    'GOOS=linux GOARCH=amd64 make bin',
     deps=[
-        './cmd', 
+        './cmd',
         './pkg',
     ]
 )
 
 docker_build_with_restart(
-    'localhost:5001/weaveworks/wego-app', 
+    'localhost:5001/weaveworks/wego-app',
     '.',
     only=[
         './bin',


### PR DESCRIPTION
Tilt install assume you already have a working cluster. That's not really needed.

Now that we have acceptance test change how we handle the image in the real deployment yaml file, we can bootstrap a dev environment and then let tilt take over so it monitors all files.

<img width="1918" alt="Screenshot 2022-02-08 at 12 53 25" src="https://user-images.githubusercontent.com/182850/152981932-c86faf85-10e1-4f46-b1a5-bf7f18e26357.png">

This is now working with a booted up dev cluster from 0 -> 100 without running anything before hand just this:

```
TEST_CONFIG_REPO=ssh://git@github.com/Skarlso/gitops-training.git make cluster-dev
```

There is also a convenient make target to clean everything up: `make clean-dev-cluster`.

# Question

Do people would like to have an option to disable the bootstrap part and still use tilt with an existing cluster?

Closes https://github.com/weaveworks/weave-gitops/issues/1406