### PR TITLE
Set exact version of node/go in both release/pr

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [16.13.2]
     steps:
       - uses: actions/checkout@v2
       - name: Node modules cache
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.17.x]
+        go-version: [1.17.5]
     steps:
       - uses: actions/checkout@v2
       - name: Go modules cache
@@ -83,7 +83,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.17.x]
+        go-version: [1.17.5]
     steps:
       - uses: actions/checkout@v2
       - name: Setup Go
@@ -221,7 +221,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.x
+        go-version: 1.17.5
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Clean

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,11 +22,11 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.x
+          go-version: 1.17.5
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 16.x
+          node-version: 16.13.2
       - name: Set env var
         run: |
           make -B dependencies
@@ -123,7 +123,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.x
+          go-version: 1.17.5
       - name: Create GitOps binary
         run: |
           make all


### PR DESCRIPTION
I should have done this change in be3920adc, but I clicked merge too
quickly.