### PR TITLE
Move Breadcrumbs and reconfigure for V2Routes

### DIFF
--- a/ui/components/AutomationsTable.tsx
+++ b/ui/components/AutomationsTable.tsx
@@ -4,6 +4,7 @@ import { Automation } from "../hooks/automations";
 import { formatURL } from "../lib/nav";
 import { AutomationType, V2Routes } from "../lib/types";
 import DataTable, { SortType } from "./DataTable";
+import KubeStatusIndicator, { computeReady } from "./KubeStatusIndicator";
 import Link from "./Link";
 
 type Props = {
@@ -46,6 +47,24 @@ function AutomationsTable({ className, automations }: Props) {
           label: "Namespace",
           value: "namespace",
         },
+        {
+          label: "Cluster",
+          value: "cluster",
+        },
+        {
+          label: "Status",
+          value: (a: Automation) =>
+            a.conditions.length > 0 ? (
+              <KubeStatusIndicator conditions={a.conditions} />
+            ) : null,
+          sortType: SortType.bool,
+          sortValue: ({ conditions }) => computeReady(conditions),
+        },
+        {
+          label: "Revision",
+          value: "lastAttemptedRevision",
+        },
+        { label: "Last Synced At", value: "lastHandledReconciledAt" },
       ]}
       rows={automations}
     />

--- a/ui/components/AutomationsTable.tsx
+++ b/ui/components/AutomationsTable.tsx
@@ -4,7 +4,6 @@ import { Automation } from "../hooks/automations";
 import { formatURL } from "../lib/nav";
 import { AutomationType, V2Routes } from "../lib/types";
 import DataTable, { SortType } from "./DataTable";
-import KubeStatusIndicator from "./KubeStatusIndicator";
 import Link from "./Link";
 
 type Props = {
@@ -47,22 +46,6 @@ function AutomationsTable({ className, automations }: Props) {
           label: "Namespace",
           value: "namespace",
         },
-        {
-          label: "Cluster",
-          value: "cluster",
-        },
-        {
-          label: "Status",
-          value: (a: Automation) =>
-            a.conditions.length > 0 ? (
-              <KubeStatusIndicator conditions={a.conditions} />
-            ) : null,
-        },
-        {
-          label: "Revision",
-          value: "lastAttemptedRevision",
-        },
-        { label: "Last Synced At", value: "lastHandledReconciledAt" },
       ]}
       rows={automations}
     />

--- a/ui/components/Breadcrumbs.tsx
+++ b/ui/components/Breadcrumbs.tsx
@@ -1,8 +1,7 @@
-import qs from "query-string";
 import React from "react";
 import styled from "styled-components";
 import useNavigation from "../hooks/navigation";
-import { getParentNavValue, V2Routes } from "../lib/nav";
+import { getPageLabel, getParentNavValue, V2Routes } from "../lib/nav";
 import Flex from "./Flex";
 import Icon, { IconType } from "./Icon";
 import Link from "./Link";
@@ -19,14 +18,6 @@ export const Breadcrumbs = () => {
   const { currentPage } = useNavigation();
   const parentValue = getParentNavValue(currentPage);
 
-  function pageLookup(route) {
-    const parsed = qs.parse(location.search);
-    if (route === V2Routes.Automations) return "Applications";
-    else if (route === V2Routes.Sources) return "Sources";
-    else if (route === V2Routes.FluxRuntime) return "Flux Runtime";
-    else return parsed.name;
-  }
-
   return (
     <Flex align>
       {parentValue !== currentPage && (
@@ -34,7 +25,7 @@ export const Breadcrumbs = () => {
           to={V2Routes[parentValue as V2Routes] || ""}
           textProps={{ bold: true }}
         >
-          {pageLookup(parentValue)}
+          {getPageLabel(parentValue as V2Routes)}
         </CrumbLink>
       )}
       {parentValue !== currentPage && (
@@ -44,7 +35,7 @@ export const Breadcrumbs = () => {
         to={currentPage}
         textProps={parentValue === currentPage && { bold: true }}
       >
-        {pageLookup(currentPage)}
+        {getPageLabel(currentPage)}
       </CrumbLink>
     </Flex>
   );

--- a/ui/components/Breadcrumbs.tsx
+++ b/ui/components/Breadcrumbs.tsx
@@ -1,0 +1,53 @@
+import qs from "query-string";
+import React from "react";
+import styled from "styled-components";
+import useNavigation from "../hooks/navigation";
+import { getParentNavValue, V2Routes } from "../lib/nav";
+import Flex from "./Flex";
+import Icon, { IconType } from "./Icon";
+import Link from "./Link";
+import Text from "./Text";
+
+const CrumbLink = styled(Link)`
+  ${Text} {
+    font-size: ${(props) => props.theme.fontSizes.large};
+    color: ${(props) => props.theme.colors.neutral00};
+  }
+`;
+
+export const Breadcrumbs = () => {
+  const { currentPage } = useNavigation();
+  const parentValue = getParentNavValue(currentPage);
+
+  function pageLookup(route) {
+    const parsed = qs.parse(location.search);
+    if (route === V2Routes.Automations) return "Applications";
+    else if (route === V2Routes.Sources) return "Sources";
+    else if (route === V2Routes.FluxRuntime) return "Flux Runtime";
+    else return parsed.name;
+  }
+
+  return (
+    <Flex align>
+      {parentValue !== currentPage && (
+        <CrumbLink
+          to={V2Routes[parentValue as V2Routes] || ""}
+          textProps={{ bold: true }}
+        >
+          {pageLookup(parentValue)}
+        </CrumbLink>
+      )}
+      {parentValue !== currentPage && (
+        <Icon type={IconType.NavigateNextIcon} size="large" color="neutral00" />
+      )}
+      <CrumbLink
+        to={currentPage}
+        textProps={parentValue === currentPage && { bold: true }}
+      >
+        {pageLookup(currentPage)}
+      </CrumbLink>
+    </Flex>
+  );
+};
+
+export default styled(Breadcrumbs)``;

--- a/ui/components/DataTable.tsx
+++ b/ui/components/DataTable.tsx
@@ -83,7 +83,6 @@ function defaultSortFunc(sort: Field): Sorter {
 
 export const sortWithType = (rows: Row[], sort: Field) => {
   const sortFn = sort.sortValue || defaultSortFunc(sort);
-
   return (rows || []).sort((a: Row, b: Row) => {
     switch (sort.sortType) {
       case SortType.number:
@@ -107,7 +106,7 @@ export const sortWithType = (rows: Row[], sort: Field) => {
 function UnstyledDataTable({
   className,
   fields,
-  rows = [],
+  rows,
   defaultSort = 0,
   widths,
   children,

--- a/ui/components/DataTable.tsx
+++ b/ui/components/DataTable.tsx
@@ -41,7 +41,7 @@ export interface Props {
   /** A list of objects with four fields: `label`, which is a string representing the column header, `value`, which can be a string, or a function that extracts the data needed to fill the table cell, `sortType`, which determines the sorting function to be used, and `sortValue`, which customizes your input to the search function */
   fields: Field[];
   /** A list of data that will be iterated through to create the columns described in `fields`. */
-  rows: any[];
+  rows?: any[];
   /** index of field to initially sort against. */
   defaultSort?: number;
   /** an optional list of string widths for each field/column. */
@@ -84,7 +84,7 @@ function defaultSortFunc(sort: Field): Sorter {
 export const sortWithType = (rows: Row[], sort: Field) => {
   const sortFn = sort.sortValue || defaultSortFunc(sort);
 
-  return rows.sort((a: Row, b: Row) => {
+  return (rows || []).sort((a: Row, b: Row) => {
     switch (sort.sortType) {
       case SortType.number:
         return sortFn(a) - sortFn(b);
@@ -107,7 +107,7 @@ export const sortWithType = (rows: Row[], sort: Field) => {
 function UnstyledDataTable({
   className,
   fields,
-  rows,
+  rows = [],
   defaultSort = 0,
   widths,
   children,

--- a/ui/components/Layout.tsx
+++ b/ui/components/Layout.tsx
@@ -6,10 +6,15 @@ import { FeatureFlags } from "../contexts/FeatureFlags";
 import useNavigation from "../hooks/navigation";
 import { formatURL, getParentNavValue } from "../lib/nav";
 import { V2Routes } from "../lib/types";
+import Breadcrumbs from "./Breadcrumbs";
 import Flex from "./Flex";
 import Link from "./Link";
 import Logo from "./Logo";
+<<<<<<< HEAD
 import UserSettings from "./UserSettings";
+=======
+import Spacer from "./Spacer";
+>>>>>>> b0a4020d (breadcrumbs)
 
 type Props = {
   className?: string;
@@ -131,12 +136,19 @@ const TopToolBar = styled(Flex)`
 function Layout({ className, children }: Props) {
   const { authFlag } = React.useContext(FeatureFlags);
   const { currentPage } = useNavigation();
+
   return (
     <div className={className}>
       <AppContainer>
-        <TopToolBar between align>
+        <TopToolBar start align>
           <Logo />
+<<<<<<< HEAD
           {authFlag ? <UserSettings /> : null}
+=======
+          <Spacer padding="xxl" />
+          <Breadcrumbs />
+          {/* code for account icon - disabled while no account functionality exists <UserAvatar size="xl" type={IconType.Account} color="white" /> */}
+>>>>>>> b0a4020d (breadcrumbs)
         </TopToolBar>
         <Main wide>
           <NavContainer>

--- a/ui/components/Layout.tsx
+++ b/ui/components/Layout.tsx
@@ -10,11 +10,8 @@ import Breadcrumbs from "./Breadcrumbs";
 import Flex from "./Flex";
 import Link from "./Link";
 import Logo from "./Logo";
-<<<<<<< HEAD
-import UserSettings from "./UserSettings";
-=======
 import Spacer from "./Spacer";
->>>>>>> b0a4020d (breadcrumbs)
+import UserSettings from "./UserSettings";
 
 type Props = {
   className?: string;
@@ -142,13 +139,9 @@ function Layout({ className, children }: Props) {
       <AppContainer>
         <TopToolBar start align>
           <Logo />
-<<<<<<< HEAD
           {authFlag ? <UserSettings /> : null}
-=======
           <Spacer padding="xxl" />
           <Breadcrumbs />
-          {/* code for account icon - disabled while no account functionality exists <UserAvatar size="xl" type={IconType.Account} color="white" /> */}
->>>>>>> b0a4020d (breadcrumbs)
         </TopToolBar>
         <Main wide>
           <NavContainer>

--- a/ui/components/Link.tsx
+++ b/ui/components/Link.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { Link as RouterLink } from "react-router-dom";
 import styled from "styled-components";
-import Text from "./Text";
+import Text, { TextProps } from "./Text";
 
 type Props = {
   className?: string;
@@ -10,6 +10,7 @@ type Props = {
   children?: any;
   href?: any;
   newTab?: boolean;
+  textProps?: TextProps;
   onClick?: () => void;
 };
 
@@ -20,9 +21,14 @@ function Link({
   to = "",
   newTab,
   onClick,
+  textProps,
   ...props
 }: Props) {
-  const txt = <Text color="primary">{children}</Text>;
+  const txt = (
+    <Text color="primary" {...textProps}>
+      {children}
+    </Text>
+  );
 
   if (href) {
     return (

--- a/ui/components/Page.tsx
+++ b/ui/components/Page.tsx
@@ -49,16 +49,6 @@ export const TitleBar = styled.div`
   }
 `;
 
-function pageLookup(p: PageRoute) {
-  switch (p) {
-    case PageRoute.Applications:
-      return "Applications";
-
-    default:
-      break;
-  }
-}
-
 function Errors({ error }) {
   const arr = _.isArray(error) ? error : [error];
   return (

--- a/ui/components/Page.tsx
+++ b/ui/components/Page.tsx
@@ -1,14 +1,11 @@
-import { Breadcrumbs } from "@material-ui/core";
 import _ from "lodash";
 import React from "react";
 import styled from "styled-components";
 import useCommon from "../hooks/common";
-import { formatURL } from "../lib/nav";
 import { PageRoute, RequestError } from "../lib/types";
 import Alert from "./Alert";
 import Flex from "./Flex";
 import Footer from "./Footer";
-import Link from "./Link";
 import LoadingPage from "./LoadingPage";
 import Spacer from "./Spacer";
 
@@ -79,7 +76,6 @@ function Page({
   className,
   children,
   title,
-  breadcrumbs,
   actions,
   loading,
   error,
@@ -98,15 +94,7 @@ function Page({
     <div className={className}>
       <Content>
         <TitleBar>
-          <Breadcrumbs>
-            {breadcrumbs &&
-              _.map(breadcrumbs, (b) => (
-                <Link key={b.page} to={formatURL(b.page, b.query)}>
-                  <h2>{pageLookup(b.page)}</h2>
-                </Link>
-              ))}
-            <h2>{title}</h2>
-          </Breadcrumbs>
+          <h2>{title}</h2>
           {actions}
         </TitleBar>
         {error && <Errors error={error} />}

--- a/ui/components/ReconciledObjectsTable.tsx
+++ b/ui/components/ReconciledObjectsTable.tsx
@@ -8,14 +8,10 @@ import {
   UnstructuredObject,
 } from "../lib/api/core/types.pb";
 import DataTable, { SortType } from "./DataTable";
-<<<<<<< HEAD
 import KubeStatusIndicator, {
   computeMessage,
   computeReady,
 } from "./KubeStatusIndicator";
-=======
-import KubeStatusIndicator, { computeReady } from "./KubeStatusIndicator";
->>>>>>> b0a4020d (breadcrumbs)
 
 type Props = {
   className?: string;
@@ -46,11 +42,6 @@ function ReconciledObjectsTable({
           {
             value: "name",
             label: "Name",
-<<<<<<< HEAD
-=======
-            sortType: SortType.string,
-            sortValue: ({ name }) => name,
->>>>>>> b0a4020d (breadcrumbs)
           },
           {
             label: "Type",
@@ -71,11 +62,7 @@ function ReconciledObjectsTable({
                 <KubeStatusIndicator conditions={u.conditions} />
               ) : null,
             sortType: SortType.bool,
-<<<<<<< HEAD
             sortValue: ({ conditions }) => computeReady(conditions),
-=======
-            sortValue: (u: UnstructuredObject) => computeReady(u.conditions),
->>>>>>> b0a4020d (breadcrumbs)
           },
           {
             label: "Message",

--- a/ui/components/ReconciledObjectsTable.tsx
+++ b/ui/components/ReconciledObjectsTable.tsx
@@ -45,9 +45,9 @@ function ReconciledObjectsTable({
           },
           {
             label: "Type",
-            value: (u: UnstructuredObject) => `${u.groupVersionKind.kind}`,
+            value: (u: UnstructuredObject) => u.groupVersionKind.kind,
             sortType: SortType.string,
-            sortValue: (u: UnstructuredObject) => `${u.groupVersionKind.kind}`,
+            sortValue: (u: UnstructuredObject) => u.groupVersionKind.kind,
           },
           {
             label: "Namespace",

--- a/ui/components/ReconciledObjectsTable.tsx
+++ b/ui/components/ReconciledObjectsTable.tsx
@@ -8,10 +8,14 @@ import {
   UnstructuredObject,
 } from "../lib/api/core/types.pb";
 import DataTable, { SortType } from "./DataTable";
+<<<<<<< HEAD
 import KubeStatusIndicator, {
   computeMessage,
   computeReady,
 } from "./KubeStatusIndicator";
+=======
+import KubeStatusIndicator, { computeReady } from "./KubeStatusIndicator";
+>>>>>>> b0a4020d (breadcrumbs)
 
 type Props = {
   className?: string;
@@ -42,14 +46,23 @@ function ReconciledObjectsTable({
           {
             value: "name",
             label: "Name",
+<<<<<<< HEAD
+=======
+            sortType: SortType.string,
+            sortValue: ({ name }) => name,
+>>>>>>> b0a4020d (breadcrumbs)
           },
           {
             label: "Type",
             value: (u: UnstructuredObject) => `${u.groupVersionKind.kind}`,
+            sortType: SortType.string,
+            sortValue: (u: UnstructuredObject) => `${u.groupVersionKind.kind}`,
           },
           {
             label: "Namespace",
             value: "namespace",
+            sortType: SortType.string,
+            sortValue: ({ namespace }) => namespace,
           },
           {
             label: "Status",
@@ -58,7 +71,11 @@ function ReconciledObjectsTable({
                 <KubeStatusIndicator conditions={u.conditions} />
               ) : null,
             sortType: SortType.bool,
+<<<<<<< HEAD
             sortValue: ({ conditions }) => computeReady(conditions),
+=======
+            sortValue: (u: UnstructuredObject) => computeReady(u.conditions),
+>>>>>>> b0a4020d (breadcrumbs)
           },
           {
             label: "Message",

--- a/ui/components/Text.tsx
+++ b/ui/components/Text.tsx
@@ -2,7 +2,7 @@ import styled from "styled-components";
 // eslint-disable-next-line
 import { colors, fontSizes } from "../typedefs/styled";
 
-type Props = {
+export interface TextProps {
   className?: string;
   size?: keyof typeof fontSizes;
   bold?: boolean;
@@ -10,9 +10,9 @@ type Props = {
   capitalize?: boolean;
   italic?: boolean;
   color?: keyof typeof colors;
-};
+}
 
-const Text = styled.span<Props>`
+const Text = styled.span<TextProps>`
   font-family: ${(props) => props.theme.fontFamilies.regular};
   font-size: ${(props) => props.theme.fontSizes[props.size]};
   font-weight: ${(props) => {

--- a/ui/components/__tests__/Breadcrumbs.test.tsx
+++ b/ui/components/__tests__/Breadcrumbs.test.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import renderer from "react-test-renderer";
+import { createMockClient, withContext, withTheme } from "../../lib/test-utils";
+import Breadcrumbs from "../Breadcrumbs";
+
+describe("snapshots", () => {
+  it("renders", () => {
+    const tree = renderer
+      .create(
+        withTheme(
+          withContext(<Breadcrumbs />, "/automations", {
+            applicationsClient: createMockClient({}),
+          })
+        )
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/ui/components/__tests__/Breadcrumbs.test.tsx
+++ b/ui/components/__tests__/Breadcrumbs.test.tsx
@@ -16,4 +16,16 @@ describe("snapshots", () => {
       .toJSON();
     expect(tree).toMatchSnapshot();
   });
+  it("renders child route", () => {
+    const tree = renderer
+      .create(
+        withTheme(
+          withContext(<Breadcrumbs />, "/kustomization?name=flux", {
+            applicationsClient: createMockClient({}),
+          })
+        )
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 });

--- a/ui/components/__tests__/__snapshots__/Breadcrumbs.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/Breadcrumbs.test.tsx.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`snapshots renders 1`] = `
+<div
+  className="sc-bdvvtL lacWsj"
+>
+  <a
+    className="sc-hKwDye sc-eCImPb kCA-dBN cQVkzF"
+    href="/automations"
+    onClick={[Function]}
+  >
+    <span
+      className="sc-gsDKAQ klFDZy"
+      color="primary"
+      size="normal"
+    >
+      Applications
+    </span>
+  </a>
+</div>
+`;

--- a/ui/components/__tests__/__snapshots__/Breadcrumbs.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/Breadcrumbs.test.tsx.snap
@@ -19,3 +19,50 @@ exports[`snapshots renders 1`] = `
   </a>
 </div>
 `;
+
+exports[`snapshots renders child route 1`] = `
+<div
+  className="sc-bdvvtL lacWsj"
+>
+  <a
+    className="sc-hKwDye sc-eCImPb kCA-dBN cQVkzF"
+    href="/"
+    onClick={[Function]}
+  >
+    <span
+      className="sc-gsDKAQ klFDZy"
+      color="primary"
+      size="normal"
+    >
+      Applications
+    </span>
+  </a>
+  <div
+    className="sc-bdvvtL lacWsj sc-dkPtRN hTjxvJ"
+  >
+    <svg
+      aria-hidden={true}
+      className="MuiSvgIcon-root"
+      focusable="false"
+      viewBox="0 0 24 24"
+    >
+      <path
+        d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"
+      />
+    </svg>
+  </div>
+  <a
+    className="sc-hKwDye sc-eCImPb kCA-dBN cQVkzF"
+    href="/kustomization"
+    onClick={[Function]}
+  >
+    <span
+      className="sc-gsDKAQ fcdFvu"
+      color="primary"
+      size="normal"
+    >
+      flux
+    </span>
+  </a>
+</div>
+`;

--- a/ui/components/__tests__/__snapshots__/Page.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/Page.test.tsx.snap
@@ -106,19 +106,7 @@ exports[`Page snapshots default 1`] = `
     <div
       className="c2"
     >
-      <nav
-        className="MuiTypography-root MuiBreadcrumbs-root MuiTypography-body1 MuiTypography-colorTextSecondary"
-      >
-        <ol
-          className="MuiBreadcrumbs-ol"
-        >
-          <li
-            className="MuiBreadcrumbs-li"
-          >
-            <h2 />
-          </li>
-        </ol>
-      </nav>
+      <h2 />
     </div>
     <div
       className="c3"

--- a/ui/contexts/AppContext.tsx
+++ b/ui/contexts/AppContext.tsx
@@ -68,7 +68,6 @@ export default function AppContextProvider({
   const history = useHistory();
   const [appState, setAppState] = React.useState({
     error: null,
-    counts: { main: 0, secondary: 0 },
   });
 
   const clearAsyncError = () => {

--- a/ui/contexts/AppContext.tsx
+++ b/ui/contexts/AppContext.tsx
@@ -68,6 +68,7 @@ export default function AppContextProvider({
   const history = useHistory();
   const [appState, setAppState] = React.useState({
     error: null,
+    counts: { main: 0, secondary: 0 },
   });
 
   const clearAsyncError = () => {

--- a/ui/lib/nav.ts
+++ b/ui/lib/nav.ts
@@ -1,4 +1,5 @@
 import qs from "query-string";
+import { useLocation } from "react-router-dom";
 import { SourceRefSourceKind } from "./api/core/types.pb";
 import { PageRoute } from "./types";
 
@@ -38,6 +39,24 @@ export const getParentNavValue = (
     default:
       // The "Tabs" component of material-ui wants a bool
       return false;
+  }
+};
+
+export const getPageLabel = (currentPage: string): string => {
+  const parsed = qs.parse(useLocation().search);
+  switch (currentPage) {
+    case V2Routes.Automations:
+      return "Applications";
+    case V2Routes.Sources:
+      return "Sources";
+    case V2Routes.FluxRuntime:
+      return "Flux Runtime";
+    case V2Routes.Kustomization:
+    case V2Routes.HelmRelease:
+    case V2Routes.GitRepo:
+    case V2Routes.HelmChart:
+    case V2Routes.Bucket:
+      return parsed.name as string;
   }
 };
 

--- a/ui/pages/v2/FluxRuntime.tsx
+++ b/ui/pages/v2/FluxRuntime.tsx
@@ -2,7 +2,9 @@ import _ from "lodash";
 import * as React from "react";
 import styled from "styled-components";
 import DataTable, { SortType } from "../../components/DataTable";
-import KubeStatusIndicator from "../../components/KubeStatusIndicator";
+import KubeStatusIndicator, {
+  computeReady,
+} from "../../components/KubeStatusIndicator";
 import Link from "../../components/Link";
 import Page from "../../components/Page";
 import { useListFluxRuntimeObjects } from "../../hooks/flux";
@@ -31,6 +33,8 @@ function FluxRuntime({ className }: Props) {
               <KubeStatusIndicator conditions={v.conditions} />
             ),
             label: "Status",
+            sortType: SortType.bool,
+            sortValue: ({ conditions }) => computeReady(conditions),
           },
           {
             label: "Cluster",


### PR DESCRIPTION

Closes: #1509 

![image](https://user-images.githubusercontent.com/65822698/156068683-acfe5d62-1b60-40f2-a8d9-ca892d73db29.png)

Adds Breadcrumbs component, and should also fix some errors caused by data tables mixing with the new sorting pr.

