### PR TITLE
fix profiles tests in nightly-build

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -166,7 +166,6 @@ jobs:
       run: |
         export WEGO_BIN_PATH=$(pwd)/bin/gitops-${{matrix.os}}-nightly
         export CLUSTER_PROVIDER=kubectl
-        export CLUSTER_NAME=wego-nightly-cluster-$OS_NAME
         export DELETE_WEGO_RUNTIME_ON_EACH_TEST=true
         # cleanup the cluster
         $WEGO_BIN_PATH flux uninstall --silent
@@ -181,7 +180,6 @@ jobs:
       run: |
         export WEGO_BIN_PATH=$(pwd)/bin/gitops-${{matrix.os}}-nightly
         export CLUSTER_PROVIDER=kubectl
-        export CLUSTER_NAME=wego-nightly-cluster-$OS_NAME
         export DELETE_WEGO_RUNTIME_ON_EACH_TEST=true
         # cleanup the cluster
         $WEGO_BIN_PATH flux uninstall --silent
@@ -302,7 +300,6 @@ jobs:
       run: |
         export WEGO_BIN_PATH=$(pwd)/bin/gitops-${{matrix.os}}-nightly
         export CLUSTER_PROVIDER=kubectl
-        export CLUSTER_NAME=wego-nightly-cluster-$OS_NAME
         export DELETE_WEGO_RUNTIME_ON_EACH_TEST=true
         # cleanup the cluster
         $WEGO_BIN_PATH flux uninstall --silent
@@ -317,7 +314,6 @@ jobs:
       run: |
         export WEGO_BIN_PATH=$(pwd)/bin/gitops-${{matrix.os}}-nightly
         export CLUSTER_PROVIDER=kubectl
-        export CLUSTER_NAME=wego-nightly-cluster-$OS_NAME
         export DELETE_WEGO_RUNTIME_ON_EACH_TEST=true
         # cleanup the cluster
         $WEGO_BIN_PATH flux uninstall --silent

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -171,7 +171,7 @@ jobs:
         $WEGO_BIN_PATH flux uninstall --silent
         $WEGO_BIN_PATH flux uninstall --namespace test-namespace --silent
         kubectl get all --all-namespaces -o wide
-        ginkgo --reportFile=${{ env.ARTIFACTS_BASE_DIR }}/test-results/acceptance-test-results.xml --skip=@skipOnNightly -v ./test/acceptance/test/...
+        ginkgo --reportFile=${{ env.ARTIFACTS_BASE_DIR }}/test-results/acceptance-test-results.xml --focus=JAKE -v ./test/acceptance/test/...
       if: always()
     - name: User Acceptance Tests for GitLab (${{matrix.os}})
       if: |
@@ -186,7 +186,7 @@ jobs:
         $WEGO_BIN_PATH flux uninstall --namespace test-namespace --silent
         kubectl get all --all-namespaces -o wide
         export GIT_PROVIDER=gitlab
-        ginkgo --reportFile=${{ env.ARTIFACTS_BASE_DIR }}/test-results/acceptance-test-results.xml --skip=@skipOnNightly -v ./test/acceptance/test/...
+        ginkgo --reportFile=${{ env.ARTIFACTS_BASE_DIR }}/test-results/acceptance-test-results.xml --focus=JAKE -v ./test/acceptance/test/...
     - name: Store acceptance test results
       if: ${{ always() }}
       continue-on-error: true
@@ -305,7 +305,7 @@ jobs:
         $WEGO_BIN_PATH flux uninstall --silent
         $WEGO_BIN_PATH flux uninstall --namespace test-namespace --silent
         kubectl get all --all-namespaces -o wide
-        ginkgo --reportFile=${{ env.ARTIFACTS_BASE_DIR }}/test-results/acceptance-test-results.xml --skip=@skipOnNightly -v ./test/acceptance/test/...
+        ginkgo --reportFile=${{ env.ARTIFACTS_BASE_DIR }}/test-results/acceptance-test-results.xml --focus=JAKE -v ./test/acceptance/test/...
       if: always()
     - name: User Acceptance Tests for GitLab (${{matrix.os}})
       if: |
@@ -320,7 +320,7 @@ jobs:
         $WEGO_BIN_PATH flux uninstall --namespace test-namespace --silent
         kubectl get all --all-namespaces -o wide
         export GIT_PROVIDER=gitlab
-        ginkgo --reportFile=${{ env.ARTIFACTS_BASE_DIR }}/test-results/acceptance-test-results.xml --skip=@skipOnNightly -v ./test/acceptance/test/...
+        ginkgo --reportFile=${{ env.ARTIFACTS_BASE_DIR }}/test-results/acceptance-test-results.xml --focus=JAKE -v ./test/acceptance/test/...
     - name: Store acceptance test results
       if: ${{ always() }}
       continue-on-error: true

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -166,6 +166,7 @@ jobs:
       run: |
         export WEGO_BIN_PATH=$(pwd)/bin/gitops-${{matrix.os}}-nightly
         export CLUSTER_PROVIDER=kubectl
+        export CLUSTER_NAME=wego-nightly-cluster-$OS_NAME
         export DELETE_WEGO_RUNTIME_ON_EACH_TEST=true
         # cleanup the cluster
         $WEGO_BIN_PATH flux uninstall --silent
@@ -180,6 +181,7 @@ jobs:
       run: |
         export WEGO_BIN_PATH=$(pwd)/bin/gitops-${{matrix.os}}-nightly
         export CLUSTER_PROVIDER=kubectl
+        export CLUSTER_NAME=wego-nightly-cluster-$OS_NAME
         export DELETE_WEGO_RUNTIME_ON_EACH_TEST=true
         # cleanup the cluster
         $WEGO_BIN_PATH flux uninstall --silent
@@ -300,6 +302,7 @@ jobs:
       run: |
         export WEGO_BIN_PATH=$(pwd)/bin/gitops-${{matrix.os}}-nightly
         export CLUSTER_PROVIDER=kubectl
+        export CLUSTER_NAME=wego-nightly-cluster-$OS_NAME
         export DELETE_WEGO_RUNTIME_ON_EACH_TEST=true
         # cleanup the cluster
         $WEGO_BIN_PATH flux uninstall --silent
@@ -314,6 +317,7 @@ jobs:
       run: |
         export WEGO_BIN_PATH=$(pwd)/bin/gitops-${{matrix.os}}-nightly
         export CLUSTER_PROVIDER=kubectl
+        export CLUSTER_NAME=wego-nightly-cluster-$OS_NAME
         export DELETE_WEGO_RUNTIME_ON_EACH_TEST=true
         # cleanup the cluster
         $WEGO_BIN_PATH flux uninstall --silent

--- a/test/acceptance/test/add_tests.go
+++ b/test/acceptance/test/add_tests.go
@@ -1523,7 +1523,7 @@ var _ = Describe("Weave GitOps Add Tests With Long Cluster Name", func() {
 		})
 	})
 
-	It("SmokeTestLong - Verify that gitops can deploy an app with long name", func() {
+	It("JAKE SmokeTestLong - Verify that gitops can deploy an app with long name", func() {
 		var configRepoRemoteURL string
 		var listOutput string
 		var appStatus string

--- a/test/acceptance/test/profiles_test.go
+++ b/test/acceptance/test/profiles_test.go
@@ -64,7 +64,7 @@ var _ = Describe("Weave GitOps Profiles API", func() {
 		deleteNamespace(namespace)
 	})
 
-	It("@skipOnNightly gets deployed and is accessible via the service", func() {
+	It("JAKE gets deployed and is accessible via the service", func() {
 		By("Installing the Profiles API and setting up the profile helm repository")
 		appRepoRemoteURL = "git@github.com:" + githubOrg + "/" + tip.appRepoName + ".git"
 		installAndVerifyWego(namespace, appRepoRemoteURL)
@@ -143,7 +143,7 @@ Namespace: %s`, clusterName, namespace)))
 			deleteNamespace("other")
 		})
 
-		It("@skipOnNightly should not error", func() {
+		It("JAKE should not error", func() {
 			By("Installing the Profiles API and setting up the profile helm repository")
 			appRepoRemoteURL = "git@github.com:" + githubOrg + "/" + tip.appRepoName + ".git"
 			installAndVerifyWego(namespace, appRepoRemoteURL)

--- a/test/acceptance/test/utils.go
+++ b/test/acceptance/test/utils.go
@@ -240,7 +240,7 @@ func ResetOrCreateClusterWithName(namespace string, deleteWegoRuntime bool, clus
 
 		clusterName = os.Getenv("CLUSTER_NAME")
 		if clusterName == "" {
-			name, _ := runCommandAndReturnStringOutput("kubectl config current-context")
+			name, _ := runCommandAndReturnStringOutput("kubectl config view --minify -o jsonpath='{.clusters[].name}'")
 			clusterName = strings.TrimSuffix(name, "\n")
 		}
 	}

--- a/test/acceptance/test/utils.go
+++ b/test/acceptance/test/utils.go
@@ -238,8 +238,11 @@ func ResetOrCreateClusterWithName(namespace string, deleteWegoRuntime bool, clus
 			uninstallWegoRuntime(namespace)
 		}
 
-		name, _ := runCommandAndReturnStringOutput("kubectl config current-context")
-		clusterName = strings.TrimSuffix(name, "\n")
+		clusterName = os.Getenv("CLUSTER_NAME")
+		if clusterName == "" {
+			name, _ := runCommandAndReturnStringOutput("kubectl config current-context")
+			clusterName = strings.TrimSuffix(name, "\n")
+		}
 	}
 
 	if provider == "kind" {

--- a/test/acceptance/test/utils.go
+++ b/test/acceptance/test/utils.go
@@ -437,7 +437,9 @@ func VerifyKustomizations(clusterName, namespace string) {
 }
 
 func installAndVerifyWego(wegoNamespace, repoURL string) {
-	command := exec.Command("sh", "-c", fmt.Sprintf("%s install --namespace=%s --config-repo=%s --auto-merge", gitopsBinaryPath, wegoNamespace, repoURL))
+	installCommand := fmt.Sprintf("%s install --namespace=%s --config-repo=%s --auto-merge", gitopsBinaryPath, wegoNamespace, repoURL)
+	fmt.Println(installCommand)
+	command := exec.Command("sh", "-c", installCommand)
 	session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 	Expect(err).ShouldNot(HaveOccurred())
 	Eventually(session, INSTALL_SUCCESSFUL_TIMEOUT).Should(gexec.Exit())
@@ -446,7 +448,9 @@ func installAndVerifyWego(wegoNamespace, repoURL string) {
 }
 
 func installAndVerifyWegoViaPullRequest(wegoNamespace, repoURL, repoPath string) {
-	command := exec.Command("sh", "-c", fmt.Sprintf("%s install --namespace=%s --config-repo=%s", gitopsBinaryPath, wegoNamespace, repoURL))
+	installCommand := fmt.Sprintf("%s install --namespace=%s --config-repo=%s", gitopsBinaryPath, wegoNamespace, repoURL)
+	fmt.Println(installCommand)
+	command := exec.Command("sh", "-c", installCommand)
 	session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 	Expect(err).ShouldNot(HaveOccurred())
 	Eventually(session, INSTALL_SUCCESSFUL_TIMEOUT).Should(gexec.Exit())


### PR DESCRIPTION
Two failures:
```
[Fail] Weave GitOps Profiles API [It] gets deployed and is accessible via the service 
/home/runner/work/weave-gitops/weave-gitops/test/acceptance/test/profiles_test.go:118

[Fail] Weave GitOps Profiles API [It] profiles are installed into a different namespace 
/home/runner/work/weave-gitops/weave-gitops/test/acceptance/test/profiles_test.go:140
```

First is because the `cluster-name` is incorrect, the tests wasn't picking it up from the environment variable, this PR fixes that.

Second is because `other` namespace isn't being cleaned up, so creation was failing, this PR fixes that also.