### PR TITLE
Specify docker file in release job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -110,6 +110,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          file: gitops-server.dockerfile
   update-doc-repo-files:
     needs: goreleaser
     runs-on: ubuntu-latest


### PR DESCRIPTION
The gitops-server dockerfile name has been changed, and the release job didn't get changed to reflect that