### PR TITLE
Log out response from GitHub when there's an error.

### DIFF
--- a/pkg/services/auth/github.go
+++ b/pkg/services/auth/github.go
@@ -73,14 +73,14 @@ func doRequest(req *http.Request, client *http.Client) ([]byte, error) {
 	}
 	defer res.Body.Close()
 
-	if res.StatusCode != http.StatusOK {
-		// err is falsey even on 4XX or 5XX
-		return nil, fmt.Errorf("request failed with status code: %v", res.StatusCode)
-	}
-
 	rb, err := ioutil.ReadAll(res.Body)
 	if err != nil {
 		return nil, err
+	}
+
+	if res.StatusCode != http.StatusOK {
+		// err is falsey even on 4XX or 5XX
+		return nil, fmt.Errorf("request failed with status code (%s): %v", rb, res.StatusCode)
 	}
 
 	return rb, nil

--- a/pkg/services/auth/github.go
+++ b/pkg/services/auth/github.go
@@ -80,7 +80,7 @@ func doRequest(req *http.Request, client *http.Client) ([]byte, error) {
 
 	if res.StatusCode != http.StatusOK {
 		// err is falsey even on 4XX or 5XX
-		return nil, fmt.Errorf("request failed with status code (%s): %v", rb, res.StatusCode)
+		return nil, parseGitHubError(rb, res.StatusCode)
 	}
 
 	return rb, nil
@@ -222,4 +222,25 @@ func NewGithubDeviceFlowHandler(client *http.Client) BlockingCLIAuthHandler {
 
 		return pollAuthStatus(time.Sleep, retryInterval, client, codeRes.DeviceCode)
 	}
+}
+
+func parseGitHubError(b []byte, statusCode int) error {
+	var gerr GitHubError
+	if err := json.Unmarshal(b, &gerr); err != nil {
+		return fmt.Errorf("failed to unmarshal GitHub error: %w", err)
+	}
+	gerr.StatusCode = statusCode
+	return gerr
+}
+
+// GitHubError indicates a failure response from GitHub.
+type GitHubError struct {
+	Type        string `json:"error"`
+	Description string `json:"error_description"`
+	URI         string `json:"error_uri"`
+	StatusCode  int
+}
+
+func (e GitHubError) Error() string {
+	return fmt.Sprintf("GitHub %d - %s (%q) more information at %s", e.StatusCode, e.Type, e.Description, e.URI)
 }

--- a/pkg/services/auth/github_test.go
+++ b/pkg/services/auth/github_test.go
@@ -58,6 +58,14 @@ func (t *sleeper) now() time.Time {
 	return t.time
 }
 
+var _ = Describe("GitHub error parsing", func() {
+	It("parses from a response", func() {
+		err := parseGitHubError([]byte(`{"error":"device_flow_disabled","error_description":"Device Flow must be explicitly enabled for this App","error_uri":"https://docs.github.com"}`), http.StatusBadRequest)
+
+		Expect(err).To(MatchError(`GitHub 400 - device_flow_disabled ("Device Flow must be explicitly enabled for this App") more information at https://docs.github.com`))
+	})
+})
+
 var _ = Describe("Github Device Flow", func() {
 	var ts *httptest.Server
 	var client *http.Client


### PR DESCRIPTION
Closes: 

**What changed?**
GitHub now require an explicit Device Flow flag for Apps https://github.blog/changelog/2022-03-16-enable-oauth-device-authentication-flow-for-apps/

This logs out the response from GitHub in the event of an error making a request, which would likely help diagnose this.

<!-- Tell your future self why have you made these changes -->
**Why?**
With this change, the error makes it easy to diagnose the failures caused by GitHub's policy change.
```
Error: failed getting git clients: error creating auth service: error obtaining git provider token: could not complete auth flow: could not do code request: error doing code request: request failed with status code "{\"error\":\"device_flow_disabled\",\"error_description\":\"Device Flow must be explicitly enabled for this App\",\"error_uri\":\"https://docs.github.com\"}": 400
```

<!-- How have you verified this change? Tested locally? Added unit test/integration/acceptance test(s)? -->
**How did you test it?**
See above

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it. -->
**Release notes**
No Release notes necessary

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**