### PR TITLE
Make sourceRef namespace optional

### DIFF
--- a/ui/components/AutomationsTable.tsx
+++ b/ui/components/AutomationsTable.tsx
@@ -93,7 +93,7 @@ function AutomationsTable({ className, automations, hideSource }: Props) {
             sourceRef={{
               kind: sourceKind,
               name: sourceName,
-              namespace: a.sourceRef.namespace,
+              namespace: a.sourceRef?.namespace,
             }}
           />
         );


### PR DESCRIPTION
This was causing a crash if the helm release didn't have a source ref defined