### PR TITLE
Fix Crash on Sort By Message

### DIFF
--- a/ui/components/KubeStatusIndicator.tsx
+++ b/ui/components/KubeStatusIndicator.tsx
@@ -22,8 +22,10 @@ export function computeReady(conditions: Condition[]): boolean {
 }
 
 export function computeMessage(conditions: Condition[]) {
-  const readyCondition = _.find(conditions, (c) => c.type === "Ready");
-
+  const readyCondition =
+    _.find(conditions, { type: "Ready" }) ||
+    // see above
+    _.find(conditions, { type: "Available" });
   return readyCondition.message;
 }
 


### PR DESCRIPTION
Closes: #1591 

Adds the `Available` type back into the computeMessage function!

![image](https://user-images.githubusercontent.com/65822698/157325256-96dffb33-6485-4bc6-816f-6dd33862ac2b.png)
