### PR TITLE
clean up docs references to `wego` CLI

### DIFF
--- a/cmd/gitops/flux/cmd.go
+++ b/cmd/gitops/flux/cmd.go
@@ -15,7 +15,7 @@ var Cmd = &cobra.Command{
 	Use:                "flux [flux commands or flags]",
 	Short:              "Use flux commands",
 	DisableFlagParsing: true,
-	Example:            "wego flux install -h",
+	Example:            "gitops flux install -h",
 	Run:                runCmd,
 }
 
@@ -29,7 +29,7 @@ func init() {
 	Cmd.AddCommand(StatusCmd)
 }
 
-// Example flux command with flags 'wego flux -- install -h'
+// Example flux command with flags 'gitops flux -- install -h'
 func runCmd(cmd *cobra.Command, args []string) {
 	cliRunner := &runner.CLIRunner{}
 	fluxClient := flux.New(osys.New(), cliRunner)

--- a/website/docs/cli-reference/gitops_flux.md
+++ b/website/docs/cli-reference/gitops_flux.md
@@ -9,7 +9,7 @@ gitops flux [flux commands or flags] [flags]
 ### Examples
 
 ```
-wego flux install -h
+gitops flux install -h
 ```
 
 ### Options


### PR DESCRIPTION
It is called `gitops` CLI now.

This is a duplicate of #1425, by @kingdonb. Unfortunately, some bits of our test suite that are required for merging don’t work when run against a forked repo.