### PR TITLE
Align titles, fix fonts, and link logo to applications page

### DIFF
--- a/ui/components/InfoList.tsx
+++ b/ui/components/InfoList.tsx
@@ -25,9 +25,6 @@ const InfoList = styled(
     );
   }
 )`
-  table {
-    border-spacing: 0;
-  }
   tbody tr td:first-child {
     min-width: 200px;
   }

--- a/ui/components/Layout.tsx
+++ b/ui/components/Layout.tsx
@@ -10,7 +10,6 @@ import Breadcrumbs from "./Breadcrumbs";
 import Flex from "./Flex";
 import Link from "./Link";
 import Logo from "./Logo";
-import Spacer from "./Spacer";
 import UserSettings from "./UserSettings";
 
 type Props = {
@@ -62,11 +61,10 @@ const AppContainer = styled.div`
   min-height: 100vh;
   margin: 0 auto;
   padding: 0;
-  overflow-x: hidden;
 `;
 
 const NavContainer = styled.div`
-  width: 240px;
+  min-width: 200px;
   height: 100%;
   margin-top: ${(props) => props.theme.spacing.medium};
   background-color: ${(props) => props.theme.colors.neutral00};
@@ -125,7 +123,6 @@ const Main = styled(Flex)``;
 const TopToolBar = styled(Flex)`
   background-color: ${(props) => props.theme.colors.primary};
   height: 80px;
-
   ${UserSettings} {
     justify-self: flex-end;
     margin-left: auto;
@@ -141,7 +138,7 @@ function Layout({ className, children }: Props) {
       <AppContainer>
         <TopToolBar start align wide>
           <Logo />
-          <Spacer padding="xs" />
+
           <Breadcrumbs />
           {flags.WEAVE_GITOPS_AUTH_ENABLED ? <UserSettings /> : null}
         </TopToolBar>

--- a/ui/components/Layout.tsx
+++ b/ui/components/Layout.tsx
@@ -57,6 +57,7 @@ const StyleLinkTab = styled(LinkTab)`
 
 const AppContainer = styled.div`
   width: 100%;
+  min-width: 1024px;
   max-width: 100vw;
   min-height: 100vh;
   margin: 0 auto;
@@ -138,7 +139,6 @@ function Layout({ className, children }: Props) {
       <AppContainer>
         <TopToolBar start align wide>
           <Logo />
-
           <Breadcrumbs />
           {flags.WEAVE_GITOPS_AUTH_ENABLED ? <UserSettings /> : null}
         </TopToolBar>

--- a/ui/components/Logo.tsx
+++ b/ui/components/Logo.tsx
@@ -1,7 +1,9 @@
 import * as React from "react";
 import styled from "styled-components";
 import images from "../lib/images";
+import { V2Routes } from "../lib/types";
 import Flex from "./Flex";
+import Link from "./Link";
 import Spacer from "./Spacer";
 
 type Props = {
@@ -10,15 +12,20 @@ type Props = {
 
 function Logo({ className }: Props) {
   return (
-    <Flex className={className} align start>
-      <img src={images.logoSrc} style={{ height: 56 }} />
-      <Spacer padding="xxs" />
-      <img src={images.titleSrc} />
+    <Flex className={className} start>
+      <Link to={V2Routes.Automations}>
+        <Flex align>
+          <img src={images.logoSrc} style={{ height: 56 }} />
+          <Spacer padding="xxs" />
+          <img src={images.titleSrc} />
+        </Flex>
+      </Link>
     </Flex>
   );
 }
 
 export default styled(Logo)`
-  margin-left: ${(props) => props.theme.spacing.medium};
-  width: 240px;
+  padding-left: ${(props) => props.theme.spacing.medium};
+  //this width plus medium spacing (24px) lines up the breadcrumbs with the page title.
+  width: 224px;
 `;

--- a/ui/components/Page.tsx
+++ b/ui/components/Page.tsx
@@ -28,7 +28,6 @@ export const Content = styled(Flex)`
   border-radius: 10px;
   box-sizing: border-box;
   margin: 0 auto;
-  min-width: 1260px;
   min-height: 480px;
   max-width: 100%;
   padding-bottom: ${(props) => props.theme.spacing.medium};

--- a/ui/components/Page.tsx
+++ b/ui/components/Page.tsx
@@ -10,6 +10,7 @@ import Footer from "./Footer";
 import LoadingPage from "./LoadingPage";
 import PollingIndicator from "./PollingIndicator";
 import Spacer from "./Spacer";
+import Text from "./Text";
 
 export type PageProps = {
   className?: string;
@@ -40,10 +41,8 @@ export const Content = styled(Flex)`
 const Children = styled(Flex)``;
 
 export const TitleBar = styled(Flex)`
-  h2 {
-    margin: 0 !important;
-    color: ${(props) => props.theme.colors.neutral40} !important;
-  }
+  //matches nav tabs
+  line-height: 1.75;
 `;
 
 function Errors({ error }) {
@@ -84,7 +83,9 @@ function Page({
     <Content wide tall start column className={className}>
       <TitleBar wide start between>
         <Flex align>
-          <h2>{title}</h2>
+          <Text semiBold size="large">
+            {title}
+          </Text>
           <Spacer padding="small" />
           <PollingIndicator loading={fetching > 0} />
         </Flex>

--- a/ui/components/PageStatus.tsx
+++ b/ui/components/PageStatus.tsx
@@ -39,12 +39,15 @@ function PageStatus({ conditions, suspended, className }: StatusProps) {
 export default styled(PageStatus).attrs({ className: PageStatus.name })`
   position: relative;
   max-width: 45%;
-  right: ${(props) => props.theme.spacing.medium};
   bottom: ${(props) => props.theme.spacing.large};
   padding: ${(props) => props.theme.spacing.small};
   color: ${(props) => props.theme.colors.neutral30};
   &.error-border {
     border: 1px solid ${(props) => props.theme.colors.neutral20};
     border-radius: 10px;
+  }
+  span {
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 `;

--- a/ui/components/PageStatus.tsx
+++ b/ui/components/PageStatus.tsx
@@ -42,6 +42,7 @@ export default styled(PageStatus).attrs({ className: PageStatus.name })`
   bottom: ${(props) => props.theme.spacing.large};
   padding: ${(props) => props.theme.spacing.small};
   color: ${(props) => props.theme.colors.neutral30};
+  overflow: hidden;
   &.error-border {
     border: 1px solid ${(props) => props.theme.colors.neutral20};
     border-radius: 10px;

--- a/ui/components/SubRouterTabs.tsx
+++ b/ui/components/SubRouterTabs.tsx
@@ -7,6 +7,7 @@ import styled from "styled-components";
 import { formatURL } from "../lib/nav";
 import Flex from "./Flex";
 import Link from "./Link";
+import Spacer from "./Spacer";
 import Text from "./Text";
 
 type Props = {
@@ -82,6 +83,7 @@ function SubRouterTabs({ className, children, rootPath }: Props) {
           />
         ))}
       </Tabs>
+      <Spacer padding="xs" />
       <Switch>
         {children}
         <Redirect from="*" to={formatURL(rootPath, query)} />

--- a/ui/components/UserSettings.tsx
+++ b/ui/components/UserSettings.tsx
@@ -70,4 +70,6 @@ function UserSettings({ className }: { className?: string }) {
   );
 }
 
-export default styled(UserSettings)``;
+export default styled(UserSettings)`
+  padding-right: ${(props) => props.theme.spacing.small};
+`;

--- a/ui/components/__tests__/Logo.test.tsx
+++ b/ui/components/__tests__/Logo.test.tsx
@@ -1,13 +1,15 @@
 import "jest-styled-components";
 import React from "react";
 import renderer from "react-test-renderer";
-import { withTheme } from "../../lib/test-utils";
+import { withContext, withTheme } from "../../lib/test-utils";
 import Logo from "../Logo";
 
 describe("Logo", () => {
   describe("snapshots", () => {
     it("renders", () => {
-      const tree = renderer.create(withTheme(<Logo />)).toJSON();
+      const tree = renderer
+        .create(withTheme(withContext(<Logo />, "", {})))
+        .toJSON();
       expect(tree).toMatchSnapshot();
     });
   });

--- a/ui/components/__tests__/__snapshots__/Logo.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/Logo.test.tsx.snap
@@ -9,41 +9,89 @@ exports[`Logo snapshots renders 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+  -webkit-align-items: start;
+  -webkit-box-align: start;
+  -ms-flex-align: start;
+  align-items: start;
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
   justify-content: flex-start;
 }
 
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c3 {
+  font-family: 'proxima-nova',Helvetica,Arial,sans-serif;
+  font-size: 16px;
+  font-weight: 400;
+  text-transform: none;
+  font-style: normal;
+  color: #00b3ec;
+}
+
 .c2 {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2.title-bar-button {
+  width: 250px;
+}
+
+.c5 {
   padding: 4px;
 }
 
 .c1 {
-  margin-left: 24px;
-  width: 240px;
+  padding-left: 24px;
+  width: 224px;
 }
 
 <div
   className="c0 c1"
 >
-  <img
-    src=""
-    style={
-      Object {
-        "height": 56,
-      }
-    }
-  />
-  <div
+  <a
     className="c2"
-  />
-  <img
-    src=""
-  />
+    href="/applications"
+    onClick={[Function]}
+  >
+    <span
+      className="c3"
+      color="primary"
+      size="normal"
+    >
+      <div
+        className="c4"
+      >
+        <img
+          src=""
+          style={
+            Object {
+              "height": 56,
+            }
+          }
+        />
+        <div
+          className="c5"
+        />
+        <img
+          src=""
+        />
+      </div>
+    </span>
+  </a>
 </div>
 `;

--- a/ui/components/__tests__/__snapshots__/Page.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/Page.test.tsx.snap
@@ -165,7 +165,6 @@ exports[`Page snapshots default 1`] = `
   border-radius: 10px;
   box-sizing: border-box;
   margin: 0 auto;
-  min-width: 1260px;
   min-height: 480px;
   max-width: 100%;
   padding-bottom: 24px;

--- a/ui/components/__tests__/__snapshots__/Page.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/Page.test.tsx.snap
@@ -58,7 +58,7 @@ exports[`Page snapshots default 1`] = `
   align-items: center;
 }
 
-.c8 {
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -77,7 +77,7 @@ exports[`Page snapshots default 1`] = `
   justify-content: space-between;
 }
 
-.c10 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -91,7 +91,15 @@ exports[`Page snapshots default 1`] = `
   align-items: start;
 }
 
-.c11 {
+.c6 {
+  font-family: 'proxima-nova',Helvetica,Arial,sans-serif;
+  font-size: 20px;
+  font-weight: 600;
+  text-transform: none;
+  font-style: normal;
+}
+
+.c12 {
   font-family: 'proxima-nova',Helvetica,Arial,sans-serif;
   font-size: 16px;
   font-weight: 400;
@@ -100,7 +108,7 @@ exports[`Page snapshots default 1`] = `
   color: #737373;
 }
 
-.c14 {
+.c15 {
   font-family: 'proxima-nova',Helvetica,Arial,sans-serif;
   font-size: 16px;
   font-weight: 400;
@@ -109,46 +117,46 @@ exports[`Page snapshots default 1`] = `
   color: #00b3ec;
 }
 
-.c13 {
+.c14 {
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c13.title-bar-button {
+.c14.title-bar-button {
   width: 250px;
 }
 
-.c6 {
+.c7 {
   padding: 12px;
 }
 
-.c12 {
+.c13 {
   padding: 4px;
 }
 
-.c15 {
+.c16 {
   padding-right: 24px;
 }
 
-.c9 {
+.c10 {
   color: #737373;
 }
 
-.c7 {
+.c8 {
   padding-left: 8px;
 }
 
-.c7 .MuiCircularProgress-root {
+.c8 .MuiCircularProgress-root {
   -webkit-transition: opacity 2s;
   transition: opacity 2s;
   margin-bottom: 0;
 }
 
-.c7 .MuiCircularProgress-root.in {
+.c8 .MuiCircularProgress-root.in {
   opacity: 1;
 }
 
-.c7 .MuiCircularProgress-root.out {
+.c8 .MuiCircularProgress-root.out {
   opacity: 0;
 }
 
@@ -167,9 +175,8 @@ exports[`Page snapshots default 1`] = `
   overflow: hidden;
 }
 
-.c4 h2 {
-  margin: 0 !important;
-  color: #1a1a1a !important;
+.c4 {
+  line-height: 1.75;
 }
 
 .c2 .MuiAlert-root {
@@ -185,12 +192,15 @@ exports[`Page snapshots default 1`] = `
     <div
       className="c5"
     >
-      <h2 />
-      <div
+      <span
         className="c6"
+        size="large"
       />
       <div
-        className="c5 c7"
+        className="c7"
+      />
+      <div
+        className="c5 c8"
       >
         <div
           className="MuiCircularProgress-root out MuiCircularProgress-colorPrimary MuiCircularProgress-indeterminate"
@@ -224,29 +234,29 @@ exports[`Page snapshots default 1`] = `
     className="c0"
   />
   <footer
-    className="c8 c9 Footer"
+    className="c9 c10 Footer"
   >
     <div
-      className="c10"
+      className="c11"
     >
       <span
-        className="c11"
+        className="c12"
         color="neutral30"
         size="normal"
       >
         Need help? Contact us at
       </span>
       <div
-        className="c12"
+        className="c13"
       />
       <a
-        className="c13"
+        className="c14"
         href="mailto:support@weave.works"
         rel="noreferrer"
         target="_blank"
       >
         <span
-          className="c14"
+          className="c15"
           color="primary"
           size="normal"
         >
@@ -255,13 +265,13 @@ exports[`Page snapshots default 1`] = `
       </a>
     </div>
     <div
-      className="c10 c15"
+      className="c11 c16"
     >
       <div
-        className="c12"
+        className="c13"
       />
       <span
-        className="c11"
+        className="c12"
         color="neutral30"
         size="normal"
       >


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes #1971 

<!-- Describe what has changed in this PR -->
The page content title is now semi bold, as it should be. I also threw in some other small changes, such as aligning the title with the nav tabs and breadcrumbs, which was a huge pet peeve of mine, and adding a link to the logo that sends the user to the applications page. The extra padding on the user icon is so that the hover state doesn't brush up against the edge of the page.

<img width="1537" alt="image" src="https://user-images.githubusercontent.com/65822698/164772105-f474c5b7-4b40-4d34-85d2-3338073489e1.png">
