### PR TITLE
Sort by Status

### DIFF
--- a/ui/components/AutomationsTable.tsx
+++ b/ui/components/AutomationsTable.tsx
@@ -5,12 +5,10 @@ import { Automation } from "../hooks/automations";
 import { HelmRelease, SourceRefSourceKind } from "../lib/api/core/types.pb";
 import { formatURL } from "../lib/nav";
 import { AutomationType, V2Routes } from "../lib/types";
+import { statusSortHelper } from "../lib/utils";
 import DataTable, { Field, SortType } from "./DataTable";
 import FilterableTable, { filterConfigForType } from "./FilterableTable";
-import KubeStatusIndicator, {
-  computeMessage,
-  computeReady,
-} from "./KubeStatusIndicator";
+import KubeStatusIndicator, { computeMessage } from "./KubeStatusIndicator";
 import Link from "./Link";
 import SourceLink from "./SourceLink";
 
@@ -96,11 +94,8 @@ function AutomationsTable({ className, automations, hideSource }: Props) {
           />
         ) : null,
       sortType: SortType.number,
-      sortValue: ({ conditions, suspended }) => {
-        if (suspended) return 2;
-        if (computeReady(conditions)) return 3;
-        else return 1;
-      },
+      sortValue: ({ conditions, suspended }) =>
+        statusSortHelper(suspended, conditions),
       width: 7.5,
     },
     {

--- a/ui/components/AutomationsTable.tsx
+++ b/ui/components/AutomationsTable.tsx
@@ -94,8 +94,7 @@ function AutomationsTable({ className, automations, hideSource }: Props) {
           />
         ) : null,
       sortType: SortType.number,
-      sortValue: ({ conditions, suspended }) =>
-        statusSortHelper(suspended, conditions),
+      sortValue: statusSortHelper,
       width: 7.5,
     },
     {

--- a/ui/components/AutomationsTable.tsx
+++ b/ui/components/AutomationsTable.tsx
@@ -95,8 +95,12 @@ function AutomationsTable({ className, automations, hideSource }: Props) {
             suspended={a.suspended}
           />
         ) : null,
-      sortType: SortType.bool,
-      sortValue: ({ conditions }) => computeReady(conditions),
+      sortType: SortType.number,
+      sortValue: ({ conditions, suspended }) => {
+        if (suspended) return 2;
+        if (computeReady(conditions)) return 3;
+        else return 1;
+      },
       width: 7.5,
     },
     {

--- a/ui/components/ReconciledObjectsTable.tsx
+++ b/ui/components/ReconciledObjectsTable.tsx
@@ -7,11 +7,9 @@ import {
   GroupVersionKind,
   UnstructuredObject,
 } from "../lib/api/core/types.pb";
+import { statusSortHelper } from "../lib/utils";
 import DataTable, { SortType } from "./DataTable";
-import KubeStatusIndicator, {
-  computeMessage,
-  computeReady,
-} from "./KubeStatusIndicator";
+import KubeStatusIndicator, { computeMessage } from "./KubeStatusIndicator";
 import RequestStateHandler from "./RequestStateHandler";
 
 export interface ReconciledVisualizationProps {
@@ -65,8 +63,9 @@ function ReconciledObjectsTable({
                     suspended={u.suspended}
                   />
                 ) : null,
-              sortType: SortType.bool,
-              sortValue: ({ conditions }) => computeReady(conditions),
+              sortType: SortType.number,
+              sortValue: ({ conditions, suspended }) =>
+                statusSortHelper(suspended, conditions),
             },
             {
               label: "Message",

--- a/ui/components/ReconciledObjectsTable.tsx
+++ b/ui/components/ReconciledObjectsTable.tsx
@@ -64,8 +64,7 @@ function ReconciledObjectsTable({
                   />
                 ) : null,
               sortType: SortType.number,
-              sortValue: ({ conditions, suspended }) =>
-                statusSortHelper(suspended, conditions),
+              sortValue: statusSortHelper,
             },
             {
               label: "Message",

--- a/ui/components/SourcesTable.tsx
+++ b/ui/components/SourcesTable.tsx
@@ -10,13 +10,10 @@ import {
 import { formatURL, sourceTypeToRoute } from "../lib/nav";
 import { showInterval } from "../lib/time";
 import { Source } from "../lib/types";
-import { convertGitURLToGitProvider } from "../lib/utils";
+import { convertGitURLToGitProvider, statusSortHelper } from "../lib/utils";
 import { SortType } from "./DataTable";
 import FilterableTable, { filterConfigForType } from "./FilterableTable";
-import KubeStatusIndicator, {
-  computeMessage,
-  computeReady,
-} from "./KubeStatusIndicator";
+import KubeStatusIndicator, { computeMessage } from "./KubeStatusIndicator";
 import Link from "./Link";
 import Timestamp from "./Timestamp";
 
@@ -69,11 +66,8 @@ function SourcesTable({ className, sources }: Props) {
               />
             ),
             sortType: SortType.number,
-            sortValue: ({ conditions, suspended }) => {
-              if (suspended) return 2;
-              if (computeReady(conditions)) return 3;
-              else return 1;
-            },
+            sortValue: ({ conditions, suspended }) =>
+              statusSortHelper(suspended, conditions),
             width: 5,
           },
           {

--- a/ui/components/SourcesTable.tsx
+++ b/ui/components/SourcesTable.tsx
@@ -66,8 +66,7 @@ function SourcesTable({ className, sources }: Props) {
               />
             ),
             sortType: SortType.number,
-            sortValue: ({ conditions, suspended }) =>
-              statusSortHelper(suspended, conditions),
+            sortValue: statusSortHelper,
             width: 5,
           },
           {

--- a/ui/components/SourcesTable.tsx
+++ b/ui/components/SourcesTable.tsx
@@ -13,7 +13,10 @@ import { Source } from "../lib/types";
 import { convertGitURLToGitProvider } from "../lib/utils";
 import { SortType } from "./DataTable";
 import FilterableTable, { filterConfigForType } from "./FilterableTable";
-import KubeStatusIndicator, { computeMessage } from "./KubeStatusIndicator";
+import KubeStatusIndicator, {
+  computeMessage,
+  computeReady,
+} from "./KubeStatusIndicator";
 import Link from "./Link";
 import Timestamp from "./Timestamp";
 
@@ -65,6 +68,12 @@ function SourcesTable({ className, sources }: Props) {
                 suspended={s.suspended}
               />
             ),
+            sortType: SortType.number,
+            sortValue: ({ conditions, suspended }) => {
+              if (suspended) return 2;
+              if (computeReady(conditions)) return 3;
+              else return 1;
+            },
             width: 5,
           },
           {

--- a/ui/components/__tests__/DataTable.test.tsx
+++ b/ui/components/__tests__/DataTable.test.tsx
@@ -41,8 +41,8 @@ describe("DataTable", () => {
       sortType: SortType.number,
       sortValue: ({ status, suspended }) => {
         if (suspended) return 2;
-        if (status) return 1;
-        else return 3;
+        if (status) return 3;
+        else return 1;
       },
     },
     {

--- a/ui/components/__tests__/DataTable.test.tsx
+++ b/ui/components/__tests__/DataTable.test.tsx
@@ -9,13 +9,13 @@ describe("DataTable", () => {
   const rows = [
     {
       name: "the-cool-app",
-      status: "Ready",
+      status: true,
       lastUpdate: "2005-01-02T15:04:05-0700",
       lastSyncedAt: 1000,
     },
     {
       name: "podinfo",
-      status: "Failed",
+      status: false,
       lastUpdate: "2006-01-02T15:04:05-0700",
       lastSyncedAt: 2000,
     },
@@ -24,6 +24,7 @@ describe("DataTable", () => {
       status: "Ready",
       lastUpdate: "2004-01-02T15:04:05-0700",
       lastSyncedAt: 3000,
+      suspended: true,
     },
   ];
 
@@ -37,8 +38,12 @@ describe("DataTable", () => {
     {
       label: "Status",
       value: "status",
-      sortType: SortType.bool,
-      sortValue: ({ status }) => (status === "Ready" ? true : false),
+      sortType: SortType.number,
+      sortValue: ({ status, suspended }) => {
+        if (suspended) return 2;
+        if (status) return 1;
+        else return 3;
+      },
     },
     {
       label: "Last Updated",
@@ -69,11 +74,15 @@ describe("DataTable", () => {
         const boolSort = sortWithType(rows, {
           label: "Status",
           value: "status",
-          sortType: SortType.bool,
-          sortValue: ({ status }) => (status === "Ready" ? true : false),
+          sortType: SortType.number,
+          sortValue: ({ status, suspended }) => {
+            if (suspended) return 2;
+            if (status) return 3;
+            else return 1;
+          },
         });
-        expect(boolSort[0].status).toBe("Failed");
-        expect(boolSort[2].status).toBe("Ready");
+        expect(boolSort[0].status).toBe(false);
+        expect(boolSort[2].status).toBe(true);
       });
       it("should handle sorting with case SortType.date", () => {
         const dateSort = sortWithType(rows, {

--- a/ui/components/__tests__/__snapshots__/Breadcrumbs.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/Breadcrumbs.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`snapshots renders 1`] = `
   className="sc-bdvvtL lacWsj"
 >
   <a
-    className="sc-hKwDye sc-eCImPb kCA-dBN cQVkzF"
+    className="sc-eCImPb sc-jRQBWg FjdOF fzVcqy"
     href="/applications"
     onClick={[Function]}
   >
@@ -25,7 +25,7 @@ exports[`snapshots renders child route 1`] = `
   className="sc-bdvvtL lacWsj"
 >
   <a
-    className="sc-hKwDye sc-eCImPb kCA-dBN cQVkzF"
+    className="sc-eCImPb sc-jRQBWg FjdOF fzVcqy"
     href="/applications"
     onClick={[Function]}
   >
@@ -52,7 +52,7 @@ exports[`snapshots renders child route 1`] = `
     </svg>
   </div>
   <a
-    className="sc-hKwDye sc-eCImPb kCA-dBN cQVkzF"
+    className="sc-eCImPb sc-jRQBWg FjdOF fzVcqy"
     href="/kustomization?name=flux"
     onClick={[Function]}
   >
@@ -72,7 +72,7 @@ exports[`snapshots renders on the root page 1`] = `
   className="sc-bdvvtL lacWsj"
 >
   <a
-    className="sc-hKwDye sc-eCImPb kCA-dBN cQVkzF"
+    className="sc-eCImPb sc-jRQBWg FjdOF fzVcqy"
     href="/"
     onClick={[Function]}
   >
@@ -97,7 +97,7 @@ exports[`snapshots renders on the root page 1`] = `
     </svg>
   </div>
   <a
-    className="sc-hKwDye sc-eCImPb kCA-dBN cQVkzF"
+    className="sc-eCImPb sc-jRQBWg FjdOF fzVcqy"
     href="/"
     onClick={[Function]}
   >

--- a/ui/components/__tests__/__snapshots__/DataTable.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/DataTable.test.tsx.snap
@@ -1,17 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DataTable snapshots renders 1`] = `
-.c2.MuiButton-root {
-  line-height: 1;
-  border-radius: 2px;
-  font-weight: 600;
-}
-
-.c2.MuiButton-outlined {
-  padding: 8px 12px;
-  border-color: #d8d8d8;
-}
-
 .c1 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -76,6 +65,17 @@ exports[`DataTable snapshots renders 1`] = `
 
 .c6 .c7 {
   margin-left: 4px;
+}
+
+.c2.MuiButton-root {
+  line-height: 1;
+  border-radius: 2px;
+  font-weight: 600;
+}
+
+.c2.MuiButton-outlined {
+  padding: 8px 12px;
+  border-color: #d8d8d8;
 }
 
 .c4 {

--- a/ui/components/__tests__/__snapshots__/DataTable.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/DataTable.test.tsx.snap
@@ -437,9 +437,7 @@ exports[`DataTable snapshots renders 1`] = `
             <span
               className="c7 c8"
               size="normal"
-            >
-              Failed
-            </span>
+            />
           </td>
           <td
             aria-sort={null}
@@ -490,9 +488,7 @@ exports[`DataTable snapshots renders 1`] = `
             <span
               className="c7 c8"
               size="normal"
-            >
-              Ready
-            </span>
+            />
           </td>
           <td
             aria-sort={null}

--- a/ui/components/__tests__/__snapshots__/GithubDeviceAuthModal.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/GithubDeviceAuthModal.test.tsx.snap
@@ -107,17 +107,6 @@ exports[`GithubDeviceAuthModal snapshots renders 1`] = `
   justify-content: space-evenly;
 }
 
-.c8.MuiButton-root {
-  line-height: 1;
-  border-radius: 2px;
-  font-weight: 600;
-}
-
-.c8.MuiButton-outlined {
-  padding: 8px 12px;
-  border-color: #d8d8d8;
-}
-
 .c7 {
   font-family: 'proxima-nova',Helvetica,Arial,sans-serif;
   font-size: 32px;
@@ -146,6 +135,17 @@ exports[`GithubDeviceAuthModal snapshots renders 1`] = `
 
 .c11 .c6 {
   margin-left: 4px;
+}
+
+.c8.MuiButton-root {
+  line-height: 1;
+  border-radius: 2px;
+  font-weight: 600;
+}
+
+.c8.MuiButton-outlined {
+  padding: 8px 12px;
+  border-color: #d8d8d8;
 }
 
 .c0 {

--- a/ui/lib/utils.ts
+++ b/ui/lib/utils.ts
@@ -48,7 +48,12 @@ export function pageTitleWithAppName(title: string, appName?: string) {
   return `${title}${appName ? ` for ${appName}` : ""}`;
 }
 
-export function statusSortHelper(suspended: boolean, conditions: Condition[]) {
+interface Statusable {
+  conditions: Condition[];
+  suspended: boolean;
+}
+
+export function statusSortHelper({ suspended, conditions }: Statusable) {
   if (suspended) return 2;
   if (computeReady(conditions)) return 3;
   else return 1;

--- a/ui/lib/utils.ts
+++ b/ui/lib/utils.ts
@@ -1,4 +1,6 @@
 import { toast } from "react-toastify";
+import { computeReady } from "../components/KubeStatusIndicator";
+import { Condition } from "./api/core/types.pb";
 import { PageRoute } from "./types";
 
 export function notifySuccess(message: string) {
@@ -44,4 +46,10 @@ export function convertGitURLToGitProvider(uri: string) {
 
 export function pageTitleWithAppName(title: string, appName?: string) {
   return `${title}${appName ? ` for ${appName}` : ""}`;
+}
+
+export function statusSortHelper(suspended: boolean, conditions: Condition[]) {
+  if (suspended) return 2;
+  if (computeReady(conditions)) return 3;
+  else return 1;
 }

--- a/ui/pages/v2/FluxRuntime.tsx
+++ b/ui/pages/v2/FluxRuntime.tsx
@@ -2,14 +2,13 @@ import _ from "lodash";
 import * as React from "react";
 import styled from "styled-components";
 import DataTable, { SortType } from "../../components/DataTable";
-import KubeStatusIndicator, {
-  computeReady,
-} from "../../components/KubeStatusIndicator";
+import KubeStatusIndicator from "../../components/KubeStatusIndicator";
 import Link from "../../components/Link";
 import Page from "../../components/Page";
 import Spacer from "../../components/Spacer";
 import { useListFluxRuntimeObjects } from "../../hooks/flux";
 import { Deployment } from "../../lib/api/core/types.pb";
+import { statusSortHelper } from "../../lib/utils";
 
 type Props = {
   className?: string;
@@ -39,11 +38,8 @@ function FluxRuntime({ className }: Props) {
             ),
             label: "Status",
             sortType: SortType.number,
-            sortValue: ({ conditions, suspended }) => {
-              if (suspended) return 2;
-              if (computeReady(conditions)) return 3;
-              else return 1;
-            },
+            sortValue: ({ conditions, suspended }) =>
+              statusSortHelper(suspended, conditions),
           },
           {
             label: "Cluster",

--- a/ui/pages/v2/FluxRuntime.tsx
+++ b/ui/pages/v2/FluxRuntime.tsx
@@ -38,8 +38,12 @@ function FluxRuntime({ className }: Props) {
               />
             ),
             label: "Status",
-            sortType: SortType.bool,
-            sortValue: ({ conditions }) => computeReady(conditions),
+            sortType: SortType.number,
+            sortValue: ({ conditions, suspended }) => {
+              if (suspended) return 2;
+              if (computeReady(conditions)) return 3;
+              else return 1;
+            },
           },
           {
             label: "Cluster",

--- a/ui/pages/v2/FluxRuntime.tsx
+++ b/ui/pages/v2/FluxRuntime.tsx
@@ -38,8 +38,7 @@ function FluxRuntime({ className }: Props) {
             ),
             label: "Status",
             sortType: SortType.number,
-            sortValue: ({ conditions, suspended }) =>
-              statusSortHelper(suspended, conditions),
+            sortValue: statusSortHelper,
           },
           {
             label: "Cluster",


### PR DESCRIPTION
<!-- Use # to add the issue this pull request is related to -->
Closes: #1763 

<!-- Describe what has changed in this PR -->
Clicking on the Status column of a data table will now sort by failing, then suspended, then ready

https://user-images.githubusercontent.com/65822698/160177547-83a615b1-b05a-4976-a829-dae828d6d230.mov