### PR TITLE
Add a date prefix to the docker tag for PR images

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -164,7 +164,7 @@ jobs:
       - name: Push images to gcloud
         run: |
           docker load --input /tmp/${{ matrix.docker-image }}.tar
-          docker push "${{ env.CI_CONTAINER_REPOSITORY }}/${{ matrix.docker-image }}:${{ github.sha }}"
+          docker push "${{ env.CI_CONTAINER_REPOSITORY }}/${{ matrix.docker-image }}:${date +%s}-${{ github.sha }}"
 
   ci-upload-binary:
     name: Upload Binary

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -164,7 +164,7 @@ jobs:
       - name: Push images to gcloud
         run: |
           docker load --input /tmp/${{ matrix.docker-image }}.tar
-          docker push "${{ env.CI_CONTAINER_REPOSITORY }}/${{ matrix.docker-image }}:${date +%s}-${{ github.sha }}"
+          docker push "${{ env.CI_CONTAINER_REPOSITORY }}/${{ matrix.docker-image }}:${date -u +%s}-${{ github.sha }}"
 
   ci-upload-binary:
     name: Upload Binary


### PR DESCRIPTION
We want to use Flux's image policies to auto deploy the latest version
of main to a staging cluster. To do this the images need to be tagged
in a sortable manner. The easiest way to do this is using the unix time
so we'll add that as a prefix.
