### PR TITLE
Added validation to registry script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,8 +45,8 @@ local-registry:
 	./tools/deploy-local-registry.sh
 
 local-docker-image:
-	DOCKER_BUILDKIT=1 docker build -t localhost:5000/wego-app:latest . --build-arg FLUX_VERSION=$(FLUX_VERSION)
-	docker push localhost:5000/wego-app:latest
+	DOCKER_BUILDKIT=1 docker build -t localhost:5001/wego-app:latest . --build-arg FLUX_VERSION=$(FLUX_VERSION)
+	docker push localhost:5001/wego-app:latest
 
 test: dependencies cmd/gitops-server/cmd/dist/index.html
 	go test -v ./core/...
@@ -77,7 +77,7 @@ endif
 gitops: bin/gitops ## Build the Gitops CLI, accepts a 'DEBUG' flag
 gitops-server: cmd/gitops-server/cmd/dist/index.html bin/gitops-server ## Build the Gitops UI server, accepts a 'DEBUG' flag
 
-DOCKER_REGISTRY?=localhost:5000
+DOCKER_REGISTRY?=localhost:5001
 
 _docker:
 	DOCKER_BUILDKIT=1 docker build $(DOCKERARGS)\

--- a/Tiltfile
+++ b/Tiltfile
@@ -11,7 +11,7 @@ local_resource(
 )
 
 docker_build_with_restart(
-    'localhost:5000/weaveworks/wego-app', 
+    'localhost:5001/weaveworks/wego-app', 
     '.',
     only=[
         './bin',

--- a/test/acceptance/test/scripts/kind-cluster.sh
+++ b/test/acceptance/test/scripts/kind-cluster.sh
@@ -35,7 +35,7 @@ fi
 kind_version=$(kind version)
 kind_network='kind'
 reg_name='kind-registry'
-reg_port='5000'
+reg_port='5001'
 case "${kind_version}" in
   "kind v0.7."* | "kind v0.6."* | "kind v0.5."*)
     kind_network='bridge'

--- a/tools/deploy-local-registry.sh
+++ b/tools/deploy-local-registry.sh
@@ -20,13 +20,13 @@
 set -o errexit
 
 reg_name='kind-registry'
-reg_port='5000'
+reg_port='5001'
 
 # create registry container unless it already exists
 running="$(docker inspect -f '{{.State.Running}}' "${reg_name}" 2>/dev/null || true)"
 if [ "${running}" != 'true' ]; then
   docker run \
-    -d --restart=always -p "${reg_port}:5000" --name "${reg_name}" \
+    -d --restart=always -p "127.0.0.1:${reg_port}:5000" --name "${reg_name}" \
     registry:2
   echo "registry deployed"
 else

--- a/tools/kind-with-registry.sh
+++ b/tools/kind-with-registry.sh
@@ -43,6 +43,14 @@ if [ "${running}" != 'true' ]; then
   docker run \
     -d --restart=always -p "127.0.0.1:${reg_port}:5000" --name "${reg_name}" \
     registry:2
+else
+  # Validate the ports used by the running register are the ones we need.
+  right_mapping_ports="5000/tcp -> 127.0.0.1:${reg_port}"
+  registry_port=$(docker port ${reg_name})
+  if [ "${registry_port}" != "${right_mapping_ports}" ]; then
+    echo "It seems the current registry is running on different port configuration than expected:\n\n Current => ($registry_port) \n Expected ($right_mapping_ports). \n\nTry deleting registry manually using 'docker rm -f $reg_name' "
+    exit 1
+  fi
 fi
 
 reg_host="${reg_name}"

--- a/tools/kind-with-registry.sh
+++ b/tools/kind-with-registry.sh
@@ -30,7 +30,7 @@ fi
 kind_version=$(kind version)
 kind_network='kind'
 reg_name='kind-registry'
-reg_port='5000'
+reg_port='5001'
 case "${kind_version}" in
   "kind v0.7."* | "kind v0.6."* | "kind v0.5."*)
     kind_network='bridge'
@@ -41,7 +41,7 @@ esac
 running="$(docker inspect -f '{{.State.Running}}' "${reg_name}" 2>/dev/null || true)"
 if [ "${running}" != 'true' ]; then
   docker run \
-    -d --restart=always -p "${reg_port}:5000" --name "${reg_name}" \
+    -d --restart=always -p "127.0.0.1:${reg_port}:5000" --name "${reg_name}" \
     registry:2
 fi
 

--- a/tools/wego-app-dev.yaml
+++ b/tools/wego-app-dev.yaml
@@ -14,7 +14,7 @@ spec:
       serviceAccountName: wego-app-service-account
       containers:
         - name: wego-app
-          image: localhost:5000/weaveworks/wego-app:latest
+          image: localhost:5001/weaveworks/wego-app:latest
           args: ["-l", "--helm-repo-namespace", "wego-system"]
           ports:
             - containerPort: 9001


### PR DESCRIPTION
<!-- Use # to add the issue this pull request is related to -->
Closes: 

<!-- Describe what has changed in this PR -->
**What changed?**
- Added validation with creating registry

<!-- Tell your future self why have you made these changes -->
**Why?**
- We used to use port 5000 for the local registry. But the current script uses port 5001 and only creates the registry if it is running. But if the register is using different ports from what tilt is expecting then tilt won't be able to push to the registry. 

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**
- Manually

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
**Release notes**

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**