### PR TITLE
Fix KubeStatusIndicator overflow and color

### DIFF
--- a/ui/components/AutomationsTable.tsx
+++ b/ui/components/AutomationsTable.tsx
@@ -4,14 +4,18 @@ import { Automation } from "../hooks/automations";
 import { formatURL } from "../lib/nav";
 import { AutomationType, V2Routes } from "../lib/types";
 import DataTable, { SortType } from "./DataTable";
+import Flex from "./Flex";
 import KubeStatusIndicator, { computeReady } from "./KubeStatusIndicator";
 import Link from "./Link";
+import Text from "./Text";
 
 type Props = {
   className?: string;
   automations: Automation[];
   appName?: string;
 };
+
+const statusWidth = 360;
 
 function AutomationsTable({ className, automations }: Props) {
   return (
@@ -59,6 +63,7 @@ function AutomationsTable({ className, automations }: Props) {
             ) : null,
           sortType: SortType.bool,
           sortValue: ({ conditions }) => computeReady(conditions),
+          width: statusWidth,
         },
         {
           label: "Revision",
@@ -73,4 +78,12 @@ function AutomationsTable({ className, automations }: Props) {
 
 export default styled(AutomationsTable).attrs({
   className: AutomationsTable.name,
-})``;
+})`
+  /* Setting this here to get the ellipsis to work */
+  /* Because this is a div within a td, overflow doesn't apply to the td */
+  ${KubeStatusIndicator} ${Flex} ${Text} {
+    max-width: ${statusWidth}px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+`;

--- a/ui/components/KubeStatusIndicator.tsx
+++ b/ui/components/KubeStatusIndicator.tsx
@@ -4,6 +4,7 @@ import styled from "styled-components";
 import { Condition } from "../lib/api/core/types.pb";
 import Flex from "./Flex";
 import Icon, { IconType } from "./Icon";
+import Text from "./Text";
 
 type Props = {
   className?: string;
@@ -39,4 +40,9 @@ function KubeStatusIndicator({ className, conditions }: Props) {
 
 export default styled(KubeStatusIndicator).attrs({
   className: KubeStatusIndicator.name,
-})``;
+})`
+  ${Icon} ${Text} {
+    color: ${(props) => props.theme.colors.black};
+    font-weight: 400;
+  }
+`;

--- a/ui/components/__tests__/KubeStatusIndicator.test.tsx
+++ b/ui/components/__tests__/KubeStatusIndicator.test.tsx
@@ -1,0 +1,97 @@
+import { render, screen } from "@testing-library/react";
+import "jest-styled-components";
+import React from "react";
+import renderer from "react-test-renderer";
+import { withTheme } from "../../lib/test-utils";
+import KubeStatusIndicator from "../KubeStatusIndicator";
+
+describe("KubeStatusIndicator", () => {
+  it("renders ready", () => {
+    const conditions = [
+      {
+        type: "Ready",
+        status: "True",
+        reason: "ReconciliationSucceeded",
+        message:
+          "Applied revision: main/a3a54ef4a87f8963b14915639f032aa6ec1b8161",
+        timestamp: "2022-03-03 17:00:38 +0000 UTC",
+      },
+    ];
+    render(withTheme(<KubeStatusIndicator conditions={conditions} />));
+
+    const ready = screen.getByText("Ready");
+    expect(ready).toBeTruthy();
+  });
+  it("renders an error", () => {
+    const conditions = [
+      {
+        type: "Ready",
+        status: "False",
+        reason: "BigTrouble",
+        message: "There was a problem",
+        timestamp: "2022-03-03 17:00:38 +0000 UTC",
+      },
+    ];
+    render(withTheme(<KubeStatusIndicator conditions={conditions} />));
+
+    const msg = screen.getByText(conditions[0].message);
+    expect(msg).toBeTruthy();
+  });
+  it("1593 - handles unhealthy", () => {
+    const conditions = [
+      {
+        type: "Ready",
+        status: "False",
+        reason: "HealthCheckFailed",
+        message:
+          "Health check failed after 30.004470633s, timeout waiting for: [Deployment/test/backend status: 'Failed']",
+        timestamp: "2022-03-03 16:55:29 +0000 UTC",
+      },
+      {
+        type: "Healthy",
+        status: "False",
+        reason: "HealthCheckFailed",
+        message: "HealthCheckFailed",
+        timestamp: "2022-03-03 16:55:29 +0000 UTC",
+      },
+    ];
+
+    render(withTheme(<KubeStatusIndicator conditions={conditions} />));
+
+    const msg = screen.getByText(conditions[0].message);
+    expect(msg).toBeTruthy();
+  });
+  describe("snapshots", () => {
+    it("renders success", () => {
+      const conditions = [
+        {
+          type: "Ready",
+          status: "True",
+          reason: "ReconciliationSucceeded",
+          message:
+            "Applied revision: main/a3a54ef4a87f8963b14915639f032aa6ec1b8161",
+          timestamp: "2022-03-03 17:00:38 +0000 UTC",
+        },
+      ];
+      const tree = renderer
+        .create(withTheme(<KubeStatusIndicator conditions={conditions} />))
+        .toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+    it("renders error", () => {
+      const conditions = [
+        {
+          type: "Ready",
+          status: "False",
+          reason: "BigTrouble",
+          message: "There was a problem",
+          timestamp: "2022-03-03 17:00:38 +0000 UTC",
+        },
+      ];
+      const tree = renderer
+        .create(withTheme(<KubeStatusIndicator conditions={conditions} />))
+        .toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+  });
+});

--- a/ui/components/__tests__/__snapshots__/KubeStatusIndicator.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/KubeStatusIndicator.test.tsx.snap
@@ -1,0 +1,201 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`KubeStatusIndicator snapshots renders error 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: space-evenly;
+  -webkit-justify-content: space-evenly;
+  -ms-flex-pack: space-evenly;
+  justify-content: space-evenly;
+}
+
+.c6 {
+  font-family: 'proxima-nova',Helvetica,Arial,sans-serif;
+  font-size: 16px;
+  font-weight: 800;
+  text-transform: none;
+  font-style: normal;
+  color: #BC381D;
+}
+
+.c4 svg {
+  fill: #BC381D !important;
+  height: 16px;
+  width: 16px;
+}
+
+.c4.downward {
+  -webkit-transform: rotate(180deg);
+  -ms-transform: rotate(180deg);
+  transform: rotate(180deg);
+}
+
+.c4.upward {
+  -webkit-transform: initial;
+  -ms-transform: initial;
+  transform: initial;
+}
+
+.c4 .c5 {
+  margin-left: 4px;
+  color: #BC381D;
+}
+
+.c1 .c3 .c5 {
+  color: #1a1a1a;
+  font-weight: 400;
+}
+
+<div
+  className="c0 c1 KubeStatusIndicator"
+>
+  <div
+    className="c2 c3 c4"
+  >
+    <svg
+      viewBox="0 0 100 100"
+    >
+      <circle
+        cx="50"
+        cy="50"
+        r="45"
+      />
+    </svg>
+    <span
+      className="c5 c6"
+      color="alert"
+      size="normal"
+    >
+      There was a problem
+    </span>
+  </div>
+</div>
+`;
+
+exports[`KubeStatusIndicator snapshots renders success 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: space-evenly;
+  -webkit-justify-content: space-evenly;
+  -ms-flex-pack: space-evenly;
+  justify-content: space-evenly;
+}
+
+.c6 {
+  font-family: 'proxima-nova',Helvetica,Arial,sans-serif;
+  font-size: 16px;
+  font-weight: 800;
+  text-transform: none;
+  font-style: normal;
+  color: #27AE60;
+}
+
+.c4 svg {
+  fill: #27AE60 !important;
+  height: 16px;
+  width: 16px;
+}
+
+.c4.downward {
+  -webkit-transform: rotate(180deg);
+  -ms-transform: rotate(180deg);
+  transform: rotate(180deg);
+}
+
+.c4.upward {
+  -webkit-transform: initial;
+  -ms-transform: initial;
+  transform: initial;
+}
+
+.c4 .c5 {
+  margin-left: 4px;
+  color: #27AE60;
+}
+
+.c1 .c3 .c5 {
+  color: #1a1a1a;
+  font-weight: 400;
+}
+
+<div
+  className="c0 c1 KubeStatusIndicator"
+>
+  <div
+    className="c2 c3 c4"
+  >
+    <svg
+      viewBox="0 0 100 100"
+    >
+      <circle
+        cx="50"
+        cy="50"
+        r="45"
+      />
+    </svg>
+    <span
+      className="c5 c6"
+      color="success"
+      size="normal"
+    >
+      Ready
+    </span>
+  </div>
+</div>
+`;

--- a/ui/pages/v2/KustomizationDetail.tsx
+++ b/ui/pages/v2/KustomizationDetail.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import styled from "styled-components";
-import Flex from "../../components/Flex";
 import Heading from "../../components/Heading";
 import InfoList from "../../components/InfoList";
 import Interval from "../../components/Interval";
@@ -46,13 +45,9 @@ function KustomizationDetail({ className, name }: Props) {
             ],
             [
               "Status",
-              <Flex start>
-                <KubeStatusIndicator conditions={kustomization?.conditions} />
-                <div>
-                  &nbsp; Applied revision {kustomization?.lastAppliedRevision}
-                </div>
-              </Flex>,
+              <KubeStatusIndicator conditions={kustomization?.conditions} />,
             ],
+            ["Applied Revision", kustomization?.lastAppliedRevision],
             ["Cluster", ""],
             ["Path", kustomization?.path],
             ["Interval", <Interval interval={kustomization?.interval} />],


### PR DESCRIPTION
Closes #1593 
Closes #1586
Closes #1585

Fixes the color and bold-ness of the status indications:
![Screenshot from 2022-03-03 10-04-50](https://user-images.githubusercontent.com/2802257/156625031-a2b50874-6a79-4b26-a0a2-7d16a7573e8a.png)
![Screenshot from 2022-03-03 10-04-41](https://user-images.githubusercontent.com/2802257/156625052-e5ad3c76-fa58-49c2-bd94-1f2a69e9c048.png)

Also fixes the overflow when they are shown in a table:
![Screenshot from 2022-03-03 10-05-38](https://user-images.githubusercontent.com/2802257/156625099-89161bcb-346d-41af-a4ec-af94ccc3d1b6.png)

Moves `Applied Revision` to the Info section for better consistency:
![Screenshot from 2022-03-03 10-07-14](https://user-images.githubusercontent.com/2802257/156625223-916952fb-1974-41b1-8c2a-ed5b4985515a.png)


