### PR TITLE
Remove flux-system as the default namespace from requests

### DIFF
--- a/ui/components/AddGitRepoForm.tsx
+++ b/ui/components/AddGitRepoForm.tsx
@@ -3,7 +3,7 @@ import _ from "lodash";
 import * as React from "react";
 import styled from "styled-components";
 import { GitProvider } from "../lib/api/applications/applications.pb";
-import { WeGONamespace } from "../lib/types";
+import { NoNamespace } from "../lib/types";
 import Button from "./Button";
 import Flex from "./Flex";
 import Form from "./Form";
@@ -21,7 +21,7 @@ type Props = {
 const initialState = () => ({
   provider: "",
   name: "",
-  namespace: WeGONamespace,
+  namespace: NoNamespace,
   publicRepo: "true",
   intervalMinutes: 3,
   intervalSeconds: 0,

--- a/ui/components/AutomationsTable.tsx
+++ b/ui/components/AutomationsTable.tsx
@@ -2,7 +2,11 @@ import _ from "lodash";
 import * as React from "react";
 import styled from "styled-components";
 import { Automation } from "../hooks/automations";
-import { HelmRelease, SourceRefSourceKind } from "../lib/api/core/types.pb";
+import {
+  HelmRelease,
+  Kustomization,
+  SourceRefSourceKind,
+} from "../lib/api/core/types.pb";
 import { formatURL } from "../lib/nav";
 import { AutomationType, V2Routes } from "../lib/types";
 import { statusSortHelper } from "../lib/utils";
@@ -11,6 +15,7 @@ import FilterableTable, { filterConfigForType } from "./FilterableTable";
 import KubeStatusIndicator, { computeMessage } from "./KubeStatusIndicator";
 import Link from "./Link";
 import SourceLink from "./SourceLink";
+import Timestamp from "./Timestamp";
 
 type Props = {
   className?: string;
@@ -109,7 +114,13 @@ function AutomationsTable({ className, automations, hideSource }: Props) {
       value: "lastAttemptedRevision",
       width: 15,
     },
-    { label: "Last Updated", value: "lastHandledReconciledAt", width: 10 },
+    {
+      label: "Last Updated",
+      value: (a: Automation) => (
+        <Timestamp time={(a as Kustomization).lastHandledReconciledAt} />
+      ),
+      width: 10,
+    },
   ];
 
   if (hideSource) fields = _.filter(fields, (f) => f.label !== "Source");

--- a/ui/components/EventsTable.tsx
+++ b/ui/components/EventsTable.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import styled from "styled-components";
 import { useListFluxEvents } from "../hooks/events";
 import { Event, ObjectReference } from "../lib/api/core/types.pb";
-import { WeGONamespace } from "../lib/types";
+import { NoNamespace } from "../lib/types";
 import Alert from "./Alert";
 import DataTable from "./DataTable";
 import Flex from "./Flex";
@@ -19,7 +19,7 @@ type Props = {
 
 function EventsTable({
   className,
-  namespace = WeGONamespace,
+  namespace = NoNamespace,
   involvedObject,
 }: Props) {
   const { data, isLoading, error } = useListFluxEvents(

--- a/ui/components/HelmReleaseDetail.tsx
+++ b/ui/components/HelmReleaseDetail.tsx
@@ -8,7 +8,6 @@ import {
   HelmRelease,
   SourceRefSourceKind,
 } from "../lib/api/core/types.pb";
-import { WeGONamespace } from "../lib/types";
 import Alert from "./Alert";
 import EventsTable from "./EventsTable";
 import Flex from "./Flex";
@@ -57,7 +56,7 @@ export default function HelmReleaseDetail({
   };
 
   return (
-    <Flex wide tall column align>
+    <Flex className={className} wide tall column align>
       <Flex wide between>
         <Info>
           <Heading level={2}>{helmRelease?.namespace}</Heading>
@@ -99,7 +98,6 @@ export default function HelmReleaseDetail({
             <ReconciledObjectsTable
               kinds={helmRelease?.inventory}
               automationName={helmRelease?.name}
-              namespace={WeGONamespace}
               automationKind={AutomationKind.HelmReleaseAutomation}
               clusterName={helmRelease?.clusterName}
             />

--- a/ui/components/KustomizationDetail.tsx
+++ b/ui/components/KustomizationDetail.tsx
@@ -4,7 +4,6 @@ import styled from "styled-components";
 import { AppContext } from "../contexts/AppContext";
 import { useSyncAutomation } from "../hooks/automations";
 import { AutomationKind, Kustomization } from "../lib/api/core/types.pb";
-import { WeGONamespace } from "../lib/types";
 import Alert from "./Alert";
 import EventsTable from "./EventsTable";
 import Flex from "./Flex";
@@ -93,7 +92,6 @@ function KustomizationDetail({ kustomization, name, className }: Props) {
               automationKind={AutomationKind.KustomizationAutomation}
               automationName={kustomization?.name}
               kinds={kustomization?.inventory}
-              namespace={WeGONamespace}
               clusterName={kustomization?.clusterName}
             />
           </HashRouterTab>
@@ -112,7 +110,6 @@ function KustomizationDetail({ kustomization, name, className }: Props) {
               automationName={kustomization?.name}
               kinds={kustomization?.inventory}
               parentObject={kustomization}
-              namespace={WeGONamespace}
               clusterName={kustomization?.clusterName}
             />
           </HashRouterTab>

--- a/ui/components/ReconciledObjectsTable.tsx
+++ b/ui/components/ReconciledObjectsTable.tsx
@@ -7,6 +7,7 @@ import {
   GroupVersionKind,
   UnstructuredObject,
 } from "../lib/api/core/types.pb";
+import { NoNamespace } from "../lib/types";
 import { statusSortHelper } from "../lib/utils";
 import DataTable, { SortType } from "./DataTable";
 import KubeStatusIndicator, { computeMessage } from "./KubeStatusIndicator";
@@ -15,7 +16,7 @@ import RequestStateHandler from "./RequestStateHandler";
 export interface ReconciledVisualizationProps {
   className?: string;
   automationName: string;
-  namespace: string;
+  namespace?: string;
   automationKind: AutomationKind;
   kinds: GroupVersionKind[];
   clusterName: string;
@@ -24,7 +25,7 @@ export interface ReconciledVisualizationProps {
 function ReconciledObjectsTable({
   className,
   automationName,
-  namespace,
+  namespace = NoNamespace,
   automationKind,
   kinds,
   clusterName,

--- a/ui/components/SourcesTable.tsx
+++ b/ui/components/SourcesTable.tsx
@@ -56,6 +56,7 @@ function SourcesTable({ className, sources }: Props) {
           textSearchable: true,
         },
         { label: "Type", value: "type", width: 5 },
+        { label: "Namespace", value: "namespace", width: 5 },
         {
           label: "Status",
           value: (s: Source) => (

--- a/ui/components/SourcesTable.tsx
+++ b/ui/components/SourcesTable.tsx
@@ -32,6 +32,7 @@ function SourcesTable({ className, sources }: Props) {
 
   return (
     <FilterableTable
+      className={className}
       filters={initialFilterState}
       rows={sources}
       dialogOpen={filterDialogOpen}

--- a/ui/hooks/automations.ts
+++ b/ui/hooks/automations.ts
@@ -14,14 +14,14 @@ import { Kustomization } from "../lib/api/core/types.pb";
 import {
   AutomationType,
   DefaultCluster,
+  NoNamespace,
   RequestError,
   Syncable,
-  WeGONamespace,
 } from "../lib/types";
 
 export type Automation = Kustomization & { type: AutomationType };
 
-export function useListAutomations(namespace = WeGONamespace) {
+export function useListAutomations(namespace = NoNamespace) {
   const { api } = useContext(AppContext);
 
   return useQuery<Automation[], RequestError>(
@@ -61,7 +61,7 @@ export function useListAutomations(namespace = WeGONamespace) {
 export function useGetKustomization(
   name: string,
   clusterName = DefaultCluster,
-  namespace = WeGONamespace
+  namespace = NoNamespace
 ) {
   const { api } = useContext(AppContext);
 
@@ -75,7 +75,7 @@ export function useGetKustomization(
 export function useGetHelmRelease(
   name: string,
   clusterName = DefaultCluster,
-  namespace = WeGONamespace
+  namespace = NoNamespace
 ) {
   const { api } = useContext(AppContext);
 

--- a/ui/hooks/flux.ts
+++ b/ui/hooks/flux.ts
@@ -8,9 +8,12 @@ import {
   UnstructuredObject,
 } from "../lib/api/core/types.pb";
 import { getChildren } from "../lib/graph";
-import { RequestError, WeGONamespace, DefaultCluster } from "../lib/types";
+import { DefaultCluster, NoNamespace, RequestError } from "../lib/types";
 
-export function useListFluxRuntimeObjects(clusterName = DefaultCluster, namespace = WeGONamespace) {
+export function useListFluxRuntimeObjects(
+  clusterName = DefaultCluster,
+  namespace = NoNamespace
+) {
   const { api } = useContext(AppContext);
 
   return useQuery<ListFluxRuntimeObjectsResponse, RequestError>(
@@ -25,7 +28,7 @@ export function useGetReconciledObjects(
   namespace: string,
   type: AutomationKind,
   kinds: GroupVersionKind[],
-  clusterName = DefaultCluster,
+  clusterName = DefaultCluster
 ) {
   const { api } = useContext(AppContext);
 

--- a/ui/hooks/sources.ts
+++ b/ui/hooks/sources.ts
@@ -9,11 +9,11 @@ import {
   ListHelmRepositoriesResponse,
 } from "../lib/api/core/core.pb";
 import { SourceRefSourceKind } from "../lib/api/core/types.pb";
-import { RequestError, Source, WeGONamespace } from "../lib/types";
+import { NoNamespace, RequestError, Source } from "../lib/types";
 
 export function useListSources(
   appName?: string,
-  namespace: string = WeGONamespace
+  namespace: string = NoNamespace
 ) {
   const { api } = useContext(AppContext);
 

--- a/ui/lib/nav.ts
+++ b/ui/lib/nav.ts
@@ -1,6 +1,6 @@
 import qs from "query-string";
 import { SourceRefSourceKind } from "./api/core/types.pb";
-import { PageRoute, V2Routes, WeGONamespace } from "./types";
+import { NoNamespace, PageRoute, V2Routes } from "./types";
 
 // getParentNavValue returns the parent for a child page.
 // This keeps the nav element highlighted if we are on a child page.
@@ -47,7 +47,7 @@ export const formatURL = (page: string, query: any = {}) => {
 export const formatSourceURL = (
   kind: SourceRefSourceKind,
   name: string,
-  namespace: string = WeGONamespace
+  namespace: string = NoNamespace
 ) => {
   return formatURL(sourceTypeToRoute(kind), { name, namespace });
 };

--- a/ui/lib/types.ts
+++ b/ui/lib/types.ts
@@ -41,6 +41,7 @@ export enum V2Routes {
 
 export const WeGONamespace = "flux-system";
 export const DefaultCluster = "Default";
+export const NoNamespace = "";
 
 export interface Source {
   name?: string;


### PR DESCRIPTION
The new default should be `NoNamepsace`, which is an empty string. Objects for all namespaces should be returned.