### PR TITLE
feat: Set vars when TLS disabled or Dev enabled

### DIFF
--- a/cmd/gitops-server/cmd/cmd.go
+++ b/cmd/gitops-server/cmd/cmd.go
@@ -100,7 +100,7 @@ func NewCommand() *cobra.Command {
 }
 
 func runCmd(cmd *cobra.Command, args []string) error {
-	log, err := logger.New(options.LogLevel, options.Insecure)
+	log, err := logger.New(options.LogLevel, options.DevMode)
 	if err != nil {
 		return err
 	}
@@ -181,7 +181,8 @@ func runCmd(cmd *cobra.Command, args []string) error {
 		}
 
 		if options.DevMode {
-			log.Info("WARNING: dev mode enabled. This should be used for local work only")
+			log.Info("WARNING: dev mode enabled. Authentication will be bypassed in some instances. This should be used for LOCAL WORK ONLY.")
+			os.Setenv(server.DevModeFeatureFlag, "true")
 			tsv.SetDevMode(options.DevUser)
 		}
 
@@ -286,7 +287,10 @@ func runCmd(cmd *cobra.Command, args []string) error {
 
 func listenAndServe(log logr.Logger, srv *http.Server, options Options) error {
 	if options.Insecure {
-		log.Info("TLS connections disabled")
+		log.Info(
+			"WARNING: TLS connections disabled by the `--insecure` flag. All data INCLUDING AUTH TOKENS will be transmitted without encryption.")
+		os.Setenv(server.TlsDisabledFeatureFlag, "true")
+
 		return srv.ListenAndServe()
 	}
 

--- a/pkg/server/handler.go
+++ b/pkg/server/handler.go
@@ -19,6 +19,10 @@ import (
 
 const (
 	AuthEnabledFeatureFlag = "WEAVE_GITOPS_AUTH_ENABLED"
+	TlsDisabledFeatureFlag = "WEAVE_GITOPS_TLS_DISABLED"
+	DevModeFeatureFlag     = "WEAVE_GITOPS_DEV_MODE_ENABLED"
+	ClusterUserAuthFlag    = "CLUSTER_USER_AUTH"
+	OidcAuthFlag           = "OIDC_AUTH"
 )
 
 var (
@@ -31,6 +35,10 @@ func AuthEnabled() bool {
 	return os.Getenv(AuthEnabledFeatureFlag) == "true"
 }
 
+func TlsEnabled() bool {
+	return os.Getenv(TlsDisabledFeatureFlag) != "true"
+}
+
 type Config struct {
 	AppConfig        *ApplicationsConfig
 	AppOptions       []ApplicationsOption
@@ -41,7 +49,7 @@ type Config struct {
 
 func NewHandlers(ctx context.Context, log logr.Logger, cfg *Config) (http.Handler, error) {
 	mux := runtime.NewServeMux(middleware.WithGrpcErrorLogging(log))
-	httpHandler := middleware.WithLogging(log, mux)
+	httpHandler := middleware.WithLogging(log, mux, TlsEnabled())
 
 	if AuthEnabled() {
 		clustersFetcher, err := fetcher.NewSingleClusterFetcher(cfg.CoreServerConfig.RestCfg)

--- a/pkg/server/middleware/middleware.go
+++ b/pkg/server/middleware/middleware.go
@@ -44,7 +44,7 @@ func WithGrpcErrorLogging(log logr.Logger) runtime.ServeMuxOption {
 
 // WithLogging adds basic logging for HTTP requests.
 // Note that this accepts a grpc-gateway ServeMux instead of an http.Handler.
-func WithLogging(log logr.Logger, mux *runtime.ServeMux) http.Handler {
+func WithLogging(log logr.Logger, mux *runtime.ServeMux, secure bool) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		recorder := &statusRecorder{
 			ResponseWriter: w,
@@ -52,7 +52,7 @@ func WithLogging(log logr.Logger, mux *runtime.ServeMux) http.Handler {
 		}
 		mux.ServeHTTP(recorder, r)
 
-		l := log.WithValues("uri", r.RequestURI, "status", recorder.Status)
+		l := log.WithValues("uri", r.RequestURI, "status", recorder.Status, "tls-secured", secure)
 
 		if recorder.Status < 400 {
 			l.V(logger.LogLevelDebug).Info(RequestOkText)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -227,7 +227,9 @@ func (s *applicationServer) ValidateProviderToken(ctx context.Context, msg *pb.V
 func (s *applicationServer) GetFeatureFlags(ctx context.Context, msg *pb.GetFeatureFlagsRequest) (*pb.GetFeatureFlagsResponse, error) {
 	flags := make(map[string]string)
 
-	flags["WEAVE_GITOPS_AUTH_ENABLED"] = os.Getenv("WEAVE_GITOPS_AUTH_ENABLED")
+	flags[AuthEnabledFeatureFlag] = os.Getenv(AuthEnabledFeatureFlag)
+	flags[TlsDisabledFeatureFlag] = os.Getenv(TlsDisabledFeatureFlag)
+	flags[DevModeFeatureFlag] = os.Getenv(DevModeFeatureFlag)
 
 	cl, err := s.clientGetter.Client(ctx)
 	if err != nil {
@@ -242,12 +244,12 @@ func (s *applicationServer) GetFeatureFlags(ctx context.Context, msg *pb.GetFeat
 
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			flags["CLUSTER_USER_AUTH"] = "false"
+			flags[ClusterUserAuthFlag] = "false"
 		} else {
 			s.log.Error(err, "could not get secret for cluster user")
 		}
 	} else {
-		flags["CLUSTER_USER_AUTH"] = "true"
+		flags[ClusterUserAuthFlag] = "true"
 	}
 
 	err = cl.Get(ctx, client.ObjectKey{
@@ -257,12 +259,12 @@ func (s *applicationServer) GetFeatureFlags(ctx context.Context, msg *pb.GetFeat
 
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			flags["OIDC_AUTH"] = "false"
+			flags[OidcAuthFlag] = "false"
 		} else {
 			s.log.Error(err, "could not get secret for oidc")
 		}
 	} else {
-		flags["OIDC_AUTH"] = "true"
+		flags[OidcAuthFlag] = "true"
 	}
 
 	return &pb.GetFeatureFlagsResponse{


### PR DESCRIPTION
This is so that the UI can query what has been set on the server and
display appropriate warning messages.

It will also be logged on each request whether TLS is enabled or not.

Part of https://github.com/weaveworks/weave-gitops/issues/1959