### PR TITLE
release: Fix github action for tagging docker images

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,6 +13,8 @@ jobs:
   tag-release:
     if: github.event.review.state == 'approved' && startsWith(github.event.pull_request.head.ref, 'releases/')
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.release-version.outputs.version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -98,7 +100,9 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   build-and-push-image:
-    needs: goreleaser
+    needs:
+      - goreleaser
+      - tag-release
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -122,8 +126,8 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=ref,event=tag
-            type=semver,pattern={{version}}
+            type=raw,value=${{ needs.tag-release.outputs.version }}
+            type=semver,pattern={{version}},value=${{ needs.tag-release.outputs.version }}
           flavor: |
             latest=true
       - name: Build and push Docker image


### PR DESCRIPTION
Because this pipeline is triggered by a review, not by a tag, it can't
use the plain auto-discovery of tags. Set explicit values.

This tries to preserve the old behaviour of tagging an image both
e.g. `v0.7.1` and `0.7.1`.