### PR TITLE
ui: Port graph + tests away from using Applications types

### DIFF
--- a/ui/lib/__tests__/graph.test.ts
+++ b/ui/lib/__tests__/graph.test.ts
@@ -1,7 +1,6 @@
 import _ from "lodash";
-import { Core } from "../api/core/core.pb";
 import { getChildren } from "../graph";
-import { createMockClient } from "../test-utils";
+import { createCoreMockClient } from "../test-utils";
 
 describe("graph lib", () => {
   it("getChildren", async () => {
@@ -15,7 +14,7 @@ describe("graph lib", () => {
     const name = "stringly";
     const rsName = name + "-7d9b7454c7";
     const podName = rsName + "-mvz75";
-    const client = createMockClient({
+    const client = createCoreMockClient({
       GetReconciledObjects: () => {
         return {
           objects: [
@@ -73,8 +72,7 @@ describe("graph lib", () => {
     });
 
     const objects = await getChildren(
-      // @ts-ignore
-      client as typeof Core,
+      client,
       app.name,
       app.namespace,
       [{ group: "apps", version: "v1", kind: "Deployment" }]

--- a/ui/lib/graph.ts
+++ b/ui/lib/graph.ts
@@ -4,7 +4,7 @@ import _ from "lodash";
 import {
   GroupVersionKind,
   UnstructuredObject,
-} from "./api/applications/applications.pb";
+} from "./api/core/types.pb";
 import { Core } from "./api/core/core.pb";
 
 export type UnstructuredObjectWithParent = UnstructuredObject & {


### PR DESCRIPTION
We've moved the endpoints required to render the graph to the core
proto, however two things hadn't been moved:

Graph was still using some type definitions from applications. This is
an easy fix of just changing the import.

The graph tests were using the plain Application mock, because that's
the only client mock we have. This copy-pastes the mock setup code so
that we can mock Core or Application.

Doing this will allow me to delete both the endpoints and their                 
types from the Applications proto.

This commit is intended to establish a pattern, not finish the work -
    subsequent endpoints will be moved in the same commit that deletes the
    endpoint in question.