### PR TITLE
Move javascript out of the server binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,9 +68,6 @@ fakes: ## Generate testing fakes
 install: bin ## Install binaries to GOPATH
 	cp bin/$(BINARY_NAME) ${GOPATH}/bin/
 
-api-dev: ## Server and watch gitops-server, will reload automatically on change
-	reflex -r '.go' -R 'node_modules' -s -- sh -c 'go run -ldflags "$(LDFLAGS)" cmd/gitops-server/main.go'
-
 cluster-dev: ## Start tilt to do development with wego-app running on the cluster
 	./tools/bin/tilt up
 
@@ -78,9 +75,8 @@ clean-dev-cluster:
 	kind delete cluster --name kind && docker rm -f kind-registry
 
 ##@ Build
-# In addition to the main file depend on all go files and any other files in
-# the cmd directory (e.g. dist, on the assumption that there won't be many)
-bin/%: cmd/%/main.go $(shell find . -name "*.go") $(shell find cmd -type f)
+# In addition to the main file depend on all go files
+bin/%: cmd/%/main.go $(shell find . -name "*.go")
 ifdef DEBUG
 		CGO_ENABLED=0 go build -ldflags "$(LDFLAGS)" -o $@ $(GO_BUILD_OPTS) $<
 else
@@ -89,7 +85,7 @@ endif
 
 gitops: bin/gitops ## Build the Gitops CLI, accepts a 'DEBUG' flag
 
-gitops-server: cmd/gitops-server/cmd/dist/index.html bin/gitops-server ## Build the Gitops UI server, accepts a 'DEBUG' flag
+gitops-server: bin/gitops-server ## Build the Gitops UI server, accepts a 'DEBUG' flag
 
 # Clean up images and binaries
 clean: ## Clean up images and binaries
@@ -147,9 +143,7 @@ docker-gitops-server: _docker ## Build a Docker image of the Gitops UI Server
 
 ##@ UI
 # Build the UI for embedding
-ui: cmd/gitops-server/cmd/dist/index.html ## Build the UI
-
-cmd/gitops-server/cmd/dist/index.html: node_modules $(shell find ui -type f)
+ui: node_modules $(shell find ui -type f) ## Build the UI
 	npm run build
 
 node_modules: ## Install node modules

--- a/Tiltfile
+++ b/Tiltfile
@@ -7,7 +7,15 @@ local_resource(
         './cmd',
         './pkg',
         './core',
-        './charts',
+        './api',
+    ]
+)
+
+local_resource(
+    'ui-server',
+    'make ui',
+    deps=[
+        './ui',
     ]
 )
 
@@ -34,4 +42,4 @@ def helmfiles(chart, values):
 k8s_yaml(helmfiles('./charts/gitops-server', './tools/helm-values-dev.yaml'))
 k8s_yaml(helmfiles('./tools/charts/dev', './tools/charts/dev/values.yaml'))
 
-k8s_resource('dev-weave-gitops', port_forwards='9001', resource_deps=['gitops-server'])
+k8s_resource('dev-weave-gitops', port_forwards='9001', resource_deps=['gitops-server', 'ui-server'])

--- a/cmd/gitops-server/cmd/cmd.go
+++ b/cmd/gitops-server/cmd/cmd.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
-	"embed"
 	"fmt"
 	"io/fs"
 	"io/ioutil"
@@ -12,6 +11,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"path"
 	"path/filepath"
 	"syscall"
 	"time"
@@ -316,15 +316,13 @@ func listenAndServe(log logr.Logger, srv *http.Server, options Options) error {
 	return srv.ListenAndServeTLS(options.TLSCertFile, options.TLSKeyFile)
 }
 
-//go:embed dist/*
-var static embed.FS
-
 func getAssets() fs.FS {
-	f, err := fs.Sub(static, "dist")
-
+	exec, err := os.Executable()
 	if err != nil {
 		panic(err)
 	}
+
+	f := os.DirFS(path.Join(path.Dir(exec), "dist"))
 
 	return f
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Weave GitOps core",
   "targets": {
     "default": {
-      "distDir": "cmd/gitops-server/cmd/dist",
+      "distDir": "bin/dist",
       "source": "ui/index.html",
       "sourceMap": false
     },


### PR DESCRIPTION
The server binary now just loads files from disk, instead of
files embedded into the binary.

This has the advantage that the build process becomes slightly more
straightforward - we can compile the go binary without building
javascript, and we can refresh the javascript in docker images without
re-building the go binary.

I've hard-coded the server binary to look at the sub-directory
"dist" below the binary's directory, and dumped the generated files in
`bin/dist` - it's a bit of an odd place to put the dist files, but
`bin` is a directory of generated files already, and this makes it
very easy to accidentally get right.