### PR TITLE
fix: Reconciled objects not appearing in a helm release

### DIFF
--- a/ui/hooks/flux.ts
+++ b/ui/hooks/flux.ts
@@ -31,7 +31,7 @@ export function useGetReconciledObjects(
 
   return useQuery<UnstructuredObject[], RequestError>(
     ["reconciled_objects", { name, namespace, type, kinds }],
-    () => getChildren(api, name, namespace, kinds, clusterName),
+    () => getChildren(api, name, namespace, type, kinds, clusterName),
     { retry: false, refetchOnWindowFocus: false, refetchInterval: 5000 }
   );
 }

--- a/ui/lib/__tests__/graph.test.ts
+++ b/ui/lib/__tests__/graph.test.ts
@@ -1,12 +1,14 @@
 import _ from "lodash";
 import { getChildren } from "../graph";
 import { createCoreMockClient } from "../test-utils";
+import {AutomationKind} from "../api/core/types.pb";
 
 describe("graph lib", () => {
   it("getChildren", async () => {
     const app = {
       name: "my-app",
       namespace: "my-namespace",
+      automationKind: AutomationKind.HelmReleaseAutomation,
       reconciledObjectKinds: [
         { group: "apps", version: "v1", kind: "Deployment" },
       ],
@@ -76,6 +78,7 @@ describe("graph lib", () => {
       client,
       app.name,
       app.namespace,
+      app.automationKind,
       [{ group: "apps", version: "v1", kind: "Deployment" }],
       app.clusterName
     );

--- a/ui/lib/graph.ts
+++ b/ui/lib/graph.ts
@@ -2,6 +2,7 @@
 // with in the context of their parent-child relationships.
 import _ from "lodash";
 import {
+  AutomationKind,
   GroupVersionKind,
   UnstructuredObject,
 } from "./api/core/types.pb";
@@ -77,12 +78,14 @@ export const getChildren = async (
   client: typeof Core,
   automationName,
   namespace,
+  automationKind: AutomationKind,
   kinds: GroupVersionKind[],
   clusterName,
 ): Promise<UnstructuredObject[]> => {
   const { objects } = await client.GetReconciledObjects({
     automationName,
     namespace,
+    automationKind,
     kinds,
     clusterName,
   });


### PR DESCRIPTION
Root cause:
The reconciled_objects request did not contain the automation type and
defaulted to 0 which is Kustomization.

Closes #1833
