### PR TITLE
Add a fallback option to output the latest tag

### DIFF
--- a/tools/tag-release
+++ b/tools/tag-release
@@ -230,8 +230,10 @@ def _build_parser():
 
     parser.add_argument(
         "action",
-        choices=["promote", "bump", "minor", "patch"],
-        help="the type of release to tag",
+        nargs="?",
+        choices=["promote", "bump", "minor", "patch", "current"],
+        default="current",
+        help="the type of release to tag (or output the current tag)",
     )
 
     return parser
@@ -294,6 +296,10 @@ if __name__ == "__main__":
     tag_name = get_latest_tag()
     tag = original_tag = parse_tag(tag_name)
     print_err(f"Most recent tag: {original_tag}")
+
+    if args.action == "current":
+        print_err("Run with the `--help` flag for a list of available commands.")
+        sys.exit(0)
 
     try:
         tag = next_tag(original_tag, args.action, abandon=args.abandon, rc=args.rc)


### PR DESCRIPTION
This is available either by running `tag-release current` or just `tag-release` with no arguments. I realized I wanted some way to ask "hey, where are we at right now?", and figured that this was a reasonable way to do it. It also seems more approachable than spitting out an error when no arguments are provided, which feels like a useful property to have in a potentially dangerous script.