### PR TITLE
Final* small release process changes

### DIFF
--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -82,5 +82,5 @@ jobs:
           base: main
           title: "Updates for ${{ env.GITOPS_VERSION }}"
           body: "Update version references to ${{ env.GITOPS_VERSION }}"
-        env:
-          GITHUB_TOKEN: ${{ secrets.WEAVE_GITOPS_BOT_ACCESS_TOKEN }}
+          token: ${{ secrets.WEAVE_GITOPS_BOT_ACCESS_TOKEN }}
+          labels: "exclude from release notes"

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -1,19 +1,46 @@
 # Weave Gitops Release Process
+We have two types of releases: stable, and pre-releases. These change
+what steps are included.
+
+- A pre-release version has a dash in it. Typically, this is of the
+  form `v1.2.3-rc.4`, but as long as there's a dash in the version,
+  it's a pre-release.
+- A stable release does not have a dash in it. These numbers simply
+  take the form `v1.2.3`.
+
+There's two categories of things that get updated:
+- Artifacts: docker images, binaries and javascript library
+- Things that reference artifacts: links in the README, the versioned
+ manual, a helm chart and a homebrew tap.
+
+All releases release all artifacts, but only a stable release releases
+things that reference artifacts - this is how a pre-release doesn't
+get pushed to end-users.
 
 To release a new version of Weave Gitops, you need to:
-- Decide on a new release number. We use e.g. `v1.2.3-rc.4` for
-  pre-releases, and e.g. `v1.2.3` for releases.
+- Decide on an appropriate release number depending on if you want a
+  pre-release or stable release. Do include a leading `v`. See [the
+  releases page](https://github.com/weaveworks/weave-gitops/releases)
+  for previous releases.
 - Go to [the action to prepare a release](https://github.com/weaveworks/weave-gitops/actions/workflows/prepare-release.yaml)
   and click "Run workflow". In the popup, enter the version number you
   want and kick it off.
 - Wait for the action to finish (1-5 minutes, depending on if it's an
   RC or not).
-- Review the PR. Don't forget to check out the docs staging site!
-- If everything looks good, approve the PR. This will kick off the
+- Wait for CI, and review the PR.
+  - For a pre-release, currently only a javascript version number
+    should be updated.
+  - If it's a stable release, there's also updates to our helm chart,
+    documentation and README. Don't forget to check out the docs
+    staging site (there's a link in the list of github status checks
+    called "Doc site preview")
+- If everything looks good, approve the PR - do *not* merge or things
+  won't be published in the right order. This immediately kicks off the
   release job.
 - Wait for the action to finish (~20 minutes), at which point the PR
   will be merged automatically.
-- Add a record of the new version in the checkpoint system
+- If it's a stable release, add a record of the new version in the
+  checkpoint system.
 
 # Record the new version
 - Add a record in the [checkpoint system](https://checkpoint-api.weave.works/admin) to inform users of the new version.  The CLI checks for a more recent version and informs the user where to download it based on this data.


### PR DESCRIPTION
First, it fixes the prepare-release job so it actually triggers the release as an external user, so that CI actually runs. It then sets the exclude from release notes label, because this PR isn't doing anything interesting. And as a result, the whole PR actually turns green: #1977

Second, it rewrites the release process documentation to front-load more of my implicit knowledge.

* probably not actually final.