### PR TITLE
Fix mis-spelling of HelmRelease for stable documentation

### DIFF
--- a/website/versioned_docs/version-0.7.0/installation.mdx
+++ b/website/versioned_docs/version-0.7.0/installation.mdx
@@ -24,7 +24,7 @@ Weave GitOps includes a web UI which runs on your Kubernetes cluster. In order t
 Follow the guide here to appropriately configure access : [Securing access to the dashboard](configuration/securing-access-to-the-dashboard.mdx).
 
 ### Install the Helm Chart
-Weave GitOps is provided through a Helm Chart and installed as a Flux resource through a `HelmRepository` and `HelmRlease`. To install on your cluster, adjust the following where marked `<UPDATE>` based on the previous step, and commit the file to the location bootstrapped with Flux so that it is synchronized to your Cluster.
+Weave GitOps is provided through a Helm Chart and installed as a Flux resource through a `HelmRepository` and `HelmRelease`. To install on your cluster, adjust the following where marked `<UPDATE>` based on the previous step, and commit the file to the location bootstrapped with Flux so that it is synchronized to your Cluster.
 
 ```
 apiVersion: helm.toolkit.fluxcd.io/v2beta1


### PR DESCRIPTION
This effectively back-ports #1994 to the default 0.7.0 docs.