### PR TITLE
Release helm chart whenever it's changed

### DIFF
--- a/.github/workflows/chart.yaml
+++ b/.github/workflows/chart.yaml
@@ -1,0 +1,32 @@
+name: Helm chart
+
+on:
+  push:
+    branches:
+      - 'main'
+    paths:
+      - 'charts/**'
+
+jobs:
+
+  helm-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
+      - name: Generate new chart
+        run: |
+          URL=https://helm.gitops.weave.works
+          mkdir helm-release
+          helm package charts/gitops-server/ -d helm-release
+          curl -O $URL/index.yaml
+          helm repo index helm-release --merge=index.yaml --url=$URL
+      - id: auth
+        uses: google-github-actions/auth@v0.4.0
+        with:
+          credentials_json: ${{ secrets.PROD_DOCS_GITOPS_UPLOAD }}
+      - id: upload-file
+        uses: google-github-actions/upload-cloud-storage@v0.4.0
+        with:
+          path: helm-release
+          destination: helm.gitops.weave.works
+          parent: false

--- a/charts/gitops-server/Chart.yaml
+++ b/charts/gitops-server/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.0
+version: 1.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.6.2"
+appVersion: "v0.7.0-rc6"

--- a/charts/gitops-server/values.yaml
+++ b/charts/gitops-server/values.yaml
@@ -9,7 +9,7 @@ image:
   repository: ghcr.io/weaveworks/wego-app
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "v0.6.2"
+  tag: "v0.7.0-rc6"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -4,6 +4,7 @@ To release a new version of Weave Gitops, you need to:
 - Create the actual release
 - Update the [website](/website) with documentation for the new version
 - Update the `CLI Installation` section of the `README.md` in the `weave-gitops` repository to reference the new version
+- Update the helm chart version
 - Add a record of the new version in the checkpoint system
 
 # Creating the release
@@ -30,6 +31,12 @@ The go-releaser will spin for a bit, generating a changelog and artifacts.
 
 # Updating the README
 - Once the release is available, change the version in the `curl` command shown in the `CLI Installation` section of the `README.md` in the weave-gitops repository
+- Create a PR and merge when approved
+
+# Updating the helm chart
+- Update the appVersion value in [Chart.yaml](charts/gitops-server/Chart.yaml)
+- Update the image.tag value in [values.yaml](charts/gitops-server/values.yaml)
+- Bump the version value in [Chart.yaml](charts/gitops-server/Chart.yaml)
 - Create a PR and merge when approved
 
 # Record the new version


### PR DESCRIPTION
This makes us publish our helm chart into the helm repository `helm.gitops.weave.works` - this is quite literally the same as the docs workflow, just into a different bucket, so we don't need to learn another workflow or tool or system.

This does _not_ prevent replacing old artifacts - if we're not careful, we can overwrite the same chart. Thus, I've added another step to the release process, but I've not added a check to see that we can't change the chart without changing the chart version.

This means you can now install gitops using:
```
--
apiVersion: helm.toolkit.fluxcd.io/v2beta1
kind: HelmRelease
metadata:
  name: ww-gitops
  namespace: flux-system
spec:
  chart:
    spec:
      chart: weave-gitops
      sourceRef:
        kind: HelmRepository
        name: ww-gitops
  interval: 1m0s
  values:
    additionalArgs:
    - --insecure
    adminUser:
      create: true
      password: notsecure
      username: wego-admin
    namespace: flux-system
---
apiVersion: source.toolkit.fluxcd.io/v1beta1
kind: HelmRepository
metadata:
  name: ww-gitops
  namespace: flux-system
spec:
  interval: 1m0s
  url: https://helm.gitops.weave.works
```