### PR TITLE
Better bcrypt use

### DIFF
--- a/charts/gitops-server/Chart.yaml
+++ b/charts/gitops-server/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.2
+version: 2.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/gitops-server/templates/admin-user.yaml
+++ b/charts/gitops-server/templates/admin-user.yaml
@@ -44,6 +44,7 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["get", "watch", "list"]
+{{- if .Values.adminUser.createSecret }}
 ---
 apiVersion: v1
 kind: Secret
@@ -56,4 +57,5 @@ data:
   username: {{ .username | b64enc | quote }}
   password: {{ .passwordHash | required "passwordHash must be set!" | b64enc | quote }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/gitops-server/templates/admin-user.yaml
+++ b/charts/gitops-server/templates/admin-user.yaml
@@ -54,12 +54,6 @@ type: Opaque
 data:
   {{- with .Values.adminUser }}
   username: {{ .username | b64enc | quote }}
-  {{/*
-    htpasswd returns user-file format, e.g. 'username:passwordhash' so as well
-    as using htpasswd to generate the bcrypt hash we also need to extract the
-    final element before base64 enconding it for k8s (and quoting it b/c yaml)
-  */}}
-   {{- $bcryptPasswordHash := .password | required "You must set a password for this user!" | htpasswd "" }}
-  password: {{ regexSplit ":" $bcryptPasswordHash -1 | last | b64enc | quote }}
+  password: {{ .passwordHash | required "passwordHash must be set!" | b64enc | quote }}
   {{- end }}
 {{- end }}

--- a/charts/gitops-server/values.yaml
+++ b/charts/gitops-server/values.yaml
@@ -50,6 +50,7 @@ adminUser:
   # Whether the wego-admin user should be created.
   # If you use this make sure you add it to rbac.impersonationResourceNames.
   create: false
+  createSecret: true
   # Set the username and password, these will be stored in a secret in k8s.
   username: gitops-test-user
   # This needs to have been hashed using the bcrypt algorithm.

--- a/charts/gitops-server/values.yaml
+++ b/charts/gitops-server/values.yaml
@@ -52,10 +52,9 @@ adminUser:
   create: false
   # Set the username and password, these will be stored in a secret in k8s.
   username: gitops-test-user
-  # The password will be hashed using the bcrypt algorithm.
-  # It should not be stored in plain-text so is best passed using a set flag:
-  # --set adminUser.password="My $uper secure password that is not this $tring"
-  # password:
+  # This needs to have been hashed using the bcrypt algorithm.
+  # e.g. go install github.com/bitnami/bcrypt-cli@v1.0.2 2> /dev/null && echo -n '$PASSWORD' | bcrypt-cli
+  # passwordHash:
 
 podAnnotations: {}
 

--- a/website/docs/getting-started.mdx
+++ b/website/docs/getting-started.mdx
@@ -91,71 +91,19 @@ cd fleet-infra
 ```
 PASSWORD="<your password>"
 docker run -it golang:1.17 bash -c "go install github.com/bitnami/bcrypt-cli@v1.0.2 2> /dev/null && echo -n '$PASSWORD' | bcrypt-cli"
-$2a$10$OS5NJmPNEb13UTOSKngMxOWlmS7mlxX77hv4yAiISvZ71Dc7IuN3q
+$2a$10$OS5NJmPNEb13UgTOSKnMxOWlmS7mlxX77hv4yAiISvZ71Dc7IuN3q
 ```
 
-3. Now create a Kubernetes secret to store your chosen username and the password hash.
-
-Note when you update the password that you only need content between ' marks.
-
+3. Save this [bcrypt-hash](https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/Password_Storage_Cheat_Sheet.md) in a values file:
 ```
-kubectl create secret generic cluster-user-auth \
-  --namespace flux-system \
-  --from-literal=username=admin \
-  --from-literal=password='$2a$10$OS5NJmPNEb13UTOSKngMxOWlmS7mlxX77hv4yAiISvZ71Dc7IuN3q'
+# weave-gitops-values.yaml
+adminUser:
+  passwordHash: $2a$10$OS5NJmPNEb13UgTOSKnMxOWlmS7mlxX77hv4yAiISvZ71Dc7IuN3q
 ```
 
-4. Configure RBAC for the admin user
-
-Still in your local clone of `fleet-infra`, create a new YAML file in the `my-cluster` directory and add the following:
-
-```
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: wego-test-user-read-resources
-  namespace: flux-system
-subjects:
-  - kind: User
-    name: wego-admin
-    namespace: flux-system
-roleRef:
-  kind: Role
-  name: wego-admin-role
-  apiGroup: rbac.authorization.k8s.io
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: wego-admin-role
-  namespace: flux-system
-rules:
-  - apiGroups: [""]
-    resources: ["secrets", "pods" ]
-    verbs: [ "get", "list" ]
-  - apiGroups: ["apps"]
-    resources: [ "deployments", "replicasets"]
-    verbs: [ "get", "list" ]
-  - apiGroups: ["kustomize.toolkit.fluxcd.io"]
-    resources: [ "kustomizations" ]
-    verbs: [ "get", "list", "patch" ]
-  - apiGroups: ["helm.toolkit.fluxcd.io"]
-    resources: [ "helmreleases" ]
-    verbs: [ "get", "list", "patch" ]
-  - apiGroups: ["source.toolkit.fluxcd.io"]
-    resources: [ "buckets", "helmcharts", "gitrepositories", "helmrepositories" ]
-    verbs: [ "get", "list", "patch" ]
-  - apiGroups: [""]
-    resources: ["events"]
-    verbs: ["get", "watch", "list"]
-```
-
-7. Commit and push the this file `fleet-infra` repository
-
-```
-git add -A && git commit -m "Add Weave GitOps admin RBAC"
-git push
-```
+:::info
+Storing a hash of a password is relatively safe for demo and testing purposes but it is recommend that you look at more secure methods of storing secrets (such as [Flux's SOPS integration](https://fluxcd.io/docs/guides/mozilla-sops/)) for production systems.
+:::
 
 ### Install Weave GitOps
 
@@ -202,6 +150,7 @@ git push
 flux create helmrelease ww-gitops \
   --source=HelmRepository/ww-gitops \
   --chart=weave-gitops \
+  --values=<path to weave-gitops-values.yaml> \
   --export > ./clusters/my-cluster/weave-gitops-helmrelease.yaml
 ```
 
@@ -244,7 +193,7 @@ kubectl port-forward svc/ww-gitops-weave-gitops -n flux-system 9001:9001
 
 ![Weave GitOps login screen](/img/dashboard-login.png)
 
-###  Applications view
+### Applications view
 
 When you login to the dashboard you are brought to the Applications view, which allows you to quickly understand the state of your deployments across a cluster at a glance. It shows summary information from `kustomization` and `helmrelease` objects.
 

--- a/website/docs/installation.mdx
+++ b/website/docs/installation.mdx
@@ -43,7 +43,7 @@ spec:
   values:
     adminUser:
       create: true
-      password: <UPDATE>
+      passwordHash: <UPDATE>
       username: <UPDATE>
     namespace: flux-system
     rbac:

--- a/website/versioned_docs/version-0.7.0/getting-started.mdx
+++ b/website/versioned_docs/version-0.7.0/getting-started.mdx
@@ -75,7 +75,6 @@ The bootstrap command above does following:
 - Configures Flux components to track the path /clusters/my-cluster/ in the repository
 
 ### Configure access to the dashboard
-
 For this guide we will use the cluster user, for complete documentation including how to configure an OIDC provider see the documentation [here](./configuration/securing-access-to-the-dashboard.mdx).
 
 We will generate a bcyrpt hash for your chosen password and store as a secret in Kubernetes. There are several different ways to generate a bcrypt hash, this guide uses an Go Docker image to generate one.
@@ -92,71 +91,19 @@ cd fleet-infra
 ```
 PASSWORD="<your password>"
 docker run -it golang:1.17 bash -c "go install github.com/bitnami/bcrypt-cli@v1.0.2 2> /dev/null && echo -n '$PASSWORD' | bcrypt-cli"
-$2a$10$OS5NJmPNEb13UTOSKngMxOWlmS7mlxX77hv4yAiISvZ71Dc7IuN3q
+$2a$10$OS5NJmPNEb13UgTOSKnMxOWlmS7mlxX77hv4yAiISvZ71Dc7IuN3q
 ```
 
-3. Now create a Kubernetes secret to store your chosen username and the password hash.
-
-Note when you update the password that you only need content between ' marks.
-
+3. Save this [bcrypt-hash](https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/Password_Storage_Cheat_Sheet.md) in a values file:
 ```
-kubectl create secret generic cluster-user-auth \
-  --namespace flux-system \
-  --from-literal=username=admin \
-  --from-literal=password='$2a$10$OS5NJmPNEb13UTOSKngMxOWlmS7mlxX77hv4yAiISvZ71Dc7IuN3q'
+# weave-gitops-values.yaml
+adminUser:
+  passwordHash: $2a$10$OS5NJmPNEb13UgTOSKnMxOWlmS7mlxX77hv4yAiISvZ71Dc7IuN3q
 ```
 
-4. Configure RBAC for the admin user
-
-Still in your local clone of `fleet-infra`, create a new YAML file in the `my-cluster` directory and add the following:
-
-```
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: wego-test-user-read-resources
-  namespace: flux-system
-subjects:
-  - kind: User
-    name: wego-admin
-    namespace: flux-system
-roleRef:
-  kind: Role
-  name: wego-admin-role
-  apiGroup: rbac.authorization.k8s.io
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: wego-admin-role
-  namespace: flux-system
-rules:
-  - apiGroups: [""]
-    resources: ["secrets", "pods" ]
-    verbs: [ "get", "list" ]
-  - apiGroups: ["apps"]
-    resources: [ "deployments", "replicasets"]
-    verbs: [ "get", "list" ]
-  - apiGroups: ["kustomize.toolkit.fluxcd.io"]
-    resources: [ "kustomizations" ]
-    verbs: [ "get", "list", "patch" ]
-  - apiGroups: ["helm.toolkit.fluxcd.io"]
-    resources: [ "helmreleases" ]
-    verbs: [ "get", "list", "patch" ]
-  - apiGroups: ["source.toolkit.fluxcd.io"]
-    resources: [ "buckets", "helmcharts", "gitrepositories", "helmrepositories" ]
-    verbs: [ "get", "list", "patch" ]
-  - apiGroups: [""]
-    resources: ["events"]
-    verbs: ["get", "watch", "list"]
-```
-
-7. Commit and push the this file `fleet-infra` repository
-
-```
-git add -A && git commit -m "Add Weave GitOps admin RBAC"
-git push
-```
+:::info
+Storing a hash of a password is relatively safe for demo and testing purposes but it is recommend that you look at more secure methods of storing secrets (such as [Flux's SOPS integration](https://fluxcd.io/docs/guides/mozilla-sops/)) for production systems.
+:::
 
 ### Install Weave GitOps
 
@@ -203,6 +150,7 @@ git push
 flux create helmrelease ww-gitops \
   --source=HelmRepository/ww-gitops \
   --chart=weave-gitops \
+  --values=<path to weave-gitops-values.yaml> \
   --export > ./clusters/my-cluster/weave-gitops-helmrelease.yaml
 ```
 
@@ -245,7 +193,7 @@ kubectl port-forward svc/ww-gitops-weave-gitops -n flux-system 9001:9001
 
 ![Weave GitOps login screen](/img/dashboard-login.png)
 
-###  Applications view
+### Applications view
 
 When you login to the dashboard you are brought to the Applications view, which allows you to quickly understand the state of your deployments across a cluster at a glance. It shows summary information from `kustomization` and `helmrelease` objects.
 
@@ -436,4 +384,4 @@ flux resume kustomization podinfo
 
 Congratulations 🎉🎉🎉
 
-You've now completed the getting started guide. We would welcome any and all [feedback](./feedback-and-telemetry.md) on your experience.
+You've now completed the getting started guide. We would welcome any and all [feedback](feedback-and-telemetry.md) on your experience.

--- a/website/versioned_docs/version-0.7.0/installation.mdx
+++ b/website/versioned_docs/version-0.7.0/installation.mdx
@@ -43,7 +43,7 @@ spec:
   values:
     adminUser:
       create: true
-      password: <UPDATE>
+      passwordHash: <UPDATE>
       username: <UPDATE>
     namespace: flux-system
     rbac:


### PR DESCRIPTION
Closes #1925

<!-- Describe what has changed in this PR -->
**What changed?**

* `adminUser.password`->`adminUser.passwordHash` in chart which no longer calculates the password hash for the user
* added `adminUser.createSecret` toggle (so the password can be supplied via other methods without requiring manual `RoleBinding` creation

*NB* this builds upon PR #1944

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**

To discourage users from (potentially) storing passwords in plain-text in git. This way, at worst, they're storing a bcrypt-hashed copy of it which is much harder to attack. This also allows us to simplify the getting started guide.

<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**

Helm changes were tested using `helm template` and various flags to check the k8s was appropriate. The changes to the guide were also checked through.


<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**

This is a breaking change to the helm chart and minor update to the docs but I don't believe it requires any major release notes (beyond that)


<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
