### PR TITLE
Add `mkcert` tool to the `README` dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ This is a list of the tools you may need to install:
 * [kind](https://kind.sigs.k8s.io/) -- Run kubernetes clusters in docker for testing.
 * [lcov](https://github.com/linux-test-project/lcov) -- Used for code coverage.
 * [flux](https://fluxcd.io/) -- Continuous delivery system for kubernetes that weave-gitops enriches.
+* [mkcert](https://github.com/FiloSottile/mkcert) -- A TLS certificate generation tool.
 
 Some other tools are installed automatically by the makefile for you:
 


### PR DESCRIPTION
The `make tls-files` command specified in the `README` relies on this dependency, but it's not yet in our list of required tools.