### PR TITLE
fix: Namespace cach can be called before the first results come back

### DIFF
--- a/core/cache/container.go
+++ b/core/cache/container.go
@@ -108,6 +108,7 @@ func With(l logr.Logger, cachesFn CachesFunc) CacheCollection {
 
 	for _, opt := range options {
 		name, store := opt(l, clusterChan)
+
 		caches = append(caches, cacheInfo{StorageType: name, Cache: store})
 	}
 

--- a/core/cache/container.go
+++ b/core/cache/container.go
@@ -15,7 +15,7 @@ const DefaultPollIntervalSeconds = 120
 type (
 	// StorageType is the name of the cache, eg NamespaceStorage
 	StorageType string
-	// CacheCollection is a map of cache type to cache interface held
+	// CacheCollection is a list of cache info held
 	// in the container.
 	CacheCollection []cacheInfo
 )

--- a/core/cache/namespace.go
+++ b/core/cache/namespace.go
@@ -68,20 +68,23 @@ func (n *namespaceStore) Start(ctx context.Context) {
 
 	n.logger.Info("starting namespace cache")
 
+	// Force load namespaces on startup.
+	n.update(newCtx)
+
 	go func() {
 		ticker := time.NewTicker(n.interval * time.Second)
 
 		defer ticker.Stop()
 
 		for {
-			n.update(newCtx)
-
 			select {
 			case <-newCtx.Done():
 				break
 			case <-ticker.C:
 				continue
 			}
+
+			n.update(newCtx)
 		}
 	}()
 }

--- a/core/cache/namespace_test.go
+++ b/core/cache/namespace_test.go
@@ -57,8 +57,8 @@ func TestContainer_NamespaceWithClusterSync(t *testing.T) {
 	log := logr.Discard()
 
 	opts := cache.WithSyncedCaches(
-		cache.WithNamespaceCache(k8sEnv.Rest),
 		withFakeClusterCache(k8sEnv.Rest),
+		cache.WithNamespaceCache(k8sEnv.Rest),
 	)
 	cacheContainer := cache.NewContainer(log, opts)
 


### PR DESCRIPTION
It was possible to call `List()` before the first `update` finished and
populated the cache `map[string][]v1.Namespace{}`. Requests before the
first results arrived would return "default cluster not found" error.

Solution: Force sync update operation on `Start()` and move the `update`
call after the `select` for `Tick` to avoid multiple calls on `Start()`.

Closes #1919

---

feat: Force cacheContainer to maintain the order or cacheStores

Later on, some of our cache stores have dependencies between them.
Thinking of cluster clients and cluster list, these can be used in other
cache stores, so they should exists before the rest is initialised.

To achieve this, we can use a `[]cacheInfo` slice instead of a
`map[StorageType]Cache`, so the order we defined with `WithXXX`
functions will be the same as we initialise them.