### PR TITLE
Remove TLS certs from dev image and dev cycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,16 +70,13 @@ To set up a development environment for the CLI
 ### To use an existing environment
 
 1. Install go v1.17
-2. Install [buf](https://github.com/bufbuild/buf)
-3. Run `make all` to install dependencies and build binaries and assets
-4. Start a `kind` cluster like so: `KIND_CLUSTER_NAME=<some name> ./tools/kind-with-registry.sh`
-5. Run `flux install -n flux-system`
-6. Run `make tls-files`
-7. Start the in-cluster API replacement job (powered by [http://tilt.dev](tilt.dev)) with `make cluster-dev`
-8. `make` or `make unit-tests` to ensure everything built correctly.
-9. Navigate to https://localhost:9001 in your browser. Note the
-   `https`: with TLS enabled `http` will not work. The login is `dev`
-   with the password `dev`.
+1. Install [buf](https://github.com/bufbuild/buf)
+1. Run `make all` to install dependencies and build binaries and assets
+1. Start a `kind` cluster like so: `KIND_CLUSTER_NAME=<some name> ./tools/kind-with-registry.sh`
+1. Run `flux install -n flux-system`
+1. Start the in-cluster API replacement job (powered by [http://tilt.dev](tilt.dev)) with `make cluster-dev`
+1. `make` or `make unit-tests` to ensure everything built correctly.
+1. Navigate to http://localhost:9001 in your browser. The login is `dev` with the password `dev`.
 
 ### Requirements/tools
 

--- a/Tiltfile
+++ b/Tiltfile
@@ -16,11 +16,9 @@ docker_build_with_restart(
     '.',
     only=[
         './bin',
-        'localhost.pem',
-        'localhost-key.pem',
     ],
     dockerfile="dev.dockerfile",
-    entrypoint='/app/build/gitops-server -l --tls-cert-file=build/localhost.pem --tls-private-key-file=build/localhost-key.pem',
+    entrypoint='/app/build/gitops-server -l --insecure',
     live_update=[
         sync('./bin', '/app/build'),
     ],
@@ -33,4 +31,4 @@ def helmfiles(chart, values):
 
 k8s_yaml(helmfiles('./charts/weave-gitops', './tools/helm-values-dev.yaml'))
 
-k8s_resource('wego-app', port_forwards='9001', resource_deps=['gitops-server'], links=['https://localhost:9001'])
+k8s_resource('wego-app', port_forwards='9001', resource_deps=['gitops-server'])

--- a/charts/weave-gitops/templates/wego-app.yaml
+++ b/charts/weave-gitops/templates/wego-app.yaml
@@ -14,7 +14,7 @@ spec:
       containers:
         - name: wego-app
           image: "{{.Values.containerRegistry}}:{{.Values.image}}"
-          args: [ "-l", "--helm-repo-namespace","{{.Values.namespace}}" ]
+          args: [ "-l", "--helm-repo-namespace", "{{.Values.namespace}}" ]
           ports:
             - containerPort: 9001
               protocol: TCP

--- a/dev.dockerfile
+++ b/dev.dockerfile
@@ -1,6 +1,4 @@
 FROM ubuntu
 WORKDIR /app
 ADD bin build
-ADD localhost.pem build
-ADD localhost-key.pem build
 ENTRYPOINT /app/build/gitops


### PR DESCRIPTION
This saves users from having to do TLS things as part of regular dev
cycle. Plus it means we wont get used to having certs in the image which
is not something we want for prod.

Once https://github.com/weaveworks/weave-gitops/issues/1703 is played we
can add something back for dev.
