### PR TITLE
fix: smooth out v2 dev process

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Available Commands:
 
 Flags:
   -h, --help               Help for gitops
-      --namespace string   The namespace scope for this operation (default "wego-system").
+      --namespace string   The namespace scope for this operation (default "flux-system").
   -v, --verbose            Enable verbose output
 
 Use "gitops [command] --help" for more information about a command.
@@ -71,7 +71,7 @@ To set up a development environment for the CLI
 2. Install [buf](https://github.com/bufbuild/buf)
 3. Run `make all` to install dependencies and build binaries and assets
 4. Start a `kind` cluster like so: `KIND_CLUSTER_NAME=<some name> ./tools/kind-with-registry.sh`
-5. Run `./bin/gitops install --config-repo=<repo url>`
+5. Run `./bin/gitops install --config-repo=<repo url>` (or just `flux install -n flux-system` if you don't care about doing the whole dance.)
 6. Start the in-cluster API replacement job (powered by [http://tilt.dev](tilt.dev)) with `make cluster-dev`
 7. make or make unit-tests to ensure everything built correctly.
 

--- a/Tiltfile
+++ b/Tiltfile
@@ -24,7 +24,12 @@ docker_build_with_restart(
 )
 
 k8s_yaml([
-    'tools/wego-app-dev.yaml',
+    'tools/dev-manifests/wego-app.yaml',
+    'tools/dev-manifests/role.yaml',
+    'tools/dev-manifests/role-binding.yaml',
+    'tools/dev-manifests/helm_watcher_role.yaml',
+    'tools/dev-manifests/helm_watcher_role_binding.yaml',
+    'tools/dev-manifests/service-account.yaml',
 ])
 
 k8s_resource('wego-app', port_forwards='9000', resource_deps=['gitops-server'])

--- a/api/v1alpha1/application_types.go
+++ b/api/v1alpha1/application_types.go
@@ -66,7 +66,10 @@ const (
 	ResumeAction  SuspendActionType = "resume"
 )
 
-const DefaultNamespace = "wego-system"
+const (
+	DefaultNamespace           = "flux-system"
+	DefaultSuperUserSecretHash = "admin-password-hash"
+)
 
 // ApplicationStatus defines the observed state of Application
 type ApplicationStatus struct {

--- a/pkg/server/auth/server.go
+++ b/pkg/server/auth/server.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/go-logr/logr"
+	"github.com/weaveworks/weave-gitops/api/v1alpha1"
 	"golang.org/x/crypto/bcrypt"
 	"golang.org/x/oauth2"
 	corev1 "k8s.io/api/core/v1"
@@ -263,8 +264,8 @@ func (s *AuthServer) SignIn() http.HandlerFunc {
 		var hashedSecret corev1.Secret
 
 		if err := s.kubernetesClient.Get(r.Context(), ctrlclient.ObjectKey{
-			Namespace: "wego-system",
-			Name:      "admin-password-hash",
+			Namespace: v1alpha1.DefaultNamespace,
+			Name:      v1alpha1.DefaultSuperUserSecretHash,
 		}, &hashedSecret); err != nil {
 			s.logger.Error(err, "Failed to query for the secret")
 			http.Error(rw, "Please ensure that a password has been set.", http.StatusBadRequest)

--- a/tools/dev-manifests/helm_watcher_role.yaml
+++ b/tools/dev-manifests/helm_watcher_role.yaml
@@ -1,0 +1,17 @@
+# This is for profiles. I will work out what is really
+# needed here, for now I have just set everything to get
+# it to shut up.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: wego-helm-watcher-role
+rules:
+  - apiGroups: [ "source.toolkit.fluxcd.io" ]
+    resources: [ "helmrepositories"]
+    verbs: [ "get", "list", "watch", "patch", "update" ]
+  - apiGroups: [ "source.toolkit.fluxcd.io" ]
+    resources: [ "helmrepositories/finalizers" ]
+    verbs: [ "create", "delete", "get", "patch", "update" ]
+  - apiGroups: [ "source.toolkit.fluxcd.io" ]
+    resources: [ "helmrepositories/status"]
+    verbs: [ "get" ]

--- a/tools/dev-manifests/helm_watcher_role_binding.yaml
+++ b/tools/dev-manifests/helm_watcher_role_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: wego-helm-watcher-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: wego-helm-watcher-role
+subjects:
+  - kind: ServiceAccount
+    name: wego-app-service-account
+    namespace: flux-system

--- a/tools/dev-manifests/role-binding.yaml
+++ b/tools/dev-manifests/role-binding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: read-resources
+  namespace: flux-system
+subjects:
+  - kind: ServiceAccount
+    name: wego-app-service-account
+    namespace: flux-system
+roleRef:
+  kind: Role
+  name: resources-reader
+  apiGroup: rbac.authorization.k8s.io

--- a/tools/dev-manifests/role.yaml
+++ b/tools/dev-manifests/role.yaml
@@ -1,0 +1,21 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: resources-reader
+  namespace: flux-system
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: [ "get", "list" ]
+  - apiGroups: ["apps"]
+    resources: [ "deployments" ]
+    verbs: [ "list", "get" ]
+  - apiGroups: ["kustomize.toolkit.fluxcd.io"]
+    resources: [ "kustomizations" ]
+    verbs: [ "*" ]
+  - apiGroups: ["helm.toolkit.fluxcd.io"]
+    resources: [ "helmreleases" ]
+    verbs: [ "*" ]
+  - apiGroups: ["source.toolkit.fluxcd.io"]
+    resources: [ "buckets", "helmcharts", "gitrepositories", "helmrepositories" ]
+    verbs: [ "*" ]

--- a/tools/dev-manifests/service-account.yaml
+++ b/tools/dev-manifests/service-account.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: wego-app-service-account
+  namespace: flux-system
+secrets:
+  - name: wego-app-service-account-token

--- a/tools/dev-manifests/wego-app.yaml
+++ b/tools/dev-manifests/wego-app.yaml
@@ -15,11 +15,16 @@ spec:
       containers:
         - name: wego-app
           image: localhost:5001/weaveworks/wego-app:latest
-          args: ["-l", "--helm-repo-namespace", "wego-system"]
+          args: ["-l", "--helm-repo-namespace", "flux-system"]
           ports:
             - containerPort: 9001
               protocol: TCP
           imagePullPolicy: IfNotPresent
+          env:
+            # this is disabled for local development
+            # make true if testing that feature
+            # - name: WEAVE_GITOPS_AUTH_ENABLED
+            #   value: "true"
   selector:
     matchLabels:
       app: wego-app


### PR DESCRIPTION
This is not a "finished product", I am simply doing the bare minimum to
unblock people and make life easier while I tidy some things up.

Here I am just adding some more manifests to the `Tiltfile`; I have
stashed these in `tools/dev-manifests` for now, but this may change.
Either way people will not notice as they are just running `make
cluster-dev`.

The manifests under `manifests/wego-dev` are technically out of use as
we move onto a Helm Chart install flow, but I am leaving them there for
now as I tinker, plus I know other people are working on the Helm bit so
I am staying out of their way.

I have also left the SuperUser and the "stripping out the service
account" bit for now, as they do not need to be in place to unblock
people. They are next on my list.

Closes https://github.com/weaveworks/weave-gitops/issues/1594