### PR TITLE
README: Fix badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 Weave GitOps
 
-[![Coverage Status](https://coveralls.io/repos/github/weaveworks/weave-gitops/badge.svg?branch=main)](https://coveralls.io/github/weaveworks/weave-gitops?branch=main)
-![Test status](https://github.com/weaveworks/weave-gitops/actions/workflows/test.yml/badge.svg)
+![Test status](https://github.com/weaveworks/weave-gitops/actions/workflows/pr.yaml/badge.svg)
 [![LICENSE](https://img.shields.io/github/license/weaveworks/weave-gitops)](https://github.com/weaveworks/weave-gitops/blob/master/LICENSE)
 [![Contributors](https://img.shields.io/github/contributors/weaveworks/weave-gitops)](https://github.com/weaveworks/weave-gitops/graphs/contributors)
 [![Release](https://img.shields.io/github/v/release/weaveworks/weave-gitops?include_prereleases)](https://github.com/weaveworks/weave-gitops/releases/latest)


### PR DESCRIPTION
We've not been using coveralls since merging v2, and the test workflow
is now part of the CI workflow.
