### PR TITLE
Fix RBAC for weave-gitops as a helm chart

### DIFF
--- a/charts/weave-gitops/templates/wego-app.yaml
+++ b/charts/weave-gitops/templates/wego-app.yaml
@@ -24,24 +24,22 @@ spec:
       app: wego-app
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
   name: read-resources
-  namespace: {{.Values.namespace}}
 subjects:
   - kind: ServiceAccount
     name: wego-app-service-account
     namespace: {{.Values.namespace}}
 roleRef:
-  kind: Role
+  kind: ClusterRole
   name: resources-reader
   apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
   name: resources-reader
-  namespace: {{.Values.namespace}}
 rules:
   - apiGroups: [""]
     resources: ["secrets"]


### PR DESCRIPTION
<!-- Use # to add the issue this pull request is related to -->
Closes:  https://github.com/weaveworks/weave-gitops/pull/1409/files#r802811620

<!-- Describe what has changed in this PR -->
**What changed?**
Use clusterrole and clusterrolebinding instead of role/rolebinding.

<!-- Tell your future self why have you made these changes -->
**Why?**
Weave-gitops errors in log for not being able to read helmrepositories cluster wide.

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**
Installed it

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
**Release notes**

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**