### PR TITLE
refactor: Clean up kube config getting refereces

### DIFF
--- a/cmd/gitops-server/cmd/cmd.go
+++ b/cmd/gitops-server/cmd/cmd.go
@@ -32,6 +32,7 @@ import (
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
 )
 
 const (
@@ -121,8 +122,9 @@ func runCmd(cmd *cobra.Command, args []string) error {
 	assetFS := getAssets()
 	assetHandler := http.FileServer(http.FS(assetFS))
 	redirector := createRedirector(assetFS, log)
+	clusterName := kube.InClusterConfigClusterName()
 
-	rest, clusterName, err := kube.RestConfig()
+	rest, err := config.GetConfig()
 	if err != nil {
 		return fmt.Errorf("could not create client config: %w", err)
 	}

--- a/pkg/kube/kubehttp.go
+++ b/pkg/kube/kubehttp.go
@@ -112,10 +112,10 @@ func RestConfig() (*rest.Config, string, error) {
 		return nil, "", fmt.Errorf("could not create in-cluster config: %w", err)
 	}
 
-	return config, inClusterConfigClusterName(), nil
+	return config, InClusterConfigClusterName(), nil
 }
 
-func inClusterConfigClusterName() string {
+func InClusterConfigClusterName() string {
 	// kube clusters don't really know their own names
 	// try and read a unique name from the env, fall back to "default"
 	clusterName := os.Getenv("CLUSTER_NAME")

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -20,6 +20,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
 	"github.com/weaveworks/weave-gitops/api/v1alpha1"
 	pb "github.com/weaveworks/weave-gitops/pkg/api/applications"
@@ -110,8 +111,9 @@ func DefaultApplicationsConfig() (*ApplicationsConfig, error) {
 	}
 
 	jwtClient := auth.NewJwtClient(secretKey)
+	clusterName := kube.InClusterConfigClusterName()
 
-	rest, clusterName, err := kube.RestConfig()
+	rest, err := config.GetConfig()
 	if err != nil {
 		return nil, fmt.Errorf("could not create client config: %w", err)
 	}


### PR DESCRIPTION
Additional changes:

`kube.inClusterConfigClusterName` is a public function now as
`InClusterConfigClusterName`, because `config.GetConfig()` does not
return with "cluster name", our system still uses it, it's a simple
`Getenv` with default value. Maybe we can move this function into a
utility function called `GetenvOr("CLUSTER_NAME", "default")` or
something.

Closes #1719