### PR TITLE
Stop the testEnv

### DIFF
--- a/core/nsaccess/nsaccess_test.go
+++ b/core/nsaccess/nsaccess_test.go
@@ -29,6 +29,13 @@ func TestFilterAccessibleNamespaces(t *testing.T) {
 	testCfg, err := testEnv.Start()
 	g.Expect(err).NotTo(HaveOccurred())
 
+	defer func() {
+		err := testEnv.Stop()
+		if err != nil {
+			t.Error(err)
+		}
+	}()
+
 	adminClient, err := client.New(testCfg, client.Options{
 		Scheme: kube.CreateScheme(),
 	})


### PR DESCRIPTION
Closes #1915 

Show the `testEnv` who is boss.

Tested via:
```sh
$ make unit-tests
$ ps -a | grep api
```