### PR TITLE
ci: Run go & js tests in parallel

### DIFF
--- a/.github/workflows/v2.yml
+++ b/.github/workflows/v2.yml
@@ -11,23 +11,14 @@ on:
 
 name: V2 CI Workflow
 jobs:
-  ci:
-    name: V2 CI Check
+  ci-js:
+    name: V2 CI Check JS
     runs-on: ubuntu-latest
     strategy:
       matrix:
         node-version: [16.13.2]
-        go-version: [1.17.5]
     steps:
       - uses: actions/checkout@v2
-      - name: Go modules cache
-        uses: actions/cache@v1
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-
       - name: Node modules cache
         uses: actions/cache@v2
         env:
@@ -44,6 +35,28 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
+      - run: make dependencies
+      - run: make node_modules
+      - run: make ui-audit
+      - run: make ui
+      - run: make ui-lint
+      - run: make ui-test
+  ci-go:
+    name: V2 CI Check Go
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: [1.17.5]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Go modules cache
+        uses: actions/cache@v1
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
@@ -51,13 +64,15 @@ jobs:
       - name: Set up kubebuilder
         uses: fluxcd/pkg/actions/kubebuilder@main
       - run: make dependencies
-      - run: make node_modules
       - run: go mod download
-      - run: make ui-audit
-      - run: make ui
-      - run: make ui-lint
-      - run: make ui-test
       - run: make lint
       - run: make bin
       - run: make test
       # - run: make lib-test
+
+  full-ci:
+    name: V2 CI Check (16.13.2, 1.17.5)
+    runs-on: ubuntu-latest
+    needs: [ci-go, ci-js]
+    steps:
+      - run: echo "All done"

--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ fmt: ## Run go fmt against code
 vet: ## Run go vet against code
 	go vet ./...
 
-lint: ## Run linters against code
+lint: cmd/gitops/ui/run/dist/index.html ## Run linters against code
 	golangci-lint run --out-format=github-actions --timeout 600s --skip-files "tilt_modules"
 
 .deps:


### PR DESCRIPTION
I had a go test that was failing in CI but not locally, and I had to
wait for all that javascript stuff to happen - do both at the same
time, I want the answer Now!