### PR TITLE
Push to images to google as CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,5 @@ node_modules
 dist
 pkg/flux/bin/flux
 cmd/gitops-server/cmd/dist
+# Ignore generated credentials from google-github-actions/auth
+gha-creds-*.json

--- a/.github/workflows/v2.yml
+++ b/.github/workflows/v2.yml
@@ -9,6 +9,10 @@ on:
       - v2
   workflow_dispatch:
 
+env:
+  CI_CONTAINER_REGISTRY: europe-west1-docker.pkg.dev
+  CI_CONTAINER_REPOSITORY: europe-west1-docker.pkg.dev/weave-gitops-clusters/weave-gitops
+
 name: V2 CI Workflow
 jobs:
   ci-js:
@@ -70,7 +74,6 @@ jobs:
       - run: make unit-tests
       # - run: make lib-test
 
-
   ci-static:
     name: V2 CI Check Static Checks
     runs-on: ubuntu-latest
@@ -93,10 +96,26 @@ jobs:
       - name: Check that fakes are updated
         run: git diff --no-ext-diff --exit-code
 
-
   full-ci:
     name: V2 CI Check (16.13.2, 1.17.5)
     runs-on: ubuntu-latest
     needs: [ci-go, ci-static, ci-js]
+    permissions:
+      contents: 'read'
+      id-token: 'write'
     steps:
+      - uses: actions/checkout@v3
+
+      - name: Authenticate to Google Cloud
+        id: gcloud-auth
+        uses: google-github-actions/auth@v0
+        with:
+          workload_identity_provider: ${{ secrets.workload_identity_provider }}
+          service_account: ${{ secrets.service_account }}
+      - uses: google-github-actions/setup-gcloud@v0
+      - run: gcloud --quiet auth configure-docker ${{ env.CI_CONTAINER_REGISTRY }}
+      - run: make dependencies
+      - name: Build & push docker iamges to Google
+        run: DOCKER_REGISTRY=${{ env.CI_CONTAINER_REPOSITORY }} make docker-image-push
+
       - run: echo "All done"

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ tilt_modules
 
 localhost-key.pem
 localhost.pem
+
+# Ignore generated credentials from google-github-actions/auth
+gha-creds-*.json

--- a/gitops-server.dockerfile
+++ b/gitops-server.dockerfile
@@ -12,6 +12,9 @@ RUN make ui
 
 # Go build
 FROM golang:1.17 AS go-build
+# Expect to be passed these by running this via `make docker-gitops` so we don't copy all of .git/
+ARG LDFLAGS="-X localbuild=true"
+ARG GIT_COMMIT="_unset_"
 
 # Add known_hosts entries for GitHub and GitLab
 RUN mkdir ~/.ssh
@@ -25,7 +28,7 @@ RUN go mod download
 COPY --from=ui /home/app/cmd/gitops-server/cmd/dist/ /app/cmd/gitops-server/cmd/dist/
 COPY . /app
 # ignore the index.html dependency (which it otherwise would because node_modules is missing)
-RUN make -o cmd/gitops-server/cmd/dist/index.html gitops-server
+RUN LDFLAGS=$LDFLAGS GIT_COMMIT=$GIT_COMMIT make -o cmd/gitops-server/cmd/dist/index.html gitops-server
 
 #  Distroless
 FROM gcr.io/distroless/base as runtime

--- a/gitops.dockerfile
+++ b/gitops.dockerfile
@@ -6,6 +6,10 @@ FROM $FLUX_CLI as flux
 
 # Go build
 FROM golang:1.17 AS go-build
+# Expect to be passed these by running this via `make docker-gitops` so we don't copy all of .git/
+ARG LDFLAGS="-X localbuild=true"
+ARG GIT_COMMIT="_unset_"
+
 # Add known_hosts entries for GitHub and GitLab
 RUN mkdir ~/.ssh
 RUN ssh-keyscan github.com >> ~/.ssh/known_hosts
@@ -17,7 +21,7 @@ WORKDIR /app
 COPY go.* /app/
 RUN go mod download
 COPY . /app
-RUN make gitops
+RUN LDFLAGS=$LDFLAGS GIT_COMMIT=$GIT_COMMIT make gitops
 
 # Distroless
 FROM gcr.io/distroless/base as runtime

--- a/gitops.dockerfile
+++ b/gitops.dockerfile
@@ -6,9 +6,6 @@ FROM $FLUX_CLI as flux
 
 # Go build
 FROM golang:1.17 AS go-build
-# Expect to be passed these by running this via `make docker-gitops` so we don't copy all of .git/
-ARG LDFLAGS="-X localbuild=true"
-ARG GIT_COMMIT="_unset_"
 
 # Add known_hosts entries for GitHub and GitLab
 RUN mkdir ~/.ssh
@@ -21,6 +18,13 @@ WORKDIR /app
 COPY go.* /app/
 RUN go mod download
 COPY . /app
+
+# These are ARGS are defined here to minimise cache misses
+# (cf. https://docs.docker.com/engine/reference/builder/#impact-on-build-caching)
+# Pass these flags so we don't have to copy .git/ for those commands to work
+ARG LDFLAGS="-X localbuild=true"
+ARG GIT_COMMIT="_unset_"
+
 RUN LDFLAGS=$LDFLAGS GIT_COMMIT=$GIT_COMMIT make gitops
 
 # Distroless


### PR DESCRIPTION
**What changed?**

Push the CI images to a private google container registry for staging purposes (part of #1611)

**Why?**

Make images available to staging clusters without polluting our release registry.

**How did you test it?**

The make file changes have been manually tested and the GHA changes will be tested as part of this PR

Images are visible in the Google registry:

* https://console.cloud.google.com/artifacts/docker/weave-gitops-clusters/europe-west1/weave-gitops/gitops?project=weave-gitops-clusters
* https://console.cloud.google.com/artifacts/docker/weave-gitops-clusters/europe-west1/weave-gitops/gitops-server?project=weave-gitops-clusters
