### PR TITLE
Fix error on calling .localeCompare on undefined in Datatable

### DIFF
--- a/ui/components/DataTable.tsx
+++ b/ui/components/DataTable.tsx
@@ -98,7 +98,7 @@ export const sortWithType = (rows: Row[], sort: Field) => {
         else return 1;
 
       default:
-        return sortFn(a).localeCompare(sortFn(b));
+        return (sortFn(a) || "").localeCompare(sortFn(b) || "");
     }
   });
 };


### PR DESCRIPTION
Fixes an issue where a string can be `undefined` but we still call `.localeCompare` on it.