### PR TITLE
clean up docs references to `wego` CLI

### DIFF
--- a/cmd/gitops/flux/cmd.go
+++ b/cmd/gitops/flux/cmd.go
@@ -15,7 +15,7 @@ var Cmd = &cobra.Command{
 	Use:                "flux [flux commands or flags]",
 	Short:              "Use flux commands",
 	DisableFlagParsing: true,
-	Example:            "wego flux install -h",
+	Example:            "gitops flux install -h",
 	Run:                runCmd,
 }
 
@@ -29,7 +29,7 @@ func init() {
 	Cmd.AddCommand(StatusCmd)
 }
 
-// Example flux command with flags 'wego flux -- install -h'
+// Example flux command with flags 'gitops flux -- install -h'
 func runCmd(cmd *cobra.Command, args []string) {
 	cliRunner := &runner.CLIRunner{}
 	fluxClient := flux.New(osys.New(), cliRunner)

--- a/website/docs/cli-reference/gitops_flux.md
+++ b/website/docs/cli-reference/gitops_flux.md
@@ -9,7 +9,7 @@ gitops flux [flux commands or flags] [flags]
 ### Examples
 
 ```
-wego flux install -h
+gitops flux install -h
 ```
 
 ### Options


### PR DESCRIPTION
It is called `gitops` CLI now, someone pointed this out as an error during our WOUG demo of Weave GitOps today. 👍 

(I don't know if we should update the ADR too, it has some `wego` references in there. I have done it in a separate commit. If ADRs shouldn't be updated in the same PR for any reason at all, let me know and I'll withdraw that commit.)