### PR TITLE
Remove title bar padding and shrink logo

### DIFF
--- a/ui/components/Layout.tsx
+++ b/ui/components/Layout.tsx
@@ -98,7 +98,7 @@ const NavContent = styled.div`
     padding: 0px 12px;
     min-height: 24px;
     &.sub-item {
-      margin-bottom: 24px;
+      margin-bottom: 32px;
     }
   }
   ${Link} {

--- a/ui/components/Layout.tsx
+++ b/ui/components/Layout.tsx
@@ -114,7 +114,7 @@ const ContentContainer = styled.div`
   padding-top: ${(props) => props.theme.spacing.medium};
   padding-bottom: ${(props) => props.theme.spacing.medium};
   padding-right: ${(props) => props.theme.spacing.medium};
-  padding-left: ${(props) => props.theme.spacing.medium};
+  padding-left: ${(props) => props.theme.spacing.small};
   overflow: auto;
   margin-left: 240px;
 `;
@@ -122,15 +122,9 @@ const ContentContainer = styled.div`
 const Main = styled(Flex)``;
 
 const TopToolBar = styled(Flex)`
-  padding: 8px 0;
   background-color: ${(props) => props.theme.colors.primary};
   height: 80px;
   flex: 0 1 auto;
-
-  ${Logo} img {
-    width: 70px;
-    height: 72.85px;
-  }
 
   ${UserSettings} {
     justify-self: flex-end;
@@ -147,7 +141,7 @@ function Layout({ className, children }: Props) {
       <AppContainer>
         <TopToolBar start align wide>
           <Logo />
-          <Spacer padding="xl" />
+          <Spacer padding="small" />
           <Breadcrumbs />
           {flags.WEAVE_GITOPS_AUTH_ENABLED ? <UserSettings /> : null}
         </TopToolBar>

--- a/ui/components/Logo.tsx
+++ b/ui/components/Logo.tsx
@@ -14,14 +14,15 @@ type Props = {
 
 function Logo({ className }: Props) {
   return (
-    <Spacer padding="medium">
-      <Flex className={className} align>
-        <img src={logoSrc} />
-        <Spacer padding="xxs" />
-        <img src={titleSrc} style={{ height: "90%" }} />
-      </Flex>
-    </Spacer>
+    <Flex className={className} align start>
+      <img src={logoSrc} style={{ height: 56 }} />
+      <Spacer padding="xxs" />
+      <img src={titleSrc} />
+    </Flex>
   );
 }
 
-export default styled(Logo)``;
+export default styled(Logo)`
+  margin-left: ${(props) => props.theme.spacing.medium};
+  width: 240px;
+`;

--- a/ui/components/__tests__/__snapshots__/Logo.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/Logo.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Logo snapshots renders 1`] = `
-.c1 {
+.c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -13,40 +13,37 @@ exports[`Logo snapshots renders 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  -webkit-box-pack: space-evenly;
-  -webkit-justify-content: space-evenly;
-  -ms-flex-pack: space-evenly;
-  justify-content: space-evenly;
-}
-
-.c0 {
-  padding: 24px;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
 }
 
 .c2 {
   padding: 4px;
 }
 
+.c1 {
+  margin-left: 24px;
+  width: 240px;
+}
+
 <div
-  className="c0"
+  className="c0 c1"
 >
-  <div
-    className="c1 "
-  >
-    <img
-      src=""
-    />
-    <div
-      className="c2"
-    />
-    <img
-      src=""
-      style={
-        Object {
-          "height": "90%",
-        }
+  <img
+    src=""
+    style={
+      Object {
+        "height": 56,
       }
-    />
-  </div>
+    }
+  />
+  <div
+    className="c2"
+  />
+  <img
+    src=""
+  />
 </div>
 `;


### PR DESCRIPTION
<!-- Use # to add the issue this pull request is related to -->
Closes: #1796

<!-- Describe what has changed in this PR -->
Top title bar is now the correct height of 80px. Also aligns breadcrumbs and content title 

![image](https://user-images.githubusercontent.com/65822698/160162356-3e0a877d-76ad-42c3-932c-f59565abe35e.png)
