### PR TITLE
Fix workflow link in the `website` README

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -32,4 +32,4 @@ This command generates static content into the `build` directory and can be serv
 
 ## Deployment
 
-Deployment happens automatically (once the tests pass) upon merging to the default branch: see [.github/workflows/documentation.yml](.github/workflows/documentation.yml) for config.
+Deployment happens automatically (once the tests pass) upon merging to the default branch: see [.github/workflows/docs.yml](.github/workflows/docs.yml) for config.


### PR DESCRIPTION
The workflow YAML file this links to is called `docs`, rather than `documentation`.

Note: this is a PR against the `main` branch. We don’t need to mirror it against `v2` yet, as the `website` directory doesn’t exist over there.