### PR TITLE
Stop describing releases as straightforward

### DIFF
--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -1,6 +1,6 @@
 # Weave Gitops Release Process
 
-The current release process for weave gitops is fairly straightforward. You need to:
+To release a new version of Weave Gitops, you need to:
 - Create the actual release
 - Update the `weave-gitops-docs` repository with documentation for the new version
 - Update the `CLI Installation` section of the `README.md` in the `weave-gitops` repository to reference the new version


### PR DESCRIPTION
If the release process actually is straightforward, we don't really gain much from saying it's straightforward, because people can see how straightforward it is. If, on the other hand, the release process *isn't* straightforward, saying it is will only make people feel bad when they struggle to understand or follow it, and will discourage them from speaking up and calling attention to problems.