### PR TITLE
Adds a global `--insecure-skip-tls-verify` flag to the cli

### DIFF
--- a/cmd/gitops/root/cmd.go
+++ b/cmd/gitops/root/cmd.go
@@ -1,6 +1,7 @@
 package root
 
 import (
+	"crypto/tls"
 	"fmt"
 	"os"
 	"strings"
@@ -35,10 +36,11 @@ import (
 )
 
 var options struct {
-	endpoint          string
-	overrideInCluster bool
-	verbose           bool
-	gitHostTypes      map[string]string
+	endpoint              string
+	overrideInCluster     bool
+	verbose               bool
+	gitHostTypes          map[string]string
+	insecureSkipTlsVerify bool
 }
 
 // Only want AutomaticEnv to be called once!
@@ -122,6 +124,8 @@ func RootCmd(client *resty.Client) *cobra.Command {
 			if options.overrideInCluster {
 				kube.InClusterConfig = func() (*rest.Config, error) { return nil, rest.ErrNotInCluster }
 			}
+
+			client.SetTLSClientConfig(&tls.Config{InsecureSkipVerify: viper.GetBool("insecure-skip-tls-verify")})
 		},
 	}
 
@@ -130,6 +134,7 @@ func RootCmd(client *resty.Client) *cobra.Command {
 	rootCmd.PersistentFlags().StringVarP(&options.endpoint, "endpoint", "e", os.Getenv("WEAVE_GITOPS_ENTERPRISE_API_URL"), "The Weave GitOps Enterprise HTTP API endpoint")
 	rootCmd.PersistentFlags().BoolVar(&options.overrideInCluster, "override-in-cluster", false, "override running in cluster check")
 	rootCmd.PersistentFlags().StringToStringVar(&options.gitHostTypes, "git-host-types", map[string]string{}, "Specify which custom domains are running what (github or gitlab)")
+	rootCmd.PersistentFlags().BoolVar(&options.insecureSkipTlsVerify, "insecure-skip-tls-verify", false, "If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure")
 	cobra.CheckErr(rootCmd.PersistentFlags().MarkHidden("override-in-cluster"))
 	cobra.CheckErr(rootCmd.PersistentFlags().MarkHidden("git-host-types"))
 

--- a/cmd/gitops/root/cmd.go
+++ b/cmd/gitops/root/cmd.go
@@ -124,8 +124,9 @@ func RootCmd(client *resty.Client) *cobra.Command {
 			if options.overrideInCluster {
 				kube.InClusterConfig = func() (*rest.Config, error) { return nil, rest.ErrNotInCluster }
 			}
-
-			client.SetTLSClientConfig(&tls.Config{InsecureSkipVerify: viper.GetBool("insecure-skip-tls-verify")})
+			if options.insecureSkipTlsVerify {
+				client.SetTLSClientConfig(&tls.Config{InsecureSkipVerify: true})
+			}
 		},
 	}
 

--- a/cmd/gitops/root/cmd_test.go
+++ b/cmd/gitops/root/cmd_test.go
@@ -1,0 +1,48 @@
+package root_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/go-resty/resty/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/weaveworks/weave-gitops/cmd/gitops/root"
+)
+
+func TestInsecureSkipVerifyTrue(t *testing.T) {
+	client := resty.New()
+
+	cmd := root.RootCmd(client)
+	cmd.SetArgs([]string{
+		"add", "cluster",
+		"--insecure-skip-tls-verify",
+	})
+
+	// Command is incomplete and should raise an error, it helps us short circuit here to quickly
+	// test that the client has been set
+	err := cmd.Execute()
+	assert.Error(t, err)
+
+	transport, ok := client.GetClient().Transport.(*http.Transport)
+	assert.True(t, ok)
+	assert.True(t, transport.TLSClientConfig.InsecureSkipVerify, "InsecureSkipVerify wasn't set to true")
+}
+
+func TestInsecureSkipVerifyFalse(t *testing.T) {
+	client := resty.New()
+
+	cmd := root.RootCmd(client)
+	cmd.SetArgs([]string{
+		"add", "cluster",
+	})
+
+	// Command is incomplete and should raise an error, it helps us short circuit here to quickly
+	// test that the client has been set
+	err := cmd.Execute()
+	assert.Error(t, err)
+
+	transport, ok := client.GetClient().Transport.(*http.Transport)
+	assert.True(t, ok)
+	// Its set to nil and uses whatever the golang defaults are (InsecureSkipVerify: false)
+	assert.Nil(t, transport.TLSClientConfig)
+}

--- a/test/acceptance/test/install_tests.go
+++ b/test/acceptance/test/install_tests.go
@@ -58,10 +58,10 @@ Flags:
   -h, --help                 help for install
 
 Global Flags:
-  -e, --endpoint string        The Weave GitOps Enterprise HTTP API endpoint
-  --insecure-skip-tls-verify   If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
-  --namespace string           The namespace scope for this operation (default "%s")
-  -v, --verbose                Enable verbose output`, wego.DefaultNamespace, wego.DefaultNamespace)
+  -e, --endpoint string            The Weave GitOps Enterprise HTTP API endpoint
+      --insecure-skip-tls-verify   If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+      --namespace string           The namespace scope for this operation (default "%s")
+  -v, --verbose                    Enable verbose output`, wego.DefaultNamespace, wego.DefaultNamespace)
 			helpTest = regexp.QuoteMeta(helpTest)
 			Eventually(sessionOutput).Should(gbytes.Say(helpTest))
 		})
@@ -75,7 +75,7 @@ Global Flags:
 
 		By("Then I should see gitops help text displayed for 'uninstall' command", func() {
 			Eventually(string(sessionOutput.Wait().Out.Contents())).Should(MatchRegexp(
-				fmt.Sprintf(`The uninstall command removes GitOps components from the cluster.\n*Usage:\n\s*gitops uninstall \[flags]\n*Examples:\n\s*# Uninstall GitOps from the %s namespace\n\s*gitops uninstall\n*Flags:\n\s*--dry-run\s*Outputs all the manifests that would be uninstalled\n\s*--force\s*If set, 'gitops uninstall' will not ask for confirmation\n\s*-h, --help\s*help for uninstall\n*Global Flags:\n\s*-e, --endpoint string\s*The Weave GitOps Enterprise HTTP API endpoint\n\s*--insecure-skip-tls-verify\s*If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure\n*s--namespace string\s*The namespace scope for this operation \(default "%s"\)\n\s*-v, --verbose\s*Enable verbose output`, wego.DefaultNamespace, wego.DefaultNamespace)))
+				fmt.Sprintf(`The uninstall command removes GitOps components from the cluster.\n*Usage:\n\s*gitops uninstall \[flags]\n*Examples:\n\s*# Uninstall GitOps from the %s namespace\n\s*gitops uninstall\n*Flags:\n\s*--dry-run\s*Outputs all the manifests that would be uninstalled\n\s*--force\s*If set, 'gitops uninstall' will not ask for confirmation\n\s*-h, --help\s*help for uninstall\n*Global Flags:\n\s*-e, --endpoint string\s*The Weave GitOps Enterprise HTTP API endpoint\n\s*--insecure-skip-tls-verify\s*If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure\n\s*--namespace string\s*The namespace scope for this operation \(default "%s"\)\n\s*-v, --verbose\s*Enable verbose output`, wego.DefaultNamespace, wego.DefaultNamespace)))
 		})
 	})
 

--- a/test/acceptance/test/install_tests.go
+++ b/test/acceptance/test/install_tests.go
@@ -58,9 +58,10 @@ Flags:
   -h, --help                 help for install
 
 Global Flags:
-  -e, --endpoint string    The Weave GitOps Enterprise HTTP API endpoint
-      --namespace string   The namespace scope for this operation (default "%s")
-  -v, --verbose            Enable verbose output`, wego.DefaultNamespace, wego.DefaultNamespace)
+  -e, --endpoint string        The Weave GitOps Enterprise HTTP API endpoint
+  --insecure-skip-tls-verify   If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+  --namespace string           The namespace scope for this operation (default "%s")
+  -v, --verbose                Enable verbose output`, wego.DefaultNamespace, wego.DefaultNamespace)
 			helpTest = regexp.QuoteMeta(helpTest)
 			Eventually(sessionOutput).Should(gbytes.Say(helpTest))
 		})
@@ -74,7 +75,7 @@ Global Flags:
 
 		By("Then I should see gitops help text displayed for 'uninstall' command", func() {
 			Eventually(string(sessionOutput.Wait().Out.Contents())).Should(MatchRegexp(
-				fmt.Sprintf(`The uninstall command removes GitOps components from the cluster.\n*Usage:\n\s*gitops uninstall \[flags]\n*Examples:\n\s*# Uninstall GitOps from the %s namespace\n\s*gitops uninstall\n*Flags:\n\s*--dry-run\s*Outputs all the manifests that would be uninstalled\n\s*--force\s*If set, 'gitops uninstall' will not ask for confirmation\n\s*-h, --help\s*help for uninstall\n*Global Flags:\n\s*-e, --endpoint string\s*The Weave GitOps Enterprise HTTP API endpoint\n\s*--namespace string\s*The namespace scope for this operation \(default "%s"\)\n\s*-v, --verbose\s*Enable verbose output`, wego.DefaultNamespace, wego.DefaultNamespace)))
+				fmt.Sprintf(`The uninstall command removes GitOps components from the cluster.\n*Usage:\n\s*gitops uninstall \[flags]\n*Examples:\n\s*# Uninstall GitOps from the %s namespace\n\s*gitops uninstall\n*Flags:\n\s*--dry-run\s*Outputs all the manifests that would be uninstalled\n\s*--force\s*If set, 'gitops uninstall' will not ask for confirmation\n\s*-h, --help\s*help for uninstall\n*Global Flags:\n\s*-e, --endpoint string\s*The Weave GitOps Enterprise HTTP API endpoint\n\s*--insecure-skip-tls-verify\s*If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure\n*s--namespace string\s*The namespace scope for this operation \(default "%s"\)\n\s*-v, --verbose\s*Enable verbose output`, wego.DefaultNamespace, wego.DefaultNamespace)))
 		})
 	})
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Adds a global `--insecure-skip-tls-verify` flag to the cli to make requests to an api-server using self-signed TLS certs

<!-- Tell your future self why have you made these changes -->
**Why?**

API server serves on _only_ https by default now. This allows you to `gitops get clusters --insecure-skip-tls-verify` etc.

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**

Manual so far