### PR TITLE
change kind-cluster script to bash

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -116,16 +116,6 @@ jobs:
         wget  https://selenium-release.storage.googleapis.com/3.14/selenium-server-standalone-3.14.0.jar
 
         xvfb-run -a --server-args="-screen 0 1280x1024x24" java -jar ./selenium-server-standalone-3.14.0.jar &
-    - name: Setup Kubernetes
-      shell: bash
-      env:
-        KIND_CLUSTER_NAME: ${{ format('katc-{0}', github.run_id) }}
-        KIND_CLUSTER_IMAGE: kindest/node:v1.21.1
-      run: |
-        make local-kind-cluster-with-registry
-    - name: Kind-check
-      run: |
-       kubectl get pods -A
     - name: Download gitops binaries
       uses: actions/download-artifact@v2
       with:
@@ -153,6 +143,7 @@ jobs:
     - name: Run acceptance tests
       run: |
         export WEGO_BIN_PATH=$(pwd)/bin/gitops
+        export CLUSTER_PROVIDER=kind
         go get github.com/onsi/ginkgo/ginkgo
         go get github.com/onsi/gomega
         ACCEPTANCE_TEST_ARGS="--randomizeSuites --reportFile=${{ env. ARTIFACTS_BASE_DIR }}/test-results/acceptance-test-results.xml" make acceptance-tests

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -78,7 +78,7 @@ jobs:
           name: unit-tests-artefacts
           path: artefacts
           retention-days: 1
-  
+
   acceptance-tests:
     runs-on: ubuntu-latest
     needs: [build, coverage]

--- a/test/acceptance/test/scripts/kind-cluster.sh
+++ b/test/acceptance/test/scripts/kind-cluster.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Adapted from:
 # https://github.com/kubernetes-sigs/kind/commits/master/site/static/examples/kind-with-registry.sh


### PR DESCRIPTION
```
STEP: Given I have a brand new cluster with a long cluster name
time="2022-02-09T10:56:11Z" level=info msg="Creating a kind cluster "
Create a new kind cluster with name 
./scripts/kind-cluster.sh: 22: [[: not found
Registry Host: kind-registry
ERROR: failed to create cluster: node(s) already exist for a cluster with the name "kind"
time="2022-02-09T10:56:11Z" level=info msg="Failed to create kind cluster"
time="2022-02-09T10:56:11Z" level=fatal msg="exit status 1"
```
https://github.com/weaveworks/weave-gitops/runs/5123765368?check_suite_focus=true

switching to `bash` should fix this. Also removes unneeded creating of a kind cluster in the buildup, since each test creates its own cluster
