### PR TITLE
Add optional annotations to the charts's service

### DIFF
--- a/charts/gitops-server/templates/service.yaml
+++ b/charts/gitops-server/templates/service.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "chart.fullname" . }}
   labels:
     {{- include "chart.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/gitops-server/values.yaml
+++ b/charts/gitops-server/values.yaml
@@ -74,6 +74,7 @@ service:
   create: true
   type: ClusterIP
   port: 9001
+  annotations: {}
 
 ingress:
   enabled: false


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Add the option to annotate the service created by the helm chart

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**

Because to enable IAP in GKE I need to be able to annotate the service with `cloud.google.com/backend-config: '{"default": "my-backendconfig"}'` (as per the [docs](https://cloud.google.com/kubernetes-engine/docs/how-to/ingress-features#associating_backendconfig_with_your_ingress))


<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**

By running `helm template` with a local values file and checking that the service was correctly annotated
```
$  helm template -f test_values.yaml --set service.annotations.foo=bar,service.annotations.bs=ohgods ./charts/gitops-server 
```
