### PR TITLE
Generate documentation PRs against `main`

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -145,5 +145,6 @@ jobs:
           author: weave-test-user <weave-test-user@example.com>
           signoff: true
           branch: ${{ env.BRANCH }}
+          base: main
           title: "Documentation updates for ${{ env.GITOPS_VERSION }}"
           body: "Update version references to ${{ env.GITOPS_VERSION }} and create new versioned documentation set."


### PR DESCRIPTION
When the code and the docs were stored in separate repos, this would happen by default, as the release workflow would [checkout the docs repo using its `main` branch][1], which the `create-pull-request` action would pull in as a default base. Now that we're running this workflow from a release tag (which has no concept of which branch it's on), we have to be explicit about where the documentation updates go.

[1]: https://github.com/weaveworks/weave-gitops/blob/e83c56bb2969a087679a9a3d7e163d2098696e57/.github/workflows/release.yaml#L122-L127
