### PR TITLE
Fix sub page navigation

### DIFF
--- a/ui/App.tsx
+++ b/ui/App.tsx
@@ -59,12 +59,10 @@ const App = () => (
           component={withSearchParams(GitRepositoryDetail)}
         />
         <Route
-          exact
           path={V2Routes.HelmRepo}
           component={withSearchParams(HelmRepositoryDetail)}
         />
         <Route
-          exact
           path={V2Routes.Bucket}
           component={withSearchParams(BucketDetail)}
         />
@@ -73,7 +71,6 @@ const App = () => (
           component={withSearchParams(HelmReleasePage)}
         />
         <Route
-          exact
           path={V2Routes.HelmChart}
           component={withSearchParams(HelmChartDetail)}
         />

--- a/ui/components/DataTable.tsx
+++ b/ui/components/DataTable.tsx
@@ -201,7 +201,7 @@ function UnstyledDataTable({
 
 export const DataTable = styled(UnstyledDataTable)`
   width: 100%;
-  overflow-x: scroll;
+  overflow-x: auto;
   h2 {
     padding: ${(props) => props.theme.spacing.xs};
     font-size: 18px;

--- a/ui/components/__tests__/__snapshots__/DataTable.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/DataTable.test.tsx.snap
@@ -101,7 +101,7 @@ exports[`DataTable snapshots renders 1`] = `
 
 .c0 {
   width: 100%;
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 .c0 h2 {


### PR DESCRIPTION
Closes:
* #1939 

The routing logic needed to be changed to not be `exact` now that we are using path-based tabs.

Also fixes a double scrolly:
![Screenshot from 2022-04-21 07-54-03](https://user-images.githubusercontent.com/2802257/164487011-a5479bcd-4381-41f1-9840-a8a813950ede.png)

