### PR TITLE
Fix newline problem

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@weaveworks/weave-gitops",
-      "version": "0.6.2",
+      "version": "0.7.0-rc3",
       "hasInstallScript": true,
       "dependencies": {
         "http-proxy-middleware": "^2.0.3",


### PR DESCRIPTION
package-lock.json had a newline problem that tripped up the `Check Git State` CI job.