### PR TITLE
make: Turn off cgo everywhere

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,9 +69,9 @@ cluster-dev: ## Start tilt to do development with wego-app running on the cluste
 # the cmd directory (e.g. dist, on the assumption that there won't be many)
 bin/%: cmd/%/main.go $(shell find . -name "*.go") $(shell find cmd -type f)
 ifdef DEBUG
-		go build -ldflags $(LDFLAGS) -o $@ $(GO_BUILD_OPTS) $<
+		CGO_ENABLED=0 go build -ldflags $(LDFLAGS) -o $@ $(GO_BUILD_OPTS) $<
 else
-		go build -ldflags $(LDFLAGS) -gcflags='all=-N -l' -o $@ $(GO_BUILD_OPTS) $<
+		CGO_ENABLED=0 go build -ldflags $(LDFLAGS) -gcflags='all=-N -l' -o $@ $(GO_BUILD_OPTS) $<
 endif
 
 gitops: bin/gitops ## Build the Gitops CLI, accepts a 'DEBUG' flag


### PR DESCRIPTION
Three reasons:
 * It would let us ship docker images with effectively nothing but our
       binary in it. Take that, docker vuln security scans! (not included here)
 * It helps with local development when your OS is running a newer
       glibc than the tilt image.
 * We've already been running tests with CGO_ENABLED=0. I'm aware
       there's some stuff that works differently between cgo and no-cgo,
       but then we should test with that, shouldn't we?
