### PR TITLE
Docs fixes

### DIFF
--- a/website/docs/cluster-management/getting-started.mdx
+++ b/website/docs/cluster-management/getting-started.mdx
@@ -12,7 +12,7 @@ import BrowserOnly from "@docusaurus/BrowserOnly";
 
 ## Creating your first CAPD Cluster
 
-If you've followed the [Upgrade steps](../installation#weave-gitops-enterprise) in the [Installation guide](../installation) you should have:
+If you've followed the [Upgrade steps](installation.mdx#weave-gitops-enterprise) in the [Installation guide](installation.mdx) you should have:
 
 1. Weave GitOps Enterprise installed and an agent running on the management cluster.
 2. A CAPI provider installed (With support for `ClusterResourceSet`s enabled).

--- a/website/docs/configuration/securing-access-to-the-dashboard.mdx
+++ b/website/docs/configuration/securing-access-to-the-dashboard.mdx
@@ -97,26 +97,14 @@ If you need to change the OIDC configuration after running `gitops upgrade`, upd
 
 ## Login via a cluster user account
 
-Before you login via the cluster user account, you need to generate a bcrypt hash for your chosen password and store it as a secret in Kubernetes. There are several different ways to generate a bcrypt hash, this guide uses an Alpine Docker image to generate one:
+Before you login via the cluster user account, you need to generate a bcrypt hash for your chosen password and store it as a secret in Kubernetes. There are several different ways to generate a bcrypt hash, this guide uses a Go Docker image to generate one:
 
-Run an Alpine Docker image interactively and supply the password of your choice as an environment variable:
-
-```sh
-docker run -e CLEAR_PASSWORD="super secret password" -it alpine
-```
-
-Once inside the shell environment of the Alpine image, install the bcrypt library dependencies as well as the bcrypt library itself:
+Generate the password by running:
 
 ```sh
-apk add --update musl-dev gcc libffi-dev python3 python3-dev py3-pip
-pip install bcrypt
-```
-
-Run the following Python script to generate a hash:
-
-```sh
-python3 -c 'import bcrypt, os; print(bcrypt.hashpw(os.getenv("CLEAR_PASSWORD").encode(), bcrypt.gensalt()))'
-b'$2b$12$nLfl7lKBiYzgAN2aI3ii6exZSZ9KRsj18C7CEWY8kscj9.c6bRXim'
+PASSWORD="<your password>"
+docker run -it golang:1.17 bash -c "go install github.com/bitnami/bcrypt-cli@v1.0.2 2> /dev/null && echo -n '$PASSWORD' | bcrypt-cli"
+$2a$10$OS5NJmPNEb13UTOSKngMxOWlmS7mlxX77hv4yAiISvZ71Dc7IuN3q
 ```
 
 Now create a Kubernetes secret to store your chosen username and the password hash:
@@ -125,7 +113,7 @@ Now create a Kubernetes secret to store your chosen username and the password ha
 kubectl create secret generic cluster-user-auth \
   --namespace flux-system \
   --from-literal=username=admin \
-  --from-literal=password='$2b$12$nLfl7lKBiYzgAN2aI3ii6exZSZ9KRsj18C7CEWY8kscj9.c6bRXim'
+  --from-literal=password='$2a$10$OS5NJmPNEb13UTOSKngMxOWlmS7mlxX77hv4yAiISvZ71Dc7IuN3q'
 ```
 
 You should now be able to login via the cluster user account using your chosen username and password. Follow the instructions in the next section in order to configure RBAC correctly.

--- a/website/docs/getting-started.mdx
+++ b/website/docs/getting-started.mdx
@@ -452,4 +452,4 @@ flux resume kustomization podinfo
 
 Congratulations 🎉🎉🎉
 
-You've now completed the getting started guide. We would welcome any and all [feedback](./feedback-and-telemetry.md) on your experience.
+You've now completed the getting started guide. We would welcome any and all [feedback](feedback-and-telemetry.md) on your experience.

--- a/website/docs/getting-started.mdx
+++ b/website/docs/getting-started.mdx
@@ -75,43 +75,26 @@ The bootstrap command above does following:
 - Configures Flux components to track the path /clusters/my-cluster/ in the repository
 
 ### Configure access to the dashboard
-
 For this guide we will use the cluster user, for complete documentation including how to configure an OIDC provider see the documentation [here](./configuration/securing-access-to-the-dashboard.mdx).
 
-We will generate a bcyrpt hash for your chosen password and store as a secret in Kubernetes. There are several different ways to generate a bcrypt hash, this guide uses an Alpine Docker image to generate one.
+We will generate a bcyrpt hash for your chosen password and store as a secret in Kubernetes. There are several different ways to generate a bcrypt hash, this guide uses an Go Docker image to generate one.
 
-1. Run an Alpine Docker image interactively and supply the password of your choice as an environment variable by changing `<your-password>`:
-
-```
-docker run -e CLEAR_PASSWORD="<your-password>" -it alpine
-```
-
-2. Once inside the shell environment of the Alpine image, install the bcrypt library dependencies as well as the bcrypt library itself:
+1. Clone your git repository where Flux has been bootstrapped.
 
 ```
-apk add --update musl-dev gcc libffi-dev python3 python3-dev py3-pip
-pip install bcrypt
+git clone https://github.com/$GITHUB_USER/fleet-infra
+cd fleet-infra
 ```
 
-3. Run the following Python script to generate a hash:
+2. Generate the password using a golang image:
 
 ```
-python3 -c 'import bcrypt, os; print(bcrypt.hashpw(os.getenv("CLEAR_PASSWORD").encode(), bcrypt.gensalt()))'
+PASSWORD="<your password>"
+docker run -it golang:1.17 bash -c "go install github.com/bitnami/bcrypt-cli@v1.0.2 2> /dev/null && echo -n '$PASSWORD' | bcrypt-cli"
+$2a$10$OS5NJmPNEb13UTOSKngMxOWlmS7mlxX77hv4yAiISvZ71Dc7IuN3q
 ```
 
-you should get a response like:
-
-```
-b'$2b$12$FFokfwM/p8RPr0YMTdHWk.MXe3Kg1/UVyj63pT9FU8/mthUjKjm7W'
-```
-
-4. Copy the output from the above command and exit the shell
-
-```
-exit
-```
-
-5. Now create a Kubernetes secret to store your chosen username and the password hash.
+3. Now create a Kubernetes secret to store your chosen username and the password hash.
 
 Note when you update the password that you only need content between ' marks.
 
@@ -119,12 +102,12 @@ Note when you update the password that you only need content between ' marks.
 kubectl create secret generic cluster-user-auth \
   --namespace flux-system \
   --from-literal=username=admin \
-  --from-literal=password='$2b$12$FFokfwM/p8RPr0YMTdHWk.MXe3Kg1/UVyj63pT9FU8/mthUjKjm7W'
+  --from-literal=password='$2a$10$OS5NJmPNEb13UTOSKngMxOWlmS7mlxX77hv4yAiISvZ71Dc7IuN3q'
 ```
 
-6. Configure RBAC for the admin user
+4. Configure RBAC for the admin user
 
-Still in your local clone of `fleet-infra`, create a new YAML file and add the following:
+Still in your local clone of `fleet-infra`, create a new YAML file in the `my-cluster` directory and add the following:
 
 ```
 apiVersion: rbac.authorization.k8s.io/v1

--- a/website/docs/guides/deploying-capa.mdx
+++ b/website/docs/guides/deploying-capa.mdx
@@ -31,11 +31,11 @@ The `AWS_ACCESS_KEY_ID`and `AWS_SECRET_ACCESS_KEY` of a user should be configure
 The `GITHUB_TOKEN` should be set as an environment variable in the current shell. It should have permissions to create Pull Requests against the cluster config repo.
 :::
 
-If you've followed the [Upgrade steps](../installation#weave-gitops-enterprise) in the [Installation guide](../installation) you should have a management cluster ready to roll.
+If you've followed the [Upgrade steps](installation.mdx#weave-gitops-enterprise) in the [Installation guide](installation.mdx) you should have a management cluster ready to roll.
 
 ### 1. Configure a capi provider
 
-See [Cluster API Providers](../cluster-management/cluster-api-providers.mdx) page for more details on providers. He're we'll continue with `eks` and `capa` as an example.
+See [Cluster API Providers](cluster-management/cluster-api-providers.mdx) page for more details on providers. He're we'll continue with `eks` and `capa` as an example.
 
 ```bash
 # Enable support for `ClusterResourceSet`s for automatically installing CNIs
@@ -49,7 +49,7 @@ clusterctl init --infrastructure aws
 
 ### 2. Add a template
 
-See [CAPI Templates](../cluster-management/templates.mdx) page for more details on this topic. Once we load a template we can use it in the UI to create clusters!
+See [CAPI Templates](cluster-management/templates.mdx) page for more details on this topic. Once we load a template we can use it in the UI to create clusters!
 
 import CapaTemplate from "!!raw-loader!./assets/templates/capa-template.yaml";
 

--- a/website/docs/installation.mdx
+++ b/website/docs/installation.mdx
@@ -21,7 +21,7 @@ Weave GitOps is an extension to Flux and therefore requires that Flux has alread
 #### Configure access to the GitOps Dashboard web UI
 Weave GitOps includes a web UI which runs on your Kubernetes cluster. In order to allow users to access this, you must first configure an appropriate login mechanism. We support integration with OIDC providers, as well as an admin cluster user for getting started and emergencies. This cluster user can be disabled if preferred.
 
-Follow the guide here to appropriately configure access : [Securing access to the dashboard](./configuration/securing-access-to-the-dashboard).
+Follow the guide here to appropriately configure access : [Securing access to the dashboard](configuration/securing-access-to-the-dashboard.mdx).
 
 ### Install the Helm Chart
 Weave GitOps is provided through a Helm Chart and installed as a Flux resource through a `HelmRepository` and `HelmRlease`. To install on your cluster, adjust the following where marked `<UPDATE>` based on the previous step, and commit the file to the location bootstrapped with Flux so that it is synchronized to your Cluster.

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -10,6 +10,7 @@ module.exports = {
   favicon: "img/favicon_150px.png",
   organizationName: "weaveworks", // Usually your GitHub org/user name.
   projectName: "weave-gitops", // Usually your repo name.
+  trailingSlash: true,
   plugins: [
     () => ({
       // Load yaml files as blobs

--- a/website/versioned_docs/version-0.7.0/cluster-management/getting-started.mdx
+++ b/website/versioned_docs/version-0.7.0/cluster-management/getting-started.mdx
@@ -12,7 +12,7 @@ import BrowserOnly from "@docusaurus/BrowserOnly";
 
 ## Creating your first CAPD Cluster
 
-If you've followed the [Upgrade steps](../installation#weave-gitops-enterprise) in the [Installation guide](../installation) you should have:
+If you've followed the [Upgrade steps](installation.mdx#weave-gitops-enterprise) in the [Installation guide](installation.mdx) you should have:
 
 1. Weave GitOps Enterprise installed and an agent running on the management cluster.
 2. A CAPI provider installed (With support for `ClusterResourceSet`s enabled).

--- a/website/versioned_docs/version-0.7.0/configuration/securing-access-to-the-dashboard.mdx
+++ b/website/versioned_docs/version-0.7.0/configuration/securing-access-to-the-dashboard.mdx
@@ -97,26 +97,14 @@ If you need to change the OIDC configuration after running `gitops upgrade`, upd
 
 ## Login via a cluster user account
 
-Before you login via the cluster user account, you need to generate a bcrypt hash for your chosen password and store it as a secret in Kubernetes. There are several different ways to generate a bcrypt hash, this guide uses an Alpine Docker image to generate one:
+Before you login via the cluster user account, you need to generate a bcrypt hash for your chosen password and store it as a secret in Kubernetes. There are several different ways to generate a bcrypt hash, this guide uses a Go Docker image to generate one:
 
 Run an Alpine Docker image interactively and supply the password of your choice as an environment variable:
 
 ```sh
-docker run -e CLEAR_PASSWORD="super secret password" -it alpine
-```
-
-Once inside the shell environment of the Alpine image, install the bcrypt library dependencies as well as the bcrypt library itself:
-
-```sh
-apk add --update musl-dev gcc libffi-dev python3 python3-dev py3-pip
-pip install bcrypt
-```
-
-Run the following Python script to generate a hash:
-
-```sh
-python3 -c 'import bcrypt, os; print(bcrypt.hashpw(os.getenv("CLEAR_PASSWORD").encode(), bcrypt.gensalt()))'
-b'$2b$12$nLfl7lKBiYzgAN2aI3ii6exZSZ9KRsj18C7CEWY8kscj9.c6bRXim'
+PASSWORD="<your password>"
+docker run -it golang:1.17 bash -c "go install github.com/bitnami/bcrypt-cli@v1.0.2 2> /dev/null && echo -n '$PASSWORD' | bcrypt-cli"
+$2a$10$OS5NJmPNEb13UTOSKngMxOWlmS7mlxX77hv4yAiISvZ71Dc7IuN3q
 ```
 
 Now create a Kubernetes secret to store your chosen username and the password hash:
@@ -125,7 +113,7 @@ Now create a Kubernetes secret to store your chosen username and the password ha
 kubectl create secret generic cluster-user-auth \
   --namespace flux-system \
   --from-literal=username=admin \
-  --from-literal=password='$2b$12$nLfl7lKBiYzgAN2aI3ii6exZSZ9KRsj18C7CEWY8kscj9.c6bRXim'
+  --from-literal=password='$2a$10$OS5NJmPNEb13UTOSKngMxOWlmS7mlxX77hv4yAiISvZ71Dc7IuN3q'
 ```
 
 You should now be able to login via the cluster user account using your chosen username and password. Follow the instructions in the next section in order to configure RBAC correctly.

--- a/website/versioned_docs/version-0.7.0/getting-started.mdx
+++ b/website/versioned_docs/version-0.7.0/getting-started.mdx
@@ -78,40 +78,24 @@ The bootstrap command above does following:
 
 For this guide we will use the cluster user, for complete documentation including how to configure an OIDC provider see the documentation [here](./configuration/securing-access-to-the-dashboard.mdx).
 
-We will generate a bcyrpt hash for your chosen password and store as a secret in Kubernetes. There are several different ways to generate a bcrypt hash, this guide uses an Alpine Docker image to generate one.
+We will generate a bcyrpt hash for your chosen password and store as a secret in Kubernetes. There are several different ways to generate a bcrypt hash, this guide uses an Go Docker image to generate one.
 
-1. Run an Alpine Docker image interactively and supply the password of your choice as an environment variable by changing `<your-password>`:
-
-```
-docker run -e CLEAR_PASSWORD="<your-password>" -it alpine
-```
-
-2. Once inside the shell environment of the Alpine image, install the bcrypt library dependencies as well as the bcrypt library itself:
+1. Clone your git repository where Flux has been bootstrapped.
 
 ```
-apk add --update musl-dev gcc libffi-dev python3 python3-dev py3-pip
-pip install bcrypt
+git clone https://github.com/$GITHUB_USER/fleet-infra
+cd fleet-infra
 ```
 
-3. Run the following Python script to generate a hash:
+2. Generate the password using a golang image:
 
 ```
-python3 -c 'import bcrypt, os; print(bcrypt.hashpw(os.getenv("CLEAR_PASSWORD").encode(), bcrypt.gensalt()))'
+PASSWORD="<your password>"
+docker run -it golang:1.17 bash -c "go install github.com/bitnami/bcrypt-cli@v1.0.2 2> /dev/null && echo -n '$PASSWORD' | bcrypt-cli"
+$2a$10$OS5NJmPNEb13UTOSKngMxOWlmS7mlxX77hv4yAiISvZ71Dc7IuN3q
 ```
 
-you should get a response like:
-
-```
-b'$2b$12$FFokfwM/p8RPr0YMTdHWk.MXe3Kg1/UVyj63pT9FU8/mthUjKjm7W'
-```
-
-4. Copy the output from the above command and exit the shell
-
-```
-exit
-```
-
-5. Now create a Kubernetes secret to store your chosen username and the password hash.
+3. Now create a Kubernetes secret to store your chosen username and the password hash.
 
 Note when you update the password that you only need content between ' marks.
 
@@ -119,12 +103,12 @@ Note when you update the password that you only need content between ' marks.
 kubectl create secret generic cluster-user-auth \
   --namespace flux-system \
   --from-literal=username=admin \
-  --from-literal=password='$2b$12$FFokfwM/p8RPr0YMTdHWk.MXe3Kg1/UVyj63pT9FU8/mthUjKjm7W'
+  --from-literal=password='$2a$10$OS5NJmPNEb13UTOSKngMxOWlmS7mlxX77hv4yAiISvZ71Dc7IuN3q'
 ```
 
-6. Configure RBAC for the admin user
+4. Configure RBAC for the admin user
 
-Still in your local clone of `fleet-infra`, create a new YAML file and add the following:
+Still in your local clone of `fleet-infra`, create a new YAML file in the `my-cluster` directory and add the following:
 
 ```
 apiVersion: rbac.authorization.k8s.io/v1

--- a/website/versioned_docs/version-0.7.0/guides/deploying-capa.mdx
+++ b/website/versioned_docs/version-0.7.0/guides/deploying-capa.mdx
@@ -31,7 +31,7 @@ The `AWS_ACCESS_KEY_ID`and `AWS_SECRET_ACCESS_KEY` of a user should be configure
 The `GITHUB_TOKEN` should be set as an environment variable in the current shell. It should have permissions to create Pull Requests against the cluster config repo.
 :::
 
-If you've followed the [Upgrade steps](../installation#weave-gitops-enterprise) in the [Installation guide](../installation) you should have a management cluster ready to roll.
+If you've followed the [Upgrade steps](installation.mdx#weave-gitops-enterprise) in the [Installation guide](installation.mdx) you should have a management cluster ready to roll.
 
 ### 1. Configure a capi provider
 

--- a/website/versioned_docs/version-0.7.0/installation.mdx
+++ b/website/versioned_docs/version-0.7.0/installation.mdx
@@ -68,7 +68,7 @@ Windows support is a [planned enhancement](https://github.com/weaveworks/weave-g
 To install the `gitops` CLI, please follow the following steps:
 
 ```console
-curl --silent --location "https://github.com/weaveworks/weave-gitops/releases/download/v0.7.0/tmp
+curl --silent --location "https://github.com/weaveworks/weave-gitops/releases/download/v0.7.0/gitops-$(uname)-$(uname -m).tar.gz" | tar xz -C /tmp
 sudo mv /tmp/gitops /usr/local/bin
 gitops version
 ```

--- a/website/versioned_docs/version-0.7.0/installation.mdx
+++ b/website/versioned_docs/version-0.7.0/installation.mdx
@@ -21,7 +21,7 @@ Weave GitOps is an extension to Flux and therefore requires that Flux has alread
 #### Configure access to the GitOps Dashboard web UI
 Weave GitOps includes a web UI which runs on your Kubernetes cluster. In order to allow users to access this, you must first configure an appropriate login mechanism. We support integration with OIDC providers, as well as an admin cluster user for getting started and emergencies. This cluster user can be disabled if preferred.
 
-Follow the guide here to appropriately configure access : [Securing access to the dashboard](./configuration/securing-access-to-the-dashboard).
+Follow the guide here to appropriately configure access : [Securing access to the dashboard](configuration/securing-access-to-the-dashboard.mdx).
 
 ### Install the Helm Chart
 Weave GitOps is provided through a Helm Chart and installed as a Flux resource through a `HelmRepository` and `HelmRlease`. To install on your cluster, adjust the following where marked `<UPDATE>` based on the previous step, and commit the file to the location bootstrapped with Flux so that it is synchronized to your Cluster.


### PR DESCRIPTION
This combines 3 different fixes to the manual:
* Make the bcrypt generation more straightforward, and applies a couple of small bug fixes to the getting started instructions regarding this step. This is done for both main and stable.
* Fix download link in stable. This takes the fixed link (as of fce5eab4) and applies it to stable.
* Adds slashes to all URLs. There's a lot of detail in the commit message for that fix - in essence this fixes relative links if you're linked to the manual, so to reproduce see [the installation page](https://docs.gitops.weave.works/docs/installation) and click on "Securing access to the dashboard" in the Pre-requisite section. This should fail now, but [the staging docs](https://staging.docs.gitops.weave.works/docs-fixes/docs/installation/) should pass the same test.