### PR TITLE
Remove actively misleading help texts

### DIFF
--- a/cmd/gitops/add/cmd.go
+++ b/cmd/gitops/add/cmd.go
@@ -12,9 +12,6 @@ func GetCommand(endpoint *string, client *resty.Client) *cobra.Command {
 		Use:   "add",
 		Short: "Add a new Weave GitOps resource",
 		Example: `
-# Add an application to gitops from local git repository
-gitops add app . --name <app-name>
-
 # Add a new cluster using a CAPI template
 gitops add cluster`,
 	}

--- a/cmd/gitops/delete/cmd.go
+++ b/cmd/gitops/delete/cmd.go
@@ -11,9 +11,6 @@ func DeleteCommand(endpoint *string, client *resty.Client) *cobra.Command {
 		Use:   "delete",
 		Short: "Delete one or many Weave GitOps resources",
 		Example: `
-# Delete an application from gitops
-gitops delete app <app-name>
-
 # Delete a CAPI cluster given its name
 gitops delete cluster <cluster-name>`,
 	}

--- a/cmd/gitops/get/cmd.go
+++ b/cmd/gitops/get/cmd.go
@@ -14,12 +14,6 @@ func GetCommand(endpoint *string, client *resty.Client) *cobra.Command {
 		Use:   "get",
 		Short: "Display one or many Weave GitOps resources",
 		Example: `
-# Get all applications under gitops control
-gitops get apps
-
-# Get last 10 commits for an application
-gitops get commits <app-name>
-
 # Get all CAPI templates
 gitops get templates
 

--- a/cmd/gitops/root/cmd.go
+++ b/cmd/gitops/root/cmd.go
@@ -50,42 +50,19 @@ func RootCmd(client *resty.Client) *cobra.Command {
 		SilenceErrors: true,
 		Short:         "Weave GitOps",
 		Long:          "Command line utility for managing Kubernetes applications via GitOps.",
-		Example: fmt.Sprintf(`
+		Example: `
   # Get verbose output for any gitops command
   gitops [command] -v, --verbose
 
-  # Get gitops app help
-  gitops help app
-
-  # Add application to gitops control from a local git repository
-  gitops add app . --name <myapp>
-  OR
-  gitops add app <myapp-directory>
-
-  # Add application to gitops control from a github repository
-  gitops add app \
-    --name <myapp> \
-    --url git@github.com:myorg/<myapp> \
-    --branch prod-<myapp>
-
-  # Get status of application under gitops control
-  gitops get app podinfo
-
-  # Get help for gitops add app command
-  gitops add app -h
-  gitops help add app
-
-  # Show manifests that would be installed by the gitops install command
-  gitops install --dry-run
-
-  # Install gitops in the %s namespace
-  gitops install
+  # Get help for gitops add cluster command
+  gitops add cluster -h
+  gitops help add cluster
 
   # Get the version of gitops along with commit, branch, and flux version
   gitops version
 
   To learn more, you can find our documentation at https://docs.gitops.weave.works/
-`, wego.DefaultNamespace),
+`,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			configureLogger()
 


### PR DESCRIPTION
* Add, delete and get all assumed you want to add or delete an app. We
      no longer have apps. Get also mentioned getting commits, which also
      isn't available.
* The main command had many examples of how to install gitops and
  manage applications. None of that is applicable any more, so remove
  any mention of it - we'll probably want to do a _something_ with
  installation instructions, but this clears the way to do so.