### PR TITLE
Fix test build errors

### DIFF
--- a/core/server/events._test.go
+++ b/core/server/events._test.go
@@ -18,8 +18,7 @@ func TestListFluxEvents(t *testing.T) {
 
 	ctx := context.Background()
 
-	c, cleanup := makeGRPCServer(k8sEnv.Rest, t)
-	defer cleanup()
+	c := makeGRPCServer(k8sEnv.Rest, t)
 
 	_, k, err := kube.NewKubeHTTPClientWithConfig(k8sEnv.Rest, "")
 	g.Expect(err).NotTo(HaveOccurred())

--- a/core/server/namespace_test.go
+++ b/core/server/namespace_test.go
@@ -63,8 +63,7 @@ func TestListNamespaces(t *testing.T) {
 
 	ctx := context.Background()
 
-	coreClient, cleanup := makeGRPCServer(k8sEnv.Rest, t)
-	defer cleanup()
+	coreClient := makeGRPCServer(k8sEnv.Rest, t)
 
 	_, client, err := kube.NewKubeHTTPClientWithConfig(k8sEnv.Rest, "")
 	g.Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
Merging #1663 caused tests to fail. This should make them pass again.