### PR TITLE
Allow overflowed data to scroll

### DIFF
--- a/ui/components/AutomationsTable.tsx
+++ b/ui/components/AutomationsTable.tsx
@@ -46,23 +46,23 @@ function AutomationsTable({ className, automations, hideSource }: Props) {
         );
       },
       sortValue: ({ name }) => name,
-      width: 64,
+      width: 5,
       textSearchable: true,
     },
     {
       label: "Type",
       value: "type",
-      width: 96,
+      width: 5,
     },
     {
       label: "Namespace",
       value: "namespace",
-      width: 64,
+      width: 5,
     },
     {
       label: "Cluster",
       value: () => "Default",
-      width: 64,
+      width: 5,
     },
     {
       label: "Source",
@@ -83,7 +83,7 @@ function AutomationsTable({ className, automations, hideSource }: Props) {
         );
       },
       sortValue: (a: Automation) => a.sourceRef?.name,
-      width: 160,
+      width: 10,
     },
     {
       label: "Status",
@@ -97,20 +97,20 @@ function AutomationsTable({ className, automations, hideSource }: Props) {
         ) : null,
       sortType: SortType.bool,
       sortValue: ({ conditions }) => computeReady(conditions),
-      width: 64,
+      width: 7.5,
     },
     {
       label: "Message",
       value: (a: Automation) => computeMessage(a.conditions),
-      width: 360,
+      width: 37.5,
       sortValue: ({ conditions }) => computeMessage(conditions),
     },
     {
       label: "Revision",
       value: "lastAttemptedRevision",
-      width: 72,
+      width: 15,
     },
-    { label: "Last Updated", value: "lastHandledReconciledAt", width: 120 },
+    { label: "Last Updated", value: "lastHandledReconciledAt", width: 10 },
   ];
 
   if (hideSource) fields = _.filter(fields, { label: "Source" });

--- a/ui/components/DataTable.tsx
+++ b/ui/components/DataTable.tsx
@@ -155,7 +155,7 @@ function UnstyledDataTable({
   const r = _.map(sorted, (r, i) => (
     <TableRow key={i}>
       {_.map(fields, (f) => (
-        <TableCell style={f.width && { width: f.width }} key={f.label}>
+        <TableCell style={f.width && { width: `${f.width}%` }} key={f.label}>
           <Text>{typeof f.value === "function" ? f.value(r) : r[f.value]}</Text>
         </TableCell>
       ))}

--- a/ui/components/HashRouterTabs.tsx
+++ b/ui/components/HashRouterTabs.tsx
@@ -6,6 +6,7 @@ import * as React from "react";
 import { HashRouter, Redirect, Route, Switch } from "react-router-dom";
 import styled from "styled-components";
 import Link from "./Link";
+import Spacer from "./Spacer";
 import Text from "./Text";
 
 type Props = {
@@ -89,6 +90,7 @@ function HashRouterTabs({ className, children, defaultPath, history }: Props) {
       </div>
       <div>
         <HashRouter>
+          <Spacer padding="small" />
           <Switch>
             {children}
             <Redirect exact from="/" to={defaultPath} />

--- a/ui/components/Layout.tsx
+++ b/ui/components/Layout.tsx
@@ -64,8 +64,6 @@ const AppContainer = styled.div`
 `;
 
 const NavContainer = styled.div`
-  position: absolute;
-  left: 0;
   width: 240px;
   height: 100%;
   margin-top: ${(props) => props.theme.spacing.medium};
@@ -115,11 +113,11 @@ const ContentContainer = styled.div`
   padding-bottom: ${(props) => props.theme.spacing.medium};
   padding-right: ${(props) => props.theme.spacing.medium};
   padding-left: ${(props) => props.theme.spacing.medium};
-  overflow: auto;
-  margin-left: 240px;
 `;
 
-const Main = styled(Flex)``;
+const Main = styled(Flex)`
+  height: 100%;
+`;
 
 const TopToolBar = styled(Flex)`
   padding: 8px 0;

--- a/ui/components/Layout.tsx
+++ b/ui/components/Layout.tsx
@@ -58,7 +58,7 @@ const StyleLinkTab = styled(LinkTab)`
 
 const AppContainer = styled.div`
   width: 100%;
-  height: 100%;
+  min-height: 100vh;
   margin: 0 auto;
   padding: 0;
 `;
@@ -109,6 +109,7 @@ const NavContent = styled.div`
 
 const ContentContainer = styled.div`
   width: 100%;
+  height: 100%;
   padding-top: ${(props) => props.theme.spacing.medium};
   padding-bottom: ${(props) => props.theme.spacing.medium};
   padding-right: ${(props) => props.theme.spacing.medium};

--- a/ui/components/Page.tsx
+++ b/ui/components/Page.tsx
@@ -33,6 +33,7 @@ export const Content = styled.div`
   padding-left: ${(props) => props.theme.spacing.large};
   padding-top: ${(props) => props.theme.spacing.medium};
   width: 100%;
+  height: 100%;
 `;
 
 const Children = styled.div``;
@@ -103,6 +104,7 @@ function Page({
 }
 
 export default styled(Page)`
+  height: 100%;
   .MuiAlert-root {
     width: 100%;
   }

--- a/ui/components/Page.tsx
+++ b/ui/components/Page.tsx
@@ -86,7 +86,7 @@ function Page({
         <TitleBar>
           <Flex align>
             <h2>{title}</h2>
-            <Spacer padding="xs" />
+            <Spacer padding="medium" />
             {error ? (
               <Errors error={error} />
             ) : (

--- a/ui/components/Page.tsx
+++ b/ui/components/Page.tsx
@@ -86,7 +86,7 @@ function Page({
         <TitleBar>
           <Flex align>
             <h2>{title}</h2>
-            <Spacer padding="medium" />
+            <Spacer padding="small" />
             {error ? (
               <Errors error={error} />
             ) : (

--- a/ui/components/SourcesTable.tsx
+++ b/ui/components/SourcesTable.tsx
@@ -117,7 +117,7 @@ function SourcesTable({ className, sources }: Props) {
             width: 25,
           },
           {
-            label: "Ref",
+            label: "Reference",
             value: (s: Source) => {
               const isGit = s.type === SourceRefSourceKind.GitRepository;
               const repo = s as GitRepository;

--- a/ui/components/SourcesTable.tsx
+++ b/ui/components/SourcesTable.tsx
@@ -23,8 +23,6 @@ type Props = {
   appName?: string;
 };
 
-const statusWidth = 340;
-
 function SourcesTable({ className, sources }: Props) {
   const [filterDialogOpen, setFilterDialog] = React.useState(false);
 
@@ -54,10 +52,10 @@ function SourcesTable({ className, sources }: Props) {
             ),
             sortType: SortType.string,
             sortValue: (s: Source) => s.name || "",
-            width: 96,
+            width: 5,
             textSearchable: true,
           },
-          { label: "Type", value: "type", width: 96 },
+          { label: "Type", value: "type", width: 5 },
           {
             label: "Status",
             value: (s: Source) => (
@@ -67,18 +65,18 @@ function SourcesTable({ className, sources }: Props) {
                 suspended={s.suspended}
               />
             ),
-            width: 96,
+            width: 5,
           },
           {
             label: "Message",
             value: (s) => computeMessage(s.conditions),
 
-            width: statusWidth,
+            width: 45,
           },
           {
             label: "Cluster",
             value: () => "Default",
-            width: 96,
+            width: 5,
           },
           {
             label: "URL",
@@ -116,10 +114,10 @@ function SourcesTable({ className, sources }: Props) {
                 text
               );
             },
-            width: 240,
+            width: 25,
           },
           {
-            label: "Reference",
+            label: "Ref",
             value: (s: Source) => {
               const isGit = s.type === SourceRefSourceKind.GitRepository;
               const repo = s as GitRepository;
@@ -131,18 +129,19 @@ function SourcesTable({ className, sources }: Props) {
 
               return isGit ? ref : "-";
             },
-            width: 96,
+            width: 5,
           },
           {
             label: "Interval",
             value: (s: Source) => showInterval(s.interval),
-            width: 96,
+            width: 5,
           },
           {
             label: "Last Updated",
             value: (s: Source) => (
               <Timestamp time={(s as GitRepository).lastUpdatedAt} />
             ),
+            width: 5,
           },
         ]}
       />

--- a/ui/components/__tests__/__snapshots__/Page.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/Page.test.tsx.snap
@@ -85,7 +85,7 @@ exports[`Page snapshots default 1`] = `
 }
 
 .c4 {
-  padding: 8px;
+  padding: 12px;
 }
 
 .c1 {
@@ -99,6 +99,7 @@ exports[`Page snapshots default 1`] = `
   padding-left: 32px;
   padding-top: 24px;
   width: 100%;
+  height: 100%;
 }
 
 .c2 {
@@ -120,6 +121,10 @@ exports[`Page snapshots default 1`] = `
 .c2 h2 {
   margin: 0 !important;
   color: #1a1a1a !important;
+}
+
+.c0 {
+  height: 100%;
 }
 
 .c0 .MuiAlert-root {

--- a/ui/lib/theme.ts
+++ b/ui/lib/theme.ts
@@ -83,7 +83,6 @@ export const GlobalStyle = createGlobalStyle`
   }
   
   body {
-    overflow: hidden;
     font-family: ${(props) => props.theme.fontFamilies.regular};
     font-size: ${(props) => props.theme.fontSizes.normal};
     color: ${(props) => props.theme.colors.black};


### PR DESCRIPTION
Closes: #1761 

Fixes various spacing issues, and removes overflow: hidden from the body to allow overflowed pages to scroll. Adjusts nav and content to match. 