### PR TITLE
fix: incorrect interval reported on the Sources list page

### DIFF
--- a/.proxyrc
+++ b/.proxyrc
@@ -3,6 +3,6 @@
     "target": "http://localhost:9000/",
   }, 
   "/oauth2": {
-    "target": "http://localhost:9000 /"
+    "target": "http://localhost:9000/"
   },
 }

--- a/core/server/types/gitrepository.go
+++ b/core/server/types/gitrepository.go
@@ -57,8 +57,8 @@ func GitRepositoryToProto(repository *v1beta1.GitRepository) *pb.GitRepository {
 		},
 		Interval: &pb.Interval{
 			Hours:   int64(repository.Spec.Interval.Hours()),
-			Minutes: int64(repository.Spec.Interval.Minutes()),
-			Seconds: int64(repository.Spec.Interval.Seconds()),
+			Minutes: int64(repository.Spec.Interval.Minutes()) % 60,
+			Seconds: int64(repository.Spec.Interval.Seconds()) % 60,
 		},
 		Conditions: mapConditions(repository.Status.Conditions),
 	}

--- a/core/server/types/helmrepository.go
+++ b/core/server/types/helmrepository.go
@@ -29,13 +29,17 @@ func ProtoToHelmRepository(hr *pb.HelmRepository) v1beta1.HelmRepository {
 }
 
 func HelmRepositoryToProto(helmRepository *v1beta1.HelmRepository) *pb.HelmRepository {
+	interval := &pb.Interval{
+		Hours:   int64(helmRepository.Spec.Interval.Hours()),
+		Minutes: int64(helmRepository.Spec.Interval.Minutes()) % 60,
+		Seconds: int64(helmRepository.Spec.Interval.Seconds()) % 60,
+	}
+
 	return &pb.HelmRepository{
-		Name:      helmRepository.Name,
-		Namespace: helmRepository.Namespace,
-		Url:       helmRepository.Spec.URL,
-		Interval: &pb.Interval{
-			Minutes: 1,
-		},
+		Name:       helmRepository.Name,
+		Namespace:  helmRepository.Namespace,
+		Url:        helmRepository.Spec.URL,
+		Interval:   interval,
 		Conditions: mapConditions(helmRepository.Status.Conditions),
 	}
 }

--- a/ui/components/Interval.tsx
+++ b/ui/components/Interval.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import styled from "styled-components";
 import { Interval as IntervalType } from "../lib/api/core/types.pb";
+import { showInterval } from "../lib/time" 
 
 type Props = {
   className?: string;
@@ -10,7 +11,7 @@ type Props = {
 function Interval({ className, interval }: Props) {
   return (
     <span className={className}>
-      {interval.hours}h {interval.minutes}m
+      {showInterval(interval)}
     </span>
   );
 }

--- a/ui/components/SourcesTable.tsx
+++ b/ui/components/SourcesTable.tsx
@@ -9,6 +9,7 @@ import {
 import { formatURL, sourceTypeToRoute } from "../lib/nav";
 import { Source } from "../lib/types";
 import { convertGitURLToGitProvider } from "../lib/utils";
+import { showInterval } from "../lib/time";
 import DataTable, { SortType } from "./DataTable";
 import Flex from "./Flex";
 import KubeStatusIndicator from "./KubeStatusIndicator";
@@ -102,8 +103,7 @@ function SourcesTable({ className, sources }: Props) {
           },
           {
             label: "Interval",
-            value: (s: Source) =>
-              `${s.interval.hours}h${s.interval.minutes}m${s.interval.seconds}s`,
+            value: (s: Source) => showInterval(s.interval)
           },
         ]}
       />

--- a/ui/lib/time.ts
+++ b/ui/lib/time.ts
@@ -1,0 +1,24 @@
+import { Interval } from "./api/core/types.pb";
+
+export function showInterval(interval: Interval): string {
+  const parts = [];
+
+  if (interval.hours !== "0") {
+    parts.push(`${interval.hours}h`);
+  }
+
+  if (interval.minutes !== "0" || parts.length > 0) {
+    // Show minutes we have Hour, but minute is zero.
+    // For example: 1h 0m 23s
+    // It's easier to read, without it, it's easy to misread the
+    // value "1h 23s" as "1m 23s"
+    parts.push(`${interval.minutes}m`);
+  }
+
+  if (interval.seconds !== "0" || parts.length > 0) {
+    // Same as minute.
+    parts.push(`${interval.seconds}s`);
+  }
+
+  return parts.join(" ");
+}


### PR DESCRIPTION
**UI**

* Utility function to convert `interval` to string, that way we have to
  change only in one place if we want to change the format.

**Back-end**

* Fix interval calculation on `HelmRepository` and `GitRepository`.
  The issues was: `.Minutes()` and `.Seconds()` return with the value of
  the whole interval, not just the minutes/seconds parts.

Closes: #1589