### PR TITLE
fix: Check for Available condition's message

### DIFF
--- a/ui/components/KubeStatusIndicator.tsx
+++ b/ui/components/KubeStatusIndicator.tsx
@@ -18,11 +18,14 @@ export function computeReady(conditions: Condition[]): boolean {
     // Deployment conditions work slightly differently;
     // they show "Available" instead of 'Ready'
     _.find(conditions, { type: "Available" });
+
   return ready?.status == "True";
 }
 
 export function computeMessage(conditions: Condition[]) {
-  const readyCondition = _.find(conditions, (c) => c.type === "Ready");
+  const readyCondition =
+    _.find(conditions, (c) => c.type === "Ready") ||
+    _.find(conditions, (c) => c.type === "Available");
 
   return readyCondition.message;
 }
@@ -31,7 +34,6 @@ function KubeStatusIndicator({ className, conditions, short }: Props) {
   const ready = computeReady(conditions);
   const readyText = ready ? "Ready" : "Not Ready";
   const icon = ready ? IconType.SuccessIcon : IconType.FailedIcon;
-
   const message = computeMessage(conditions);
 
   return (

--- a/ui/components/__tests__/KubeStatusIndicator.test.tsx
+++ b/ui/components/__tests__/KubeStatusIndicator.test.tsx
@@ -22,6 +22,22 @@ describe("KubeStatusIndicator", () => {
     const msg = screen.getByText(conditions[0].message);
     expect(msg).toBeTruthy();
   });
+  it("renders when available", () => {
+    const conditions = [
+      {
+        type: "Available",
+        status: "True",
+        reason: "ReconciliationSucceeded",
+        message:
+          "Applied revision: main/a3a54ef4a87f8963b14915639f032aa6ec1b8161",
+        timestamp: "2022-03-03 17:00:38 +0000 UTC",
+      },
+    ];
+    render(withTheme(<KubeStatusIndicator conditions={conditions} />));
+
+    const msg = screen.getByText(conditions[0].message);
+    expect(msg).toBeTruthy();
+  });
   it("renders ready - short", () => {
     const conditions = [
       {


### PR DESCRIPTION
## I just had some spare time and thought I would play around, please close if it is garbage 😄 

<!-- Use # to add the issue this pull request is related to -->
Closes https://github.com/weaveworks/weave-gitops/issues/1642

<!-- Describe what has changed in this PR -->
The `computeMessage` was returning nothing for Flux runtime objects
since those have `Available` conditions, not `Ready` ones. This PR
updates that.



<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**
Manually clocking the UI.
I also added a UI test, but I never got a clean run of those here so not sure if it actually works


**Random thought on UX:**

The `KubeStatusIndicator` takes a `short` bool, but would it make sense to have the `short` be set internally based on the value of `ready`? If the value is `False` (ie the pod is failing) then the message computed for that row will be shown in long-form (per [this](https://github.com/weaveworks/weave-gitops/blob/v2/ui/components/KubeStatusIndicator.tsx#L39)), with all the still `Ready` lines keeping it nice and short. Do we care about the message at all if the pod is running fine?