### PR TITLE
Add go mod tidy to static checks, clarify action when git diff fails

### DIFF
--- a/.github/workflows/v2.yml
+++ b/.github/workflows/v2.yml
@@ -86,11 +86,14 @@ jobs:
       - run: make dependencies
       - run: make check-format
       - run: make lint
+      - run: go mod tidy
+      - name: Check that go mod tidy has been run
+        run: git diff --no-ext-diff --exit-code
       - run: make proto
-      - name: Check that proto is updated
+      - name: Check that make proto has been run
         run: git diff --no-ext-diff --exit-code
       - run: make fakes
-      - name: Check that fakes are updated
+      - name: Check that make fakes has been run
         run: git diff --no-ext-diff --exit-code
 
 


### PR DESCRIPTION
github.com/sclevine/agouti was accidentally left behind in the go.mod
after being removed from the code, which is now causing random changes
in random other PRs.

The first time I had one of these checks fail, the text was very
confusing to me, and I wrote it. "Check that fakes are updated" makes
me ask "how", so make sure the command you need to run is part of the
thing that goes red in your PR.