### PR TITLE
Populate namespace on automation detail screens

### DIFF
--- a/ui/App.tsx
+++ b/ui/App.tsx
@@ -38,13 +38,7 @@ function withSearchParams(Cmp) {
   return ({ location: { search }, ...rest }) => {
     const params = qs.parse(search);
 
-    return (
-      <Cmp
-        {...rest}
-        name={params.name as string}
-        clusterName={params.clusterName as string}
-      />
-    );
+    return <Cmp {...rest} {...params} />;
   };
 }
 

--- a/ui/components/AutomationsTable.tsx
+++ b/ui/components/AutomationsTable.tsx
@@ -89,7 +89,13 @@ function AutomationsTable({ className, automations, hideSource }: Props) {
         }
 
         return (
-          <SourceLink sourceRef={{ kind: sourceKind, name: sourceName }} />
+          <SourceLink
+            sourceRef={{
+              kind: sourceKind,
+              name: sourceName,
+              namespace: a.sourceRef.namespace,
+            }}
+          />
         );
       },
       sortValue: (a: Automation) => a.sourceRef?.name,

--- a/ui/components/KustomizationDetail.tsx
+++ b/ui/components/KustomizationDetail.tsx
@@ -19,7 +19,6 @@ import SyncButton from "./SyncButton";
 import Timestamp from "./Timestamp";
 
 type Props = {
-  name: string;
   kustomization?: Kustomization;
   className?: string;
 };
@@ -34,7 +33,7 @@ const TabContent = styled(Flex)`
   height: 100%;
 `;
 
-function KustomizationDetail({ kustomization, name, className }: Props) {
+function KustomizationDetail({ kustomization, className }: Props) {
   const { notifySuccess } = React.useContext(AppContext);
   const { path } = useRouteMatch();
 
@@ -97,9 +96,10 @@ function KustomizationDetail({ kustomization, name, className }: Props) {
           </RouterTab>
           <RouterTab name="Events" path={`${path}/events`}>
             <EventsTable
+              namespace={kustomization?.namespace}
               involvedObject={{
                 kind: "Kustomization",
-                name,
+                name: kustomization?.name,
                 namespace: kustomization?.namespace,
               }}
             />

--- a/ui/components/SourceLink.tsx
+++ b/ui/components/SourceLink.tsx
@@ -11,12 +11,12 @@ type Props = {
 
 function SourceLink({ className, sourceRef }: Props) {
   if (!sourceRef) {
-    return <div />
+    return <div />;
   }
   return (
     <Link
       className={className}
-      to={formatSourceURL(sourceRef.kind, sourceRef.name)}
+      to={formatSourceURL(sourceRef.kind, sourceRef.name, sourceRef.namespace)}
     >
       {sourceRef.kind}/{sourceRef.name}
     </Link>

--- a/ui/hooks/automations.ts
+++ b/ui/hooks/automations.ts
@@ -60,8 +60,9 @@ export function useListAutomations(namespace = NoNamespace) {
 
 export function useGetKustomization(
   name: string,
-  clusterName = DefaultCluster,
-  namespace = NoNamespace
+
+  namespace = NoNamespace,
+  clusterName = DefaultCluster
 ) {
   const { api } = useContext(AppContext);
 
@@ -74,8 +75,8 @@ export function useGetKustomization(
 
 export function useGetHelmRelease(
   name: string,
-  clusterName = DefaultCluster,
-  namespace = NoNamespace
+  namespace = NoNamespace,
+  clusterName = DefaultCluster
 ) {
   const { api } = useContext(AppContext);
 

--- a/ui/pages/v2/HelmReleaseDetail.tsx
+++ b/ui/pages/v2/HelmReleaseDetail.tsx
@@ -6,17 +6,26 @@ import { useGetHelmRelease } from "../../hooks/automations";
 
 type Props = {
   name: string;
+  namespace: string;
   clusterName: string;
   className?: string;
 };
 
-function HelmReleaseDetail({ className, name, clusterName }: Props) {
-  const { data, isLoading, error } = useGetHelmRelease(name, clusterName);
+function HelmReleaseDetail({ className, name, namespace, clusterName }: Props) {
+  const { data, isLoading, error } = useGetHelmRelease(
+    name,
+    namespace,
+    clusterName
+  );
   const helmRelease = data?.helmRelease;
 
   return (
     <Page loading={isLoading} error={error} className={className} title={name}>
-      <HelmReleaseComponent helmRelease={helmRelease} name={name} clusterName={clusterName} />
+      <HelmReleaseComponent
+        helmRelease={helmRelease}
+        name={name}
+        clusterName={clusterName}
+      />
     </Page>
   );
 }

--- a/ui/pages/v2/KustomizationDetail.tsx
+++ b/ui/pages/v2/KustomizationDetail.tsx
@@ -6,16 +6,26 @@ import { useGetKustomization } from "../../hooks/automations";
 
 type Props = {
   name: string;
+  namespace?: string;
   clusterName: string;
   className?: string;
 };
 
-function KustomizationDetail({ className, name, clusterName }: Props) {
-  const { data, isLoading, error } = useGetKustomization(name, clusterName);
+function KustomizationDetail({
+  className,
+  name,
+  namespace,
+  clusterName,
+}: Props) {
+  const { data, isLoading, error } = useGetKustomization(
+    name,
+    namespace,
+    clusterName
+  );
   const kustomization = data?.kustomization;
   return (
     <Page loading={isLoading} error={error} className={className} title={name}>
-      <KustomizationComponent kustomization={kustomization} name={name} />
+      <KustomizationComponent kustomization={kustomization} />
     </Page>
   );
 }


### PR DESCRIPTION
Fixes an issue where the backend complained about a namespace not being populated. This only happens when the `k8s` client does a `.Get` instead of a `.List`