### PR TITLE
fix: Ordering within filter menu changes periodically

### DIFF
--- a/ui/components/FilterDialog.tsx
+++ b/ui/components/FilterDialog.tsx
@@ -120,7 +120,7 @@ function UnstyledFilterDialog({
                             </Text>
                             <List>
                               {_.map(
-                                [...options].sort(),
+                                _.sortBy(options),
                                 (option: string, index: number) => {
                                   return (
                                     <ListItem key={index}>

--- a/ui/components/FilterDialog.tsx
+++ b/ui/components/FilterDialog.tsx
@@ -120,7 +120,7 @@ function UnstyledFilterDialog({
                             </Text>
                             <List>
                               {_.map(
-                                options,
+                                [...options].sort(),
                                 (option: string, index: number) => {
                                   return (
                                     <ListItem key={index}>


### PR DESCRIPTION
Approach: Sort filter options alphabetical

I don't know if react will reload things or not if the `options` list is
changed or not, so went with a immutable option using
`[...options].sort()`

Closes #1759