### PR TITLE
Remove width constraints from data tables to allow for horizontal scrolling

### DIFF
--- a/ui/components/AutomationsTable.tsx
+++ b/ui/components/AutomationsTable.tsx
@@ -10,7 +10,7 @@ import {
 import { formatURL } from "../lib/nav";
 import { AutomationType, V2Routes } from "../lib/types";
 import { statusSortHelper } from "../lib/utils";
-import DataTable, { Field, SortType } from "./DataTable";
+import { Field, SortType } from "./DataTable";
 import FilterableTable, {
   filterConfigForStatus,
   filterConfigForString,
@@ -56,23 +56,19 @@ function AutomationsTable({ className, automations, hideSource }: Props) {
         );
       },
       sortValue: ({ name }) => name,
-      width: 5,
       textSearchable: true,
     },
     {
       label: "Type",
       value: "type",
-      width: 5,
     },
     {
       label: "Namespace",
       value: "namespace",
-      width: 5,
     },
     {
       label: "Cluster",
       value: "clusterName",
-      width: 5,
     },
     {
       label: "Source",
@@ -99,7 +95,6 @@ function AutomationsTable({ className, automations, hideSource }: Props) {
         );
       },
       sortValue: (a: Automation) => a.sourceRef?.name,
-      width: 10,
     },
     {
       label: "Status",
@@ -113,25 +108,21 @@ function AutomationsTable({ className, automations, hideSource }: Props) {
         ) : null,
       sortType: SortType.number,
       sortValue: statusSortHelper,
-      width: 7.5,
     },
     {
       label: "Message",
       value: (a: Automation) => computeMessage(a.conditions),
-      width: 37.5,
       sortValue: ({ conditions }) => computeMessage(conditions),
     },
     {
       label: "Revision",
       value: "lastAttemptedRevision",
-      width: 15,
     },
     {
       label: "Last Updated",
       value: (a: Automation) => (
         <Timestamp time={(a as Kustomization).lastHandledReconciledAt} />
       ),
-      width: 10,
     },
   ];
 
@@ -149,9 +140,4 @@ function AutomationsTable({ className, automations, hideSource }: Props) {
 
 export default styled(AutomationsTable).attrs({
   className: AutomationsTable.name,
-})`
-  ${DataTable} table {
-    table-layout: fixed;
-    width: 100%;
-  }
-`;
+})``;

--- a/ui/components/ConditionsTable.tsx
+++ b/ui/components/ConditionsTable.tsx
@@ -24,7 +24,6 @@ function ConditionsTable({ className, conditions }: Props) {
       ]}
       rows={conditions}
       className={className}
-      widths={["10%", "10%", "25%", "55%"]}
     />
   );
 }

--- a/ui/components/DataTable.tsx
+++ b/ui/components/DataTable.tsx
@@ -169,10 +169,7 @@ function UnstyledDataTable({
           <TableHead>
             <TableRow>
               {_.map(fields, (f) => (
-                <TableCell
-                  style={f.width ? { width: `${f.width}%` } : {}}
-                  key={f.label}
-                >
+                <TableCell key={f.label}>
                   <SortableLabel field={f} />
                 </TableCell>
               ))}
@@ -209,6 +206,7 @@ function UnstyledDataTable({
 export const DataTable = styled(UnstyledDataTable)`
   width: 100%;
   padding-right: ${(props) => props.theme.spacing.medium};
+  overflow-x: scroll;
   h2 {
     padding: 0;
     font-size: 18px;

--- a/ui/components/DataTable.tsx
+++ b/ui/components/DataTable.tsx
@@ -56,7 +56,6 @@ const EmptyRow = styled(TableRow)<{ colSpan: number }>`
 
 const TableButton = styled(Button)`
   &.MuiButton-root {
-    padding: 0;
     margin: 0;
     text-transform: none;
   }
@@ -204,7 +203,7 @@ export const DataTable = styled(UnstyledDataTable)`
   width: 100%;
   overflow-x: scroll;
   h2 {
-    padding: 0;
+    padding: ${(props) => props.theme.spacing.xs};
     font-size: 18px;
     font-weight: 600;
     color: ${(props) => props.theme.colors.neutral30};
@@ -218,6 +217,9 @@ export const DataTable = styled(UnstyledDataTable)`
   .MuiTableRow-root:not(.MuiTableRow-head):hover {
     background: ${(props) => props.theme.colors.neutral10};
     transition: background 0.5s ease-in-out;
+  }
+  th {
+    padding: 0;
   }
 
   td {

--- a/ui/components/DataTable.tsx
+++ b/ui/components/DataTable.tsx
@@ -31,7 +31,6 @@ export type Field = {
   value: string | ((k: any) => string | JSX.Element);
   sortType?: SortType;
   sortValue?: Sorter;
-  width?: number;
   textSearchable?: boolean;
 };
 
@@ -45,8 +44,6 @@ export interface Props {
   rows?: any[];
   /** index of field to initially sort against. */
   defaultSort?: number;
-  /** an optional list of string widths for each field/column. */
-  widths?: string[];
   /** for passing pagination */
   children?: any;
 }
@@ -155,7 +152,7 @@ function UnstyledDataTable({
   const r = _.map(sorted, (r, i) => (
     <TableRow key={i}>
       {_.map(fields, (f) => (
-        <TableCell style={f.width && { width: `${f.width}%` }} key={f.label}>
+        <TableCell key={f.label}>
           <Text>{typeof f.value === "function" ? f.value(r) : r[f.value]}</Text>
         </TableCell>
       ))}
@@ -205,7 +202,6 @@ function UnstyledDataTable({
 
 export const DataTable = styled(UnstyledDataTable)`
   width: 100%;
-  padding-right: ${(props) => props.theme.spacing.medium};
   overflow-x: scroll;
   h2 {
     padding: 0;

--- a/ui/components/EventsTable.tsx
+++ b/ui/components/EventsTable.tsx
@@ -50,14 +50,12 @@ function EventsTable({
         {
           value: (e: Event) => <Text capitalize>{e.reason}</Text>,
           label: "Reason",
-          width: 25,
         },
-        { value: "message", label: "Message", width: 25 },
-        { value: "component", label: "Component", width: 25 },
+        { value: "message", label: "Message" },
+        { value: "component", label: "Component" },
         {
           label: "Timestamp",
           value: (e: Event) => <Timestamp time={e.timestamp} />,
-          width: 25,
         },
       ]}
       rows={data.events}

--- a/ui/components/FilterDialog.tsx
+++ b/ui/components/FilterDialog.tsx
@@ -19,7 +19,7 @@ const SlideContainer = styled.div`
   transition-duration: 0.5s;
   transition-timing-function: ease-in-out;
   &.open {
-    left: 0;
+    left: 0px;
     width: 350px;
   }
 `;

--- a/ui/components/FilterableTable.tsx
+++ b/ui/components/FilterableTable.tsx
@@ -14,7 +14,6 @@ import Flex from "./Flex";
 import Icon, { IconType } from "./Icon";
 import { computeReady } from "./KubeStatusIndicator";
 import SearchField from "./SearchField";
-import Spacer from "./Spacer";
 
 type Props = {
   className?: string;
@@ -212,7 +211,6 @@ function FilterableTable({
           >
             <Icon type={IconType.FilterIcon} size="medium" color="neutral30" />
           </IconButton>
-          <Spacer padding="xs" />
         </Flex>
       </Flex>
       <Flex wide tall>

--- a/ui/components/Layout.tsx
+++ b/ui/components/Layout.tsx
@@ -58,6 +58,7 @@ const StyleLinkTab = styled(LinkTab)`
 
 const AppContainer = styled.div`
   width: 100%;
+  max-width: 100vw;
   min-height: 100vh;
   margin: 0 auto;
   padding: 0;
@@ -110,11 +111,13 @@ const NavContent = styled.div`
 
 const ContentContainer = styled.div`
   width: 100%;
+  max-width: 100%;
   height: 100%;
   padding-top: ${(props) => props.theme.spacing.medium};
   padding-bottom: ${(props) => props.theme.spacing.medium};
   padding-right: ${(props) => props.theme.spacing.medium};
   padding-left: ${(props) => props.theme.spacing.medium};
+  overflow: hidden;
 `;
 
 const Main = styled(Flex)``;

--- a/ui/components/Page.tsx
+++ b/ui/components/Page.tsx
@@ -29,9 +29,12 @@ export const Content = styled(Flex)`
   margin: 0 auto;
   min-width: 1260px;
   min-height: 480px;
+  max-width: 100%;
   padding-bottom: ${(props) => props.theme.spacing.medium};
-  padding-left: ${(props) => props.theme.spacing.large};
+  padding-left: ${(props) => props.theme.spacing.medium};
+  padding-right: ${(props) => props.theme.spacing.medium};
   padding-top: ${(props) => props.theme.spacing.medium};
+  overflow: hidden;
 `;
 
 const Children = styled(Flex)``;

--- a/ui/components/SourcesTable.tsx
+++ b/ui/components/SourcesTable.tsx
@@ -57,11 +57,10 @@ function SourcesTable({ className, sources }: Props) {
           ),
           sortType: SortType.string,
           sortValue: (s: Source) => s.name || "",
-          width: 5,
           textSearchable: true,
         },
-        { label: "Type", value: "type", width: 5 },
-        { label: "Namespace", value: "namespace", width: 5 },
+        { label: "Type", value: "type" },
+        { label: "Namespace", value: "namespace" },
         {
           label: "Status",
           value: (s: Source) => (
@@ -73,18 +72,14 @@ function SourcesTable({ className, sources }: Props) {
           ),
           sortType: SortType.number,
           sortValue: statusSortHelper,
-          width: 5,
         },
         {
           label: "Message",
           value: (s) => computeMessage(s.conditions),
-
-          width: 45,
         },
         {
           label: "Cluster",
           value: (s: Source) => s.clusterName,
-          width: 5,
         },
         {
           label: "URL",
@@ -92,7 +87,6 @@ function SourcesTable({ className, sources }: Props) {
             let text;
             let url;
             let link = false;
-
             switch (s.type) {
               case SourceRefSourceKind.GitRepository:
                 text = (s as GitRepository).url;
@@ -113,7 +107,6 @@ function SourcesTable({ className, sources }: Props) {
                 link = true;
                 break;
             }
-
             return link ? (
               <Link newTab href={url}>
                 {text}
@@ -122,7 +115,6 @@ function SourcesTable({ className, sources }: Props) {
               text
             );
           },
-          width: 25,
         },
         {
           label: "Reference",
@@ -134,30 +126,22 @@ function SourcesTable({ className, sources }: Props) {
               repo?.reference?.commit ||
               repo?.reference?.tag ||
               repo?.reference?.semver;
-
             return isGit ? ref : "-";
           },
-          width: 5,
         },
         {
           label: "Interval",
           value: (s: Source) => showInterval(s.interval),
-          width: 5,
         },
         {
           label: "Last Updated",
           value: (s: Source) => (
             <Timestamp time={(s as GitRepository).lastUpdatedAt} />
           ),
-          width: 5,
         },
       ]}
     />
   );
 }
 
-export default styled(SourcesTable).attrs({ className: SourcesTable.name })`
-  table {
-    table-layout: fixed;
-  }
-`;
+export default styled(SourcesTable).attrs({ className: SourcesTable.name })``;

--- a/ui/components/__tests__/__snapshots__/DataTable.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/DataTable.test.tsx.snap
@@ -102,7 +102,7 @@ exports[`DataTable snapshots renders 1`] = `
 
 .c0 {
   width: 100%;
-  padding-right: 24px;
+  overflow-x: scroll;
 }
 
 .c0 h2 {
@@ -157,7 +157,6 @@ exports[`DataTable snapshots renders 1`] = `
             aria-sort={null}
             className="MuiTableCell-root MuiTableCell-head"
             scope="col"
-            style={Object {}}
           >
             <div
               className="c1"
@@ -213,7 +212,6 @@ exports[`DataTable snapshots renders 1`] = `
             aria-sort={null}
             className="MuiTableCell-root MuiTableCell-head"
             scope="col"
-            style={Object {}}
           >
             <div
               className="c1"
@@ -262,7 +260,6 @@ exports[`DataTable snapshots renders 1`] = `
             aria-sort={null}
             className="MuiTableCell-root MuiTableCell-head"
             scope="col"
-            style={Object {}}
           >
             <div
               className="c1"
@@ -311,7 +308,6 @@ exports[`DataTable snapshots renders 1`] = `
             aria-sort={null}
             className="MuiTableCell-root MuiTableCell-head"
             scope="col"
-            style={Object {}}
           >
             <div
               className="c1"

--- a/ui/components/__tests__/__snapshots__/DataTable.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/DataTable.test.tsx.snap
@@ -83,7 +83,6 @@ exports[`DataTable snapshots renders 1`] = `
 }
 
 .c3.MuiButton-root {
-  padding: 0;
   margin: 0;
   text-transform: none;
 }
@@ -106,7 +105,7 @@ exports[`DataTable snapshots renders 1`] = `
 }
 
 .c0 h2 {
-  padding: 0;
+  padding: 8px;
   font-size: 18px;
   font-weight: 600;
   color: #737373;
@@ -124,6 +123,10 @@ exports[`DataTable snapshots renders 1`] = `
   background: #f5f5f5;
   -webkit-transition: background 0.5s ease-in-out;
   transition: background 0.5s ease-in-out;
+}
+
+.c0 th {
+  padding: 0;
 }
 
 .c0 td {

--- a/ui/components/__tests__/__snapshots__/Page.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/Page.test.tsx.snap
@@ -159,9 +159,12 @@ exports[`Page snapshots default 1`] = `
   margin: 0 auto;
   min-width: 1260px;
   min-height: 480px;
+  max-width: 100%;
   padding-bottom: 24px;
-  padding-left: 32px;
+  padding-left: 24px;
+  padding-right: 24px;
   padding-top: 24px;
+  overflow: hidden;
 }
 
 .c4 h2 {


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes #1942 
Closes #1853

Setting some max-widths on parents and removing width constraints on table cells allows for horizontal scrolling of the data table. Also adjusts the filter bar animation to match - you can continue to scroll and see all data while the filter bar is open. 

https://user-images.githubusercontent.com/65822698/164079345-0b4173d0-fdb4-45b4-81de-507c4b3343a9.mov

How do we feel about this now that we are looking at it?
