### PR TITLE
Remove flux check from check cmd

### DIFF
--- a/cmd/gitops/check/cmd.go
+++ b/cmd/gitops/check/cmd.go
@@ -5,12 +5,6 @@ import (
 	"fmt"
 
 	"github.com/weaveworks/weave-gitops/pkg/services/check"
-	"github.com/weaveworks/weave-gitops/pkg/version"
-
-	"github.com/weaveworks/weave-gitops/pkg/osys"
-	"github.com/weaveworks/weave-gitops/pkg/runner"
-
-	"github.com/weaveworks/weave-gitops/pkg/flux"
 
 	"github.com/spf13/cobra"
 	"github.com/weaveworks/weave-gitops/pkg/kube"
@@ -37,8 +31,6 @@ func init() {
 func runCmd(_ *cobra.Command, _ []string) error {
 	ctx := context.Background()
 
-	fluxClient := flux.New(osys.New(), &runner.CLIRunner{})
-
 	rest, clusterName, err := kube.RestConfig()
 	if err != nil {
 		return fmt.Errorf("failed getting rest config: %w", err)
@@ -53,7 +45,7 @@ func runCmd(_ *cobra.Command, _ []string) error {
 		Client: k8sClient,
 	}
 
-	output, err := check.Pre(ctx, kubeClient, fluxClient, version.FluxVersion)
+	output, err := check.Pre(ctx, kubeClient)
 	if err != nil {
 		return err
 	}

--- a/cmd/gitops/check/cmd.go
+++ b/cmd/gitops/check/cmd.go
@@ -1,13 +1,11 @@
 package check
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/weaveworks/weave-gitops/pkg/services/check"
 
 	"github.com/spf13/cobra"
-	"github.com/weaveworks/weave-gitops/pkg/kube"
 )
 
 var (
@@ -29,23 +27,7 @@ func init() {
 }
 
 func runCmd(_ *cobra.Command, _ []string) error {
-	ctx := context.Background()
-
-	rest, clusterName, err := kube.RestConfig()
-	if err != nil {
-		return fmt.Errorf("failed getting rest config: %w", err)
-	}
-
-	_, k8sClient, err := kube.NewKubeHTTPClientWithConfig(rest, clusterName)
-	if err != nil {
-		return fmt.Errorf("failed creating k8s client: %w", err)
-	}
-
-	kubeClient := &kube.KubeHTTP{
-		Client: k8sClient,
-	}
-
-	output, err := check.Pre(ctx, kubeClient)
+	output, err := check.Pre()
 	if err != nil {
 		return err
 	}

--- a/pkg/flux/flux.go
+++ b/pkg/flux/flux.go
@@ -17,7 +17,6 @@ type Flux interface {
 	SetupBin()
 	CreateSecretGit(name string, repoUrl gitproviders.RepoURL, namespace string) ([]byte, error)
 	GetAllResourcesStatus(name string, namespace string) ([]byte, error)
-	PreCheck() (string, error)
 }
 
 const (
@@ -95,18 +94,4 @@ func (f *FluxClient) fluxPath() (string, error) {
 	path := fmt.Sprintf("%v/.wego/bin", homeDir)
 
 	return fmt.Sprintf("%v/flux-%v", path, version.FluxVersion), nil
-}
-
-func (f *FluxClient) PreCheck() (string, error) {
-	args := []string{
-		"check",
-		"--pre",
-	}
-
-	output, err := f.runFluxCmd(args...)
-	if err != nil {
-		return "", fmt.Errorf("failed running flux pre check %w", err)
-	}
-
-	return string(output), nil
 }

--- a/pkg/flux/fluxfakes/fake_flux.go
+++ b/pkg/flux/fluxfakes/fake_flux.go
@@ -38,18 +38,6 @@ type FakeFlux struct {
 		result1 []byte
 		result2 error
 	}
-	PreCheckStub        func() (string, error)
-	preCheckMutex       sync.RWMutex
-	preCheckArgsForCall []struct {
-	}
-	preCheckReturns struct {
-		result1 string
-		result2 error
-	}
-	preCheckReturnsOnCall map[int]struct {
-		result1 string
-		result2 error
-	}
 	SetupBinStub        func()
 	setupBinMutex       sync.RWMutex
 	setupBinArgsForCall []struct {
@@ -189,62 +177,6 @@ func (fake *FakeFlux) GetAllResourcesStatusReturnsOnCall(i int, result1 []byte, 
 	}{result1, result2}
 }
 
-func (fake *FakeFlux) PreCheck() (string, error) {
-	fake.preCheckMutex.Lock()
-	ret, specificReturn := fake.preCheckReturnsOnCall[len(fake.preCheckArgsForCall)]
-	fake.preCheckArgsForCall = append(fake.preCheckArgsForCall, struct {
-	}{})
-	stub := fake.PreCheckStub
-	fakeReturns := fake.preCheckReturns
-	fake.recordInvocation("PreCheck", []interface{}{})
-	fake.preCheckMutex.Unlock()
-	if stub != nil {
-		return stub()
-	}
-	if specificReturn {
-		return ret.result1, ret.result2
-	}
-	return fakeReturns.result1, fakeReturns.result2
-}
-
-func (fake *FakeFlux) PreCheckCallCount() int {
-	fake.preCheckMutex.RLock()
-	defer fake.preCheckMutex.RUnlock()
-	return len(fake.preCheckArgsForCall)
-}
-
-func (fake *FakeFlux) PreCheckCalls(stub func() (string, error)) {
-	fake.preCheckMutex.Lock()
-	defer fake.preCheckMutex.Unlock()
-	fake.PreCheckStub = stub
-}
-
-func (fake *FakeFlux) PreCheckReturns(result1 string, result2 error) {
-	fake.preCheckMutex.Lock()
-	defer fake.preCheckMutex.Unlock()
-	fake.PreCheckStub = nil
-	fake.preCheckReturns = struct {
-		result1 string
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeFlux) PreCheckReturnsOnCall(i int, result1 string, result2 error) {
-	fake.preCheckMutex.Lock()
-	defer fake.preCheckMutex.Unlock()
-	fake.PreCheckStub = nil
-	if fake.preCheckReturnsOnCall == nil {
-		fake.preCheckReturnsOnCall = make(map[int]struct {
-			result1 string
-			result2 error
-		})
-	}
-	fake.preCheckReturnsOnCall[i] = struct {
-		result1 string
-		result2 error
-	}{result1, result2}
-}
-
 func (fake *FakeFlux) SetupBin() {
 	fake.setupBinMutex.Lock()
 	fake.setupBinArgsForCall = append(fake.setupBinArgsForCall, struct {
@@ -276,8 +208,6 @@ func (fake *FakeFlux) Invocations() map[string][][]interface{} {
 	defer fake.createSecretGitMutex.RUnlock()
 	fake.getAllResourcesStatusMutex.RLock()
 	defer fake.getAllResourcesStatusMutex.RUnlock()
-	fake.preCheckMutex.RLock()
-	defer fake.preCheckMutex.RUnlock()
 	fake.setupBinMutex.RLock()
 	defer fake.setupBinMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/pkg/services/check/check.go
+++ b/pkg/services/check/check.go
@@ -2,117 +2,70 @@ package check
 
 import (
 	"context"
-	"errors"
 	"fmt"
+	"os/exec"
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
-	"github.com/weaveworks/weave-gitops/pkg/flux"
 	"github.com/weaveworks/weave-gitops/pkg/kube"
 )
-
-var ErrKubernetesNotFound = errors.New("no kubernetes version found")
 
 const (
 	FluxCompatibleMessage    = "Current flux version is compatible"
 	FluxNotCompatibleMessage = "Current flux version is not compatible"
+	kubernetesConstraints    = ">=1.20.6-0"
 )
 
 // Pre runs pre-install checks
-func Pre(ctx context.Context, kubeClient kube.Kube, fluxClient flux.Flux, expectedFluxVersion string) (string, error) {
-	output := ""
-
-	k8sOutput, err := runKubernetesCheck(fluxClient)
+func Pre(ctx context.Context, kubeClient kube.Kube) (string, error) {
+	k8sOutput, err := runKubernetesCheck()
 	if err != nil {
 		return "", err
 	}
 
-	output += k8sOutput + "\n"
-
-	currentFluxVersion, err := getCurrentFluxVersion(ctx, kubeClient)
-	if err != nil {
-		if errors.Is(err, kube.ErrNamespaceNotFound) {
-			output += "✔ Flux is not installed"
-			return output, nil
-		}
-
-		return "", fmt.Errorf("failed getting installed flux version: %w", err)
-	}
-
-	fluxOutput, err := validateFluxVersion(currentFluxVersion, expectedFluxVersion)
-	if err != nil {
-		return "", err
-	}
-
-	output += fluxOutput
-
-	return output, nil
+	return k8sOutput, nil
 }
 
-func runKubernetesCheck(fluxClient flux.Flux) (string, error) {
-	output, err := fluxClient.PreCheck()
+func runKubernetesCheck() (string, error) {
+	versionOutput, err := exec.Command("kubectl", "version", "--short").CombinedOutput()
 	if err != nil {
-		return "", fmt.Errorf("failed running flux pre check %w", err)
+		return "", fmt.Errorf("unable to get kubernetes version: %w", err)
 	}
 
-	lines := strings.Split(output, "\n")
+	v, err := parseVersion(string(versionOutput))
+	if err != nil {
+		return "", fmt.Errorf("kubernetes version can't be determined: %w", err)
+	}
+
+	return checkKubernetesVersion(v)
+}
+
+func checkKubernetesVersion(version *semver.Version) (string, error) {
+	var valid bool
+	var vrange string
+	c, _ := semver.NewConstraint(kubernetesConstraints)
+	if c.Check(version) {
+		valid = true
+		vrange = kubernetesConstraints
+	}
+
+	if !valid {
+		return "", fmt.Errorf("✗ kubernetes version %s does not match %s", version.Original(), kubernetesConstraints)
+	}
+
+	return fmt.Sprintf("✔ Kubernetes %s %s", version.String(), vrange), nil
+}
+
+func parseVersion(text string) (*semver.Version, error) {
+	version := ""
+	lines := strings.Split(text, "\n")
 	for _, line := range lines {
-		if strings.Contains(line, "Kubernetes") {
-			return line, nil
+		if strings.Contains(line, "Server") {
+			version = strings.Replace(line, "Server Version: v", "", 1)
 		}
 	}
 
-	return "", ErrKubernetesNotFound
-}
-
-func getCurrentFluxVersion(ctx context.Context, kubeClient kube.Kube) (string, error) {
-	namespace, err := kubeClient.FetchNamespaceWithLabel(ctx, flux.PartOfLabelKey, flux.PartOfLabelValue)
-	if err != nil {
-		return "", err
-	}
-
-	labels := namespace.GetLabels()
-
-	return labels[flux.VersionLabelKey], nil
-}
-
-func validateFluxVersion(actualFluxVersion string, expectedFluxVersion string) (string, error) {
-	actualParsedFluxVersion, err := parseVersion(actualFluxVersion)
-	if err != nil {
-		return "", err
-	}
-
-	expectedParsedFluxVersion, err := parseVersion(expectedFluxVersion)
-	if err != nil {
-		return "", err
-	}
-
-	fluxOutput := ""
-
-	expectedMajor := expectedParsedFluxVersion.Major()
-	expectedMinor := expectedParsedFluxVersion.Minor()
-	constraintFormat := fmt.Sprintf("~%d.%d.x", expectedMajor, expectedMinor)
-
-	constraint, err := semver.NewConstraint(constraintFormat)
-	if err != nil {
-		return "", fmt.Errorf("failed creating semver constraint: %w", err)
-	}
-
-	check := constraint.Check(actualParsedFluxVersion)
-	if check {
-		fluxOutput += fmt.Sprintf("✔ Flux %s ~=%s\n", actualParsedFluxVersion, expectedParsedFluxVersion)
-		fluxOutput += FluxCompatibleMessage
-	} else {
-		fluxOutput += fmt.Sprintf("✗ Flux %s !=%s\n", actualParsedFluxVersion, constraintFormat)
-		fluxOutput += FluxNotCompatibleMessage
-	}
-
-	return fluxOutput, nil
-}
-
-func parseVersion(version string) (*semver.Version, error) {
-	versionLessV := strings.TrimPrefix(version, "v")
-	if _, err := semver.StrictNewVersion(versionLessV); err != nil {
+	if _, err := semver.StrictNewVersion(version); err != nil {
 		return nil, err
 	}
 

--- a/pkg/services/check/check.go
+++ b/pkg/services/check/check.go
@@ -1,23 +1,19 @@
 package check
 
 import (
-	"context"
 	"fmt"
 	"os/exec"
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
-	"github.com/weaveworks/weave-gitops/pkg/kube"
 )
 
 const (
-	FluxCompatibleMessage    = "Current flux version is compatible"
-	FluxNotCompatibleMessage = "Current flux version is not compatible"
-	kubernetesConstraints    = ">=1.20.6-0"
+	kubernetesConstraints = ">=1.20.6-0"
 )
 
 // Pre runs pre-install checks
-func Pre(ctx context.Context, kubeClient kube.Kube) (string, error) {
+func Pre() (string, error) {
 	k8sOutput, err := runKubernetesCheck()
 	if err != nil {
 		return "", err

--- a/pkg/services/check/check.go
+++ b/pkg/services/check/check.go
@@ -42,7 +42,9 @@ func runKubernetesCheck() (string, error) {
 
 func checkKubernetesVersion(version *semver.Version) (string, error) {
 	var valid bool
+
 	var vrange string
+
 	c, _ := semver.NewConstraint(kubernetesConstraints)
 	if c.Check(version) {
 		valid = true
@@ -59,6 +61,7 @@ func checkKubernetesVersion(version *semver.Version) (string, error) {
 func parseVersion(text string) (*semver.Version, error) {
 	version := ""
 	lines := strings.Split(text, "\n")
+
 	for _, line := range lines {
 		if strings.Contains(line, "Server") {
 			version = strings.Replace(line, "Server Version: v", "", 1)

--- a/pkg/services/check/check_test.go
+++ b/pkg/services/check/check_test.go
@@ -1,161 +1,40 @@
 package check
 
 import (
-	"context"
-	"errors"
-
-	"github.com/weaveworks/weave-gitops/pkg/kube"
-
-	"github.com/weaveworks/weave-gitops/pkg/flux"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	corev1 "k8s.io/api/core/v1"
-
-	"github.com/weaveworks/weave-gitops/pkg/kube/kubefakes"
+	"github.com/Masterminds/semver/v3"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/weaveworks/weave-gitops/pkg/flux/fluxfakes"
 )
 
-var _ = Describe("Check", func() {
-
-	var fakeFluxClient *fluxfakes.FakeFlux
-	var fakeKubeClient *kubefakes.FakeKube
-	someError := errors.New("some error")
-	var context context.Context
-	const successfulFluxPreCheckOutput = `► checking prerequisites
-✔ Kubernetes 1.21.1 >=1.19.0-0
-✔ prerequisites checks passed`
-	const expectedFluxVersion = "1.21.1"
-	BeforeEach(func() {
-		fakeFluxClient = &fluxfakes.FakeFlux{}
-		fakeKubeClient = &kubefakes.FakeKube{}
-	})
-
-	It("should fail running flux.PreCheck", func() {
-		fakeFluxClient.PreCheckReturns("", someError)
-
-		out, err := Pre(context, fakeKubeClient, fakeFluxClient, expectedFluxVersion)
-		Expect(err.Error()).To(ContainSubstring(someError.Error()))
-		Expect(out).Should(BeEmpty())
-	})
-
-	It("should show flux is not installed", func() {
-
-		fakeFluxClient.PreCheckReturns(successfulFluxPreCheckOutput, nil)
-
-		fakeKubeClient.FetchNamespaceWithLabelReturns(&corev1.Namespace{}, kube.ErrNamespaceNotFound)
-
-		actualOutput, err := Pre(context, fakeKubeClient, fakeFluxClient, expectedFluxVersion)
+var _ = Describe("Check kubernetes version", func() {
+	It("should show kuberetes is a valid version", func() {
+		version, err := semver.NewVersion("1.21.1")
 		Expect(err).ShouldNot(HaveOccurred())
 
-		expectedOutput := `✔ Kubernetes 1.21.1 >=1.19.0-0
-✔ Flux is not installed`
-		Expect(actualOutput).To(Equal(expectedOutput))
-	})
-
-	It("should fail while getting namespaces", func() {
-
-		fakeFluxClient.PreCheckReturns(successfulFluxPreCheckOutput, nil)
-
-		fakeKubeClient.FetchNamespaceWithLabelReturns(nil, someError)
-
-		out, err := Pre(context, fakeKubeClient, fakeFluxClient, expectedFluxVersion)
-		Expect(err.Error()).To(ContainSubstring(someError.Error()))
-		Expect(out).Should(BeEmpty())
-	})
-
-	It("should fail parsing actual version", func() {
-
-		output, err := validateFluxVersion("", "")
-		Expect(err).Should(HaveOccurred())
-		Expect(output).To(BeEmpty())
-
-	})
-
-	It("should fail parsing expected version", func() {
-
-		output, err := validateFluxVersion("v0.0.0", "")
-		Expect(err).Should(HaveOccurred())
-		Expect(output).To(BeEmpty())
-
-	})
-
-	It("should fail when there is no Kubernetes when running flux pre check", func() {
-
-		fakeFluxClient.PreCheckReturns("", nil)
-
-		output, err := Pre(context, fakeKubeClient, fakeFluxClient, expectedFluxVersion)
-		Expect(err).Should(Equal(ErrKubernetesNotFound))
-		Expect(output).To(BeEmpty())
-
-	})
-
-	It("should fail when expected flux version is not valid", func() {
-
-		fakeFluxClient.PreCheckReturns(successfulFluxPreCheckOutput, nil)
-
-		fakeKubeClient.FetchNamespaceWithLabelReturns(&corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Labels: map[string]string{
-					flux.PartOfLabelKey:  flux.PartOfLabelValue,
-					flux.VersionLabelKey: expectedFluxVersion,
-				},
-			},
-		}, nil)
-
-		output, err := Pre(context, fakeKubeClient, fakeFluxClient, "")
-		Expect(err).Should(HaveOccurred())
-		Expect(output).To(BeEmpty())
-
-	})
-
-	It("should show flux version is compatible", func() {
-
-		fakeFluxClient.PreCheckReturns(successfulFluxPreCheckOutput, nil)
-
-		fakeKubeClient.FetchNamespaceWithLabelReturns(&corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Labels: map[string]string{
-					flux.PartOfLabelKey:  flux.PartOfLabelValue,
-					flux.VersionLabelKey: expectedFluxVersion,
-				},
-			},
-		}, nil)
-
-		actualOutput, err := Pre(context, fakeKubeClient, fakeFluxClient, expectedFluxVersion)
+		output, err := checkKubernetesVersion(version)
 		Expect(err).ShouldNot(HaveOccurred())
 
-		expectedOutput := `✔ Kubernetes 1.21.1 >=1.19.0-0
-✔ Flux 1.21.1 ~=1.21.1
-` + FluxCompatibleMessage
-		Expect(actualOutput).To(Equal(expectedOutput))
+		Expect(output).To(Equal("✔ Kubernetes 1.21.1 >=1.20.6-0"))
 	})
 
-	It("should show that the current flux version is not compatible", func() {
-
-		fakeFluxClient.PreCheckReturns(successfulFluxPreCheckOutput, nil)
-
-		differentFluxVersion := "v0.0.0"
-
-		fakeKubeClient.FetchNamespaceWithLabelReturns(&corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Labels: map[string]string{
-					flux.PartOfLabelKey:  flux.PartOfLabelValue,
-					flux.VersionLabelKey: differentFluxVersion,
-				},
-			},
-		}, nil)
-
-		actualOutput, err := Pre(context, fakeKubeClient, fakeFluxClient, expectedFluxVersion)
+	It("should fail with version does not match", func() {
+		version, err := semver.NewVersion("1.19.1")
 		Expect(err).ShouldNot(HaveOccurred())
 
-		expectedOutput := `✔ Kubernetes 1.21.1 >=1.19.0-0
-✗ Flux 0.0.0 !=~1.21.x
-` + FluxNotCompatibleMessage
-		Expect(actualOutput).To(Equal(expectedOutput))
+		_, err = checkKubernetesVersion(version)
+		Expect(err.Error()).Should(Equal("✗ kubernetes version 1.19.1 does not match >=1.20.6-0"))
 	})
+})
 
+var _ = Describe("parse version", func() {
+	It("should parse version", func() {
+		expectedVersion, err := semver.NewVersion("1.21.1")
+		Expect(err).ShouldNot(HaveOccurred())
+
+		output, err := parseVersion("Server Version: v1.21.1")
+		Expect(err).ShouldNot(HaveOccurred())
+
+		Expect(output).To(Equal(expectedVersion))
+	})
 })


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
I removed the flux check from the check cmd. I also changed the kubernetes check to no longer use flux to validate it. It is now getting the kubernetes version by running kubclt cmd. I copied the validation code from flux. We will have to keep the supported kubernetes version up to date in the code now. 

<!-- Tell your future self why have you made these changes -->
**Why?**
The flux binary will no longer exist in the code so this command needed to change.

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
**Release notes**

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**