### PR TITLE
Update upgrade cmd to no longer create a pr

### DIFF
--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -42,42 +42,22 @@ type Commit struct {
 	Message string
 }
 
-// WegoRoot is the default root directory for the GitOps repo
-const WegoRoot = ".weave-gitops"
-
-// WegoAppDir is where applications information will live in the GitOps repo
-const WegoAppDir = "apps"
-
 // WegoClusterDir is where cluster information and manifests will live in the GitOps repo
-const WegoClusterDir = "clusters"
+const WegoClusterDir = "./clusters"
 
-// WegoClusterOSWorkloadDir is where OS workload manifests will live in the GitOps repo
-const WegoClusterOSWorkloadDir = "system"
-
-// WegoClusterUserWorkloadDir is where user workload manifests will live in the GitOps repo
-const WegoClusterUserWorkloadDir = "user"
-
-func getClusterPath(clusterName string) string {
-	return filepath.Join(WegoRoot, WegoClusterDir, clusterName)
-}
-
-func GetSystemPath(clusterName string) string {
-	return filepath.Join(getClusterPath(clusterName), WegoClusterOSWorkloadDir)
-}
-
-func GetUserPath(clusterName string) string {
-	return filepath.Join(getClusterPath(clusterName), WegoClusterUserWorkloadDir)
+func GetClusterPath(clusterName string) string {
+	return filepath.Join(WegoClusterDir, clusterName)
 }
 
 // GetSystemQualifiedPath returns the path of the relativePath joined with the cluster's system directory
 func GetSystemQualifiedPath(clusterName string, relativePath string) string {
-	return filepath.Join(GetSystemPath(clusterName), relativePath)
+	return filepath.Join(GetClusterPath(clusterName), relativePath)
 }
 
 // GetProfilesPath returns the path of the file containing the manifests of installed Profiles
 // joined with the cluster's system directory
 func GetProfilesPath(clusterName, profilesManifestPath string) string {
-	return filepath.Join(GetSystemPath(clusterName), profilesManifestPath)
+	return filepath.Join(GetClusterPath(clusterName), profilesManifestPath)
 }
 
 // Git is an interface for basic Git operations on a single branch of a

--- a/pkg/services/profiles/add.go
+++ b/pkg/services/profiles/add.go
@@ -74,9 +74,9 @@ func (s *ProfilesSvc) Add(ctx context.Context, gitProvider gitproviders.GitProvi
 
 	newRelease := helm.MakeHelmRelease(opts.Name, version, opts.Cluster, opts.Namespace, helmRepo)
 
-	files, err := gitProvider.GetRepoDirFiles(ctx, configRepoURL, git.GetSystemPath(opts.Cluster), defaultBranch)
+	files, err := gitProvider.GetRepoDirFiles(ctx, configRepoURL, git.GetClusterPath(opts.Cluster), defaultBranch)
 	if err != nil {
-		return fmt.Errorf("failed to get files in '%s' for config repository %q: %s", git.GetSystemPath(opts.Cluster), configRepoURL, err)
+		return fmt.Errorf("failed to get files in '%s' for config repository %q: %s", git.GetClusterPath(opts.Cluster), configRepoURL, err)
 	}
 
 	file, err := AppendProfileToFile(files, newRelease, git.GetProfilesPath(opts.Cluster, models.WegoProfilesPath))

--- a/pkg/upgrade/upgrade_test.go
+++ b/pkg/upgrade/upgrade_test.go
@@ -42,7 +42,7 @@ func TestUpgradeDryRun(t *testing.T) {
 		CommitMessage: "Upgrade to wge",
 		Namespace:     wego.DefaultNamespace,
 		DryRun:        true,
-	}, k, gitClient, kubeClient, gitProvider, logger, &output)
+	}, k, gitClient, kubeClient, logger, &output)
 
 	assert.NoError(t, err)
 	assert.Contains(t, output.String(), "kind: HelmRelease")
@@ -82,7 +82,7 @@ func TestUpgrade(t *testing.T) {
 		BaseBranch:    "main",
 		CommitMessage: "Upgrade to wge",
 		Namespace:     wego.DefaultNamespace,
-	}, k, gitClient, kubeClient, gitProvider, logger, &output)
+	}, k, gitClient, kubeClient, logger, &output)
 
 	assert.NoError(t, err)
 }

--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -13,7 +13,6 @@ import (
 	"github.com/olekukonko/tablewriter"
 
 	"github.com/benbjohnson/clock"
-	"github.com/weaveworks/weave-gitops/pkg/git"
 
 	validation "k8s.io/apimachinery/pkg/api/validation"
 )
@@ -157,24 +156,4 @@ func ConvertCommitURLToShort(url string) string {
 	hash := urlArray[1][:7]
 
 	return path + hash
-}
-
-func MigrateToNewDirStructure(orig string) string {
-	if orig == "" {
-		return orig
-	}
-
-	f := strings.Split(orig, string(os.PathSeparator))
-
-	switch len(f) {
-	case 1:
-		// single file
-		return orig
-	case 2:
-		// handles the case apps/ and clusters/
-		return filepath.Join(git.WegoRoot, orig)
-	default:
-		// used for paths with apps under clusters
-		return filepath.Join(git.WegoRoot, git.WegoAppDir, f[len(f)-2], f[len(f)-1])
-	}
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
So this is just an idea and I would like some thoughts on it. This pr changes upgrade cmd to no longer create a PR. Instead it just adds the files locally and the user pushes it up. There are some issue I think may occur. I am assuming the top level folder being used is "clusters". I dont think we can assume that in the future but I am not really sure how we can determine what the file structure for all users will look like. The command also now has to be run from the app config dir. The config repo url is determined based off the .git file of the current dir. I am also assuming that the subfolder for clusters is named after the cluster. I know in flux this isnt the case so that can also be an issue.

Things to address before merging:
-  I am fairly certain I have broken profiles with this pr. Honestly still not sure how they work.
-  I will update the tests after I know if this is a working solution.

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
**Release notes**

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**