### PR TITLE
Fix the scan pipeline upon merges 

### DIFF
--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -82,9 +82,11 @@ jobs:
         with:
           sarif_file: snyk.sarif
       - name: Upload result to Snyk
-        uses: github/codeql-action/upload-sarif@v1
+        uses: snyk/actions/docker@master
         with:
           command: monitor
+          image: ghcr.io/weaveworks/wego-app:latest
+          args: --file=Dockerfile
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_API_TOKEN }}
         if: ${{ github.event_name == 'push' }}


### PR DESCRIPTION
I copy-pasted entirely the wrong thing - the snyk upload of container
    issues was absolutely broken.
    
This copy-pastes the right thing, so uploads actually do uploads. I've
    run it myself without the if condition, and it does work now and
    upload what I expect.
