### PR TITLE
Switch isFetching to useIsFetching

### DIFF
--- a/ui/components/Page.tsx
+++ b/ui/components/Page.tsx
@@ -1,5 +1,6 @@
 import _ from "lodash";
 import React from "react";
+import { useIsFetching } from "react-query";
 import styled from "styled-components";
 import useCommon from "../hooks/common";
 import { PageRoute, RequestError } from "../lib/types";
@@ -8,6 +9,7 @@ import Flex from "./Flex";
 import Footer from "./Footer";
 import LoadingPage from "./LoadingPage";
 import PollingIndicator from "./PollingIndicator";
+import Spacer from "./Spacer";
 
 export type PageProps = {
   className?: string;
@@ -66,9 +68,9 @@ function Page({
   actions,
   loading,
   error,
-  isFetching,
 }: PageProps) {
   const { settings } = useCommon();
+  const fetching = useIsFetching();
 
   if (loading) {
     return (
@@ -84,11 +86,15 @@ function Page({
         <TitleBar>
           <Flex align>
             <h2>{title}</h2>
-            {title && <PollingIndicator loading={isFetching} />}
+            <Spacer padding="xs" />
+            {error ? (
+              <Errors error={error} />
+            ) : (
+              <PollingIndicator loading={fetching > 0} />
+            )}
           </Flex>
           {actions}
         </TitleBar>
-        {error && <Errors error={error} />}
         <Children>{children}</Children>
       </Content>
       {settings.renderFooter && <Footer />}

--- a/ui/components/PageStatus.tsx
+++ b/ui/components/PageStatus.tsx
@@ -37,8 +37,10 @@ function PageStatus({ conditions, suspended, className }: StatusProps) {
   );
 }
 export default styled(PageStatus).attrs({ className: PageStatus.name })`
+  position: relative;
   max-width: 45%;
-  margin-right: ${(props) => props.theme.spacing.medium};
+  right: ${(props) => props.theme.spacing.medium};
+  bottom: ${(props) => props.theme.spacing.large};
   padding: ${(props) => props.theme.spacing.small};
   color: ${(props) => props.theme.colors.neutral30};
   &.error-border {

--- a/ui/components/SourceDetail.tsx
+++ b/ui/components/SourceDetail.tsx
@@ -14,7 +14,7 @@ import Heading from "./Heading";
 import InfoList, { InfoField } from "./InfoList";
 import LoadingPage from "./LoadingPage";
 import PageStatus from "./PageStatus";
-import PollingIndicator from "./PollingIndicator";
+
 type Props = {
   className?: string;
   type: SourceRefSourceKind;
@@ -25,7 +25,7 @@ type Props = {
 };
 
 function SourceDetail({ className, name, info, type }: Props) {
-  const { data: sources, isLoading, error, isFetching } = useListSources();
+  const { data: sources, isLoading, error } = useListSources();
   const { data: automations } = useListAutomations();
 
   if (isLoading) {
@@ -62,10 +62,6 @@ function SourceDetail({ className, name, info, type }: Props) {
     <div className={className}>
       <Flex wide between>
         <div>
-          <Flex align start>
-            <Heading level={1}>{s.name}</Heading>
-            <PollingIndicator loading={isFetching} />
-          </Flex>
           <Heading level={2}>{s.type}</Heading>
           <InfoList items={items} />
         </div>
@@ -94,6 +90,7 @@ function SourceDetail({ className, name, info, type }: Props) {
 }
 
 export default styled(SourceDetail).attrs({ className: SourceDetail.name })`
+  padding-top: ${(props) => props.theme.spacing.xs};
   ${InfoList} {
     margin-bottom: 60px;
   }

--- a/ui/components/__tests__/__snapshots__/Page.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/Page.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`Page snapshots default 1`] = `
   justify-content: space-evenly;
 }
 
-.c5 {
+.c7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -42,14 +42,14 @@ exports[`Page snapshots default 1`] = `
   justify-content: center;
 }
 
-.c4 {
+.c6 {
   width: 100%;
   max-width: 1400px;
   margin: 0 auto;
   font-size: 14px;
 }
 
-.c4 ul {
+.c6 ul {
   list-style: none;
   display: -webkit-box;
   display: -webkit-flex;
@@ -57,13 +57,35 @@ exports[`Page snapshots default 1`] = `
   display: flex;
 }
 
-.c4 ul li {
+.c6 ul li {
   padding: 0 16px;
 }
 
-.c4 a {
+.c6 a {
   -webkit-text-decoration: none;
   text-decoration: none;
+}
+
+.c5 {
+  padding-left: 8px;
+}
+
+.c5 .MuiCircularProgress-root {
+  -webkit-transition: opacity 2s;
+  transition: opacity 2s;
+  margin-bottom: 0;
+}
+
+.c5 .MuiCircularProgress-root.in {
+  opacity: 1;
+}
+
+.c5 .MuiCircularProgress-root.out {
+  opacity: 0;
+}
+
+.c4 {
+  padding: 8px;
 }
 
 .c1 {
@@ -117,6 +139,38 @@ exports[`Page snapshots default 1`] = `
         className="c3"
       >
         <h2 />
+        <div
+          className="c4"
+        />
+        <div
+          className="c3 c5"
+        >
+          <div
+            className="MuiCircularProgress-root out MuiCircularProgress-colorPrimary MuiCircularProgress-indeterminate"
+            role="progressbar"
+            style={
+              Object {
+                "height": "16px",
+                "width": "16px",
+              }
+            }
+          >
+            <svg
+              className="MuiCircularProgress-svg"
+              viewBox="22 22 44 44"
+            >
+              <circle
+                className="MuiCircularProgress-circle MuiCircularProgress-circleIndeterminate"
+                cx={44}
+                cy={44}
+                fill="none"
+                r={20.2}
+                strokeWidth={3.6}
+                style={Object {}}
+              />
+            </svg>
+          </div>
+        </div>
       </div>
     </div>
     <div
@@ -124,10 +178,10 @@ exports[`Page snapshots default 1`] = `
     />
   </div>
   <footer
-    className="c4 Footer"
+    className="c6 Footer"
   >
     <div
-      className="c5"
+      className="c7"
     >
       <ul>
         <li>

--- a/ui/lib/test-utils.tsx
+++ b/ui/lib/test-utils.tsx
@@ -2,6 +2,7 @@ import { MuiThemeProvider } from "@material-ui/core";
 import { createMemoryHistory } from "history";
 import _ from "lodash";
 import * as React from "react";
+import { QueryClient, QueryClientProvider } from "react-query";
 import { Router } from "react-router-dom";
 import { ThemeProvider } from "styled-components";
 import AppContextProvider, { AppProps } from "../contexts/AppContext";
@@ -18,22 +19,20 @@ import {
 } from "./api/applications/applications.pb";
 import {
   Core,
-  GetReconciledObjectsRequest,
-  GetReconciledObjectsResponse,
   GetChildObjectsRequest,
   GetChildObjectsResponse,
+  GetReconciledObjectsRequest,
+  GetReconciledObjectsResponse,
 } from "./api/core/core.pb";
-
 import theme, { muiTheme } from "./theme";
 import { RequestError } from "./types";
-
 
 export type CoreOverrides = {
   GetChildObjects?: (req: GetChildObjectsRequest) => GetChildObjectsResponse;
   GetReconciledObjects?: (
     req: GetReconciledObjectsRequest
   ) => GetReconciledObjectsResponse;
-}
+};
 
 export const createCoreMockClient = (
   ovr: CoreOverrides,
@@ -104,12 +103,14 @@ export function withTheme(element) {
 export function withContext(TestComponent, url: string, ctxProps: AppProps) {
   const history = createMemoryHistory();
   history.push(url);
-
+  const queryClient = new QueryClient();
   const isElement = React.isValidElement(TestComponent);
   return (
     <Router history={history}>
       <AppContextProvider renderFooter {...ctxProps}>
-        {isElement ? TestComponent : <TestComponent />}
+        <QueryClientProvider client={queryClient}>
+          {isElement ? TestComponent : <TestComponent />}
+        </QueryClientProvider>
       </AppContextProvider>
     </Router>
   );

--- a/ui/pages/v2/Automations.tsx
+++ b/ui/pages/v2/Automations.tsx
@@ -9,18 +9,12 @@ type Props = {
 };
 
 function Automations({ className }: Props) {
-  const {
-    data: automations,
-    error,
-    isLoading,
-    isFetching,
-  } = useListAutomations();
+  const { data: automations, error, isLoading } = useListAutomations();
   return (
     <Page
       error={error}
       loading={isLoading}
       title="Applications"
-      isFetching={isFetching}
       className={className}
     >
       <AutomationsTable automations={automations} />

--- a/ui/pages/v2/BucketDetail.tsx
+++ b/ui/pages/v2/BucketDetail.tsx
@@ -14,7 +14,7 @@ type Props = {
 
 function BucketDetail({ className, name, namespace }: Props) {
   return (
-    <Page error={null} className={className}>
+    <Page error={null} className={className} title={name}>
       <SourceDetail
         name={name}
         namespace={namespace}

--- a/ui/pages/v2/FluxRuntime.tsx
+++ b/ui/pages/v2/FluxRuntime.tsx
@@ -7,6 +7,7 @@ import KubeStatusIndicator, {
 } from "../../components/KubeStatusIndicator";
 import Link from "../../components/Link";
 import Page from "../../components/Page";
+import Spacer from "../../components/Spacer";
 import { useListFluxRuntimeObjects } from "../../hooks/flux";
 import { Deployment } from "../../lib/api/core/types.pb";
 
@@ -15,16 +16,16 @@ type Props = {
 };
 
 function FluxRuntime({ className }: Props) {
-  const { data, isLoading, error, isFetching } = useListFluxRuntimeObjects();
+  const { data, isLoading, error } = useListFluxRuntimeObjects();
 
   return (
     <Page
       title="Flux Runtime"
       loading={isLoading}
       error={error}
-      isFetching={isFetching}
       className={className}
     >
+      <Spacer padding="xs" />
       <DataTable
         defaultSort={2}
         fields={[

--- a/ui/pages/v2/GitRepositoryDetail.tsx
+++ b/ui/pages/v2/GitRepositoryDetail.tsx
@@ -17,7 +17,7 @@ type Props = {
 
 function GitRepositoryDetail({ className, name, namespace }: Props) {
   return (
-    <Page error={null} className={className}>
+    <Page error={null} className={className} title={name}>
       <SourceDetail
         name={name}
         namespace={namespace}

--- a/ui/pages/v2/HelmChartDetail.tsx
+++ b/ui/pages/v2/HelmChartDetail.tsx
@@ -14,7 +14,7 @@ type Props = {
 
 function HelmChartDetail({ className, name, namespace }: Props) {
   return (
-    <Page error={null} className={className}>
+    <Page error={null} className={className} title={name}>
       <SourceDetail
         name={name}
         namespace={namespace}

--- a/ui/pages/v2/HelmReleaseDetail.tsx
+++ b/ui/pages/v2/HelmReleaseDetail.tsx
@@ -6,13 +6,13 @@ import InfoList from "../../components/InfoList";
 import Interval from "../../components/Interval";
 import Page from "../../components/Page";
 import PageStatus from "../../components/PageStatus";
-import PollingIndicator from "../../components/PollingIndicator";
 import ReconciledObjectsTable from "../../components/ReconciledObjectsTable";
 import SourceLink from "../../components/SourceLink";
+import Spacer from "../../components/Spacer";
 import { useGetHelmRelease } from "../../hooks/automations";
 import {
   AutomationKind,
-  SourceRefSourceKind
+  SourceRefSourceKind,
 } from "../../lib/api/core/types.pb";
 import { WeGONamespace } from "../../lib/types";
 
@@ -26,17 +26,14 @@ const Info = styled.div`
 `;
 
 function HelmReleaseDetail({ className, name }: Props) {
-  const { data, isLoading, error, isFetching } = useGetHelmRelease(name);
+  const { data, isLoading, error } = useGetHelmRelease(name);
   const helmRelease = data?.helmRelease;
 
   return (
-    <Page loading={isLoading} error={error} className={className}>
+    <Page loading={isLoading} error={error} className={className} title={name}>
+      <Spacer padding="xs" />
       <Flex wide between>
         <Info>
-          <Flex align start>
-            <Heading level={1}>{helmRelease?.name}</Heading>
-            <PollingIndicator loading={isFetching} />
-          </Flex>
           <Heading level={2}>{helmRelease?.namespace}</Heading>
           <InfoList
             items={[

--- a/ui/pages/v2/HelmRepositoryDetail.tsx
+++ b/ui/pages/v2/HelmRepositoryDetail.tsx
@@ -18,7 +18,7 @@ type Props = {
 
 function HelmRepositoryDetail({ className, name, namespace }: Props) {
   return (
-    <Page error={null} className={className}>
+    <Page error={null} className={className} title={name}>
       <SourceDetail
         name={name}
         namespace={namespace}

--- a/ui/pages/v2/KustomizationDetail.tsx
+++ b/ui/pages/v2/KustomizationDetail.tsx
@@ -9,9 +9,9 @@ import InfoList from "../../components/InfoList";
 import Interval from "../../components/Interval";
 import Page from "../../components/Page";
 import PageStatus from "../../components/PageStatus";
-import PollingIndicator from "../../components/PollingIndicator";
 import ReconciledObjectsTable from "../../components/ReconciledObjectsTable";
 import SourceLink from "../../components/SourceLink";
+import Spacer from "../../components/Spacer";
 import { useGetKustomization } from "../../hooks/automations";
 import { AutomationKind } from "../../lib/api/core/types.pb";
 import { WeGONamespace } from "../../lib/types";
@@ -30,17 +30,14 @@ const TabContent = styled.div`
 `;
 
 function KustomizationDetail({ className, name }: Props) {
-  const { data, isLoading, error, isFetching } = useGetKustomization(name);
+  const { data, isLoading, error } = useGetKustomization(name);
   const hashHistory = createHashHistory();
   const kustomization = data?.kustomization;
   return (
-    <Page loading={isLoading} error={error} className={className}>
+    <Page loading={isLoading} error={error} className={className} title={name}>
+      <Spacer padding="xs" />
       <Flex wide between>
         <Info>
-          <Flex align start>
-            <Heading level={1}>{kustomization?.name}</Heading>
-            <PollingIndicator loading={isFetching} />
-          </Flex>
           <Heading level={2}>{kustomization?.namespace}</Heading>
           <InfoList
             items={[

--- a/ui/pages/v2/Sources.tsx
+++ b/ui/pages/v2/Sources.tsx
@@ -9,13 +9,12 @@ type Props = {
 };
 
 function SourcesList({ className }: Props) {
-  const { data: sources, error, isLoading, isFetching } = useListSources();
+  const { data: sources, error, isLoading } = useListSources();
   return (
     <Page
       title="Sources"
       error={error}
       loading={isLoading}
-      isFetching={isFetching}
       className={className}
     >
       <SourcesTable sources={sources} />


### PR DESCRIPTION
Related to and might close: #1757

Source Detail pages now use the `Page` component to render their title, and `Page` holds the global is fetching state with the `useIsFetching` hook. I don't like that it's pushed the `PageStatus` component down, but there's no way to render that one outside of `SourceDetail`

<img width="1533" alt="image" src="https://user-images.githubusercontent.com/65822698/159079476-ff529730-7fcc-42b5-9f1d-a50899415acf.png">

`SourceDetail` errors appear under title - could set error state of page in parent component of source detail, or have all queries alter app context error state?

<img width="1287" alt="image" src="https://user-images.githubusercontent.com/65822698/159079205-a68cd21b-7178-4ea0-822b-98dc62b83695.png">
