### PR TITLE
Add logout endpoint

### DIFF
--- a/pkg/server/auth/auth.go
+++ b/pkg/server/auth/auth.go
@@ -31,6 +31,7 @@ const (
 // the authentication flow completes.
 func RegisterAuthServer(mux *http.ServeMux, prefix string, srv *AuthServer) {
 	mux.Handle(prefix+"/callback", srv)
+	mux.Handle(prefix+"/logout", srv.Logout())
 }
 
 type principalCtxKey struct{}

--- a/pkg/server/auth/server.go
+++ b/pkg/server/auth/server.go
@@ -194,6 +194,21 @@ func (c *AuthServer) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	http.Redirect(rw, r, state.ReturnURL, http.StatusSeeOther)
 }
 
+func (s *AuthServer) Logout() http.HandlerFunc {
+	return func(rw http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			s.logger.Info("Only POST requests allowed")
+			rw.WriteHeader(http.StatusMethodNotAllowed)
+
+			return
+		}
+
+		http.SetCookie(rw, s.clearCookie(IDTokenCookieName))
+		rw.WriteHeader(http.StatusOK)
+
+	}
+}
+
 func (c *AuthServer) createCookie(name, value string) *http.Cookie {
 	cookie := &http.Cookie{
 		Name:     name,

--- a/pkg/server/auth/server.go
+++ b/pkg/server/auth/server.go
@@ -205,9 +205,7 @@ func (s *AuthServer) Logout() http.HandlerFunc {
 
 		http.SetCookie(rw, s.clearCookie(IDTokenCookieName))
 		rw.WriteHeader(http.StatusOK)
-
 	}
-
 }
 
 func (c *AuthServer) createCookie(name, value string) *http.Cookie {

--- a/pkg/server/auth/server.go
+++ b/pkg/server/auth/server.go
@@ -207,6 +207,7 @@ func (s *AuthServer) Logout() http.HandlerFunc {
 		rw.WriteHeader(http.StatusOK)
 
 	}
+
 }
 
 func (c *AuthServer) createCookie(name, value string) *http.Cookie {

--- a/pkg/server/auth/server_test.go
+++ b/pkg/server/auth/server_test.go
@@ -1,0 +1,64 @@
+package auth_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/oauth2-proxy/mockoidc"
+	"github.com/weaveworks/weave-gitops/pkg/server/auth"
+	"gotest.tools/v3/assert"
+)
+
+func TestLogoutSuccess(t *testing.T) {
+	m, err := mockoidc.Run()
+	if err != nil {
+		t.Errorf("failed to create mock OIDC server: %v", err)
+	}
+
+	s, err := auth.NewAuthServer(context.Background(), logr.Discard(), http.DefaultClient, auth.AuthConfig{
+		OIDCConfig: auth.OIDCConfig{
+			IssuerURL: m.Config().Issuer,
+		},
+		CookieConfig: auth.CookieConfig{
+			CookieDuration: 5,
+		},
+	})
+
+	assert.NilError(t, err)
+
+	cookie := &http.Cookie{
+		Name:     "id_token",
+		Value:    "foo",
+		Path:     "/",
+		Expires:  time.Now().UTC().Add(5),
+		HttpOnly: true,
+	}
+
+	w := httptest.NewRecorder()
+
+	http.SetCookie(w, cookie)
+
+	req := httptest.NewRequest(http.MethodPost, "https://example.com/logout", nil)
+	s.Logout().ServeHTTP(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected status to be 200 but got %v instead", resp.StatusCode)
+	}
+
+	fmt.Println(resp.Cookies())
+
+	for _, c := range resp.Cookies() {
+		if c.Name == auth.IDTokenCookieName {
+			cookie = c
+			break
+		}
+	}
+
+	assert.Equal(t, cookie.Value, "")
+}

--- a/pkg/server/auth/server_test.go
+++ b/pkg/server/auth/server_test.go
@@ -2,7 +2,6 @@ package auth_test
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -10,8 +9,8 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/oauth2-proxy/mockoidc"
+	"github.com/stretchr/testify/assert"
 	"github.com/weaveworks/weave-gitops/pkg/server/auth"
-	"gotest.tools/v3/assert"
 )
 
 func TestLogoutSuccess(t *testing.T) {
@@ -29,7 +28,7 @@ func TestLogoutSuccess(t *testing.T) {
 		},
 	})
 
-	assert.NilError(t, err)
+	assert.Nil(t, err)
 
 	cookie := &http.Cookie{
 		Name:     "id_token",
@@ -41,8 +40,6 @@ func TestLogoutSuccess(t *testing.T) {
 
 	w := httptest.NewRecorder()
 
-	http.SetCookie(w, cookie)
-
 	req := httptest.NewRequest(http.MethodPost, "https://example.com/logout", nil)
 	s.Logout().ServeHTTP(w, req)
 
@@ -50,8 +47,6 @@ func TestLogoutSuccess(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("expected status to be 200 but got %v instead", resp.StatusCode)
 	}
-
-	fmt.Println(resp.Cookies())
 
 	for _, c := range resp.Cookies() {
 		if c.Name == auth.IDTokenCookieName {

--- a/pkg/server/auth/server_test.go
+++ b/pkg/server/auth/server_test.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/oauth2-proxy/mockoidc"
@@ -30,14 +29,6 @@ func TestLogoutSuccess(t *testing.T) {
 
 	assert.Nil(t, err)
 
-	cookie := &http.Cookie{
-		Name:     "id_token",
-		Value:    "foo",
-		Path:     "/",
-		Expires:  time.Now().UTC().Add(5),
-		HttpOnly: true,
-	}
-
 	w := httptest.NewRecorder()
 
 	req := httptest.NewRequest(http.MethodPost, "https://example.com/logout", nil)
@@ -48,6 +39,8 @@ func TestLogoutSuccess(t *testing.T) {
 		t.Errorf("expected status to be 200 but got %v instead", resp.StatusCode)
 	}
 
+	cookie := &http.Cookie{}
+
 	for _, c := range resp.Cookies() {
 		if c.Name == auth.IDTokenCookieName {
 			cookie = c
@@ -56,4 +49,32 @@ func TestLogoutSuccess(t *testing.T) {
 	}
 
 	assert.Equal(t, cookie.Value, "")
+}
+
+func TestLogoutWithWrongMethod(t *testing.T) {
+	m, err := mockoidc.Run()
+	if err != nil {
+		t.Errorf("failed to create mock OIDC server: %v", err)
+	}
+
+	s, err := auth.NewAuthServer(context.Background(), logr.Discard(), http.DefaultClient, auth.AuthConfig{
+		OIDCConfig: auth.OIDCConfig{
+			IssuerURL: m.Config().Issuer,
+		},
+		CookieConfig: auth.CookieConfig{
+			CookieDuration: 5,
+		},
+	})
+
+	assert.Nil(t, err)
+
+	w := httptest.NewRecorder()
+
+	req := httptest.NewRequest(http.MethodGet, "https://example.com/logout", nil)
+	s.Logout().ServeHTTP(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Errorf("expected status to be 405 but got %v instead", resp.StatusCode)
+	}
 }


### PR DESCRIPTION
<!-- Use # to add the issue this pull request is related to -->
Closes: https://github.com/weaveworks/weave-gitops-enterprise/issues/407

<!-- Describe what has changed in this PR -->
**What changed?**
Added a new /logout endpoint to be called by FE for cookie deletion.

<!-- Tell your future self why have you made these changes -->
**Why?**
Part of Auth implementation.

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**
Tested locally + unit tests.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
**Release notes**

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**