### PR TITLE
refactor: Simplify makeGRPCServer API in tests

### DIFF
--- a/core/server/fluxruntime_test.go
+++ b/core/server/fluxruntime_test.go
@@ -20,8 +20,7 @@ func TestGetReconciledObjects(t *testing.T) {
 
 	ctx := context.Background()
 
-	c, cleanup := makeGRPCServer(k8sEnv.Rest, t)
-	defer cleanup()
+	c := makeGRPCServer(k8sEnv.Rest, t)
 
 	_, k, err := kube.NewKubeHTTPClientWithConfig(k8sEnv.Rest, "")
 	g.Expect(err).NotTo(HaveOccurred())
@@ -80,8 +79,7 @@ func TestGetChildObjects(t *testing.T) {
 
 	ctx := context.Background()
 
-	c, cleanup := makeGRPCServer(k8sEnv.Rest, t)
-	defer cleanup()
+	c := makeGRPCServer(k8sEnv.Rest, t)
 
 	_, k, err := kube.NewKubeHTTPClientWithConfig(k8sEnv.Rest, "")
 	g.Expect(err).NotTo(HaveOccurred())

--- a/core/server/helm_release_test.go
+++ b/core/server/helm_release_test.go
@@ -24,8 +24,7 @@ func TestListHelmReleases(t *testing.T) {
 	g := NewGomegaWithT(t)
 	ctx := context.Background()
 
-	c, cleanup := makeGRPCServer(k8sEnv.Rest, t)
-	defer cleanup()
+	c := makeGRPCServer(k8sEnv.Rest, t)
 
 	_, k, err := kube.NewKubeHTTPClientWithConfig(k8sEnv.Rest, "")
 	g.Expect(err).NotTo(HaveOccurred())
@@ -47,8 +46,7 @@ func TestGetHelmRelease(t *testing.T) {
 	g := NewGomegaWithT(t)
 	ctx := context.Background()
 
-	c, cleanup := makeGRPCServer(k8sEnv.Rest, t)
-	defer cleanup()
+	c := makeGRPCServer(k8sEnv.Rest, t)
 
 	_, k, err := kube.NewKubeHTTPClientWithConfig(k8sEnv.Rest, "")
 	g.Expect(err).NotTo(HaveOccurred())
@@ -94,8 +92,7 @@ func TestGetHelmRelease_withInventory(t *testing.T) {
 	g := NewGomegaWithT(t)
 	ctx := context.Background()
 
-	c, cleanup := makeGRPCServer(k8sEnv.Rest, t)
-	defer cleanup()
+	c := makeGRPCServer(k8sEnv.Rest, t)
 
 	_, k, err := kube.NewKubeHTTPClientWithConfig(k8sEnv.Rest, "")
 	g.Expect(err).NotTo(HaveOccurred())
@@ -176,8 +173,7 @@ func TestGetHelmRelease_withInventoryCompressed(t *testing.T) {
 	g := NewGomegaWithT(t)
 	ctx := context.Background()
 
-	c, cleanup := makeGRPCServer(k8sEnv.Rest, t)
-	defer cleanup()
+	c := makeGRPCServer(k8sEnv.Rest, t)
 
 	_, k, err := kube.NewKubeHTTPClientWithConfig(k8sEnv.Rest, "")
 	g.Expect(err).NotTo(HaveOccurred())

--- a/core/server/kustomization_test.go
+++ b/core/server/kustomization_test.go
@@ -23,8 +23,7 @@ func TestListKustomizations(t *testing.T) {
 
 	ctx := context.Background()
 
-	c, cleanup := makeGRPCServer(k8sEnv.Rest, t)
-	defer cleanup()
+	c := makeGRPCServer(k8sEnv.Rest, t)
 
 	_, k, err := kube.NewKubeHTTPClientWithConfig(k8sEnv.Rest, "")
 	g.Expect(err).NotTo(HaveOccurred())
@@ -57,8 +56,7 @@ func TestGetKustomization(t *testing.T) {
 
 	ctx := context.Background()
 
-	c, cleanup := makeGRPCServer(k8sEnv.Rest, t)
-	defer cleanup()
+	c := makeGRPCServer(k8sEnv.Rest, t)
 
 	_, k, err := kube.NewKubeHTTPClientWithConfig(k8sEnv.Rest, "")
 	g.Expect(err).NotTo(HaveOccurred())

--- a/core/server/namespace_test.go
+++ b/core/server/namespace_test.go
@@ -17,8 +17,7 @@ func TestGetFluxNamespace(t *testing.T) {
 
 	ctx := context.Background()
 
-	coreClient, cleanup := makeGRPCServer(k8sEnv.Rest, t)
-	defer cleanup()
+	coreClient := makeGRPCServer(k8sEnv.Rest, t)
 
 	_, client, err := kube.NewKubeHTTPClientWithConfig(k8sEnv.Rest, "")
 	g.Expect(err).NotTo(HaveOccurred())
@@ -50,8 +49,7 @@ func TestGetFluxNamespace_notFound(t *testing.T) {
 
 	ctx := context.Background()
 
-	coreClient, cleanup := makeGRPCServer(k8sEnv.Rest, t)
-	defer cleanup()
+	coreClient := makeGRPCServer(k8sEnv.Rest, t)
 
 	_, _, err := kube.NewKubeHTTPClientWithConfig(k8sEnv.Rest, "")
 	g.Expect(err).NotTo(HaveOccurred())

--- a/core/server/sources_test.go
+++ b/core/server/sources_test.go
@@ -16,8 +16,7 @@ func TestListHelmRepositories(t *testing.T) {
 
 	ctx := context.Background()
 
-	c, cleanup := makeGRPCServer(k8sEnv.Rest, t)
-	defer cleanup()
+	c := makeGRPCServer(k8sEnv.Rest, t)
 
 	_, k, err := kube.NewKubeHTTPClientWithConfig(k8sEnv.Rest, "")
 	g.Expect(err).NotTo(HaveOccurred())
@@ -44,8 +43,7 @@ func TestListHelmCharts(t *testing.T) {
 
 	ctx := context.Background()
 
-	c, cleanup := makeGRPCServer(k8sEnv.Rest, t)
-	defer cleanup()
+	c := makeGRPCServer(k8sEnv.Rest, t)
 
 	_, k, err := kube.NewKubeHTTPClientWithConfig(k8sEnv.Rest, "")
 	g.Expect(err).NotTo(HaveOccurred())
@@ -78,8 +76,7 @@ func TestListBuckets(t *testing.T) {
 
 	ctx := context.Background()
 
-	c, cleanup := makeGRPCServer(k8sEnv.Rest, t)
-	defer cleanup()
+	c := makeGRPCServer(k8sEnv.Rest, t)
 
 	_, k, err := kube.NewKubeHTTPClientWithConfig(k8sEnv.Rest, "")
 	g.Expect(err).NotTo(HaveOccurred())

--- a/core/server/suite_test.go
+++ b/core/server/suite_test.go
@@ -37,7 +37,7 @@ func TestMain(m *testing.M) {
 	os.Exit(code)
 }
 
-func makeGRPCServer(cfg *rest.Config, t *testing.T) (pb.CoreClient, func()) {
+func makeGRPCServer(cfg *rest.Config, t *testing.T) pb.CoreClient {
 	s := grpc.NewServer()
 
 	coreCfg := server.NewCoreConfig(cfg, "foobar")
@@ -57,15 +57,20 @@ func makeGRPCServer(cfg *rest.Config, t *testing.T) (pb.CoreClient, func()) {
 		}
 	}(t)
 
-	conn, err := grpc.DialContext(context.Background(), "bufnet", grpc.WithContextDialer(dialer), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.DialContext(
+		context.Background(),
+		"bufnet",
+		grpc.WithContextDialer(dialer),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	cleanup := func() {
+	t.Cleanup(func() {
 		s.GracefulStop()
 		conn.Close()
-	}
+	})
 
-	return pb.NewCoreClient(conn), cleanup
+	return pb.NewCoreClient(conn)
 }


### PR DESCRIPTION
We use the `cleanup` function always in `defer`, which can be simplified
and let `makeGRPCServer` handle that part as it can already access `testing.T`.

Closes #1649