### PR TITLE
Fix date substitution in PR workflow

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -164,7 +164,7 @@ jobs:
       - name: Push images to gcloud
         run: |
           docker load --input /tmp/${{ matrix.docker-image }}.tar
-          docker push "${{ env.CI_CONTAINER_REPOSITORY }}/${{ matrix.docker-image }}:${date -u +%s}-${{ github.sha }}"
+          docker push "${{ env.CI_CONTAINER_REPOSITORY }}/${{ matrix.docker-image }}:$(date -u +%s)-${{ github.sha }}"
 
   ci-upload-binary:
     name: Upload Binary


### PR DESCRIPTION
This needs to use parenthesis, not curly braces, for process substitution.

Fixes the error thrown here: https://github.com/weaveworks/weave-gitops/runs/5690575142?check_suite_focus=true#step:7:18