### PR TITLE
Restyle Filter Modal

### DIFF
--- a/ui/components/AutomationsTable.tsx
+++ b/ui/components/AutomationsTable.tsx
@@ -115,13 +115,11 @@ function AutomationsTable({ className, automations, hideSource }: Props) {
   if (hideSource) fields = _.filter(fields, (f) => f.label !== "Source");
 
   return (
-    <div className={className}>
-      <FilterableTable
-        fields={fields}
-        filters={initialFilterState}
-        rows={automations}
-      />
-    </div>
+    <FilterableTable
+      fields={fields}
+      filters={initialFilterState}
+      rows={automations}
+    />
   );
 }
 

--- a/ui/components/AutomationsTable.tsx
+++ b/ui/components/AutomationsTable.tsx
@@ -119,6 +119,7 @@ function AutomationsTable({ className, automations, hideSource }: Props) {
       fields={fields}
       filters={initialFilterState}
       rows={automations}
+      className={className}
     />
   );
 }

--- a/ui/components/DataTable.tsx
+++ b/ui/components/DataTable.tsx
@@ -208,11 +208,9 @@ function UnstyledDataTable({
 
 export const DataTable = styled(UnstyledDataTable)`
   width: 100%;
-<<<<<<< HEAD
-=======
   padding-right: ${(props) => props.theme.spacing.medium};
->>>>>>> 0d674b88 (massive height changes everywhere and almost made it on the filter table in automations table component)
   h2 {
+    padding: 0;
     font-size: 18px;
     font-weight: 600;
     color: ${(props) => props.theme.colors.neutral30};

--- a/ui/components/DataTable.tsx
+++ b/ui/components/DataTable.tsx
@@ -208,6 +208,10 @@ function UnstyledDataTable({
 
 export const DataTable = styled(UnstyledDataTable)`
   width: 100%;
+<<<<<<< HEAD
+=======
+  padding-right: ${(props) => props.theme.spacing.medium};
+>>>>>>> 0d674b88 (massive height changes everywhere and almost made it on the filter table in automations table component)
   h2 {
     font-size: 18px;
     font-weight: 600;

--- a/ui/components/DataTable.tsx
+++ b/ui/components/DataTable.tsx
@@ -215,6 +215,8 @@ export const DataTable = styled(UnstyledDataTable)`
     font-weight: 600;
     color: ${(props) => props.theme.colors.neutral30};
     margin: 0px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
   .MuiTableRow-root {
     transition: background 0.5s ease-in-out;

--- a/ui/components/FilterDialog.tsx
+++ b/ui/components/FilterDialog.tsx
@@ -7,7 +7,6 @@ import ControlledForm from "./ControlledForm";
 import Flex from "./Flex";
 import FormCheckbox from "./FormCheckbox";
 import Icon, { IconType } from "./Icon";
-import Spacer from "./Spacer";
 import Text from "./Text";
 
 export type FilterConfig = { [key: string]: string[] };
@@ -91,6 +90,7 @@ function UnstyledFilterDialog({
     <SlideContainer>
       <SlideWrapper>
         <Slide direction="left" in={open} mountOnEnter unmountOnExit>
+<<<<<<< HEAD
 <<<<<<< HEAD
           <Paper elevation={4}>
             <Flex className={className + " filter-bar"} align start>
@@ -199,6 +199,56 @@ function UnstyledFilterDialog({
                 </List>
               </ControlledForm>
             </Spacer>
+=======
+          <Flex className={className + " filter-bar"} start column>
+            <Flex wide align between>
+              <Text size="extraLarge" color="neutral30">
+                Filters
+              </Text>
+              <Button variant="text" color="inherit" onClick={onClose}>
+                <Icon
+                  type={IconType.ClearIcon}
+                  size="large"
+                  color="neutral30"
+                />
+              </Button>
+            </Flex>
+            <ControlledForm
+              state={{ values: formState }}
+              onChange={onFormChange}
+            >
+              <List>
+                {_.map(filterList, (options: string[], header: string) => {
+                  return (
+                    <ListItem key={header}>
+                      <Flex column>
+                        <Text capitalize size="large" color="neutral30">
+                          {header}
+                        </Text>
+                        <List>
+                          {_.map(options, (option: string, index: number) => {
+                            return (
+                              <ListItem key={index}>
+                                <ListItemIcon>
+                                  <FormCheckbox
+                                    label=""
+                                    name={`${header}${filterSeparator}${option}`}
+                                  />
+                                </ListItemIcon>
+                                <Text color="neutral30">
+                                  {_.toString(option)}
+                                </Text>
+                              </ListItem>
+                            );
+                          })}
+                        </List>
+                      </Flex>
+                    </ListItem>
+                  );
+                })}
+              </List>
+            </ControlledForm>
+>>>>>>> 4bee3a76 (spacer fix)
           </Flex>
 >>>>>>> 4b588120 (corrected filter class)
         </Slide>
@@ -212,7 +262,8 @@ export default styled(UnstyledFilterDialog)`
     background: ${(props) => props.theme.colors.neutral00};
     min-width: 450px;
     border-left: 2px solid ${(props) => props.theme.colors.neutral20};
-    padding-left: ${(props) => props.theme.spacing.medium};
+    padding: ${(props) => props.theme.spacing.medium};
+    padding-left: ${(props) => props.theme.spacing.large};
   }
   .MuiListItem-gutters {
     padding-left: 0px;

--- a/ui/components/FilterDialog.tsx
+++ b/ui/components/FilterDialog.tsx
@@ -1,4 +1,4 @@
-import { List, ListItem, ListItemIcon, Slide } from "@material-ui/core";
+import { List, ListItem, ListItemIcon } from "@material-ui/core";
 import _ from "lodash";
 import * as React from "react";
 import styled from "styled-components";
@@ -14,13 +14,25 @@ export type DialogFormState = { [inputName: string]: boolean };
 
 const SlideContainer = styled.div`
   position: relative;
+  height: 94%;
   width: 0px;
+  left: ${(props) => props.theme.spacing.medium};
+  transition: width 0.5s ease-in-out;
+  &.open {
+    left: 0;
+    margin-right: ${(props) => props.theme.spacing.medium};
+    width: 350px;
+  }
 `;
 
-const SlideWrapper = styled.div`
-  position: absolute;
-  right: 0;
-  top: 0;
+const SlideContent = styled.div`
+  // this bg color factors in the opacity of the content container while keeping the filters opaque
+  background: rgb(250, 250, 250);
+  height: 100%;
+  width: 100%;
+  border-left: 2px solid ${(props) => props.theme.colors.neutral20};
+  padding: ${(props) => props.theme.spacing.medium};
+  padding-left: ${(props) => props.theme.spacing.large};
 `;
 
 export const filterSeparator = ":";
@@ -87,185 +99,56 @@ function UnstyledFilterDialog({
   };
 
   return (
-    <SlideContainer>
-      <SlideWrapper>
-        <Slide direction="left" in={open} mountOnEnter unmountOnExit>
-<<<<<<< HEAD
-<<<<<<< HEAD
-          <Paper elevation={4}>
-            <Flex className={className + " filter-bar"} align start>
-              <Spacer padding="medium">
-                <Flex wide align between>
-                  <Text size="extraLarge" color="neutral30">
-                    Filters
-                  </Text>
-                  <Button variant="text" color="inherit" onClick={onClose}>
-                    <Icon
-                      type={IconType.ClearIcon}
-                      size="large"
-                      color="neutral30"
-                    />
-                  </Button>
-                </Flex>
-                <ControlledForm
-                  state={{ values: formState }}
-                  onChange={onFormChange}
-                >
-                  <List>
-                    {_.map(filterList, (options: string[], header: string) => {
-                      return (
-                        <ListItem key={header}>
-                          <Flex column>
-                            <Text capitalize size="large" color="neutral30">
-                              {header}
-                            </Text>
-                            <List>
-                              {_.map(
-                                _.sortBy(options),
-                                (option: string, index: number) => {
-                                  return (
-                                    <ListItem key={index}>
-                                      <ListItemIcon>
-                                        <FormCheckbox
-                                          label=""
-                                          name={`${header}${filterSeparator}${option}`}
-                                        />
-                                      </ListItemIcon>
-                                      <Text color="neutral30">
-                                        {_.toString(option)}
-                                      </Text>
-                                    </ListItem>
-                                  );
-                                }
-                              )}
-                            </List>
-                          </Flex>
-                        </ListItem>
-                      );
-                    })}
-                  </List>
-                </ControlledForm>
-              </Spacer>
-            </Flex>
-          </Paper>
-=======
-          <Flex className={className + " filter-bar"} align start>
-            <Spacer padding="medium">
-              <Flex wide align between>
-                <Text size="extraLarge" color="neutral30">
-                  Filters
-                </Text>
-                <Button variant="text" color="inherit" onClick={onClose}>
-                  <Icon
-                    type={IconType.ClearIcon}
-                    size="large"
-                    color="neutral30"
-                  />
-                </Button>
-              </Flex>
-              <ControlledForm
-                state={{ values: formState }}
-                onChange={onFormChange}
-              >
-                <List>
-                  {_.map(filterList, (options: string[], header: string) => {
-                    return (
-                      <ListItem key={header}>
-                        <Flex column>
-                          <Text capitalize size="large" color="neutral30">
-                            {header}
-                          </Text>
-                          <List>
-                            {_.map(options, (option: string, index: number) => {
-                              return (
-                                <ListItem key={index}>
-                                  <ListItemIcon>
-                                    <FormCheckbox
-                                      label=""
-                                      name={`${header}${filterSeparator}${option}`}
-                                    />
-                                  </ListItemIcon>
-                                  <Text color="neutral30">
-                                    {_.toString(option)}
-                                  </Text>
-                                </ListItem>
-                              );
-                            })}
-                          </List>
-                        </Flex>
-                      </ListItem>
-                    );
-                  })}
-                </List>
-              </ControlledForm>
-            </Spacer>
-=======
-          <Flex className={className + " filter-bar"} start column>
-            <Flex wide align between>
-              <Text size="large" color="neutral30">
-                Filters
-              </Text>
-              <Button variant="text" color="inherit" onClick={onClose}>
-                <Icon
-                  type={IconType.ClearIcon}
-                  size="large"
-                  color="neutral30"
-                />
-              </Button>
-            </Flex>
-            <ControlledForm
-              state={{ values: formState }}
-              onChange={onFormChange}
-            >
-              <List>
-                {_.map(filterList, (options: string[], header: string) => {
-                  return (
-                    <ListItem key={header}>
-                      <Flex column>
-                        <Text capitalize size="small" color="neutral30">
-                          {header}
-                        </Text>
-                        <List>
-                          {_.map(options, (option: string, index: number) => {
-                            return (
-                              <ListItem key={index}>
-                                <ListItemIcon>
-                                  <FormCheckbox
-                                    label=""
-                                    name={`${header}${filterSeparator}${option}`}
-                                  />
-                                </ListItemIcon>
-                                <Text color="neutral30" size="small">
-                                  {_.toString(option)}
-                                </Text>
-                              </ListItem>
-                            );
-                          })}
-                        </List>
-                      </Flex>
-                    </ListItem>
-                  );
-                })}
-              </List>
-            </ControlledForm>
->>>>>>> 4bee3a76 (spacer fix)
+    <SlideContainer className={`${open ? "open" : ""}`}>
+      <SlideContent>
+        <Flex className={className} start column>
+          <Flex wide align between>
+            <Text size="large" color="neutral30">
+              Filters
+            </Text>
+            <Button variant="text" color="inherit" onClick={onClose}>
+              <Icon type={IconType.ClearIcon} size="large" color="neutral30" />
+            </Button>
           </Flex>
->>>>>>> 4b588120 (corrected filter class)
-        </Slide>
-      </SlideWrapper>
+          <ControlledForm state={{ values: formState }} onChange={onFormChange}>
+            <List>
+              {_.map(filterList, (options: string[], header: string) => {
+                return (
+                  <ListItem key={header}>
+                    <Flex column>
+                      <Text capitalize size="small" color="neutral30">
+                        {header}
+                      </Text>
+                      <List>
+                        {_.map(options, (option: string, index: number) => {
+                          return (
+                            <ListItem key={index}>
+                              <ListItemIcon>
+                                <FormCheckbox
+                                  label=""
+                                  name={`${header}${filterSeparator}${option}`}
+                                />
+                              </ListItemIcon>
+                              <Text color="neutral30" size="small">
+                                {_.toString(option)}
+                              </Text>
+                            </ListItem>
+                          );
+                        })}
+                      </List>
+                    </Flex>
+                  </ListItem>
+                );
+              })}
+            </List>
+          </ControlledForm>
+        </Flex>
+      </SlideContent>
     </SlideContainer>
   );
 }
 
 export default styled(UnstyledFilterDialog)`
-  &.filter-bar {
-    // this bg color factors in the opacity of the content container while keeping the filters opaque
-    background: rgb(250, 250, 250);
-    min-width: 300px;
-    border-left: 2px solid ${(props) => props.theme.colors.neutral20};
-    padding: ${(props) => props.theme.spacing.medium};
-    padding-left: ${(props) => props.theme.spacing.xl};
-  }
   .MuiListItem-gutters {
     padding-left: 0px;
   }

--- a/ui/components/FilterDialog.tsx
+++ b/ui/components/FilterDialog.tsx
@@ -18,7 +18,13 @@ const SlideContainer = styled.div`
   width: 0px;
   left: ${(props) => props.theme.spacing.medium};
   transition: width 0.5s ease-in-out;
+  ${Icon} {
+    display: none;
+  }
   &.open {
+    ${Icon} {
+      display: block;
+    }
     left: 0;
     margin-right: ${(props) => props.theme.spacing.medium};
     width: 350px;

--- a/ui/components/FilterDialog.tsx
+++ b/ui/components/FilterDialog.tsx
@@ -1,4 +1,4 @@
-import { List, ListItem, ListItemIcon, Paper, Slide } from "@material-ui/core";
+import { List, ListItem, ListItemIcon, Slide } from "@material-ui/core";
 import _ from "lodash";
 import * as React from "react";
 import styled from "styled-components";
@@ -91,6 +91,7 @@ function UnstyledFilterDialog({
     <SlideContainer>
       <SlideWrapper>
         <Slide direction="left" in={open} mountOnEnter unmountOnExit>
+<<<<<<< HEAD
           <Paper elevation={4}>
             <Flex className={className + " filter-bar"} align start>
               <Spacer padding="medium">
@@ -147,6 +148,59 @@ function UnstyledFilterDialog({
               </Spacer>
             </Flex>
           </Paper>
+=======
+          <Flex className={className + " filter-bar"} align start>
+            <Spacer padding="medium">
+              <Flex wide align between>
+                <Text size="extraLarge" color="neutral30">
+                  Filters
+                </Text>
+                <Button variant="text" color="inherit" onClick={onClose}>
+                  <Icon
+                    type={IconType.ClearIcon}
+                    size="large"
+                    color="neutral30"
+                  />
+                </Button>
+              </Flex>
+              <ControlledForm
+                state={{ values: formState }}
+                onChange={onFormChange}
+              >
+                <List>
+                  {_.map(filterList, (options: string[], header: string) => {
+                    return (
+                      <ListItem key={header}>
+                        <Flex column>
+                          <Text capitalize size="large" color="neutral30">
+                            {header}
+                          </Text>
+                          <List>
+                            {_.map(options, (option: string, index: number) => {
+                              return (
+                                <ListItem key={index}>
+                                  <ListItemIcon>
+                                    <FormCheckbox
+                                      label=""
+                                      name={`${header}${filterSeparator}${option}`}
+                                    />
+                                  </ListItemIcon>
+                                  <Text color="neutral30">
+                                    {_.toString(option)}
+                                  </Text>
+                                </ListItem>
+                              );
+                            })}
+                          </List>
+                        </Flex>
+                      </ListItem>
+                    );
+                  })}
+                </List>
+              </ControlledForm>
+            </Spacer>
+          </Flex>
+>>>>>>> 4b588120 (corrected filter class)
         </Slide>
       </SlideWrapper>
     </SlideContainer>
@@ -154,9 +208,10 @@ function UnstyledFilterDialog({
 }
 
 export default styled(UnstyledFilterDialog)`
-  .MuiPopover-paper {
+  &.filter-bar {
+    background: ${(props) => props.theme.colors.neutral00};
     min-width: 450px;
-    border-left: 2px solid ${(props) => props.theme.colors.neutral30};
+    border-left: 2px solid ${(props) => props.theme.colors.neutral20};
     padding-left: ${(props) => props.theme.spacing.medium};
   }
   .MuiListItem-gutters {

--- a/ui/components/FilterDialog.tsx
+++ b/ui/components/FilterDialog.tsx
@@ -99,7 +99,7 @@ function UnstyledFilterDialog({
   };
 
   return (
-    <SlideContainer className={`${open ? "open" : ""}`}>
+    <SlideContainer className={`${open ? "open" : ""}`} data-testid="container">
       <SlideContent>
         <Flex className={className} start column>
           <Flex wide align between>
@@ -149,12 +149,6 @@ function UnstyledFilterDialog({
 }
 
 export default styled(UnstyledFilterDialog)`
-  &.filter-bar {
-    background: ${(props) => props.theme.colors.neutral00};
-    min-width: 450px;
-    border-left: 2px solid ${(props) => props.theme.colors.neutral20};
-    padding-left: ${(props) => props.theme.spacing.medium};
-  }
   .MuiListItem-gutters {
     padding-left: 0px;
   }

--- a/ui/components/FilterDialog.tsx
+++ b/ui/components/FilterDialog.tsx
@@ -259,7 +259,8 @@ function UnstyledFilterDialog({
 
 export default styled(UnstyledFilterDialog)`
   &.filter-bar {
-    background: ${(props) => props.theme.colors.neutral00};
+    // this bg color factors in the opacity of the content container while keeping the filters opaque
+    background: rgb(250, 250, 250);
     min-width: 300px;
     border-left: 2px solid ${(props) => props.theme.colors.neutral20};
     padding: ${(props) => props.theme.spacing.medium};

--- a/ui/components/FilterDialog.tsx
+++ b/ui/components/FilterDialog.tsx
@@ -202,7 +202,7 @@ function UnstyledFilterDialog({
 =======
           <Flex className={className + " filter-bar"} start column>
             <Flex wide align between>
-              <Text size="extraLarge" color="neutral30">
+              <Text size="large" color="neutral30">
                 Filters
               </Text>
               <Button variant="text" color="inherit" onClick={onClose}>
@@ -222,7 +222,7 @@ function UnstyledFilterDialog({
                   return (
                     <ListItem key={header}>
                       <Flex column>
-                        <Text capitalize size="large" color="neutral30">
+                        <Text capitalize size="small" color="neutral30">
                           {header}
                         </Text>
                         <List>
@@ -235,7 +235,7 @@ function UnstyledFilterDialog({
                                     name={`${header}${filterSeparator}${option}`}
                                   />
                                 </ListItemIcon>
-                                <Text color="neutral30">
+                                <Text color="neutral30" size="small">
                                   {_.toString(option)}
                                 </Text>
                               </ListItem>
@@ -260,10 +260,10 @@ function UnstyledFilterDialog({
 export default styled(UnstyledFilterDialog)`
   &.filter-bar {
     background: ${(props) => props.theme.colors.neutral00};
-    min-width: 450px;
+    min-width: 300px;
     border-left: 2px solid ${(props) => props.theme.colors.neutral20};
     padding: ${(props) => props.theme.spacing.medium};
-    padding-left: ${(props) => props.theme.spacing.large};
+    padding-left: ${(props) => props.theme.spacing.xl};
   }
   .MuiListItem-gutters {
     padding-left: 0px;

--- a/ui/components/FilterDialog.tsx
+++ b/ui/components/FilterDialog.tsx
@@ -149,6 +149,12 @@ function UnstyledFilterDialog({
 }
 
 export default styled(UnstyledFilterDialog)`
+  &.filter-bar {
+    background: ${(props) => props.theme.colors.neutral00};
+    min-width: 450px;
+    border-left: 2px solid ${(props) => props.theme.colors.neutral20};
+    padding-left: ${(props) => props.theme.spacing.medium};
+  }
   .MuiListItem-gutters {
     padding-left: 0px;
   }

--- a/ui/components/FilterDialog.tsx
+++ b/ui/components/FilterDialog.tsx
@@ -14,7 +14,7 @@ export type DialogFormState = { [inputName: string]: boolean };
 
 const SlideContainer = styled.div`
   position: relative;
-  height: 94%;
+  height: 100%;
   width: 0px;
   left: ${(props) => props.theme.spacing.medium};
   transition: width 0.5s ease-in-out;

--- a/ui/components/FilterableTable.tsx
+++ b/ui/components/FilterableTable.tsx
@@ -165,7 +165,7 @@ function FilterableTable({
   };
 
   return (
-    <div className={className} style={{ height: "100%", width: "100%" }}>
+    <Flex className={className} wide tall column>
       <Flex wide>
         <ChipGroup
           chips={chips}
@@ -189,7 +189,7 @@ function FilterableTable({
           open={filterDialogOpen}
         />
       </Flex>
-    </div>
+    </Flex>
   );
 }
 

--- a/ui/components/FilterableTable.tsx
+++ b/ui/components/FilterableTable.tsx
@@ -164,10 +164,6 @@ function FilterableTable({
     setFilterState({ ...filterState, filters, formState });
   };
 
-  const TableFlex = styled(Flex)`
-    height: 100%;
-  `;
-  console.log(filterDialogOpen);
   return (
     <div className={className} style={{ height: "100%", width: "100%" }}>
       <Flex wide>
@@ -183,7 +179,7 @@ function FilterableTable({
           />
         </Flex>
       </Flex>
-      <TableFlex wide>
+      <Flex wide tall>
         <DataTable className={className} fields={fields} rows={filtered} />
         <FilterDialog
           onClose={() => setFilterDialog(!filterDialogOpen)}
@@ -192,7 +188,7 @@ function FilterableTable({
           formState={filterState.formState}
           open={filterDialogOpen}
         />
-      </TableFlex>
+      </Flex>
     </div>
   );
 }

--- a/ui/components/FilterableTable.tsx
+++ b/ui/components/FilterableTable.tsx
@@ -164,9 +164,13 @@ function FilterableTable({
     setFilterState({ ...filterState, filters, formState });
   };
 
+  const TableFlex = styled(Flex)`
+    height: 100%;
+  `;
+  console.log(filterDialogOpen);
   return (
-    <div className={className}>
-      <Flex>
+    <div className={className} style={{ height: "100%", width: "100%" }}>
+      <Flex wide>
         <ChipGroup
           chips={chips}
           onChipRemove={handleChipRemove}
@@ -179,7 +183,7 @@ function FilterableTable({
           />
         </Flex>
       </Flex>
-      <Flex>
+      <TableFlex wide>
         <DataTable className={className} fields={fields} rows={filtered} />
         <FilterDialog
           onClose={() => setFilterDialog(!filterDialogOpen)}
@@ -188,7 +192,7 @@ function FilterableTable({
           formState={filterState.formState}
           open={filterDialogOpen}
         />
-      </Flex>
+      </TableFlex>
     </div>
   );
 }

--- a/ui/components/Flex.tsx
+++ b/ui/components/Flex.tsx
@@ -16,7 +16,7 @@ const Styled = (component) => styled(component)`
   display: flex;
   flex-direction: ${(props) => (props.column ? "column" : "row")};
   align-items: ${(props) => (props.align ? "center" : "start")};
-  ${(props) => props.height && `height: ${props.height};`}
+  ${({ tall }) => tall && `height: 100%`};
   ${({ wide }) => wide && "width: 100%"};
   ${({ wrap }) => wrap && "flex-wrap: wrap"};
   ${({ start }) => start && "justify-content: flex-start"};

--- a/ui/components/Footer.tsx
+++ b/ui/components/Footer.tsx
@@ -3,6 +3,8 @@ import styled from "styled-components";
 import p from "../../package.json";
 import Flex from "./Flex";
 import Link from "./Link";
+import Spacer from "./Spacer";
+import Text from "./Text";
 
 type Props = {
   className?: string;
@@ -10,17 +12,16 @@ type Props = {
 
 const RightFoot = styled(Flex)`
   padding-right: ${(props) => props.theme.spacing.medium};
-  width: 275px;
 `;
 
-const LeftFoot = styled(Flex)`
-  width: 350px;
-`;
+const LeftFoot = styled(Flex)``;
+
 function Footer({ className }: Props) {
   return (
     <Flex as="footer" wide between className={className}>
       <LeftFoot>
-        Need help? Contact us at
+        <Text color="neutral30">Need help? Contact us at</Text>
+        <Spacer padding="xxs" />
         <Link newTab href="mailto:support@weave.works">
           support@weave.works
         </Link>
@@ -34,7 +35,8 @@ function Footer({ className }: Props) {
             v{p.version}
           </Link>
         )}
-        © 2022 Weaveworks
+        <Spacer padding="xxs" />
+        <Text color="neutral30">© 2022 Weaveworks</Text>
       </RightFoot>
     </Flex>
   );

--- a/ui/components/HashRouterTabs.tsx
+++ b/ui/components/HashRouterTabs.tsx
@@ -66,7 +66,7 @@ function HashRouterTabs({ className, children, defaultPath, history }: Props) {
   }));
 
   return (
-    <Flex wide column start className={className}>
+    <Flex wide tall column start className={className}>
       <Tabs
         indicatorColor="primary"
         value={routesToIndex(routes, history.location.pathname)}
@@ -101,7 +101,6 @@ function HashRouterTabs({ className, children, defaultPath, history }: Props) {
 export default styled(HashRouterTabs).attrs({
   className: HashRouterTabs.name,
 })`
-  height: 100%;
   .MuiTabs-root ${Link} .active-tab {
     background: ${(props) => props.theme.colors.primary}19;
   }

--- a/ui/components/HelmReleaseDetail.tsx
+++ b/ui/components/HelmReleaseDetail.tsx
@@ -57,7 +57,7 @@ export default function HelmReleaseDetail({
   };
 
   return (
-    <div className={className}>
+    <Flex wide tall column align>
       <Flex wide between>
         <Info>
           <Heading level={2}>{helmRelease?.namespace}</Heading>
@@ -115,6 +115,6 @@ export default function HelmReleaseDetail({
           </HashRouterTab>
         </HashRouterTabs>
       </TabContent>
-    </div>
+    </Flex>
   );
 }

--- a/ui/components/KustomizationDetail.tsx
+++ b/ui/components/KustomizationDetail.tsx
@@ -16,8 +16,11 @@ import PageStatus from "./PageStatus";
 import ReconciledObjectsTable from "./ReconciledObjectsTable";
 import ReconciliationGraph from "./ReconciliationGraph";
 import SourceLink from "./SourceLink";
+<<<<<<< HEAD
 import SyncButton from "./SyncButton";
 import Timestamp from "./Timestamp";
+=======
+>>>>>>> b4e773db (adding tall where tall was short)
 
 type Props = {
   name: string;
@@ -53,8 +56,7 @@ function KustomizationDetail({ kustomization, name, className }: Props) {
   };
 
   return (
-    <Flex wide tall column>
-      <Spacer padding="xs" />
+    <Flex wide tall column align>
       <Flex wide between>
         <Info>
           <Heading level={2}>{kustomization?.namespace}</Heading>

--- a/ui/components/KustomizationDetail.tsx
+++ b/ui/components/KustomizationDetail.tsx
@@ -16,11 +16,8 @@ import PageStatus from "./PageStatus";
 import ReconciledObjectsTable from "./ReconciledObjectsTable";
 import ReconciliationGraph from "./ReconciliationGraph";
 import SourceLink from "./SourceLink";
-<<<<<<< HEAD
 import SyncButton from "./SyncButton";
 import Timestamp from "./Timestamp";
-=======
->>>>>>> b4e773db (adding tall where tall was short)
 
 type Props = {
   name: string;
@@ -56,7 +53,7 @@ function KustomizationDetail({ kustomization, name, className }: Props) {
   };
 
   return (
-    <Flex wide tall column align>
+    <Flex wide tall column align className={className}>
       <Flex wide between>
         <Info>
           <Heading level={2}>{kustomization?.namespace}</Heading>

--- a/ui/components/KustomizationDetail.tsx
+++ b/ui/components/KustomizationDetail.tsx
@@ -53,7 +53,8 @@ function KustomizationDetail({ kustomization, name, className }: Props) {
   };
 
   return (
-    <div className={className}>
+    <Flex wide tall column>
+      <Spacer padding="xs" />
       <Flex wide between>
         <Info>
           <Heading level={2}>{kustomization?.namespace}</Heading>
@@ -118,7 +119,7 @@ function KustomizationDetail({ kustomization, name, className }: Props) {
           </HashRouterTab>
         </HashRouterTabs>
       </TabContent>
-    </div>
+    </Flex>
   );
 }
 

--- a/ui/components/Layout.tsx
+++ b/ui/components/Layout.tsx
@@ -61,6 +61,7 @@ const AppContainer = styled.div`
   min-height: 100vh;
   margin: 0 auto;
   padding: 0;
+  overflow-x: hidden;
 `;
 
 const NavContainer = styled.div`
@@ -123,7 +124,6 @@ const Main = styled(Flex)`
 const TopToolBar = styled(Flex)`
   background-color: ${(props) => props.theme.colors.primary};
   height: 80px;
-  flex: 0 1 auto;
 
   ${UserSettings} {
     justify-self: flex-end;

--- a/ui/components/Layout.tsx
+++ b/ui/components/Layout.tsx
@@ -117,9 +117,7 @@ const ContentContainer = styled.div`
   padding-left: ${(props) => props.theme.spacing.medium};
 `;
 
-const Main = styled(Flex)`
-  height: 100%;
-`;
+const Main = styled(Flex)``;
 
 const TopToolBar = styled(Flex)`
   background-color: ${(props) => props.theme.colors.primary};
@@ -144,7 +142,7 @@ function Layout({ className, children }: Props) {
           <Breadcrumbs />
           {flags.WEAVE_GITOPS_AUTH_ENABLED ? <UserSettings /> : null}
         </TopToolBar>
-        <Main wide>
+        <Main wide tall>
           <NavContainer>
             <NavContent>
               <Tabs

--- a/ui/components/Page.tsx
+++ b/ui/components/Page.tsx
@@ -32,14 +32,15 @@ export const Content = styled(Flex)`
   padding-bottom: ${(props) => props.theme.spacing.medium};
   padding-left: ${(props) => props.theme.spacing.large};
   padding-top: ${(props) => props.theme.spacing.medium};
+<<<<<<< HEAD
   padding-right: ${(props) => props.theme.spacing.large};
   width: 100%;
   height: 100%;
+=======
+>>>>>>> f40965d9 (tall prop)
 `;
 
-const Children = styled(Flex)`
-  height: 100%;
-`;
+const Children = styled(Flex)``;
 
 export const TitleBar = styled(Flex)`
   h2 {
@@ -63,20 +64,27 @@ function Errors({ error }) {
   );
 }
 
-function Page({ children, title, actions, loading, error }: PageProps) {
+function Page({
+  children,
+  title,
+  actions,
+  loading,
+  error,
+  className,
+}: PageProps) {
   const { settings } = useCommon();
   const fetching = useIsFetching();
 
   if (loading) {
     return (
-      <Content wide start column>
+      <Content wide tall start column>
         <LoadingPage />
       </Content>
     );
   }
 
   return (
-    <Content wide start column>
+    <Content wide tall start column className={className}>
       <TitleBar wide start between>
         <Flex align>
           <h2>{title}</h2>
@@ -86,16 +94,16 @@ function Page({ children, title, actions, loading, error }: PageProps) {
         {actions}
       </TitleBar>
       {error && <Errors error={error} />}
-      <Children column wide align start>
+      <Children column wide tall start>
         {children}
       </Children>
+
       {settings.renderFooter && <Footer />}
     </Content>
   );
 }
 
 export default styled(Page)`
-  height: 100%;
   .MuiAlert-root {
     width: 100%;
   }

--- a/ui/components/Page.tsx
+++ b/ui/components/Page.tsx
@@ -32,12 +32,9 @@ export const Content = styled(Flex)`
   padding-bottom: ${(props) => props.theme.spacing.medium};
   padding-left: ${(props) => props.theme.spacing.large};
   padding-top: ${(props) => props.theme.spacing.medium};
-<<<<<<< HEAD
   padding-right: ${(props) => props.theme.spacing.large};
   width: 100%;
   height: 100%;
-=======
->>>>>>> f40965d9 (tall prop)
 `;
 
 const Children = styled(Flex)``;

--- a/ui/components/SourceDetail.tsx
+++ b/ui/components/SourceDetail.tsx
@@ -59,7 +59,7 @@ function SourceDetail({ className, name, info, type }: Props) {
   });
 
   return (
-    <Flex wide column align className={className}>
+    <Flex wide tall column align className={className}>
       <Flex wide between>
         <div>
           <Heading level={2}>{s.type}</Heading>

--- a/ui/components/SourcesTable.tsx
+++ b/ui/components/SourcesTable.tsx
@@ -31,123 +31,121 @@ function SourcesTable({ className, sources }: Props) {
   };
 
   return (
-    <div className={className}>
-      <FilterableTable
-        filters={initialFilterState}
-        rows={sources}
-        dialogOpen={filterDialogOpen}
-        onDialogClose={() => setFilterDialog(false)}
-        fields={[
-          {
-            label: "Name",
-            value: (s: Source) => (
-              <Link
-                to={formatURL(sourceTypeToRoute(s.type), {
-                  name: s?.name,
-                  namespace: s?.namespace,
-                })}
-              >
-                {s?.name}
+    <FilterableTable
+      filters={initialFilterState}
+      rows={sources}
+      dialogOpen={filterDialogOpen}
+      onDialogClose={() => setFilterDialog(false)}
+      fields={[
+        {
+          label: "Name",
+          value: (s: Source) => (
+            <Link
+              to={formatURL(sourceTypeToRoute(s.type), {
+                name: s?.name,
+                namespace: s?.namespace,
+              })}
+            >
+              {s?.name}
+            </Link>
+          ),
+          sortType: SortType.string,
+          sortValue: (s: Source) => s.name || "",
+          width: 5,
+          textSearchable: true,
+        },
+        { label: "Type", value: "type", width: 5 },
+        {
+          label: "Status",
+          value: (s: Source) => (
+            <KubeStatusIndicator
+              short
+              conditions={s.conditions}
+              suspended={s.suspended}
+            />
+          ),
+          sortType: SortType.number,
+          sortValue: statusSortHelper,
+          width: 5,
+        },
+        {
+          label: "Message",
+          value: (s) => computeMessage(s.conditions),
+
+          width: 45,
+        },
+        {
+          label: "Cluster",
+          value: (s: Source) => s.clusterName,
+          width: 5,
+        },
+        {
+          label: "URL",
+          value: (s: Source) => {
+            let text;
+            let url;
+            let link = false;
+
+            switch (s.type) {
+              case SourceRefSourceKind.GitRepository:
+                text = (s as GitRepository).url;
+                url = convertGitURLToGitProvider((s as GitRepository).url);
+                link = true;
+                break;
+              case SourceRefSourceKind.Bucket:
+                text = (s as Bucket).endpoint;
+                break;
+              case SourceRefSourceKind.HelmChart:
+                text = `https://${(s as HelmChart).sourceRef?.name}`;
+                url = (s as HelmChart).chart;
+                link = true;
+                break;
+              case SourceRefSourceKind.HelmRepository:
+                text = (s as HelmRepository).url;
+                url = text;
+                link = true;
+                break;
+            }
+
+            return link ? (
+              <Link newTab href={url}>
+                {text}
               </Link>
-            ),
-            sortType: SortType.string,
-            sortValue: (s: Source) => s.name || "",
-            width: 5,
-            textSearchable: true,
+            ) : (
+              text
+            );
           },
-          { label: "Type", value: "type", width: 5 },
-          {
-            label: "Status",
-            value: (s: Source) => (
-              <KubeStatusIndicator
-                short
-                conditions={s.conditions}
-                suspended={s.suspended}
-              />
-            ),
-            sortType: SortType.number,
-            sortValue: statusSortHelper,
-            width: 5,
-          },
-          {
-            label: "Message",
-            value: (s) => computeMessage(s.conditions),
+          width: 25,
+        },
+        {
+          label: "Reference",
+          value: (s: Source) => {
+            const isGit = s.type === SourceRefSourceKind.GitRepository;
+            const repo = s as GitRepository;
+            const ref =
+              repo?.reference?.branch ||
+              repo?.reference?.commit ||
+              repo?.reference?.tag ||
+              repo?.reference?.semver;
 
-            width: 45,
+            return isGit ? ref : "-";
           },
-          {
-            label: "Cluster",
-            value: (s: Source) => s.clusterName,
-            width: 5,
-          },
-          {
-            label: "URL",
-            value: (s: Source) => {
-              let text;
-              let url;
-              let link = false;
-
-              switch (s.type) {
-                case SourceRefSourceKind.GitRepository:
-                  text = (s as GitRepository).url;
-                  url = convertGitURLToGitProvider((s as GitRepository).url);
-                  link = true;
-                  break;
-                case SourceRefSourceKind.Bucket:
-                  text = (s as Bucket).endpoint;
-                  break;
-                case SourceRefSourceKind.HelmChart:
-                  text = `https://${(s as HelmChart).sourceRef?.name}`;
-                  url = (s as HelmChart).chart;
-                  link = true;
-                  break;
-                case SourceRefSourceKind.HelmRepository:
-                  text = (s as HelmRepository).url;
-                  url = text;
-                  link = true;
-                  break;
-              }
-
-              return link ? (
-                <Link newTab href={url}>
-                  {text}
-                </Link>
-              ) : (
-                text
-              );
-            },
-            width: 25,
-          },
-          {
-            label: "Reference",
-            value: (s: Source) => {
-              const isGit = s.type === SourceRefSourceKind.GitRepository;
-              const repo = s as GitRepository;
-              const ref =
-                repo?.reference?.branch ||
-                repo?.reference?.commit ||
-                repo?.reference?.tag ||
-                repo?.reference?.semver;
-
-              return isGit ? ref : "-";
-            },
-            width: 5,
-          },
-          {
-            label: "Interval",
-            value: (s: Source) => showInterval(s.interval),
-            width: 5,
-          },
-          {
-            label: "Last Updated",
-            value: (s: Source) => (
-              <Timestamp time={(s as GitRepository).lastUpdatedAt} />
-            ),
-            width: 5,
-          },
-        ]}
-      />
-    </div>
+          width: 5,
+        },
+        {
+          label: "Interval",
+          value: (s: Source) => showInterval(s.interval),
+          width: 5,
+        },
+        {
+          label: "Last Updated",
+          value: (s: Source) => (
+            <Timestamp time={(s as GitRepository).lastUpdatedAt} />
+          ),
+          width: 5,
+        },
+      ]}
+    />
   );
 }
 

--- a/ui/components/SyncButton.tsx
+++ b/ui/components/SyncButton.tsx
@@ -13,7 +13,7 @@ type Props = {
 function SyncButton({ className, loading, onClick }: Props) {
   const [withSource, setWithSource] = React.useState(true);
   return (
-    <Flex align start className={className}>
+    <Flex wide align start className={className}>
       <Button
         style={{ marginRight: 8 }}
         loading={loading}

--- a/ui/components/__tests__/FilterDialog.test.tsx
+++ b/ui/components/__tests__/FilterDialog.test.tsx
@@ -18,10 +18,13 @@ describe("FilterDialog", () => {
           filterList={filterList}
           formState={initialFormState(filterList)}
           onFilterSelect={setActiveFilters}
+          open={false}
         />
       )
     );
-    expect(screen.queryByText("Name")).toBeNull();
+    expect(screen.getByTestId("container").getAttribute("class")).not.toContain(
+      "open"
+    );
   });
   it("should reveal filter list when open", () => {
     render(
@@ -34,7 +37,9 @@ describe("FilterDialog", () => {
         />
       )
     );
-    expect(screen.queryByText("Name")).toBeTruthy();
+    expect(screen.getByTestId("container").getAttribute("class")).toContain(
+      "open"
+    );
   });
   it("should return a value when a parameter is clicked", () => {
     const onFilterSelect = jest.fn();

--- a/ui/components/__tests__/FilterableTable.test.tsx
+++ b/ui/components/__tests__/FilterableTable.test.tsx
@@ -110,8 +110,8 @@ describe("FilterableTable", () => {
       withTheme(<FilterableTable fields={fields} rows={rows} filters={{}} />)
     );
 
-    expect(screen.queryByText("slick")).toBeTruthy();
-    expect(screen.queryByText("cool")).toBeTruthy();
+    expect(screen.queryAllByText("slick")).toBeTruthy();
+    expect(screen.queryAllByText("cool")).toBeTruthy();
   });
   it("should filter rows", () => {
     render(
@@ -124,8 +124,8 @@ describe("FilterableTable", () => {
       )
     );
 
-    expect(screen.queryByText("slick")).toBeTruthy();
-    expect(screen.queryByText("cool")).toBeFalsy();
+    expect(screen.queryAllByText("slick")[0]).toBeTruthy();
+    expect(screen.queryAllByText("cool")[0]).toBeFalsy();
   });
   it("should filter on click", () => {
     const initialFilterState = {

--- a/ui/components/__tests__/__snapshots__/Breadcrumbs.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/Breadcrumbs.test.tsx.snap
@@ -2,14 +2,14 @@
 
 exports[`snapshots renders 1`] = `
 <div
+<<<<<<< HEAD
   className="sc-bdvvtL jUaaBj"
+=======
+  className="sc-bdvvtL goAlmQ"
+>>>>>>> 2abfcd2b (updated tests)
 >
   <a
-<<<<<<< HEAD
-    className="sc-eCImPb sc-jRQBWg FjdOF fzVcqy"
-=======
-    className="sc-hKwDye sc-eCImPb kCA-dBN eGkDTD"
->>>>>>> 6e734d90 (snaps and bg)
+    className="sc-eCImPb sc-jRQBWg FjdOF eKqFqk"
     href="/applications"
     onClick={[Function]}
   >
@@ -26,14 +26,14 @@ exports[`snapshots renders 1`] = `
 
 exports[`snapshots renders child route 1`] = `
 <div
+<<<<<<< HEAD
   className="sc-bdvvtL jUaaBj"
+=======
+  className="sc-bdvvtL goAlmQ"
+>>>>>>> 2abfcd2b (updated tests)
 >
   <a
-<<<<<<< HEAD
-    className="sc-eCImPb sc-jRQBWg FjdOF fzVcqy"
-=======
-    className="sc-hKwDye sc-eCImPb kCA-dBN eGkDTD"
->>>>>>> 6e734d90 (snaps and bg)
+    className="sc-eCImPb sc-jRQBWg FjdOF eKqFqk"
     href="/applications"
     onClick={[Function]}
   >
@@ -46,7 +46,11 @@ exports[`snapshots renders child route 1`] = `
     </span>
   </a>
   <div
+<<<<<<< HEAD
     className="sc-bdvvtL jUaaBj sc-dkPtRN hTjxvJ"
+=======
+    className="sc-bdvvtL goAlmQ sc-dkPtRN hTjxvJ"
+>>>>>>> 2abfcd2b (updated tests)
   >
     <svg
       aria-hidden={true}
@@ -60,11 +64,7 @@ exports[`snapshots renders child route 1`] = `
     </svg>
   </div>
   <a
-<<<<<<< HEAD
-    className="sc-eCImPb sc-jRQBWg FjdOF fzVcqy"
-=======
-    className="sc-hKwDye sc-eCImPb kCA-dBN eGkDTD"
->>>>>>> 6e734d90 (snaps and bg)
+    className="sc-eCImPb sc-jRQBWg FjdOF eKqFqk"
     href="/kustomization?name=flux"
     onClick={[Function]}
   >
@@ -81,14 +81,14 @@ exports[`snapshots renders child route 1`] = `
 
 exports[`snapshots renders on the root page 1`] = `
 <div
+<<<<<<< HEAD
   className="sc-bdvvtL jUaaBj"
+=======
+  className="sc-bdvvtL goAlmQ"
+>>>>>>> 2abfcd2b (updated tests)
 >
   <a
-<<<<<<< HEAD
-    className="sc-eCImPb sc-jRQBWg FjdOF fzVcqy"
-=======
-    className="sc-hKwDye sc-eCImPb kCA-dBN eGkDTD"
->>>>>>> 6e734d90 (snaps and bg)
+    className="sc-eCImPb sc-jRQBWg FjdOF eKqFqk"
     href="/"
     onClick={[Function]}
   >
@@ -99,7 +99,11 @@ exports[`snapshots renders on the root page 1`] = `
     />
   </a>
   <div
+<<<<<<< HEAD
     className="sc-bdvvtL jUaaBj sc-dkPtRN hTjxvJ"
+=======
+    className="sc-bdvvtL goAlmQ sc-dkPtRN hTjxvJ"
+>>>>>>> 2abfcd2b (updated tests)
   >
     <svg
       aria-hidden={true}
@@ -113,11 +117,7 @@ exports[`snapshots renders on the root page 1`] = `
     </svg>
   </div>
   <a
-<<<<<<< HEAD
-    className="sc-eCImPb sc-jRQBWg FjdOF fzVcqy"
-=======
-    className="sc-hKwDye sc-eCImPb kCA-dBN eGkDTD"
->>>>>>> 6e734d90 (snaps and bg)
+    className="sc-eCImPb sc-jRQBWg FjdOF eKqFqk"
     href="/"
     onClick={[Function]}
   >

--- a/ui/components/__tests__/__snapshots__/Breadcrumbs.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/Breadcrumbs.test.tsx.snap
@@ -2,11 +2,7 @@
 
 exports[`snapshots renders 1`] = `
 <div
-<<<<<<< HEAD
-  className="sc-bdvvtL jUaaBj"
-=======
-  className="sc-bdvvtL goAlmQ"
->>>>>>> 2abfcd2b (updated tests)
+  className="sc-bdvvtL dVdTOU"
 >
   <a
     className="sc-eCImPb sc-jRQBWg FjdOF eKqFqk"
@@ -26,11 +22,7 @@ exports[`snapshots renders 1`] = `
 
 exports[`snapshots renders child route 1`] = `
 <div
-<<<<<<< HEAD
-  className="sc-bdvvtL jUaaBj"
-=======
-  className="sc-bdvvtL goAlmQ"
->>>>>>> 2abfcd2b (updated tests)
+  className="sc-bdvvtL dVdTOU"
 >
   <a
     className="sc-eCImPb sc-jRQBWg FjdOF eKqFqk"
@@ -46,11 +38,7 @@ exports[`snapshots renders child route 1`] = `
     </span>
   </a>
   <div
-<<<<<<< HEAD
-    className="sc-bdvvtL jUaaBj sc-dkPtRN hTjxvJ"
-=======
-    className="sc-bdvvtL goAlmQ sc-dkPtRN hTjxvJ"
->>>>>>> 2abfcd2b (updated tests)
+    className="sc-bdvvtL dVdTOU sc-dkPtRN hTjxvJ"
   >
     <svg
       aria-hidden={true}
@@ -81,11 +69,7 @@ exports[`snapshots renders child route 1`] = `
 
 exports[`snapshots renders on the root page 1`] = `
 <div
-<<<<<<< HEAD
-  className="sc-bdvvtL jUaaBj"
-=======
-  className="sc-bdvvtL goAlmQ"
->>>>>>> 2abfcd2b (updated tests)
+  className="sc-bdvvtL dVdTOU"
 >
   <a
     className="sc-eCImPb sc-jRQBWg FjdOF eKqFqk"
@@ -99,11 +83,7 @@ exports[`snapshots renders on the root page 1`] = `
     />
   </a>
   <div
-<<<<<<< HEAD
-    className="sc-bdvvtL jUaaBj sc-dkPtRN hTjxvJ"
-=======
-    className="sc-bdvvtL goAlmQ sc-dkPtRN hTjxvJ"
->>>>>>> 2abfcd2b (updated tests)
+    className="sc-bdvvtL dVdTOU sc-dkPtRN hTjxvJ"
   >
     <svg
       aria-hidden={true}

--- a/ui/components/__tests__/__snapshots__/Breadcrumbs.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/Breadcrumbs.test.tsx.snap
@@ -5,7 +5,11 @@ exports[`snapshots renders 1`] = `
   className="sc-bdvvtL jUaaBj"
 >
   <a
+<<<<<<< HEAD
     className="sc-eCImPb sc-jRQBWg FjdOF fzVcqy"
+=======
+    className="sc-hKwDye sc-eCImPb kCA-dBN eGkDTD"
+>>>>>>> 6e734d90 (snaps and bg)
     href="/applications"
     onClick={[Function]}
   >
@@ -25,7 +29,11 @@ exports[`snapshots renders child route 1`] = `
   className="sc-bdvvtL jUaaBj"
 >
   <a
+<<<<<<< HEAD
     className="sc-eCImPb sc-jRQBWg FjdOF fzVcqy"
+=======
+    className="sc-hKwDye sc-eCImPb kCA-dBN eGkDTD"
+>>>>>>> 6e734d90 (snaps and bg)
     href="/applications"
     onClick={[Function]}
   >
@@ -52,7 +60,11 @@ exports[`snapshots renders child route 1`] = `
     </svg>
   </div>
   <a
+<<<<<<< HEAD
     className="sc-eCImPb sc-jRQBWg FjdOF fzVcqy"
+=======
+    className="sc-hKwDye sc-eCImPb kCA-dBN eGkDTD"
+>>>>>>> 6e734d90 (snaps and bg)
     href="/kustomization?name=flux"
     onClick={[Function]}
   >
@@ -72,7 +84,11 @@ exports[`snapshots renders on the root page 1`] = `
   className="sc-bdvvtL jUaaBj"
 >
   <a
+<<<<<<< HEAD
     className="sc-eCImPb sc-jRQBWg FjdOF fzVcqy"
+=======
+    className="sc-hKwDye sc-eCImPb kCA-dBN eGkDTD"
+>>>>>>> 6e734d90 (snaps and bg)
     href="/"
     onClick={[Function]}
   >
@@ -97,7 +113,11 @@ exports[`snapshots renders on the root page 1`] = `
     </svg>
   </div>
   <a
+<<<<<<< HEAD
     className="sc-eCImPb sc-jRQBWg FjdOF fzVcqy"
+=======
+    className="sc-hKwDye sc-eCImPb kCA-dBN eGkDTD"
+>>>>>>> 6e734d90 (snaps and bg)
     href="/"
     onClick={[Function]}
   >

--- a/ui/components/__tests__/__snapshots__/DataTable.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/DataTable.test.tsx.snap
@@ -102,13 +102,17 @@ exports[`DataTable snapshots renders 1`] = `
 
 .c0 {
   width: 100%;
+  padding-right: 24px;
 }
 
 .c0 h2 {
+  padding: 0;
   font-size: 18px;
   font-weight: 600;
   color: #737373;
   margin: 0px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .c0 .MuiTableRow-root {

--- a/ui/components/__tests__/__snapshots__/GithubDeviceAuthModal.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/GithubDeviceAuthModal.test.tsx.snap
@@ -53,30 +53,7 @@ exports[`GithubDeviceAuthModal snapshots renders 1`] = `
   justify-content: flex-end;
 }
 
-<<<<<<< HEAD
-.c4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: start;
-  -webkit-box-align: start;
-  -ms-flex-align: start;
-  align-items: start;
-  width: 100%;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-}
-
-.c9 {
-=======
 .c8 {
->>>>>>> 2abfcd2b (updated tests)
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;

--- a/ui/components/__tests__/__snapshots__/GithubDeviceAuthModal.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/GithubDeviceAuthModal.test.tsx.snap
@@ -27,7 +27,6 @@ exports[`GithubDeviceAuthModal snapshots renders 1`] = `
   -webkit-box-align: start;
   -ms-flex-align: start;
   align-items: start;
-  height: 150px;
   width: 100%;
   -webkit-box-pack: center;
   -webkit-justify-content: center;
@@ -35,7 +34,7 @@ exports[`GithubDeviceAuthModal snapshots renders 1`] = `
   justify-content: center;
 }
 
-.c12 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -54,6 +53,7 @@ exports[`GithubDeviceAuthModal snapshots renders 1`] = `
   justify-content: flex-end;
 }
 
+<<<<<<< HEAD
 .c4 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -74,6 +74,9 @@ exports[`GithubDeviceAuthModal snapshots renders 1`] = `
 }
 
 .c9 {
+=======
+.c8 {
+>>>>>>> 2abfcd2b (updated tests)
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -87,7 +90,7 @@ exports[`GithubDeviceAuthModal snapshots renders 1`] = `
   align-items: center;
 }
 
-.c7 {
+.c6 {
   font-family: 'proxima-nova',Helvetica,Arial,sans-serif;
   font-size: 32px;
   font-weight: 400;
@@ -95,35 +98,35 @@ exports[`GithubDeviceAuthModal snapshots renders 1`] = `
   font-style: normal;
 }
 
-.c11 svg {
+.c10 svg {
   fill: !important;
   height: 16px;
   width: 16px;
 }
 
-.c11.downward {
+.c10.downward {
   -webkit-transform: rotate(180deg);
   -ms-transform: rotate(180deg);
   transform: rotate(180deg);
 }
 
-.c11.upward {
+.c10.upward {
   -webkit-transform: initial;
   -ms-transform: initial;
   transform: initial;
 }
 
-.c11 .c6 {
+.c10 .c5 {
   margin-left: 4px;
 }
 
-.c8.MuiButton-root {
+.c7.MuiButton-root {
   line-height: 1;
   border-radius: 2px;
   font-weight: 600;
 }
 
-.c8.MuiButton-outlined {
+.c7.MuiButton-outlined {
   padding: 8px 12px;
   border-color: #d8d8d8;
 }
@@ -149,11 +152,11 @@ exports[`GithubDeviceAuthModal snapshots renders 1`] = `
   transform: translate(0,50%);
 }
 
-.c5 {
+.c4 {
   padding: 8px 0;
 }
 
-.c3 .c10 {
+.c3 .c9 {
   margin-left: 8px;
 }
 
@@ -200,20 +203,20 @@ exports[`GithubDeviceAuthModal snapshots renders 1`] = `
           class="c3"
         >
           <div
-            class="c4 c5"
+            class="c2 c4"
           >
             <span
-              class="c6 c7"
+              class="c5 c6"
             />
           </div>
           <div
-            class="c4 c5"
+            class="c2 c4"
           >
             <a
               target="_blank"
             >
               <button
-                class="MuiButtonBase-root MuiButton-root MuiButton-outlined c8 MuiButton-outlinedPrimary MuiButton-disableElevation"
+                class="MuiButtonBase-root MuiButton-root MuiButton-outlined c7 MuiButton-outlinedPrimary MuiButton-disableElevation"
                 tabindex="0"
                 type="button"
               >
@@ -224,7 +227,7 @@ exports[`GithubDeviceAuthModal snapshots renders 1`] = `
                     class="MuiButton-startIcon MuiButton-iconSizeMedium"
                   >
                     <div
-                      class="c9 c10 c11"
+                      class="c8 c9 c10"
                     >
                       <svg
                         aria-hidden="true"
@@ -247,16 +250,16 @@ exports[`GithubDeviceAuthModal snapshots renders 1`] = `
             </a>
           </div>
           <div
-            class="c4 c5"
+            class="c2 c4"
           />
         </div>
       </div>
     </div>
     <div
-      class="c12"
+      class="c11"
     >
       <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-text c8 MuiButton-colorInherit MuiButton-disableElevation"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text c7 MuiButton-colorInherit MuiButton-disableElevation"
         tabindex="0"
         type="button"
       >

--- a/ui/components/__tests__/__snapshots__/Page.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/Page.test.tsx.snap
@@ -13,6 +13,7 @@ exports[`Page snapshots default 1`] = `
   -webkit-box-align: start;
   -ms-flex-align: start;
   align-items: start;
+  height: 100%;
   width: 100%;
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
@@ -20,7 +21,7 @@ exports[`Page snapshots default 1`] = `
   justify-content: flex-start;
 }
 
-.c2 {
+.c3 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -43,7 +44,7 @@ exports[`Page snapshots default 1`] = `
   justify-content: space-between;
 }
 
-.c4 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -57,26 +58,7 @@ exports[`Page snapshots default 1`] = `
   align-items: center;
 }
 
-.c7 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  width: 100%;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
-  justify-content: flex-start;
-}
-
-.c9 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -95,7 +77,7 @@ exports[`Page snapshots default 1`] = `
   justify-content: space-between;
 }
 
-.c11 {
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -109,7 +91,7 @@ exports[`Page snapshots default 1`] = `
   align-items: start;
 }
 
-.c14 {
+.c13 {
   font-family: 'proxima-nova',Helvetica,Arial,sans-serif;
   font-size: 16px;
   font-weight: 400;
@@ -118,47 +100,47 @@ exports[`Page snapshots default 1`] = `
   color: #00b3ec;
 }
 
-.c13 {
+.c12 {
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c13.title-bar-button {
+.c12.title-bar-button {
   width: 250px;
 }
 
-.c15 {
+.c14 {
   padding-right: 24px;
   width: 275px;
 }
 
-.c12 {
+.c11 {
   width: 350px;
 }
 
-.c10 {
+.c9 {
   color: #737373;
 }
 
-.c5 {
+.c6 {
   padding: 12px;
 }
 
-.c6 {
+.c7 {
   padding-left: 8px;
 }
 
-.c6 .MuiCircularProgress-root {
+.c7 .MuiCircularProgress-root {
   -webkit-transition: opacity 2s;
   transition: opacity 2s;
   margin-bottom: 0;
 }
 
-.c6 .MuiCircularProgress-root.in {
+.c7 .MuiCircularProgress-root.in {
   opacity: 1;
 }
 
-.c6 .MuiCircularProgress-root.out {
+.c7 .MuiCircularProgress-root.out {
   opacity: 0;
 }
 
@@ -172,35 +154,38 @@ exports[`Page snapshots default 1`] = `
   padding-bottom: 24px;
   padding-left: 32px;
   padding-top: 24px;
+<<<<<<< HEAD
   padding-right: 32px;
   width: 100%;
   height: 100%;
+=======
+>>>>>>> 2abfcd2b (updated tests)
 }
 
-.c8 {
-  height: 100%;
-}
-
-.c3 h2 {
+.c4 h2 {
   margin: 0 !important;
   color: #1a1a1a !important;
 }
 
+.c2 .MuiAlert-root {
+  width: 100%;
+}
+
 <div
-  className="c0 c1"
+  className="c0 c1 c2"
 >
   <div
-    className="c2 c3"
+    className="c3 c4"
   >
     <div
-      className="c4"
+      className="c5"
     >
       <h2 />
       <div
-        className="c5"
+        className="c6"
       />
       <div
-        className="c4 c6"
+        className="c5 c7"
       >
         <div
           className="MuiCircularProgress-root out MuiCircularProgress-colorPrimary MuiCircularProgress-indeterminate"
@@ -231,23 +216,23 @@ exports[`Page snapshots default 1`] = `
     </div>
   </div>
   <div
-    className="c7 c8"
+    className="c0"
   />
   <footer
-    className="c9 c10 Footer"
+    className="c8 c9 Footer"
   >
     <div
-      className="c11 c12"
+      className="c10 c11"
     >
       Need help? Contact us at
       <a
-        className="c13"
+        className="c12"
         href="mailto:support@weave.works"
         rel="noreferrer"
         target="_blank"
       >
         <span
-          className="c14"
+          className="c13"
           color="primary"
           size="normal"
         >
@@ -256,7 +241,7 @@ exports[`Page snapshots default 1`] = `
       </a>
     </div>
     <div
-      className="c11 c15"
+      className="c10 c14"
     >
       © 2022 Weaveworks
     </div>

--- a/ui/components/__tests__/__snapshots__/Page.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/Page.test.tsx.snap
@@ -91,7 +91,16 @@ exports[`Page snapshots default 1`] = `
   align-items: start;
 }
 
-.c13 {
+.c11 {
+  font-family: 'proxima-nova',Helvetica,Arial,sans-serif;
+  font-size: 16px;
+  font-weight: 400;
+  text-transform: none;
+  font-style: normal;
+  color: #737373;
+}
+
+.c14 {
   font-family: 'proxima-nova',Helvetica,Arial,sans-serif;
   font-size: 16px;
   font-weight: 400;
@@ -100,30 +109,29 @@ exports[`Page snapshots default 1`] = `
   color: #00b3ec;
 }
 
-.c12 {
+.c13 {
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c12.title-bar-button {
+.c13.title-bar-button {
   width: 250px;
-}
-
-.c14 {
-  padding-right: 24px;
-  width: 275px;
-}
-
-.c11 {
-  width: 350px;
-}
-
-.c9 {
-  color: #737373;
 }
 
 .c6 {
   padding: 12px;
+}
+
+.c12 {
+  padding: 4px;
+}
+
+.c15 {
+  padding-right: 24px;
+}
+
+.c9 {
+  color: #737373;
 }
 
 .c7 {
@@ -154,12 +162,9 @@ exports[`Page snapshots default 1`] = `
   padding-bottom: 24px;
   padding-left: 32px;
   padding-top: 24px;
-<<<<<<< HEAD
   padding-right: 32px;
   width: 100%;
   height: 100%;
-=======
->>>>>>> 2abfcd2b (updated tests)
 }
 
 .c4 h2 {
@@ -222,17 +227,26 @@ exports[`Page snapshots default 1`] = `
     className="c8 c9 Footer"
   >
     <div
-      className="c10 c11"
+      className="c10"
     >
-      Need help? Contact us at
-      <a
+      <span
+        className="c11"
+        color="neutral30"
+        size="normal"
+      >
+        Need help? Contact us at
+      </span>
+      <div
         className="c12"
+      />
+      <a
+        className="c13"
         href="mailto:support@weave.works"
         rel="noreferrer"
         target="_blank"
       >
         <span
-          className="c13"
+          className="c14"
           color="primary"
           size="normal"
         >
@@ -241,9 +255,18 @@ exports[`Page snapshots default 1`] = `
       </a>
     </div>
     <div
-      className="c10 c14"
+      className="c10 c15"
     >
-      © 2022 Weaveworks
+      <div
+        className="c12"
+      />
+      <span
+        className="c11"
+        color="neutral30"
+        size="normal"
+      >
+        © 2022 Weaveworks
+      </span>
     </div>
   </footer>
 </div>

--- a/ui/lib/theme.ts
+++ b/ui/lib/theme.ts
@@ -14,7 +14,7 @@ export const theme: DefaultTheme = {
   fontSizes: {
     huge: "48px",
     extraLarge: "32px",
-    large: "22px",
+    large: "20px",
     normal: "16px",
     small: "14px",
     tiny: "12px",

--- a/ui/pages/SignIn.tsx
+++ b/ui/pages/SignIn.tsx
@@ -14,8 +14,6 @@ import { theme } from "../lib/theme";
 
 export const SignInPageWrapper = styled(Flex)`
   background: url(${images.signInBackground});
-  height: 100%;
-  width: 100%;
 `;
 
 export const FormWrapper = styled(Flex)`

--- a/ui/pages/SignIn.tsx
+++ b/ui/pages/SignIn.tsx
@@ -88,7 +88,7 @@ function SignIn() {
   }, []);
 
   return (
-    <SignInPageWrapper center align column>
+    <SignInPageWrapper tall wide center align column>
       <FormWrapper center align wrap>
         {error && (
           <AlertWrapper


### PR DESCRIPTION
<!-- Use # to add the issue this pull request is related to -->
Closes: #1708

<!-- Describe what has changed in this PR -->
BEFORE:
![image](https://user-images.githubusercontent.com/65822698/161097177-b78c8c4a-73e1-47bb-b45a-fa81fef80059.png)
AFTER:
![image](https://user-images.githubusercontent.com/65822698/161097160-955527e6-8d0d-480c-9064-01bdaf17fbe4.png)

Gets the filter modal pretty close to what we want. Here's what's missing:
- ability to scroll data table horizontally when modal is open / shrink table (from #1708) 
- should filter modal always take up the entire content container? It probably needs SOME sort of max-height so that we can scroll when there are too many filter options.
