### PR TITLE
Add back missing routes and simplify Breadcrumbs

### DIFF
--- a/ui/App.tsx
+++ b/ui/App.tsx
@@ -20,10 +20,13 @@ import { Core } from "./lib/api/core/core.pb";
 import Fonts from "./lib/fonts";
 import theme, { GlobalStyle, muiTheme } from "./lib/theme";
 import { V2Routes } from "./lib/types";
+import Error from "./pages/Error";
 import SignIn from "./pages/SignIn";
 import Automations from "./pages/v2/Automations";
+import BucketDetail from "./pages/v2/BucketDetail";
 import FluxRuntime from "./pages/v2/FluxRuntime";
 import GitRepositoryDetail from "./pages/v2/GitRepositoryDetail";
+import HelmRepositoryDetail from "./pages/v2/HelmRepositoryDetail";
 import KustomizationDetail from "./pages/v2/KustomizationDetail";
 import Sources from "./pages/v2/Sources";
 
@@ -54,8 +57,18 @@ const App = () => (
           path={V2Routes.GitRepo}
           component={withName(GitRepositoryDetail)}
         />
+        <Route
+          exact
+          path={V2Routes.HelmRepo}
+          component={withName(HelmRepositoryDetail)}
+        />
+        <Route
+          exact
+          path={V2Routes.Bucket}
+          component={withName(BucketDetail)}
+        />
         <Redirect exact from="/" to={V2Routes.Automations} />
-        {/* <Route exact path="*" component={Error} /> */}
+        <Route exact path="*" component={Error} />
       </Switch>
     </ErrorBoundary>
     <ToastContainer

--- a/ui/components/Breadcrumbs.tsx
+++ b/ui/components/Breadcrumbs.tsx
@@ -3,7 +3,12 @@ import React from "react";
 import { useLocation } from "react-router-dom";
 import styled from "styled-components";
 import useNavigation from "../hooks/navigation";
-import { getPageLabel, getParentNavValue, V2Routes } from "../lib/nav";
+import {
+  formatURL,
+  getPageLabel,
+  getParentNavValue,
+  V2Routes,
+} from "../lib/nav";
 import Flex from "./Flex";
 import Icon, { IconType } from "./Icon";
 import Link from "./Link";
@@ -18,28 +23,30 @@ const CrumbLink = styled(Link)`
 
 export const Breadcrumbs = () => {
   const { currentPage } = useNavigation();
-  const parentValue = getParentNavValue(currentPage);
-  const parsed = qs.parse(useLocation().search);
+  const { search } = useLocation();
+
+  const parentValue = getParentNavValue(currentPage) as V2Routes;
+  const label = getPageLabel(parentValue);
+  const parsed = qs.parse(search);
 
   return (
     <Flex align>
-      {parentValue !== currentPage && (
-        <CrumbLink
-          to={V2Routes[parentValue as V2Routes] || ""}
-          textProps={{ bold: true }}
-        >
-          {getPageLabel(parentValue as V2Routes)}
-        </CrumbLink>
-      )}
-      {parentValue !== currentPage && (
-        <Icon type={IconType.NavigateNextIcon} size="large" color="neutral00" />
-      )}
-      <CrumbLink
-        to={currentPage}
-        textProps={parentValue === currentPage && { bold: true }}
-      >
-        {getPageLabel(currentPage, parsed && (parsed.name as string))}
+      <CrumbLink to={parentValue} textProps={{ bold: true }}>
+        {label}
       </CrumbLink>
+
+      {parentValue !== currentPage && (
+        <>
+          <Icon
+            type={IconType.NavigateNextIcon}
+            size="large"
+            color="neutral00"
+          />
+          <CrumbLink to={formatURL(currentPage, parsed)}>
+            {parsed.name}
+          </CrumbLink>
+        </>
+      )}
     </Flex>
   );
 };

--- a/ui/components/__tests__/__snapshots__/Breadcrumbs.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/Breadcrumbs.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`snapshots renders child route 1`] = `
 >
   <a
     className="sc-hKwDye sc-eCImPb kCA-dBN cQVkzF"
-    href="/"
+    href="/automations"
     onClick={[Function]}
   >
     <span
@@ -53,7 +53,7 @@ exports[`snapshots renders child route 1`] = `
   </div>
   <a
     className="sc-hKwDye sc-eCImPb kCA-dBN cQVkzF"
-    href="/kustomization"
+    href="/kustomization?name=flux"
     onClick={[Function]}
   >
     <span

--- a/ui/lib/nav.ts
+++ b/ui/lib/nav.ts
@@ -42,21 +42,14 @@ export const getParentNavValue = (
   }
 };
 
-export const getPageLabel = (currentPage: string, name?: string): string => {
-  switch (currentPage) {
-    case V2Routes.Automations:
-      return "Applications";
-    case V2Routes.Sources:
-      return "Sources";
-    case V2Routes.FluxRuntime:
-      return "Flux Runtime";
-    case V2Routes.Kustomization:
-    case V2Routes.HelmRelease:
-    case V2Routes.GitRepo:
-    case V2Routes.HelmChart:
-    case V2Routes.Bucket:
-      return name;
-  }
+const pageTitles = {
+  [V2Routes.Automations]: "Applications",
+  [V2Routes.Sources]: "Sources",
+  [V2Routes.FluxRuntime]: "Flux Runtime",
+};
+
+export const getPageLabel = (route: V2Routes): string => {
+  return pageTitles[route];
 };
 
 export const formatURL = (page: string, query: any = {}) => {


### PR DESCRIPTION
Fixes some broken routes that got missing in a merge conflict resolution (by me), and simplifies the `Breadcrumbs` component to handle any of the detail routes.