### PR TITLE
docs: Fix old docs repo links in Website

### DIFF
--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -2,7 +2,7 @@
 
 The current release process for weave gitops is fairly straightforward. You need to:
 - Create the actual release
-- Update the `weave-gitops-docs` repository with documentation for the new version
+- Update the [website](/website) with documentation for the new version
 - Update the `CLI Installation` section of the `README.md` in the `weave-gitops` repository to reference the new version
 - Add a record of the new version in the checkpoint system
 
@@ -25,7 +25,7 @@ The current release process for weave gitops is fairly straightforward. You need
 
 The go-releaser will spin for a bit, generating a changelog and artifacts.
 
-# Updating weave-gitops-docs
+# Updating the website
 - Approve and merge the auto-generated PR if the release is declared satisfactory; otherwise, close the PR
 
 # Updating the README

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -9,7 +9,7 @@ module.exports = {
   onBrokenMarkdownLinks: "warn",
   favicon: "img/favicon_150px.png",
   organizationName: "weaveworks", // Usually your GitHub org/user name.
-  projectName: "weave-gitops-docs", // Usually your repo name.
+  projectName: "weave-gitops", // Usually your repo name.
   plugins: [
     () => ({
       // Load yaml files as blobs
@@ -110,7 +110,7 @@ module.exports = {
         docs: {
           sidebarPath: require.resolve("./sidebars.js"),
           // Please change this to your repo.
-          editUrl: "https://github.com/weaveworks/weave-gitops-docs/edit/main/",
+          editUrl: "https://github.com/weaveworks/weave-gitops/edit/main/website",
           lastVersion: versions[0],
           versions: {
             current: {
@@ -122,7 +122,7 @@ module.exports = {
           showReadingTime: true,
           // Please change this to your repo.
           editUrl:
-            "https://github.com/weaveworks/weave-gitops-docs/edit/main/blog/",
+            "https://github.com/weaveworks/weave-gitops/edit/main/website/blog",
         },
         theme: {
           customCss: require.resolve("./src/css/custom.css"),


### PR DESCRIPTION
- The 'Edit this page' link should now point to here.
- There is a Blog link as well, but I don't think we have a blog page
  :shrug_emoji:.

<!-- Use # to add the issue this pull request is related to -->
Closes https://github.com/weaveworks/weave-gitops/issues/1641

