### PR TITLE
Add dedicated components for core details functionality, export flux hook

### DIFF
--- a/ui/components/BucketDetail.tsx
+++ b/ui/components/BucketDetail.tsx
@@ -1,0 +1,34 @@
+import * as React from "react";
+import styled from "styled-components";
+import Interval from "../components/Interval";
+import SourceDetail from "../components/SourceDetail";
+import Timestamp from "../components/Timestamp";
+import { Bucket, SourceRefSourceKind } from "../lib/api/core/types.pb";
+
+type Props = {
+  className?: string;
+  name: string;
+  namespace: string;
+};
+
+function BucketDetail({ name, namespace, className }: Props) {
+  return (
+    <SourceDetail
+      className={className}
+      name={name}
+      namespace={namespace}
+      type={SourceRefSourceKind.Bucket}
+      // Guard against an undefined bucket with a default empty object
+      info={(b: Bucket = {}) => [
+        ["Endpoint", b.endpoint],
+        ["Bucket Name", b.name],
+        ["Last Updated", <Timestamp time={b.lastUpdatedAt} />],
+        ["Interval", <Interval interval={b.interval} />],
+        ["Cluster", b.clusterName],
+        ["Namespace", b.namespace],
+      ]}
+    />
+  );
+}
+
+export default styled(BucketDetail).attrs({ className: BucketDetail.name })``;

--- a/ui/components/FluxRuntime.tsx
+++ b/ui/components/FluxRuntime.tsx
@@ -1,0 +1,58 @@
+import _ from "lodash";
+import * as React from "react";
+import styled from "styled-components";
+import DataTable, { SortType } from "../components/DataTable";
+import KubeStatusIndicator from "../components/KubeStatusIndicator";
+import Link from "../components/Link";
+import { Deployment } from "../lib/api/core/types.pb";
+import { statusSortHelper } from "../lib/utils";
+
+type Props = {
+  className?: string;
+  deployments?: Deployment[];
+};
+
+function FluxRuntime(props: Props) {
+  return (
+    <DataTable
+      className={props.className}
+      defaultSort={2}
+      fields={[
+        {
+          label: "Name",
+          value: "name",
+        },
+        {
+          value: (v: Deployment) => (
+            <KubeStatusIndicator
+              conditions={v.conditions}
+              suspended={v.suspended}
+            />
+          ),
+          label: "Status",
+          sortValue: statusSortHelper,
+          sortType: SortType.number,
+        },
+        {
+          label: "Cluster",
+          value: "clusterName",
+        },
+        {
+          value: (v: Deployment) => (
+            <>
+              {_.map(v.images, (img) => (
+                <Link href={`https://${img}`} key={img} newTab>
+                  {img}
+                </Link>
+              ))}
+            </>
+          ),
+          label: "Image",
+        },
+      ]}
+      rows={props.deployments}
+    />
+  );
+}
+
+export default styled(FluxRuntime).attrs({ className: FluxRuntime.name })``;

--- a/ui/components/GitRepositoryDetail.tsx
+++ b/ui/components/GitRepositoryDetail.tsx
@@ -1,0 +1,40 @@
+import * as React from "react";
+import styled from "styled-components";
+import Link from "../components/Link";
+import SourceDetail from "../components/SourceDetail";
+import Timestamp from "../components/Timestamp";
+import {
+  GitRepository,
+  SourceRefSourceKind,
+} from "../lib/api/core/types.pb";
+
+type Props = {
+  className?: string;
+  name: string;
+  namespace: string;
+};
+
+function GitRepositoryDetail({ name, namespace, className }: Props) {
+  return (
+    <SourceDetail
+      className={className}
+      name={name}
+      namespace={namespace}
+      type={SourceRefSourceKind.GitRepository}
+      info={(s: GitRepository) => [
+        [
+          "URL",
+          <Link newTab href={s.url}>
+            {s.url}
+          </Link>,
+        ],
+        ["Ref", s.reference.branch],
+        ["Last Updated", <Timestamp time={s.lastUpdatedAt} />],
+        ["Cluster", s.clusterName],
+        ["Namespace", s.namespace],
+      ]}
+    />
+  );
+}
+
+export default styled(GitRepositoryDetail).attrs({ className: GitRepositoryDetail.name })``;

--- a/ui/components/HelmChartDetail.tsx
+++ b/ui/components/HelmChartDetail.tsx
@@ -1,0 +1,33 @@
+import * as React from "react";
+import styled from "styled-components";
+import Interval from "../components/Interval";
+import SourceDetail from "../components/SourceDetail";
+import Timestamp from "../components/Timestamp";
+import { HelmChart, SourceRefSourceKind } from "../lib/api/core/types.pb";
+
+type Props = {
+  className?: string;
+  name: string;
+  namespace: string;
+};
+
+function HelmChartDetail({ name, namespace, className }: Props) {
+  return (
+    <SourceDetail
+      name={name}
+      namespace={namespace}
+      type={SourceRefSourceKind.HelmChart}
+      className={className}
+      info={(ch: HelmChart) => [
+        ["Chart", ch?.chart],
+        ["Ref", ch?.sourceRef?.name],
+        ["Last Updated", <Timestamp time={ch?.lastUpdatedAt} />],
+        ["Interval", <Interval interval={ch?.interval} />],
+        ["Cluster", ch?.clusterName],
+        ["Namespace", ch?.namespace],
+      ]}
+    />
+  );
+}
+
+export default styled(HelmChartDetail).attrs({ className: HelmChartDetail.name })``;

--- a/ui/components/HelmRepositoryDetail.tsx
+++ b/ui/components/HelmRepositoryDetail.tsx
@@ -1,0 +1,42 @@
+import * as React from "react";
+import styled from "styled-components";
+import Interval from "../components/Interval";
+import Link from "../components/Link";
+import SourceDetail from "../components/SourceDetail";
+import Timestamp from "../components/Timestamp";
+import {
+  HelmRepository,
+  SourceRefSourceKind,
+} from "../lib/api/core/types.pb";
+
+type Props = {
+  className?: string;
+  name: string;
+  namespace: string;
+};
+
+function HelmRepositoryDetail({ name, namespace, className }: Props) {
+  return (
+    <SourceDetail
+      className={className}
+      name={name}
+      namespace={namespace}
+      type={SourceRefSourceKind.HelmRepository}
+      // Guard against an undefined repo with a default empty object
+      info={(hr: HelmRepository = {}) => [
+        [
+          "URL",
+          <Link newTab href={hr.url}>
+            {hr.url}
+          </Link>,
+        ],
+        ["Last Updated", <Timestamp time={hr.lastUpdatedAt} />],
+        ["Interval", <Interval interval={hr.interval} />],
+        ["Cluster", hr.clusterName],
+        ["Namespace", hr.namespace],
+      ]}
+    />
+  );
+}
+
+export default styled(HelmRepositoryDetail).attrs({ className: HelmRepositoryDetail.name })``;

--- a/ui/index.ts
+++ b/ui/index.ts
@@ -14,6 +14,7 @@ import HelmChartDetail from "./components/HelmChartDetail";
 import HelmReleaseDetail from "./components/HelmReleaseDetail";
 import HelmRepositoryDetail from "./components/HelmRepositoryDetail";
 import KustomizationDetail from "./components/KustomizationDetail";
+import Page from "./components/Page";
 import SourcesTable from "./components/SourcesTable";
 import Interval from "./components/Interval";
 import Timestamp from "./components/Timestamp";
@@ -78,6 +79,7 @@ export {
   LoadingPage,
   muiTheme,
   OAuthCallback,
+  Page,
   RepoInputWithAuth,
   SignIn,
   SourceRefSourceKind,

--- a/ui/index.ts
+++ b/ui/index.ts
@@ -7,10 +7,14 @@ import LoadingPage from "./components/LoadingPage";
 import RepoInputWithAuth from "./components/RepoInputWithAuth";
 import UserSettings from "./components/UserSettings";
 import AutomationsTable from "./components/AutomationsTable";
-import SourceDetail from "./components/SourceDetail";
-import SourcesTable from "./components/SourcesTable";
-import KustomizationDetail from "./components/KustomizationDetail";
+import BucketDetail from "./components/BucketDetail";
+import FluxRuntime from "./components/FluxRuntime";
+import GitRepositoryDetail from "./components/GitRepositoryDetail";
+import HelmChartDetail from "./components/HelmChartDetail";
 import HelmReleaseDetail from "./components/HelmReleaseDetail";
+import HelmRepositoryDetail from "./components/HelmRepositoryDetail";
+import KustomizationDetail from "./components/KustomizationDetail";
+import SourcesTable from "./components/SourcesTable";
 import Interval from "./components/Interval";
 import Timestamp from "./components/Timestamp";
 import AppContextProvider from "./contexts/AppContext";
@@ -49,17 +53,22 @@ export {
   AuthCheck,
   Automation,
   AutomationsTable,
+  BucketDetail,
   Button,
   CallbackStateContextProvider,
   clearCallbackState,
   coreClient,
   FeatureFlagsContextProvider,
   FeatureFlags,
+  FluxRuntime,
   Footer,
   getCallbackState,
   getProviderToken,
   GithubDeviceAuthModal,
+  GitRepositoryDetail,
+  HelmChartDetail,
   HelmReleaseDetail,
+  HelmRepositoryDetail,
   Icon,
   IconType,
   Interval,
@@ -69,7 +78,6 @@ export {
   OAuthCallback,
   RepoInputWithAuth,
   SignIn,
-  SourceDetail,
   SourceRefSourceKind,
   SourcesTable,
   theme,

--- a/ui/index.ts
+++ b/ui/index.ts
@@ -18,6 +18,7 @@ import SourcesTable from "./components/SourcesTable";
 import Interval from "./components/Interval";
 import Timestamp from "./components/Timestamp";
 import AppContextProvider from "./contexts/AppContext";
+import CoreClientContextProvider from "./contexts/CoreClientContext";
 import AuthContextProvider, { Auth, AuthCheck } from "./contexts/AuthContext";
 import CallbackStateContextProvider from "./contexts/CallbackStateContext";
 import {
@@ -58,6 +59,7 @@ export {
   CallbackStateContextProvider,
   clearCallbackState,
   coreClient,
+  CoreClientContextProvider,
   FeatureFlagsContextProvider,
   FeatureFlags,
   FluxRuntime,

--- a/ui/index.ts
+++ b/ui/index.ts
@@ -22,6 +22,7 @@ import {
   useGetKustomization,
   useGetHelmRelease,
 } from "./hooks/automations";
+import { useListFluxRuntimeObjects } from "./hooks/flux";
 import { useIsAuthenticated } from "./hooks/gitprovider";
 import { useListSources } from "./hooks/sources";
 import { useFeatureFlags } from "./hooks/featureflags";
@@ -79,6 +80,7 @@ export {
   useGetKustomization,
   useGetHelmRelease,
   useListAutomations,
+  useListFluxRuntimeObjects,
   UserSettings,
   V2Routes,
 };

--- a/ui/pages/v2/BucketDetail.tsx
+++ b/ui/pages/v2/BucketDetail.tsx
@@ -1,10 +1,7 @@
 import * as React from "react";
 import styled from "styled-components";
-import Interval from "../../components/Interval";
 import Page from "../../components/Page";
-import SourceDetail from "../../components/SourceDetail";
-import Timestamp from "../../components/Timestamp";
-import { Bucket, SourceRefSourceKind } from "../../lib/api/core/types.pb";
+import BucketDetailComponent from "../../components/BucketDetail";
 
 type Props = {
   className?: string;
@@ -15,19 +12,9 @@ type Props = {
 function BucketDetail({ className, name, namespace }: Props) {
   return (
     <Page error={null} className={className} title={name}>
-      <SourceDetail
+      <BucketDetailComponent
         name={name}
         namespace={namespace}
-        type={SourceRefSourceKind.Bucket}
-        // Guard against an undefined bucket with a default empty object
-        info={(b: Bucket = {}) => [
-          ["Endpoint", b.endpoint],
-          ["Bucket Name", b.name],
-          ["Last Updated", <Timestamp time={b.lastUpdatedAt} />],
-          ["Interval", <Interval interval={b.interval} />],
-          ["Cluster", b.clusterName],
-          ["Namespace", b.namespace],
-        ]}
       />
     </Page>
   );

--- a/ui/pages/v2/FluxRuntime.tsx
+++ b/ui/pages/v2/FluxRuntime.tsx
@@ -1,14 +1,9 @@
-import _ from "lodash";
 import * as React from "react";
 import styled from "styled-components";
-import DataTable, { SortType } from "../../components/DataTable";
-import KubeStatusIndicator from "../../components/KubeStatusIndicator";
-import Link from "../../components/Link";
 import Page from "../../components/Page";
 import Spacer from "../../components/Spacer";
+import FluxRuntimeComponent from "../../components/FluxRuntime";
 import { useListFluxRuntimeObjects } from "../../hooks/flux";
-import { Deployment } from "../../lib/api/core/types.pb";
-import { statusSortHelper } from "../../lib/utils";
 
 type Props = {
   className?: string;
@@ -25,43 +20,7 @@ function FluxRuntime({ className }: Props) {
       className={className}
     >
       <Spacer padding="xs" />
-      <DataTable
-        defaultSort={2}
-        fields={[
-          {
-            label: "Name",
-            value: "name",
-          },
-          {
-            value: (v: Deployment) => (
-              <KubeStatusIndicator
-                conditions={v.conditions}
-                suspended={v.suspended}
-              />
-            ),
-            label: "Status",
-            sortValue: statusSortHelper,
-            sortType: SortType.number,
-          },
-          {
-            label: "Cluster",
-            value: "clusterName",
-          },
-          {
-            value: (v: Deployment) => (
-              <>
-                {_.map(v.images, (img) => (
-                  <Link href={`https://${img}`} key={img} newTab>
-                    {img}
-                  </Link>
-                ))}
-              </>
-            ),
-            label: "Image",
-          },
-        ]}
-        rows={data?.deployments}
-      />
+      <FluxRuntimeComponent deployments={data?.deployments} />
     </Page>
   );
 }

--- a/ui/pages/v2/GitRepositoryDetail.tsx
+++ b/ui/pages/v2/GitRepositoryDetail.tsx
@@ -1,13 +1,7 @@
 import * as React from "react";
 import styled from "styled-components";
-import Link from "../../components/Link";
 import Page from "../../components/Page";
-import SourceDetail from "../../components/SourceDetail";
-import Timestamp from "../../components/Timestamp";
-import {
-  GitRepository,
-  SourceRefSourceKind,
-} from "../../lib/api/core/types.pb";
+import GitRepositoryDetailComponent from "../../components/GitRepositoryDetail";
 
 type Props = {
   className?: string;
@@ -18,22 +12,9 @@ type Props = {
 function GitRepositoryDetail({ className, name, namespace }: Props) {
   return (
     <Page error={null} className={className} title={name}>
-      <SourceDetail
+      <GitRepositoryDetailComponent
         name={name}
         namespace={namespace}
-        type={SourceRefSourceKind.GitRepository}
-        info={(s: GitRepository) => [
-          [
-            "URL",
-            <Link newTab href={s.url}>
-              {s.url}
-            </Link>,
-          ],
-          ["Ref", s.reference.branch],
-          ["Last Updated", <Timestamp time={s.lastUpdatedAt} />],
-          ["Cluster", s.clusterName],
-          ["Namespace", s.namespace],
-        ]}
       />
     </Page>
   );

--- a/ui/pages/v2/HelmChartDetail.tsx
+++ b/ui/pages/v2/HelmChartDetail.tsx
@@ -1,10 +1,7 @@
 import * as React from "react";
 import styled from "styled-components";
-import Interval from "../../components/Interval";
 import Page from "../../components/Page";
-import SourceDetail from "../../components/SourceDetail";
-import Timestamp from "../../components/Timestamp";
-import { HelmChart, SourceRefSourceKind } from "../../lib/api/core/types.pb";
+import HelmChartDetailComponent from "../../components/HelmChartDetail";
 
 type Props = {
   className?: string;
@@ -15,18 +12,9 @@ type Props = {
 function HelmChartDetail({ className, name, namespace }: Props) {
   return (
     <Page error={null} className={className} title={name}>
-      <SourceDetail
+      <HelmChartDetailComponent
         name={name}
         namespace={namespace}
-        type={SourceRefSourceKind.HelmChart}
-        info={(ch: HelmChart) => [
-          ["Chart", ch?.chart],
-          ["Ref", ch?.sourceRef?.name],
-          ["Last Updated", <Timestamp time={ch?.lastUpdatedAt} />],
-          ["Interval", <Interval interval={ch?.interval} />],
-          ["Cluster", ch?.clusterName],
-          ["Namespace", ch?.namespace],
-        ]}
       />
     </Page>
   );

--- a/ui/pages/v2/HelmRepositoryDetail.tsx
+++ b/ui/pages/v2/HelmRepositoryDetail.tsx
@@ -1,14 +1,7 @@
 import * as React from "react";
 import styled from "styled-components";
-import Interval from "../../components/Interval";
-import Link from "../../components/Link";
 import Page from "../../components/Page";
-import SourceDetail from "../../components/SourceDetail";
-import Timestamp from "../../components/Timestamp";
-import {
-  HelmRepository,
-  SourceRefSourceKind,
-} from "../../lib/api/core/types.pb";
+import HelmRepositoryDetailComponent from "../../components/HelmRepositoryDetail";
 
 type Props = {
   className?: string;
@@ -19,23 +12,9 @@ type Props = {
 function HelmRepositoryDetail({ className, name, namespace }: Props) {
   return (
     <Page error={null} className={className} title={name}>
-      <SourceDetail
+      <HelmRepositoryDetailComponent
         name={name}
         namespace={namespace}
-        type={SourceRefSourceKind.HelmRepository}
-        // Guard against an undefined repo with a default empty object
-        info={(hr: HelmRepository = {}) => [
-          [
-            "URL",
-            <Link newTab href={hr.url}>
-              {hr.url}
-            </Link>,
-          ],
-          ["Last Updated", <Timestamp time={hr.lastUpdatedAt} />],
-          ["Interval", <Interval interval={hr.interval} />],
-          ["Cluster", hr.clusterName],
-          ["Namespace", hr.namespace],
-        ]}
       />
     </Page>
   );


### PR DESCRIPTION
This creates components for all of the gitops `SourceDetails`, which is what I took away from the suggestion [here](https://github.com/weaveworks/weave-gitops-enterprise/pull/601#discussion_r840672862)

It also exports `useListFluxRuntimeObjects` so we can show the flux runtime page as suggested [here](https://weaveworks.slack.com/archives/C03244W0C8H/p1649158559625549?thread_ts=1648749524.313119&cid=C03244W0C8H)

And finally, it exports the `CoreClientContextProvider` which seems to be purely a thing that's changed in core recently that I'm catching up with.