### PR TITLE
Enterprise docs: flux to bootstrap capi clusters

### DIFF
--- a/website/docs/cluster-management/assets/bootstrap/capi-gitops-cluster-bootstrap-config.yaml
+++ b/website/docs/cluster-management/assets/bootstrap/capi-gitops-cluster-bootstrap-config.yaml
@@ -11,8 +11,8 @@ spec:
     generateName: "run-gitops-{{ .ObjectMeta.Name }}"
     spec:
       containers:
-        - image: ghcr.io/weaveworks/wego-app:v0.6.2
-          name: gitops-install
+        - image: ghcr.io/fluxcd/flux-cli:v0.27.0
+          name: flux-bootstrap
           resources: {}
           volumeMounts:
             - name: kubeconfig
@@ -20,26 +20,31 @@ spec:
               readOnly: true
           args:
             [
-              "install",
-              "--override-in-cluster",
-              "--config-repo",
-              "$(GITOPS_REPO)",
+              "bootstrap",
+              "$(GIT_PROVIDER)",
+              "--hostname=$(GIT_PROVIDER_HOSTNAME)",
+              "--namespace=wego-system",
+              "--owner=$(GITOPS_REPO_OWNER)",
+              "--repository=$(GITOPS_REPO_NAME)",
+              "--path=./.weave-gitops/clusters/{{ .ObjectMeta.Name }}/system",
             ]
+          # Secret should container GITHUB_TOKEN or GITLAB_TOKEN
+          envFrom:
+            - secretRef:
+                name: my-pat
           env:
+            # Update these values
+            - name: GIT_PROVIDER
+              value: github
+            - name: GIT_PROVIDER_HOSTNAME
+              value: github.com
+            - name: GITOPS_REPO_OWNER
+              value: my-org
+            - name: GITOPS_REPO_NAME
+              value: my-management-cluster
+
             - name: KUBECONFIG
               value: "/etc/gitops/value"
-            - name: GITOPS_REPO
-              value: "ssh://git@github.com/my-org/my-management-cluster.git"
-            - name: GITHUB_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: my-pat
-                  key: GITHUB_TOKEN
-          # - name: GITLAB_TOKEN # If your GitOps reop is on GitLab, use this instead of GITHUB_TOKEN
-          #   valueFrom:
-          #     secretKeyRef:
-          #       name: pat
-          #       key: GITLAB_TOKEN
       restartPolicy: Never
       volumes:
         - name: kubeconfig

--- a/website/docs/cluster-management/assets/templates/capd-template.yaml
+++ b/website/docs/cluster-management/assets/templates/capd-template.yaml
@@ -11,8 +11,8 @@ spec:
     - name: NAMESPACE
       description: Namespace to create the cluster in.
     - name: KUBERNETES_VERSION
-      description: The version of Kubernetes to use.
-      options: ["1.19.11", "1.20.7", "1.21.1"]
+      description: Namespace to create the cluster in
+      options: ["1.23.3"]
   resourcetemplates:
     - apiVersion: cluster.x-k8s.io/v1beta1
       kind: Cluster
@@ -25,11 +25,9 @@ spec:
       spec:
         clusterNetwork:
           services:
-            cidrBlocks:
-              - 10.128.0.0/12
+            cidrBlocks: ["10.128.0.0/12"]
           pods:
-            cidrBlocks:
-              - 192.168.0.0/16
+            cidrBlocks: ["192.168.0.0/16"]
           serviceDomain: cluster.local
         infrastructureRef:
           apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -46,17 +44,6 @@ spec:
       metadata:
         name: "${CLUSTER_NAME}"
         namespace: "${NAMESPACE}"
-    - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-      kind: DockerMachineTemplate
-      metadata:
-        name: "${CLUSTER_NAME}-control-plane"
-        namespace: "${NAMESPACE}"
-      spec:
-        template:
-          spec:
-            extraMounts:
-              - containerPath: "/var/run/docker.sock"
-                hostPath: "/var/run/docker.sock"
     - kind: KubeadmControlPlane
       apiVersion: controlplane.cluster.x-k8s.io/v1beta1
       metadata:
@@ -75,7 +62,7 @@ spec:
             controllerManager:
               extraArgs: { enable-hostpath-provisioner: "true" }
             apiServer:
-              certSANs: [localhost, 127.0.0.1]
+              certSANs: [localhost, 127.0.0.1, 0.0.0.0]
           initConfiguration:
             nodeRegistration:
               criSocket: /var/run/containerd/containerd.sock
@@ -93,6 +80,17 @@ spec:
                 cgroup-driver: cgroupfs
                 eviction-hard: "nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%"
         version: "${KUBERNETES_VERSION}"
+    - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      kind: DockerMachineTemplate
+      metadata:
+        name: "${CLUSTER_NAME}-control-plane"
+        namespace: "${NAMESPACE}"
+      spec:
+        template:
+          spec:
+            extraMounts:
+              - containerPath: "/var/run/docker.sock"
+                hostPath: "/var/run/docker.sock"
     - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: DockerMachineTemplate
       metadata:

--- a/website/docs/cluster-management/getting-started.mdx
+++ b/website/docs/cluster-management/getting-started.mdx
@@ -143,7 +143,7 @@ Download the config with
   )}
 </BrowserOnly>
 
-Then update the `GITOPS_REPO` variable to point to your cluster
+Then update the `GIT_PROVIDER_*` and `GITOPS_REPO_*` variables to point to your repository
 
 <CodeBlock
   title=".weave-gitops/apps/capi/boostrap/capi-gitops-cluster-bootstrap-config.yaml"

--- a/website/docs/enterprise/deploying-capa.mdx
+++ b/website/docs/enterprise/deploying-capa.mdx
@@ -24,7 +24,7 @@ Make sure the following software is installed before continuing with these instr
 - `kubectl` [(source)](https://kubernetes.io/docs/tasks/tools/#kubectl)
 - `eksctl` [(source)](https://github.com/weaveworks/eksctl/releases)
 - `aws cli` [(source)](https://aws.amazon.com/cli/)
-- `clusterclt` >= v1.0.1 [(source)](https://github.com/kubernetes-sigs/cluster-api/releases)
+- `clusterctl` >= v1.0.1 [(source)](https://github.com/kubernetes-sigs/cluster-api/releases)
 - `clusterawsadm` >= v1.1.0 [(source)](https://github.com/kubernetes-sigs/cluster-api-provider-aws/releases)
 
 The `AWS_ACCESS_KEY_ID`and `AWS_SECRET_ACCESS_KEY` of a user should be configured either via `aws configure` or exported in the current shell.

--- a/website/docs/enterprise/upgrading.mdx
+++ b/website/docs/enterprise/upgrading.mdx
@@ -49,12 +49,8 @@ nodes:
     extraPortMappings:
       - containerPort: 30080
         hostPort: 30080
-        listenAddress: "0.0.0.0" # Optional, defaults to "0.0.0.0"
-        protocol: tcp # Optional, defaults to tcp
       - containerPort: 31490
         hostPort: 31490
-        listenAddress: "0.0.0.0" # Optional, defaults to "0.0.0.0"
-        protocol: tcp # Optional, defaults to tcp
 ```
 
 Fire up cluster
@@ -153,7 +149,7 @@ gitops install \
 
 :::note `clusterctl` versions
 
-The example templates provided in this guide have been tested with `clusterctl` version `1.0.1`. However you might need to use an older or newer version depending on the capi-providers you plan on using.
+The example templates provided in this guide have been tested with `clusterctl` version `1.1.1`. However you might need to use an older or newer version depending on the capi-providers you plan on using.
 
 Download a specific version of clusterctl from the [releases page](https://github.com/kubernetes-sigs/cluster-api/releases).
 :::


### PR DESCRIPTION
- Update the docs to use flux to do the capi cluster bootstrapping
- Update example capd templates to work with clusterctl 1.1.1