### PR TITLE
core/server: Error out if we can't create controller client

### DIFF
--- a/core/server/suite_test.go
+++ b/core/server/suite_test.go
@@ -57,7 +57,10 @@ func makeGRPCServer(cfg *rest.Config, t *testing.T) pb.CoreClient {
 	}
 	coreCfg.NSAccess = &nsChecker
 
-	core := server.NewCoreServer(coreCfg)
+	core, err := server.NewCoreServer(coreCfg)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	lis := bufconn.Listen(1024 * 1024)
 


### PR DESCRIPTION
If we fail to create a client, then we crash as soon as the namespace
cache runs for the first time with a nil pointer error. If we're sure
we won't be able to start properly, then we should abort, not log.
