### PR TITLE
Make CI faster again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ endif
 all: gitops ## Install dependencies and build Gitops binary
 
 ##@ Test
-unit-tests: dependencies cmd/gitops-server/cmd/dist/index.html ## Run unit tests
+unit-tests: dependencies  ## Run unit tests
 	# To avoid downloading dependencies every time use `SKIP_FETCH_TOOLS=1 unit-tests`
 	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) CGO_ENABLED=0 go test -v -tags unittest ./...
 
@@ -48,7 +48,7 @@ local-docker-image:
 	DOCKER_BUILDKIT=1 docker build -t localhost:5000/wego-app:latest . --build-arg FLUX_VERSION=$(FLUX_VERSION)
 	docker push localhost:5000/wego-app:latest
 
-test: dependencies cmd/gitops-server/cmd/dist/index.html
+test: dependencies
 	go test -v ./core/...
 
 fakes: ## Generate testing fakes
@@ -110,7 +110,7 @@ fmt: ## Run go fmt against code
 vet: ## Run go vet against code
 	go vet ./...
 
-lint: cmd/gitops-server/cmd/dist/index.html ## Run linters against code
+lint: ## Run linters against code
 	golangci-lint run --out-format=github-actions --timeout 600s --skip-files "tilt_modules"
 
 .deps:
@@ -193,7 +193,7 @@ unittest.out: dependencies
 integrationtest.out: dependencies
 	go get github.com/ory/go-acc
 	go-acc --ignore fakes,acceptance,pkg/api,api -o integrationtest.out ./test/integration/... -- -v --timeout=496s -tags test
-	@go mod tidy	
+	@go mod tidy
 
 coverage:
 	@mkdir -p coverage
@@ -204,7 +204,7 @@ coverage/unittest.info: coverage unittest.out
 	gcov2lcov -infile=unittest.out -outfile=coverage/unittest.info
 
 coverage/integrationtest.info: coverage integrationtest.out
-	gcov2lcov -infile=integrationtest.out -outfile=coverage/integrationtest.info	
+	gcov2lcov -infile=integrationtest.out -outfile=coverage/integrationtest.info
 
 # Concat the JS and Go coverage files for the coveralls report/
 # Note: you need to install `lcov` to run this locally.


### PR DESCRIPTION
CI started to build javascript in the go bits. Don't!

Instead, just drop an empty file so the frontend embedding won't fail
    if we haven't built the frontend. Really, this shouldn't be embedded
    and just stored in the docker image, but future work...