### PR TITLE
Update cluster cmd

### DIFF
--- a/cmd/gitops/add/clusters/cmd.go
+++ b/cmd/gitops/add/clusters/cmd.go
@@ -14,7 +14,6 @@ import (
 	"github.com/weaveworks/weave-gitops/pkg/adapters"
 	"github.com/weaveworks/weave-gitops/pkg/capi"
 	"github.com/weaveworks/weave-gitops/pkg/gitproviders"
-	"github.com/weaveworks/weave-gitops/pkg/services/auth"
 )
 
 type clusterCommandFlags struct {
@@ -122,7 +121,7 @@ func getClusterCmdRunE(endpoint *string, client *resty.Client) func(*cobra.Comma
 			return fmt.Errorf("cannot parse url: %w", err)
 		}
 
-		token, err := internal.GetToken(url, os.Stdout, os.LookupEnv, auth.NewAuthCLIHandler, internal.NewCLILogger(os.Stdout))
+		token, err := internal.GetToken(url, os.LookupEnv)
 		if err != nil {
 			return err
 		}

--- a/cmd/gitops/delete/clusters/cmd.go
+++ b/cmd/gitops/delete/clusters/cmd.go
@@ -11,7 +11,6 @@ import (
 	"github.com/weaveworks/weave-gitops/pkg/adapters"
 	"github.com/weaveworks/weave-gitops/pkg/clusters"
 	"github.com/weaveworks/weave-gitops/pkg/gitproviders"
-	"github.com/weaveworks/weave-gitops/pkg/services/auth"
 )
 
 type clustersDeleteFlags struct {
@@ -78,7 +77,7 @@ func getClusterCmdRunE(endpoint *string, client *resty.Client) func(*cobra.Comma
 			return fmt.Errorf("cannot parse url: %w", err)
 		}
 
-		token, err := internal.GetToken(url, os.Stdout, os.LookupEnv, auth.NewAuthCLIHandler, internal.NewCLILogger(os.Stdout))
+		token, err := internal.GetToken(url, os.LookupEnv)
 		if err != nil {
 			return err
 		}

--- a/cmd/internal/provider.go
+++ b/cmd/internal/provider.go
@@ -1,16 +1,14 @@
 package internal
 
 import (
-	"context"
 	"fmt"
-	"io"
 	"os"
 
 	"github.com/weaveworks/weave-gitops/pkg/gitproviders"
 	"github.com/weaveworks/weave-gitops/pkg/logger"
 )
 
-const envVariableWarning = "Setting the %q environment variable to a valid token will allow ongoing use of the CLI without requiring a browser-based auth flow...\n"
+const missingTokenErr = "the %q environment variable needs to be set to a valid token"
 
 type gitProviderClient struct {
 	authHandlerFunc GetAuthHandler
@@ -28,10 +26,9 @@ func NewGitProviderClient(stdout *os.File, lookupEnvFunc func(key string) (strin
 	}
 }
 
-// GetProvider returns a GitProvider containing either the token stored in the <git provider>_TOKEN env var
-// or a token retrieved via the CLI auth flow
+// GetProvider returns a GitProvider containing the token stored in the <git provider>_TOKEN
 func (c *gitProviderClient) GetProvider(repoUrl gitproviders.RepoURL, getAccountType gitproviders.AccountTypeGetter) (gitproviders.GitProvider, error) {
-	token, err := GetToken(repoUrl, c.stdout, c.lookupEnvFunc, c.authHandlerFunc, c.log)
+	token, err := GetToken(repoUrl, c.lookupEnvFunc)
 	if err != nil {
 		return nil, err
 	}
@@ -59,9 +56,8 @@ func getTokenVarName(providerName gitproviders.GitProviderName) (string, error) 
 	}
 }
 
-// GetToken returns either the token stored in the <git provider>_TOKEN env var
-// or a token retrieved via the CLI auth flow
-func GetToken(repoUrl gitproviders.RepoURL, w io.Writer, lookupEnvFunc func(key string) (string, bool), authHandlerFunc GetAuthHandler, log logger.Logger) (string, error) {
+// GetToken returns the token stored in the <git provider>_TOKEN env var
+func GetToken(repoUrl gitproviders.RepoURL, lookupEnvFunc func(key string) (string, bool)) (string, error) {
 	tokenVarName, err := getTokenVarName(repoUrl.Provider())
 	if err != nil {
 		return "", fmt.Errorf("could not determine git provider token name: %w", err)
@@ -69,21 +65,7 @@ func GetToken(repoUrl gitproviders.RepoURL, w io.Writer, lookupEnvFunc func(key 
 
 	token, exists := lookupEnvFunc(tokenVarName)
 	if !exists {
-		log.Warningf(envVariableWarning, tokenVarName)
-
-		authHandler, err := authHandlerFunc(repoUrl.Provider())
-		if err != nil {
-			return "", fmt.Errorf("error initializing cli auth handler: %w", err)
-		}
-
-		ctx := context.Background()
-
-		generatedToken, err := authHandler(ctx, w)
-		if err != nil {
-			return "", fmt.Errorf("could not complete auth flow: %w", err)
-		}
-
-		token = generatedToken
+		return "", fmt.Errorf(missingTokenErr, tokenVarName)
 	} else if err != nil {
 		return "", fmt.Errorf("could not get access token: %w", err)
 	}

--- a/cmd/internal/provider.go
+++ b/cmd/internal/provider.go
@@ -66,8 +66,6 @@ func GetToken(repoUrl gitproviders.RepoURL, lookupEnvFunc func(key string) (stri
 	token, exists := lookupEnvFunc(tokenVarName)
 	if !exists {
 		return "", fmt.Errorf(missingTokenErr, tokenVarName)
-	} else if err != nil {
-		return "", fmt.Errorf("could not get access token: %w", err)
 	}
 
 	return token, nil

--- a/cmd/internal/provider_test.go
+++ b/cmd/internal/provider_test.go
@@ -40,10 +40,6 @@ func fakeEnvLookupExists(key string) (string, bool) {
 	}
 }
 
-func fakeEnvLookupDoesNotExist(key string) (string, bool) {
-	return "", false
-}
-
 var _ = Describe("Get git provider", func() {
 	var client gitproviders.Client
 	var repoUrl gitproviders.RepoURL

--- a/cmd/internal/provider_test.go
+++ b/cmd/internal/provider_test.go
@@ -1,11 +1,8 @@
 package internal
 
 import (
-	"bytes"
-	"context"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
@@ -20,22 +17,6 @@ const (
 	githubToken = "github-token-123"
 	gitlabToken = "gitlab-token-abc"
 )
-
-func fakeBlockingCLIHandlerSuccess(_ context.Context, _ io.Writer) (string, error) {
-	return githubToken, nil
-}
-
-func fakeBlockingCLIHandlerError(_ context.Context, _ io.Writer) (string, error) {
-	return "", errors.New("blocking cli handler goes ka-boom")
-}
-
-func fakeAuthHandlerFuncGoodCLI(_ gitproviders.GitProviderName) (auth.BlockingCLIAuthHandler, error) {
-	return fakeBlockingCLIHandlerSuccess, nil
-}
-
-func fakeAuthHandlerFuncBadCLI(_ gitproviders.GitProviderName) (auth.BlockingCLIAuthHandler, error) {
-	return fakeBlockingCLIHandlerError, nil
-}
 
 func fakeAuthHandlerFuncError(_ gitproviders.GitProviderName) (auth.BlockingCLIAuthHandler, error) {
 	return nil, errors.New("get auth handler goes ka-boom")
@@ -129,49 +110,4 @@ var _ = Describe("Get git provider", func() {
 			})
 		})
 	})
-
-	Describe("auth flow since token is not in an env variable", func() {
-		BeforeEach(func() {
-			fakeLogger = &loggerfakes.FakeLogger{
-				WarningfStub: func(fmtArg string, restArgs ...interface{}) {},
-			}
-			repoUrl, _ = gitproviders.NewRepoURL("ssh://git@github.com/weaveworks/weave-gitops.git")
-		})
-
-		AfterEach(func() {
-			fmtArg, restArgs := fakeLogger.WarningfArgsForCall(0)
-			Expect(fmtArg).Should(Equal(envVariableWarning))
-			Expect(restArgs).To(HaveLen(1))
-			Expect(restArgs[0]).Should(Equal("GITHUB_TOKEN"))
-			Expect(fakeLogger.WarningfCallCount()).To(Equal(1))
-		})
-
-		It("cannot generate auth flow handler", func() {
-			client = NewGitProviderClient(os.Stdout, fakeEnvLookupDoesNotExist, fakeAuthHandlerFuncError, fakeLogger)
-			provider, err := client.GetProvider(repoUrl, fakeAccountGetterError)
-
-			Expect(provider).To(BeNil())
-			_, expectedErr := fakeAuthHandlerFuncError(repoUrl.Provider())
-			Expect(err).To(MatchError(fmt.Errorf("error initializing cli auth handler: %w", expectedErr)))
-		})
-
-		It("blocking cli handler returns an error during auth flow", func() {
-			client = NewGitProviderClient(os.Stdout, fakeEnvLookupDoesNotExist, fakeAuthHandlerFuncBadCLI, fakeLogger)
-			provider, err := client.GetProvider(repoUrl, fakeAccountGetterError)
-
-			Expect(provider).To(BeNil())
-			_, expectedErr := fakeBlockingCLIHandlerError(context.Background(), bytes.NewBufferString(""))
-			Expect(err).To(MatchError(fmt.Errorf("could not complete auth flow: %w", expectedErr)))
-		})
-
-		It("success", func() {
-			client = NewGitProviderClient(os.Stdout, fakeEnvLookupDoesNotExist, fakeAuthHandlerFuncGoodCLI, fakeLogger)
-			provider, err := client.GetProvider(repoUrl, fakeAccountGetterSuccess)
-
-			Expect(err).To(BeNil())
-			expectedProvider, _ := gitproviders.New(gitproviders.Config{Provider: repoUrl.Provider(), Token: githubToken}, repoUrl.Owner(), fakeAccountGetterSuccess)
-			Expect(provider).To(Equal(expectedProvider))
-		})
-	})
-
 })


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Removed the auth flow from cluster add/delete cmd's. Core is removing git auth but enterprise still needs a git token to create PR's. For now I have left in getting the token from the env variable. I also left in all the code for gitProvider. It isnt needed for add/delete but profiles is using it and that is a problem for another task.

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
**Release notes**

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**