### PR TITLE
Make the release script compatible with Python 3.7

### DIFF
--- a/tools/tag-release
+++ b/tools/tag-release
@@ -30,8 +30,10 @@ def parse_tag(tag_name):
         """,
         re.VERBOSE,
     )
-    if tag_match := pattern.match(tag_name):
-        if rc := tag_match.group("rc"):
+    tag_match = pattern.match(tag_name)
+    if tag_match:
+        rc = tag_match.group("rc")
+        if rc:
             return RCVersion(
                 major=int(tag_match.group("major")),
                 minor=int(tag_match.group("minor")),


### PR DESCRIPTION
Python's "walrus operator" was [introduced in Python 3.8][1], and while it makes the code a little more elegant in certain cases (specifically, in this case, regex matching), it's better in this case to make sure we preserve compatibility, as some older OS versions bundle Python 3.7.x.

[1]: https://docs.python.org/3/whatsnew/3.8.html#assignment-expressions
