### PR TITLE
Unset page width and affix nav bar to left

### DIFF
--- a/ui/components/AutomationsTable.tsx
+++ b/ui/components/AutomationsTable.tsx
@@ -7,7 +7,10 @@ import DataTable, { SortType } from "./DataTable";
 import FilterableTable, { filterConfigForType } from "./FilterableTable";
 import FilterDialogButton from "./FilterDialogButton";
 import Flex from "./Flex";
-import KubeStatusIndicator, { computeReady } from "./KubeStatusIndicator";
+import KubeStatusIndicator, {
+  computeMessage,
+  computeReady,
+} from "./KubeStatusIndicator";
 import Link from "./Link";
 
 type Props = {
@@ -65,10 +68,15 @@ function AutomationsTable({ className, automations }: Props) {
       label: "Status",
       value: (a: Automation) =>
         a.conditions.length > 0 ? (
-          <KubeStatusIndicator conditions={a.conditions} />
+          <KubeStatusIndicator short conditions={a.conditions} />
         ) : null,
       sortType: SortType.bool,
       sortValue: ({ conditions }) => computeReady(conditions),
+      width: 64,
+    },
+    {
+      label: "Message",
+      value: (a: Automation) => computeMessage(a.conditions),
       width: 360,
     },
     {

--- a/ui/components/AutomationsTable.tsx
+++ b/ui/components/AutomationsTable.tsx
@@ -33,7 +33,7 @@ function AutomationsTable({ className, automations }: Props) {
         const route =
           k.type === AutomationType.Kustomization
             ? V2Routes.Kustomization
-            : V2Routes.HelmRepo;
+            : V2Routes.HelmRelease;
         return (
           <Link
             to={formatURL(route, {

--- a/ui/components/DataTable.tsx
+++ b/ui/components/DataTable.tsx
@@ -168,10 +168,7 @@ function UnstyledDataTable({
           <TableHead>
             <TableRow>
               {_.map(fields, (f) => (
-                <TableCell
-                  style={f.width && { maxWidth: f.width }}
-                  key={f.label}
-                >
+                <TableCell style={f.width && { width: f.width }} key={f.label}>
                   <SortableLabel field={f} />
                 </TableCell>
               ))}
@@ -221,6 +218,8 @@ export const DataTable = styled(UnstyledDataTable)`
   }
 
   td {
+    word-break: break-all;
+    word-wrap: break-word;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/ui/components/KubeStatusIndicator.tsx
+++ b/ui/components/KubeStatusIndicator.tsx
@@ -9,6 +9,7 @@ import Text from "./Text";
 type Props = {
   className?: string;
   conditions: Condition[];
+  short?: boolean;
 };
 
 export function computeReady(conditions: Condition[]): boolean {
@@ -26,15 +27,17 @@ export function computeMessage(conditions: Condition[]) {
   return readyCondition.message;
 }
 
-function KubeStatusIndicator({ className, conditions }: Props) {
+function KubeStatusIndicator({ className, conditions, short }: Props) {
   const ready = computeReady(conditions);
-  const readyText = ready ? "Ready" : computeMessage(conditions);
+  const readyText = ready ? "Ready" : "Not Ready";
   const icon =
     readyText === "Ready" ? IconType.SuccessIcon : IconType.FailedIcon;
 
+  const message = computeMessage(conditions);
+
   return (
     <Flex start className={className} align>
-      <Icon size="base" type={icon} text={readyText} />
+      <Icon size="base" type={icon} text={short ? readyText : message} />
     </Flex>
   );
 }

--- a/ui/components/KubeStatusIndicator.tsx
+++ b/ui/components/KubeStatusIndicator.tsx
@@ -30,8 +30,7 @@ export function computeMessage(conditions: Condition[]) {
 function KubeStatusIndicator({ className, conditions, short }: Props) {
   const ready = computeReady(conditions);
   const readyText = ready ? "Ready" : "Not Ready";
-  const icon =
-    readyText === "Ready" ? IconType.SuccessIcon : IconType.FailedIcon;
+  const icon = ready ? IconType.SuccessIcon : IconType.FailedIcon;
 
   const message = computeMessage(conditions);
 

--- a/ui/components/Layout.tsx
+++ b/ui/components/Layout.tsx
@@ -122,7 +122,6 @@ const NavContent = styled.div`
 
 const ContentContainer = styled.div`
   width: 100%;
-  /* min-height: 100vh; */
   padding-top: ${(props) => props.theme.spacing.medium};
   padding-bottom: ${(props) => props.theme.spacing.medium};
   padding-right: ${(props) => props.theme.spacing.medium};

--- a/ui/components/Layout.tsx
+++ b/ui/components/Layout.tsx
@@ -58,22 +58,33 @@ const StyleLinkTab = styled(LinkTab)`
 
 const AppContainer = styled.div`
   width: 100%;
-  overflow-x: hidden;
+  overflow: hidden;
   height: 100%;
   margin: 0 auto;
   padding: 0;
 `;
 
 const NavContainer = styled.div`
+  position: relative;
   width: 240px;
+  height: 0;
   min-height: 100%;
   margin-top: ${(props) => props.theme.spacing.medium};
+  margin-right: ${(props) => props.theme.spacing.medium};
   background-color: ${(props) => props.theme.colors.neutral00};
   border-radius: 10px;
 `;
 
+const FixedNav = styled.div`
+  background-color: white;
+  position: fixed;
+  height: 100%;
+  top: 80;
+  width: 240px;
+  left: 0;
+`;
+
 const NavContent = styled.div`
-  min-height: 100%;
   padding-top: ${(props) => props.theme.spacing.medium};
   padding-left: ${(props) => props.theme.spacing.xs};
   .MuiTab-textColorInherit {
@@ -111,7 +122,7 @@ const NavContent = styled.div`
 
 const ContentContainer = styled.div`
   width: 100%;
-  min-height: 100vh;
+  /* min-height: 100vh; */
   padding-top: ${(props) => props.theme.spacing.medium};
   padding-bottom: ${(props) => props.theme.spacing.medium};
   padding-right: ${(props) => props.theme.spacing.medium};
@@ -151,25 +162,27 @@ function Layout({ className, children }: Props) {
         </TopToolBar>
         <Main wide>
           <NavContainer>
-            <NavContent>
-              <Tabs
-                centered={false}
-                orientation="vertical"
-                value={getParentNavValue(currentPage)}
-              >
-                {_.map(navItems, (n) => (
-                  <StyleLinkTab
-                    key={n.label}
-                    label={n.label}
-                    to={formatURL(n.value)}
-                    value={n.value}
-                    className={n.sub && "sub-item"}
-                    href={n.href}
-                    newTab={n.newTab}
-                  />
-                ))}
-              </Tabs>
-            </NavContent>
+            <FixedNav>
+              <NavContent>
+                <Tabs
+                  centered={false}
+                  orientation="vertical"
+                  value={getParentNavValue(currentPage)}
+                >
+                  {_.map(navItems, (n) => (
+                    <StyleLinkTab
+                      key={n.label}
+                      label={n.label}
+                      to={formatURL(n.value)}
+                      value={n.value}
+                      className={n.sub && "sub-item"}
+                      href={n.href}
+                      newTab={n.newTab}
+                    />
+                  ))}
+                </Tabs>
+              </NavContent>
+            </FixedNav>
           </NavContainer>
           <ContentContainer>{children}</ContentContainer>
         </Main>

--- a/ui/components/Page.tsx
+++ b/ui/components/Page.tsx
@@ -20,26 +20,25 @@ export type PageProps = {
 };
 
 export const Content = styled.div`
-  margin: 0 auto;
-  width: 100%;
-  min-width: 1260px;
-  box-sizing: border-box;
   background-color: rgba(255, 255, 255, 0.75);
-  padding-left: ${(props) => props.theme.spacing.large};
-
-  padding-top: ${(props) => props.theme.spacing.large};
-  padding-bottom: ${(props) => props.theme.spacing.medium};
   border-radius: 10px;
+  box-sizing: border-box;
+  margin: 0 auto;
+  min-width: 1260px;
+  padding-bottom: ${(props) => props.theme.spacing.medium};
+  padding-left: ${(props) => props.theme.spacing.large};
+  padding-top: ${(props) => props.theme.spacing.large};
+  width: 100%;
 `;
 
 const Children = styled.div``;
 
 export const TitleBar = styled.div`
-  display: flex;
-  width: 100%;
-  justify-content: space-between;
   align-items: center;
+  display: flex;
+  justify-content: space-between;
   margin-bottom: ${(props) => props.theme.spacing.small};
+  width: 100%;
 
   h2 {
     margin: 0 !important;

--- a/ui/components/Page.tsx
+++ b/ui/components/Page.tsx
@@ -20,15 +20,13 @@ export type PageProps = {
 };
 
 export const Content = styled.div`
-  min-height: 85vh;
-  max-width: 1400px;
   margin: 0 auto;
   width: 100%;
   min-width: 1260px;
   box-sizing: border-box;
   background-color: rgba(255, 255, 255, 0.75);
   padding-left: ${(props) => props.theme.spacing.large};
-  padding-right: ${(props) => props.theme.spacing.large};
+
   padding-top: ${(props) => props.theme.spacing.large};
   padding-bottom: ${(props) => props.theme.spacing.medium};
   border-radius: 10px;
@@ -97,7 +95,6 @@ function Page({
 }
 
 export default styled(Page)`
-  min-height: 1216px;
   .MuiAlert-root {
     width: 100%;
   }

--- a/ui/components/SourceDetail.tsx
+++ b/ui/components/SourceDetail.tsx
@@ -33,6 +33,16 @@ function SourceDetail({ className, name, info }: Props) {
 
   const s = _.find(sources, { name });
 
+  if (!s) {
+    return (
+      <Alert
+        severity="error"
+        title="Not found"
+        message={`Could not find source '${name}'`}
+      />
+    );
+  }
+
   const items = info(s);
 
   const relevantAutomations = _.filter(automations, (a) => {

--- a/ui/components/SourcesTable.tsx
+++ b/ui/components/SourcesTable.tsx
@@ -14,9 +14,8 @@ import { SortType } from "./DataTable";
 import FilterableTable, { filterConfigForType } from "./FilterableTable";
 import FilterDialogButton from "./FilterDialogButton";
 import Flex from "./Flex";
-import KubeStatusIndicator from "./KubeStatusIndicator";
+import KubeStatusIndicator, { computeMessage } from "./KubeStatusIndicator";
 import Link from "./Link";
-import Text from "./Text";
 
 type Props = {
   className?: string;
@@ -60,14 +59,20 @@ function SourcesTable({ className, sources }: Props) {
             ),
             sortType: SortType.string,
             sortValue: (s: Source) => s.name || "",
-            width: 64,
+            width: 96,
           },
-          { label: "Type", value: "type" },
+          { label: "Type", value: "type", width: 96 },
           {
             label: "Status",
             value: (s: Source) => (
-              <KubeStatusIndicator conditions={s.conditions} />
+              <KubeStatusIndicator short conditions={s.conditions} />
             ),
+            width: 96,
+          },
+          {
+            label: "Message",
+            value: (s) => computeMessage(s.conditions),
+
             width: statusWidth,
           },
           {
@@ -102,7 +107,7 @@ function SourcesTable({ className, sources }: Props) {
                 text
               );
             },
-            width: 96,
+            width: 240,
           },
           {
             label: "Reference",
@@ -131,11 +136,7 @@ function SourcesTable({ className, sources }: Props) {
 }
 
 export default styled(SourcesTable).attrs({ className: SourcesTable.name })`
-  /* Setting this here to get the ellipsis to work */
-  /* Because this is a div within a td, overflow doesn't apply to the td */
-  ${KubeStatusIndicator} ${Flex} ${Text} {
-    max-width: ${statusWidth}px;
-    overflow: hidden;
-    text-overflow: ellipsis;
+  table {
+    table-layout: fixed;
   }
 `;

--- a/ui/components/SourcesTable.tsx
+++ b/ui/components/SourcesTable.tsx
@@ -7,10 +7,10 @@ import {
   SourceRefSourceKind,
 } from "../lib/api/core/types.pb";
 import { formatURL, sourceTypeToRoute } from "../lib/nav";
+import { showInterval } from "../lib/time";
 import { Source } from "../lib/types";
 import { convertGitURLToGitProvider } from "../lib/utils";
-import { showInterval } from "../lib/time";
-import DataTable, { SortType } from "./DataTable";
+import { SortType } from "./DataTable";
 import FilterableTable, { filterConfigForType } from "./FilterableTable";
 import FilterDialogButton from "./FilterDialogButton";
 import Flex from "./Flex";
@@ -24,7 +24,7 @@ type Props = {
   appName?: string;
 };
 
-const statusWidth = 480;
+const statusWidth = 340;
 
 function SourcesTable({ className, sources }: Props) {
   const [filterDialogOpen, setFilterDialog] = React.useState(false);
@@ -60,10 +60,9 @@ function SourcesTable({ className, sources }: Props) {
             ),
             sortType: SortType.string,
             sortValue: (s: Source) => s.name || "",
-            width: 100,
+            width: 64,
           },
           { label: "Type", value: "type" },
-
           {
             label: "Status",
             value: (s: Source) => (
@@ -74,6 +73,7 @@ function SourcesTable({ className, sources }: Props) {
           {
             label: "Cluster",
             value: "cluster",
+            width: 96,
           },
           {
             label: "URL",
@@ -102,6 +102,7 @@ function SourcesTable({ className, sources }: Props) {
                 text
               );
             },
+            width: 96,
           },
           {
             label: "Reference",
@@ -116,10 +117,12 @@ function SourcesTable({ className, sources }: Props) {
 
               return isGit ? ref : "-";
             },
+            width: 96,
           },
           {
             label: "Interval",
-            value: (s: Source) => showInterval(s.interval)
+            value: (s: Source) => showInterval(s.interval),
+            width: 96,
           },
         ]}
       />
@@ -134,9 +137,5 @@ export default styled(SourcesTable).attrs({ className: SourcesTable.name })`
     max-width: ${statusWidth}px;
     overflow: hidden;
     text-overflow: ellipsis;
-  }
-
-  ${DataTable} table {
-    table-layout: fixed;
   }
 `;

--- a/ui/components/__tests__/KubeStatusIndicator.test.tsx
+++ b/ui/components/__tests__/KubeStatusIndicator.test.tsx
@@ -19,6 +19,22 @@ describe("KubeStatusIndicator", () => {
     ];
     render(withTheme(<KubeStatusIndicator conditions={conditions} />));
 
+    const msg = screen.getByText(conditions[0].message);
+    expect(msg).toBeTruthy();
+  });
+  it("renders ready - short", () => {
+    const conditions = [
+      {
+        type: "Ready",
+        status: "True",
+        reason: "ReconciliationSucceeded",
+        message:
+          "Applied revision: main/a3a54ef4a87f8963b14915639f032aa6ec1b8161",
+        timestamp: "2022-03-03 17:00:38 +0000 UTC",
+      },
+    ];
+    render(withTheme(<KubeStatusIndicator short conditions={conditions} />));
+
     const ready = screen.getByText("Ready");
     expect(ready).toBeTruthy();
   });

--- a/ui/components/__tests__/__snapshots__/DataTable.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/DataTable.test.tsx.snap
@@ -123,6 +123,8 @@ exports[`DataTable snapshots renders 1`] = `
 }
 
 .c0 td {
+  word-break: break-all;
+  word-wrap: break-word;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/ui/components/__tests__/__snapshots__/KubeStatusIndicator.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/KubeStatusIndicator.test.tsx.snap
@@ -176,7 +176,7 @@ exports[`KubeStatusIndicator snapshots renders success 1`] = `
       className="c5 c6"
       size="normal"
     >
-      Ready
+      Applied revision: main/a3a54ef4a87f8963b14915639f032aa6ec1b8161
     </span>
   </div>
 </div>

--- a/ui/components/__tests__/__snapshots__/Page.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/Page.test.tsx.snap
@@ -53,44 +53,37 @@ exports[`Page snapshots default 1`] = `
 }
 
 .c1 {
-  min-height: 85vh;
-  max-width: 1400px;
-  margin: 0 auto;
-  width: 100%;
-  min-width: 1260px;
-  box-sizing: border-box;
   background-color: rgba(255,255,255,0.75);
-  padding-left: 32px;
-  padding-right: 32px;
-  padding-top: 32px;
-  padding-bottom: 24px;
   border-radius: 10px;
+  box-sizing: border-box;
+  margin: 0 auto;
+  min-width: 1260px;
+  padding-bottom: 24px;
+  padding-left: 32px;
+  padding-top: 32px;
+  width: 100%;
 }
 
 .c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  width: 100%;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   margin-bottom: 12px;
+  width: 100%;
 }
 
 .c2 h2 {
   margin: 0 !important;
   color: #1a1a1a !important;
-}
-
-.c0 {
-  min-height: 1216px;
 }
 
 .c0 .MuiAlert-root {


### PR DESCRIPTION
Closes #1577 
Closes #1527 

Sets the page-width free for larger monitors and fixes the underlying table-cell overflow problem with `KubeStatusIndicator`:
![Screenshot from 2022-03-07 15-25-30](https://user-images.githubusercontent.com/2802257/157135306-9f8b02d2-69b1-42a7-a96c-8130398b463d.png)

