### PR TITLE
ui: Make CoreClientContext monkeypatch work

### DIFF
--- a/ui/contexts/CoreClientContext.tsx
+++ b/ui/contexts/CoreClientContext.tsx
@@ -22,16 +22,19 @@ export default function CoreClientContextProvider({ api, children }: Props) {
   const wrapped = {} as typeof Core;
 
   //   Wrap each API method in a check that redirects to the signin page if a 401 is returned.
-  _.each(api, (fn: any, method) => {
+  for (const method of Object.getOwnPropertyNames(api)) {
+    if (typeof api[method] != 'function') {
+      continue
+    }
     wrapped[method] = (req, initReq) => {
-      return fn(req, initReq).catch((err) => {
+      return api[method](req, initReq).catch((err) => {
         if (err.code === 401) {
           history.push(AuthRoutes.AUTH_PATH_SIGNIN);
         }
         throw err;
       });
     };
-  });
+  }
 
   return (
     <CoreClientContext.Provider value={{ api: wrapped }}>

--- a/ui/contexts/__tests__/CoreClientContext.test.tsx
+++ b/ui/contexts/__tests__/CoreClientContext.test.tsx
@@ -1,0 +1,21 @@
+import * as React from "react";
+import renderer from "react-test-renderer";
+import { Core } from "../../lib/api/core/core.pb";
+import CoreClientContextProvider, { CoreClientContext } from "../CoreClientContext"
+
+describe("CoreContextProvider", () => {
+  it("returns a non-empty api", () => {
+    function TestComponent() {
+      const { api } = React.useContext(CoreClientContext);
+      expect(api.ListKustomizations).toBeTruthy();
+      return (
+        <div />
+      );
+    }
+
+    renderer.create(
+      <CoreClientContextProvider api={Core}><TestComponent /></CoreClientContextProvider>
+    );
+
+  });
+});


### PR DESCRIPTION
I cannot figure out any way that this ever worked. Whenever
    CoreClientContext was initialised, it tried to loop over the Core
    object's iterable methods. However, it has none, so it just ignored
    the API and returned an empty object. This then means that anything
    trying to use the API will fail.

The fix here is to use `getOwnPropertyNames` instead - static methods
aren't iterable, so we have to use something more dramatic. However,
that also returns builtins like `prototype`, `name`, `length`, and we
don't want to monkeypatch those, so just monkeypatch methods.

I've written a test that fails with the old code and passes with the
new code.