### PR TITLE
Fix empty reconciled object tables

### DIFF
--- a/ui/components/KustomizationDetail.tsx
+++ b/ui/components/KustomizationDetail.tsx
@@ -90,6 +90,7 @@ function KustomizationDetail({ kustomization, className }: Props) {
             <ReconciledObjectsTable
               automationKind={AutomationKind.KustomizationAutomation}
               automationName={kustomization?.name}
+              namespace={kustomization?.namespace}
               kinds={kustomization?.inventory}
               clusterName={kustomization?.clusterName}
             />


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes #1968 

<!-- Describe what has changed in this PR -->
Namespace was not being passed down from `KustomizationDetail`, leaving the table to run the request with no namespace specified. 
<img width="1402" alt="image" src="https://user-images.githubusercontent.com/65822698/165176542-8d2f1050-7c54-44ff-9882-3d8044fe25f2.png">
