### PR TITLE
Redirect to sign in on AJAX requests

### DIFF
--- a/pkg/server/auth/server.go
+++ b/pkg/server/auth/server.go
@@ -498,7 +498,8 @@ func JSONError(log logr.Logger, w http.ResponseWriter, errStr string, code int) 
 
 	response := struct {
 		Message string `json:"message"`
-	}{Message: errStr}
+		Code    int    `json:"code"`
+	}{Message: errStr, Code: code}
 
 	if err := json.NewEncoder(w).Encode(response); err != nil {
 		log.Error(err, "failed encoding error message", "message", errStr)

--- a/ui/App.tsx
+++ b/ui/App.tsx
@@ -15,6 +15,7 @@ import ErrorBoundary from "./components/ErrorBoundary";
 import Layout from "./components/Layout";
 import AppContextProvider from "./contexts/AppContext";
 import AuthContextProvider, { AuthCheck } from "./contexts/AuthContext";
+import CoreClientContextProvider from "./contexts/CoreClientContext";
 import FeatureFlagsContextProvider from "./contexts/FeatureFlags";
 import { Core } from "./lib/api/core/core.pb";
 import Fonts from "./lib/fonts";
@@ -103,19 +104,21 @@ export default function AppContainer() {
           <Fonts />
           <GlobalStyle />
           <Router>
-            <AppContextProvider renderFooter coreClient={Core}>
+            <AppContextProvider renderFooter>
               <FeatureFlagsContextProvider>
                 <AuthContextProvider>
-                  <Switch>
-                    {/* <Signin> does not use the base page <Layout> so pull it up here */}
-                    <Route component={SignIn} exact path="/sign_in" />
-                    <Route path="*">
-                      {/* Check we've got a logged in user otherwise redirect back to signin */}
-                      <AuthCheck>
-                        <App />
-                      </AuthCheck>
-                    </Route>
-                  </Switch>
+                  <CoreClientContextProvider api={Core}>
+                    <Switch>
+                      {/* <Signin> does not use the base page <Layout> so pull it up here */}
+                      <Route component={SignIn} exact path="/sign_in" />
+                      <Route path="*">
+                        {/* Check we've got a logged in user otherwise redirect back to signin */}
+                        <AuthCheck>
+                          <App />
+                        </AuthCheck>
+                      </Route>
+                    </Switch>
+                  </CoreClientContextProvider>
                 </AuthContextProvider>
               </FeatureFlagsContextProvider>
             </AppContextProvider>

--- a/ui/App.tsx
+++ b/ui/App.tsx
@@ -98,12 +98,12 @@ const App = () => (
 export default function AppContainer() {
   return (
     <MuiThemeProvider theme={muiTheme}>
-      <AppContextProvider renderFooter coreClient={Core}>
-        <QueryClientProvider client={queryClient}>
-          <ThemeProvider theme={theme}>
-            <Fonts />
-            <GlobalStyle />
-            <Router>
+      <QueryClientProvider client={queryClient}>
+        <ThemeProvider theme={theme}>
+          <Fonts />
+          <GlobalStyle />
+          <Router>
+            <AppContextProvider renderFooter coreClient={Core}>
               <FeatureFlagsContextProvider>
                 <AuthContextProvider>
                   <Switch>
@@ -118,10 +118,10 @@ export default function AppContainer() {
                   </Switch>
                 </AuthContextProvider>
               </FeatureFlagsContextProvider>
-            </Router>
-          </ThemeProvider>
-        </QueryClientProvider>
-      </AppContextProvider>
+            </AppContextProvider>
+          </Router>
+        </ThemeProvider>
+      </QueryClientProvider>
     </MuiThemeProvider>
   );
 }

--- a/ui/contexts/AppContext.tsx
+++ b/ui/contexts/AppContext.tsx
@@ -1,8 +1,6 @@
-import _ from "lodash";
 import * as React from "react";
 import { useHistory } from "react-router-dom";
 import { Applications } from "../lib/api/applications/applications.pb";
-import { Core } from "../lib/api/core/core.pb";
 import { formatURL } from "../lib/nav";
 import {
   clearCallbackState,
@@ -13,7 +11,6 @@ import {
 } from "../lib/storage";
 import { PageRoute, V2Routes } from "../lib/types";
 import { notifySuccess } from "../lib/utils";
-import { AuthRoutes } from "./AuthContext";
 
 type AppState = {
   error: null | { fatal: boolean; message: string; detail?: string };
@@ -31,7 +28,6 @@ export function defaultLinkResolver(incoming: string): string {
 
 export type AppContextType = {
   applicationsClient: typeof Applications;
-  api: typeof Core;
   userConfigRepoName: string;
   doAsyncError: (message: string, detail: string) => void;
   clearAsyncError: () => void;
@@ -57,7 +53,6 @@ export const AppContext = React.createContext<AppContextType>(
 
 export interface AppProps {
   applicationsClient?: typeof Applications;
-  coreClient?: typeof Core;
   linkResolver?: LinkResolver;
   children?: any;
   renderFooter?: boolean;
@@ -93,23 +88,8 @@ export default function AppContextProvider({
     });
   };
 
-  const wrapped = {} as typeof Core;
-
-  //   Wrap each API method in a check that redirects to the signin page if a 401 is returned.
-  _.each(props.coreClient, (fn: any, method) => {
-    wrapped[method] = (req, initReq) => {
-      return fn(req, initReq).catch((err) => {
-        if (err.code === 401) {
-          history.push(AuthRoutes.AUTH_PATH_SIGNIN);
-        }
-        throw err;
-      });
-    };
-  });
-
   const value: AppContextType = {
     applicationsClient,
-    api: wrapped,
     userConfigRepoName: "wego-github-jlw-config-repo",
     doAsyncError,
     clearAsyncError,

--- a/ui/contexts/AuthContext.tsx
+++ b/ui/contexts/AuthContext.tsx
@@ -3,10 +3,12 @@ import { Redirect, useHistory } from "react-router-dom";
 import { useFeatureFlags } from "../hooks/featureflags";
 import { AppContext } from "./AppContext";
 
-const USER_INFO = "/oauth2/userinfo";
-const SIGN_IN = "/oauth2/sign_in";
-const LOG_OUT = "/oauth2/logout";
-const AUTH_PATH_SIGNIN = "/sign_in";
+export enum AuthRoutes {
+  USER_INFO = "/oauth2/userinfo",
+  SIGN_IN = "/oauth2/sign_in",
+  LOG_OUT = "/oauth2/logout",
+  AUTH_PATH_SIGNIN = "/sign_in",
+}
 
 interface AuthCheckProps {
   children: any;
@@ -34,7 +36,7 @@ export const AuthCheck = ({ children, Loader }: AuthCheckProps) => {
   }
 
   // User appears not be logged in, off to signin
-  return <Redirect to={AUTH_PATH_SIGNIN} />;
+  return <Redirect to={AuthRoutes.AUTH_PATH_SIGNIN} />;
 };
 
 export type AuthContext = {
@@ -66,7 +68,7 @@ export default function AuthContextProvider({ children }) {
 
   const signIn = React.useCallback((data) => {
     setLoading(true);
-    request(SIGN_IN, {
+    request(AuthRoutes.SIGN_IN, {
       method: "POST",
       body: JSON.stringify(data),
     })
@@ -85,7 +87,7 @@ export default function AuthContextProvider({ children }) {
 
   const getUserInfo = React.useCallback(() => {
     setLoading(true);
-    return request(USER_INFO)
+    return request(AuthRoutes.USER_INFO)
       .then((response) => {
         if (response.status === 400 || response.status === 401) {
           setUserInfo(null);
@@ -100,7 +102,7 @@ export default function AuthContextProvider({ children }) {
 
   const logOut = React.useCallback(() => {
     setLoading(true);
-    request(LOG_OUT, {
+    request(AuthRoutes.LOG_OUT, {
       method: "POST",
     })
       .then((response) => {

--- a/ui/contexts/AuthContext.tsx
+++ b/ui/contexts/AuthContext.tsx
@@ -75,7 +75,10 @@ export default function AuthContextProvider({ children }) {
           setError(response);
           return;
         }
-        getUserInfo().then(() => history.push("/"));
+        getUserInfo().then(() => {
+          setError(null);
+          history.push("/");
+        });
       })
       .finally(() => setLoading(false));
   }, []);

--- a/ui/contexts/CoreClientContext.tsx
+++ b/ui/contexts/CoreClientContext.tsx
@@ -1,0 +1,41 @@
+import _ from "lodash";
+import * as React from "react";
+import { useHistory } from "react-router-dom";
+import { Core } from "../lib/api/core/core.pb";
+import { AuthRoutes } from "./AuthContext";
+
+type Props = {
+  api: typeof Core;
+  children: any;
+};
+
+export type CoreClientContextType = {
+  api: typeof Core;
+};
+
+export const CoreClientContext =
+  React.createContext<CoreClientContextType | null>(null);
+
+export default function CoreClientContextProvider({ api, children }: Props) {
+  const history = useHistory();
+
+  const wrapped = {} as typeof Core;
+
+  //   Wrap each API method in a check that redirects to the signin page if a 401 is returned.
+  _.each(api, (fn: any, method) => {
+    wrapped[method] = (req, initReq) => {
+      return fn(req, initReq).catch((err) => {
+        if (err.code === 401) {
+          history.push(AuthRoutes.AUTH_PATH_SIGNIN);
+        }
+        throw err;
+      });
+    };
+  });
+
+  return (
+    <CoreClientContext.Provider value={{ api: wrapped }}>
+      {children}
+    </CoreClientContext.Provider>
+  );
+}

--- a/ui/hooks/automations.ts
+++ b/ui/hooks/automations.ts
@@ -1,7 +1,7 @@
 import _ from "lodash";
 import { useContext } from "react";
 import { useMutation, useQuery } from "react-query";
-import { AppContext } from "../contexts/AppContext";
+import { CoreClientContext } from "../contexts/CoreClientContext";
 import {
   GetHelmReleaseResponse,
   GetKustomizationResponse,
@@ -22,7 +22,7 @@ import {
 export type Automation = Kustomization & { type: AutomationType };
 
 export function useListAutomations(namespace = NoNamespace) {
-  const { api } = useContext(AppContext);
+  const { api } = useContext(CoreClientContext);
 
   return useQuery<Automation[], RequestError>(
     "automations",
@@ -63,7 +63,7 @@ export function useGetKustomization(
   clusterName = DefaultCluster,
   namespace = NoNamespace
 ) {
-  const { api } = useContext(AppContext);
+  const { api } = useContext(CoreClientContext);
 
   return useQuery<GetKustomizationResponse, RequestError>(
     ["kustomizations", name],
@@ -77,7 +77,7 @@ export function useGetHelmRelease(
   clusterName = DefaultCluster,
   namespace = NoNamespace
 ) {
-  const { api } = useContext(AppContext);
+  const { api } = useContext(CoreClientContext);
 
   return useQuery<GetHelmReleaseResponse, RequestError>(
     ["helmrelease", name],
@@ -87,7 +87,7 @@ export function useGetHelmRelease(
 }
 
 export function useSyncAutomation(obj: Syncable) {
-  const { api } = useContext(AppContext);
+  const { api } = useContext(CoreClientContext);
   const mutation = useMutation<
     SyncAutomationResponse,
     RequestError,

--- a/ui/hooks/events.ts
+++ b/ui/hooks/events.ts
@@ -1,12 +1,12 @@
 import { useContext } from "react";
 import { useQuery } from "react-query";
-import { AppContext } from "../contexts/AppContext";
+import { CoreClientContext } from "../contexts/CoreClientContext";
 import { ListFluxEventsResponse } from "../lib/api/core/core.pb";
 import { ObjectReference } from "../lib/api/core/types.pb";
 import { RequestError } from "../lib/types";
 
 export function useListFluxEvents(namespace, obj: ObjectReference) {
-  const { api } = useContext(AppContext);
+  const { api } = useContext(CoreClientContext);
 
   return useQuery<ListFluxEventsResponse, RequestError>(
     ["events", obj],

--- a/ui/hooks/flux.ts
+++ b/ui/hooks/flux.ts
@@ -1,6 +1,6 @@
 import { useContext } from "react";
 import { useQuery } from "react-query";
-import { AppContext } from "../contexts/AppContext";
+import { CoreClientContext } from "../contexts/CoreClientContext";
 import { ListFluxRuntimeObjectsResponse } from "../lib/api/core/core.pb";
 import {
   AutomationKind,
@@ -14,7 +14,7 @@ export function useListFluxRuntimeObjects(
   clusterName = DefaultCluster,
   namespace = NoNamespace
 ) {
-  const { api } = useContext(AppContext);
+  const { api } = useContext(CoreClientContext);
 
   return useQuery<ListFluxRuntimeObjectsResponse, RequestError>(
     "flux_runtime_objects",
@@ -30,7 +30,7 @@ export function useGetReconciledObjects(
   kinds: GroupVersionKind[],
   clusterName = DefaultCluster
 ) {
-  const { api } = useContext(AppContext);
+  const { api } = useContext(CoreClientContext);
 
   return useQuery<UnstructuredObject[], RequestError>(
     ["reconciled_objects", { name, namespace, type, kinds }],

--- a/ui/hooks/sources.ts
+++ b/ui/hooks/sources.ts
@@ -1,7 +1,7 @@
 import _ from "lodash";
 import { useContext } from "react";
 import { useQuery } from "react-query";
-import { AppContext } from "../contexts/AppContext";
+import { CoreClientContext } from "../contexts/CoreClientContext";
 import {
   ListBucketsResponse,
   ListGitRepositoriesResponse,
@@ -15,7 +15,7 @@ export function useListSources(
   appName?: string,
   namespace: string = NoNamespace
 ) {
-  const { api } = useContext(AppContext);
+  const { api } = useContext(CoreClientContext);
 
   return useQuery<Source[], RequestError>(
     "sources",

--- a/ui/pages/SignIn.tsx
+++ b/ui/pages/SignIn.tsx
@@ -67,7 +67,7 @@ function SignIn() {
   }
 
   const formRef = React.useRef<HTMLFormElement>();
-  const { signIn, error, setError, loading } = React.useContext(Auth);
+  const { signIn, error, loading } = React.useContext(Auth);
   const [password, setPassword] = React.useState<string>("");
   const [username, setUsername] = React.useState<string>("");
   const [showPassword, setShowPassword] = React.useState<boolean>(false);
@@ -80,12 +80,6 @@ function SignIn() {
   };
 
   const handleUserPassSubmit = () => signIn({ username, password });
-
-  React.useEffect(() => {
-    return () => {
-      setError(null);
-    };
-  }, []);
 
   return (
     <SignInPageWrapper tall wide center align column>


### PR DESCRIPTION
Closes #1894

Wraps the `Core` client to ensure that 401s always redirect the user to the `sign_in` page.