### PR TITLE
Improve ci

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,5 @@ node_modules
 dist
 pkg/flux/bin/flux
 cmd/gitops-server/cmd/dist
+# Ignore generated credentials from google-github-actions/auth
+gha-creds-*.json

--- a/.github/workflows/v2.yml
+++ b/.github/workflows/v2.yml
@@ -9,6 +9,10 @@ on:
       - v2
   workflow_dispatch:
 
+env:
+  CI_CONTAINER_REGISTRY: europe-west1-docker.pkg.dev
+  CI_CONTAINER_REPOSITORY: europe-west1-docker.pkg.dev/weave-gitops-clusters/weave-gitops
+
 name: V2 CI Workflow
 jobs:
   ci-js:
@@ -70,7 +74,6 @@ jobs:
       - run: make unit-tests
       # - run: make lib-test
 
-
   ci-static:
     name: V2 CI Check Static Checks
     runs-on: ubuntu-latest
@@ -93,10 +96,26 @@ jobs:
       - name: Check that fakes are updated
         run: git diff --no-ext-diff --exit-code
 
-
   full-ci:
     name: V2 CI Check (16.13.2, 1.17.5)
     runs-on: ubuntu-latest
     needs: [ci-go, ci-static, ci-js]
+    permissions:
+      contents: 'read'
+      id-token: 'write'
     steps:
+      - uses: actions/checkout@v3
+
+      - name: Authenticate to Google Cloud
+        id: gcloud-auth
+        uses: google-github-actions/auth@v0
+        with:
+          workload_identity_provider: ${{ secrets.workload_identity_provider }}
+          service_account: ${{ secrets.service_account }}
+      - uses: google-github-actions/setup-gcloud@v0
+      - run: gcloud --quiet auth configure-docker ${{ env.CI_CONTAINER_REGISTRY }}
+      - run: make dependencies
+      - name: Build & push docker iamges to Google
+        run: DOCKER_REGISTRY=${{ env.CI_CONTAINER_REPOSITORY }} make docker-image-push
+
       - run: echo "All done"

--- a/.github/workflows/v2.yml
+++ b/.github/workflows/v2.yml
@@ -128,6 +128,15 @@ jobs:
           name: ${{ matrix.docker-image }}
           path: /tmp/${{ matrix.docker-image }}.tar
 
+  # We only push images on merge so create a passing check if everything finished
+  finish-ci-no-push:
+    name: V2 CI Check (16.13.2, 1.17.5)
+    runs-on: ubuntu-latest
+    needs: [ci-go, ci-static, ci-js, ci-build-gitops-image]
+    if: github.event_name != 'push'
+    steps:
+      - run: echo "All done"
+
   ci-upload-images:
     name: V2 CI Upload Images
     runs-on: ubuntu-latest
@@ -136,6 +145,7 @@ jobs:
     permissions:
       contents: 'read'
       id-token: 'write'
+    if: github.event_name == 'push'
     strategy:
       matrix:
         docker-image:
@@ -162,7 +172,7 @@ jobs:
           docker load --input /tmp/${{ matrix.docker-image }}.tar
           docker push "${{ env.CI_CONTAINER_REPOSITORY }}/${{ matrix.docker-image }}:${{ github.sha }}"
 
-  finish-ci:
+  finish-ci-push:
     # must match https://github.com/weaveworks/corp/blob/master/github-repo-weave-gitops.tf#L50
     name: V2 CI Check (16.13.2, 1.17.5)
     runs-on: ubuntu-latest

--- a/.github/workflows/v2.yml
+++ b/.github/workflows/v2.yml
@@ -16,7 +16,7 @@ env:
 name: V2 CI Workflow
 jobs:
   ci-js:
-    name: V2 CI Check JS
+    name: V2 CI Test JS
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -45,8 +45,9 @@ jobs:
       - run: make ui
       - run: make ui-lint
       - run: make ui-test
+
   ci-go:
-    name: V2 CI Check Go
+    name: V2 CI Test Go
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -69,8 +70,6 @@ jobs:
         uses: fluxcd/pkg/actions/kubebuilder@main
       - run: make dependencies
       - run: go mod download
-      - run: make gitops
-      - run: make gitops-server
       - run: make unit-tests
       # - run: make lib-test
 
@@ -96,26 +95,75 @@ jobs:
       - name: Check that fakes are updated
         run: git diff --no-ext-diff --exit-code
 
-  full-ci:
-    name: V2 CI Check (16.13.2, 1.17.5)
+  ci-build-gitops-image:
+    name: V2 CI Build Gitops Docker Image
     runs-on: ubuntu-latest
-    needs: [ci-go, ci-static, ci-js]
+    strategy:
+      matrix:
+        docker-image:
+          - gitops
+          - gitops-server
+    steps:
+      - uses: actions/checkout@v2
+      - uses: docker/setup-buildx-action@v1
+      - run: make dependencies
+      - name: Set build-time flags
+        run: |
+          echo "LDFLAGS=$(make echo-ldflags)" >> $GITHUB_ENV
+          echo "FLUX_VERSION=$(make echo-flux-version)" >> $GITHUB_ENV
+      - name: Build and export
+        uses: docker/build-push-action@v2
+        with:
+          tags: "${{ env.CI_CONTAINER_REPOSITORY }}/${{ matrix.docker-image }}:${{ github.sha }}"
+          outputs: type=docker,dest=/tmp/${{ matrix.docker-image }}.tar
+          file: ${{ matrix.docker-image }}.dockerfile
+          # Warning: the ' in build-args are fragile -- only use on LDFLAGS
+          build-args: |
+            FLUX_VERSION=${{ env.FLUX_VERSION }}
+            LDFLAGS='${{ env.LDFLAGS }}'
+            GIT_COMMIT=${{ github.sha }}
+      - name: Cache docker image
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.docker-image }}
+          path: /tmp/${{ matrix.docker-image }}.tar
+
+  ci-upload-images:
+    name: V2 CI Upload Images
+    runs-on: ubuntu-latest
+    # Make sure we only upload images if tests etc have passed
+    needs: [ci-go, ci-static, ci-js, ci-build-gitops-image]
     permissions:
       contents: 'read'
       id-token: 'write'
+    strategy:
+      matrix:
+        docker-image:
+          - gitops
+          - gitops-server
     steps:
-      - uses: actions/checkout@v3
-
+      - uses: docker/setup-buildx-action@v1
+      - uses: google-github-actions/setup-gcloud@v0
+      - name: Download cached docker image
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ matrix.docker-image }}
+          path: /tmp
       - name: Authenticate to Google Cloud
         id: gcloud-auth
         uses: google-github-actions/auth@v0
         with:
-          workload_identity_provider: ${{ secrets.workload_identity_provider }}
           service_account: ${{ secrets.service_account }}
-      - uses: google-github-actions/setup-gcloud@v0
-      - run: gcloud --quiet auth configure-docker ${{ env.CI_CONTAINER_REGISTRY }}
-      - run: make dependencies
-      - name: Build & push docker iamges to Google
-        run: DOCKER_REGISTRY=${{ env.CI_CONTAINER_REPOSITORY }} make docker-image-push
+          workload_identity_provider: ${{ secrets.workload_identity_provider }}
+      - name: Login to gcloud for docker
+        run: gcloud --quiet auth configure-docker ${{ env.CI_CONTAINER_REGISTRY }}
+      - name: Push images to gcloud
+        run: |
+          docker load --input /tmp/${{ matrix.docker-image }}.tar
+          docker push "${{ env.CI_CONTAINER_REPOSITORY }}/${{ matrix.docker-image }}:${{ github.sha }}"
 
+  finish-ci:
+    runs-on: ubuntu-latest
+    needs: ci-upload-images
+    steps:
       - run: echo "All done"

--- a/.github/workflows/v2.yml
+++ b/.github/workflows/v2.yml
@@ -163,6 +163,8 @@ jobs:
           docker push "${{ env.CI_CONTAINER_REPOSITORY }}/${{ matrix.docker-image }}:${{ github.sha }}"
 
   finish-ci:
+    # must match https://github.com/weaveworks/corp/blob/master/github-repo-weave-gitops.tf#L50
+    name: V2 CI Check (16.13.2, 1.17.5)
     runs-on: ubuntu-latest
     needs: ci-upload-images
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ tilt_modules
 
 localhost-key.pem
 localhost.pem
+
+# Ignore generated credentials from google-github-actions/auth
+gha-creds-*.json

--- a/Makefile
+++ b/Makefile
@@ -223,6 +223,14 @@ merged.lcov:
 tls-files:
 	./tools/validate-mkcert.sh
 
+
+# These echo commands exist to make it easier to pass stuff around github actions
+echo-ldflags:
+	@echo $(LDFLAGS)
+
+echo-flux-version:
+	@echo $(FLUX_VERSION)
+
 .PHONY: help
 # Thanks to https://www.thapaliya.com/en/writings/well-documented-makefiles/
 help:  ## Display this help.

--- a/gitops-server.dockerfile
+++ b/gitops-server.dockerfile
@@ -12,6 +12,9 @@ RUN make ui
 
 # Go build
 FROM golang:1.17 AS go-build
+# Expect to be passed these by running this via `make docker-gitops` so we don't copy all of .git/
+ARG LDFLAGS="-X localbuild=true"
+ARG GIT_COMMIT="_unset_"
 
 # Add known_hosts entries for GitHub and GitLab
 RUN mkdir ~/.ssh
@@ -25,7 +28,7 @@ RUN go mod download
 COPY --from=ui /home/app/cmd/gitops-server/cmd/dist/ /app/cmd/gitops-server/cmd/dist/
 COPY . /app
 # ignore the index.html dependency (which it otherwise would because node_modules is missing)
-RUN make -o cmd/gitops-server/cmd/dist/index.html gitops-server
+RUN LDFLAGS=$LDFLAGS GIT_COMMIT=$GIT_COMMIT make -o cmd/gitops-server/cmd/dist/index.html gitops-server
 
 #  Distroless
 FROM gcr.io/distroless/base as runtime

--- a/gitops.dockerfile
+++ b/gitops.dockerfile
@@ -6,6 +6,10 @@ FROM $FLUX_CLI as flux
 
 # Go build
 FROM golang:1.17 AS go-build
+# Expect to be passed these by running this via `make docker-gitops` so we don't copy all of .git/
+ARG LDFLAGS="-X localbuild=true"
+ARG GIT_COMMIT="_unset_"
+
 # Add known_hosts entries for GitHub and GitLab
 RUN mkdir ~/.ssh
 RUN ssh-keyscan github.com >> ~/.ssh/known_hosts
@@ -17,7 +21,7 @@ WORKDIR /app
 COPY go.* /app/
 RUN go mod download
 COPY . /app
-RUN make gitops
+RUN LDFLAGS=$LDFLAGS GIT_COMMIT=$GIT_COMMIT make gitops
 
 # Distroless
 FROM gcr.io/distroless/base as runtime

--- a/gitops.dockerfile
+++ b/gitops.dockerfile
@@ -6,9 +6,6 @@ FROM $FLUX_CLI as flux
 
 # Go build
 FROM golang:1.17 AS go-build
-# Expect to be passed these by running this via `make docker-gitops` so we don't copy all of .git/
-ARG LDFLAGS="-X localbuild=true"
-ARG GIT_COMMIT="_unset_"
 
 # Add known_hosts entries for GitHub and GitLab
 RUN mkdir ~/.ssh
@@ -21,6 +18,13 @@ WORKDIR /app
 COPY go.* /app/
 RUN go mod download
 COPY . /app
+
+# These are ARGS are defined here to minimise cache misses
+# (cf. https://docs.docker.com/engine/reference/builder/#impact-on-build-caching)
+# Pass these flags so we don't have to copy .git/ for those commands to work
+ARG LDFLAGS="-X localbuild=true"
+ARG GIT_COMMIT="_unset_"
+
 RUN LDFLAGS=$LDFLAGS GIT_COMMIT=$GIT_COMMIT make gitops
 
 # Distroless


### PR DESCRIPTION
Build the docker images in parallel with running the go unit tests and then upload the images to Google Artifact Registry for staging.

This is builds upon & replaces PR #1633 

```mermaid
flowchart TD;
  build-gitops-image[build gitops image]-->gitops-image[/gitops image/]:::asset
  gitops-image-->upload-images;
  build-gitops-server-image[build gitops-server image]-->gitops-server-image[/gitops-server image/]:::asset
  gitops-server-image-->upload-images;
  go-tests[run go unit tests]-.->upload-images;
  ui-tests[run ui tests]-.->upload-images;
  lint[run linters etc.]-.->upload-images;
  upload-images-->finish-ci;

  classDef asset fill:#9f9,stroke:#363;
```