### PR TITLE
Convert ssh urls to http

### DIFF
--- a/ui/components/GitRepositoryDetail.tsx
+++ b/ui/components/GitRepositoryDetail.tsx
@@ -23,7 +23,7 @@ function GitRepositoryDetail({ name, namespace, className }: Props) {
         [
           "URL",
           <Link newTab href={convertGitURLToGitProvider(s.url)}>
-            {convertGitURLToGitProvider(s.url)}
+            {s.url}
           </Link>,
         ],
         ["Ref", s.reference.branch],

--- a/ui/components/GitRepositoryDetail.tsx
+++ b/ui/components/GitRepositoryDetail.tsx
@@ -3,10 +3,8 @@ import styled from "styled-components";
 import Link from "../components/Link";
 import SourceDetail from "../components/SourceDetail";
 import Timestamp from "../components/Timestamp";
-import {
-  GitRepository,
-  SourceRefSourceKind,
-} from "../lib/api/core/types.pb";
+import { GitRepository, SourceRefSourceKind } from "../lib/api/core/types.pb";
+import { convertGitURLToGitProvider } from "../lib/utils";
 
 type Props = {
   className?: string;
@@ -24,8 +22,8 @@ function GitRepositoryDetail({ name, namespace, className }: Props) {
       info={(s: GitRepository) => [
         [
           "URL",
-          <Link newTab href={s.url}>
-            {s.url}
+          <Link newTab href={convertGitURLToGitProvider(s.url)}>
+            {convertGitURLToGitProvider(s.url)}
           </Link>,
         ],
         ["Ref", s.reference.branch],
@@ -37,4 +35,6 @@ function GitRepositoryDetail({ name, namespace, className }: Props) {
   );
 }
 
-export default styled(GitRepositoryDetail).attrs({ className: GitRepositoryDetail.name })``;
+export default styled(GitRepositoryDetail).attrs({
+  className: GitRepositoryDetail.name,
+})``;

--- a/ui/components/HelmRepositoryDetail.tsx
+++ b/ui/components/HelmRepositoryDetail.tsx
@@ -4,10 +4,8 @@ import Interval from "../components/Interval";
 import Link from "../components/Link";
 import SourceDetail from "../components/SourceDetail";
 import Timestamp from "../components/Timestamp";
-import {
-  HelmRepository,
-  SourceRefSourceKind,
-} from "../lib/api/core/types.pb";
+import { HelmRepository, SourceRefSourceKind } from "../lib/api/core/types.pb";
+import { convertGitURLToGitProvider } from "../lib/utils";
 
 type Props = {
   className?: string;
@@ -26,8 +24,8 @@ function HelmRepositoryDetail({ name, namespace, className }: Props) {
       info={(hr: HelmRepository = {}) => [
         [
           "URL",
-          <Link newTab href={hr.url}>
-            {hr.url}
+          <Link newTab href={convertGitURLToGitProvider(hr.url)}>
+            {convertGitURLToGitProvider(hr.url)}
           </Link>,
         ],
         ["Last Updated", <Timestamp time={hr.lastUpdatedAt} />],
@@ -39,4 +37,6 @@ function HelmRepositoryDetail({ name, namespace, className }: Props) {
   );
 }
 
-export default styled(HelmRepositoryDetail).attrs({ className: HelmRepositoryDetail.name })``;
+export default styled(HelmRepositoryDetail).attrs({
+  className: HelmRepositoryDetail.name,
+})``;

--- a/ui/components/HelmRepositoryDetail.tsx
+++ b/ui/components/HelmRepositoryDetail.tsx
@@ -5,7 +5,6 @@ import Link from "../components/Link";
 import SourceDetail from "../components/SourceDetail";
 import Timestamp from "../components/Timestamp";
 import { HelmRepository, SourceRefSourceKind } from "../lib/api/core/types.pb";
-import { convertGitURLToGitProvider } from "../lib/utils";
 
 type Props = {
   className?: string;
@@ -24,8 +23,8 @@ function HelmRepositoryDetail({ name, namespace, className }: Props) {
       info={(hr: HelmRepository = {}) => [
         [
           "URL",
-          <Link newTab href={convertGitURLToGitProvider(hr.url)}>
-            {convertGitURLToGitProvider(hr.url)}
+          <Link newTab href={hr.url}>
+            {hr.url}
           </Link>,
         ],
         ["Last Updated", <Timestamp time={hr.lastUpdatedAt} />],


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes: #2009

<!-- Describe what has changed in this PR -->
We had a way to reformat ssh urls, it just never made its way into `GitRepositoryDetail` and `HelmRepositoryDetail`. Do we need to check the helm repo urls? If it's already http it will just return the url as is, so I'm not anticipating these changes breaking anything....is there any other way that a url for a helm repo might be broken/wrong?
