### PR TITLE
Allow exclusion of issue from release notes via the "exclude from release notes" label

### DIFF
--- a/.github/changelog/changelog_configuration.json
+++ b/.github/changelog/changelog_configuration.json
@@ -26,7 +26,7 @@
         }
     ],
     "ignore_labels": [
-        "null"
+        "exclude from release notes"
     ],
     "template": "${{CHANGELOG}}\n\n<details>\n<summary>Uncategorized</summary>\n\n${{UNCATEGORIZED}}\n</details>",
     "pr_template": "- PR: #${{NUMBER}} - ${{TITLE}}",


### PR DESCRIPTION


<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes #1872 

<!-- Describe what has changed in this PR -->
**What changed?**
The changelog generation configuration was updated to include the label "exclude from release notes" which indicates that a so-labeled issue should be ignored.

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**
This was already supposed to work; this fixes it

