### PR TITLE
docs: Fix manual download instructions, update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,30 +37,48 @@ Please see the [getting started guide](https://docs.gitops.weave.works/docs/gett
 ## CLI Reference
 
 ```console
-Weave GitOps
 Command line utility for managing Kubernetes applications via GitOps.
 
 Usage:
   gitops [command]
 
+Examples:
+
+  # Get verbose output for any gitops command
+  gitops [command] -v, --verbose
+
+  # Get help for gitops add cluster command
+  gitops add cluster -h
+  gitops help add cluster
+
+  # Get the version of gitops along with commit, branch, and flux version
+  gitops version
+
+  To learn more, you can find our documentation at https://docs.gitops.weave.works/
+
+
 Available Commands:
-  app         Add or status application
-  flux        Use flux commands
+  add         Add a new Weave GitOps resource
+  check       Validates flux compatibility
+  completion  Generate the autocompletion script for the specified shell
+  delete      Delete one or many Weave GitOps resources
+  get         Display one or many Weave GitOps resources
   help        Help about any command
-  install     Install or upgrade Weave GitOps
-  ui          Manages Weave GitOps UI
-  uninstall   Uninstall Weave GitOps
-  version     Display Weave GitOps version
+  update      Update a Weave GitOps resource
+  upgrade     Upgrade to Weave GitOps Enterprise
+  version     Display gitops version
 
 Flags:
-  -h, --help               Help for gitops
-      --namespace string   The namespace scope for this operation (default "flux-system").
-  -v, --verbose            Enable verbose output
+  -e, --endpoint string            The Weave GitOps Enterprise HTTP API endpoint
+  -h, --help                       help for gitops
+      --insecure-skip-tls-verify   If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+      --namespace string           The namespace scope for this operation (default "flux-system")
+  -v, --verbose                    Enable verbose output
 
 Use "gitops [command] --help" for more information about a command.
 ```
 
-For more information please see the [docs](https://docs.gitops.weave.works/docs/cli-reference)
+For more information please see the [docs](https://docs.gitops.weave.works/docs/cli-reference/gitops)
 
 ## CLI/API development
 

--- a/tools/update-docs.sh
+++ b/tools/update-docs.sh
@@ -7,12 +7,12 @@ WEAVE_GITOPS_DOC_REPO=$2
 cd $WEAVE_GITOPS_DOC_REPO/docs
 yarn install
 # update version information
+sed -i
 ex - installation.mdx << EOS
 /download\/
-%s,download/\(.*\)/,download/${GITOPS_VERSION}/,
+%s,download/\([^/]*\)/,download/${GITOPS_VERSION}/,
 /Current Version
-.,+4! ${WEAVE_GITOPS_BINARY} version
-+5d
+.,+3! ${WEAVE_GITOPS_BINARY} version
 wq!
 EOS
 # create CLI reference
@@ -20,15 +20,7 @@ git rm -f --ignore-unmatch cli-reference.md
 git rm -rf --ignore-unmatch cli-reference
 mkdir -p cli-reference
 cd cli-reference
-ex - _category_.json << EOS
-1i
-{
-  "label": "CLI Reference",
-  "position": 3
-}
-.
-wq!
-EOS
+git checkout _category_.json
 ${WEAVE_GITOPS_BINARY} docs
 git add *.md
 # create versioned docs

--- a/website/docs/cli-reference/_category_.json
+++ b/website/docs/cli-reference/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "CLI Reference",
-  "position": 3
+  "position": 8
 }

--- a/website/docs/installation.mdx
+++ b/website/docs/installation.mdx
@@ -68,7 +68,7 @@ Windows support is a [planned enhancement](https://github.com/weaveworks/weave-g
 To install the `gitops` CLI, please follow the following steps:
 
 ```console
-curl --silent --location "https://github.com/weaveworks/weave-gitops/releases/download/v0.7.0/tmp
+curl --silent --location "https://github.com/weaveworks/weave-gitops/releases/download/0.7.0/gitops-$(uname)-$(uname -m).tar.gz" | tar xz -C /tmp
 sudo mv /tmp/gitops /usr/local/bin
 gitops version
 ```
@@ -76,11 +76,12 @@ gitops version
 You should see:
 
 ```console
-Current Version: v0.7.0-rc13-1-g3d246fd0
+Current Version: v0.7.0
 GitCommit: 3d246fd0
-BuildTime: 2022-04-12_23:34:46
+BuildTime: 2022-04-14_14:32:54
 Branch: HEAD
 ```
+
 ## Weave GitOps Enterprise<TierLabel tiers="enterprise" />
 
 Weave Gitops Enterprise (WGE) provides ops teams with an easy way to assess the


### PR DESCRIPTION
* Fix the CLI download instructions - they were broken by the release.
* Improve a few things in the script that generates the CLI download instructions - they shouldn't break the download instructions every release.
* Restore the CLI reference's position back to lower down in the docs navigation.
* Update README to not suggest e.g. gitops install is a thing.
* Point README's cli-reference link to somewhere that doesn't 404.