### PR TITLE
UI Responsiveness Pass

### DIFF
--- a/ui/components/AutomationsTable.tsx
+++ b/ui/components/AutomationsTable.tsx
@@ -57,7 +57,7 @@ function AutomationsTable({ className, automations, hideSource }: Props) {
       },
       sortValue: ({ name }) => name,
       textSearchable: true,
-      maxWidth: 200,
+      maxWidth: 600,
     },
     {
       label: "Type",
@@ -115,7 +115,7 @@ function AutomationsTable({ className, automations, hideSource }: Props) {
       label: "Message",
       value: (a: Automation) => computeMessage(a.conditions),
       sortValue: ({ conditions }) => computeMessage(conditions),
-      maxWidth: 200,
+      maxWidth: 600,
     },
     {
       label: "Revision",

--- a/ui/components/AutomationsTable.tsx
+++ b/ui/components/AutomationsTable.tsx
@@ -113,6 +113,7 @@ function AutomationsTable({ className, automations, hideSource }: Props) {
       label: "Message",
       value: (a: Automation) => computeMessage(a.conditions),
       sortValue: ({ conditions }) => computeMessage(conditions),
+      maxWidth: 200,
     },
     {
       label: "Revision",

--- a/ui/components/AutomationsTable.tsx
+++ b/ui/components/AutomationsTable.tsx
@@ -57,6 +57,7 @@ function AutomationsTable({ className, automations, hideSource }: Props) {
       },
       sortValue: ({ name }) => name,
       textSearchable: true,
+      maxWidth: 200,
     },
     {
       label: "Type",
@@ -86,6 +87,7 @@ function AutomationsTable({ className, automations, hideSource }: Props) {
 
         return (
           <SourceLink
+            short
             sourceRef={{
               kind: sourceKind,
               name: sourceName,

--- a/ui/components/BucketDetail.tsx
+++ b/ui/components/BucketDetail.tsx
@@ -20,6 +20,7 @@ function BucketDetail({ name, namespace, className }: Props) {
       type={SourceRefSourceKind.Bucket}
       // Guard against an undefined bucket with a default empty object
       info={(b: Bucket = {}) => [
+        ["Type", SourceRefSourceKind.Bucket],
         ["Endpoint", b.endpoint],
         ["Bucket Name", b.name],
         ["Last Updated", <Timestamp time={b.lastUpdatedAt} />],

--- a/ui/components/DataTable.tsx
+++ b/ui/components/DataTable.tsx
@@ -153,7 +153,11 @@ function UnstyledDataTable({
     <TableRow key={i}>
       {_.map(fields, (f) => (
         <TableCell
-          style={f.maxWidth && { maxWidth: f.maxWidth, whiteSpace: "pre-line" }}
+          style={
+            f.maxWidth && {
+              maxWidth: f.maxWidth,
+            }
+          }
           key={f.label}
         >
           <Text>{typeof f.value === "function" ? f.value(r) : r[f.value]}</Text>
@@ -169,15 +173,7 @@ function UnstyledDataTable({
           <TableHead>
             <TableRow>
               {_.map(fields, (f) => (
-                <TableCell
-                  style={
-                    f.maxWidth && {
-                      maxWidth: f.maxWidth,
-                      whiteSpace: "pre-line",
-                    }
-                  }
-                  key={f.label}
-                >
+                <TableCell key={f.label}>
                   <SortableLabel field={f} />
                 </TableCell>
               ))}
@@ -220,6 +216,7 @@ export const DataTable = styled(UnstyledDataTable)`
     font-weight: 600;
     color: ${(props) => props.theme.colors.neutral30};
     margin: 0px;
+    white-space: nowrap;
   }
   .MuiTableRow-root {
     transition: background 0.5s ease-in-out;
@@ -232,8 +229,9 @@ export const DataTable = styled(UnstyledDataTable)`
     padding: 0;
   }
   td {
-    word-wrap: break-word;
     white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 `;
 

--- a/ui/components/DataTable.tsx
+++ b/ui/components/DataTable.tsx
@@ -32,6 +32,7 @@ export type Field = {
   sortType?: SortType;
   sortValue?: Sorter;
   textSearchable?: boolean;
+  maxWidth?: number;
 };
 
 /** DataTable Properties  */
@@ -151,7 +152,10 @@ function UnstyledDataTable({
   const r = _.map(sorted, (r, i) => (
     <TableRow key={i}>
       {_.map(fields, (f) => (
-        <TableCell key={f.label}>
+        <TableCell
+          style={f.maxWidth && { maxWidth: f.maxWidth, whiteSpace: "pre-line" }}
+          key={f.label}
+        >
           <Text>{typeof f.value === "function" ? f.value(r) : r[f.value]}</Text>
         </TableCell>
       ))}
@@ -165,7 +169,15 @@ function UnstyledDataTable({
           <TableHead>
             <TableRow>
               {_.map(fields, (f) => (
-                <TableCell key={f.label}>
+                <TableCell
+                  style={
+                    f.maxWidth && {
+                      maxWidth: f.maxWidth,
+                      whiteSpace: "pre-line",
+                    }
+                  }
+                  key={f.label}
+                >
                   <SortableLabel field={f} />
                 </TableCell>
               ))}
@@ -208,8 +220,6 @@ export const DataTable = styled(UnstyledDataTable)`
     font-weight: 600;
     color: ${(props) => props.theme.colors.neutral30};
     margin: 0px;
-    text-overflow: ellipsis;
-    white-space: nowrap;
   }
   .MuiTableRow-root {
     transition: background 0.5s ease-in-out;
@@ -221,13 +231,9 @@ export const DataTable = styled(UnstyledDataTable)`
   th {
     padding: 0;
   }
-
   td {
-    word-break: break-all;
     word-wrap: break-word;
     white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
   }
 `;
 

--- a/ui/components/DirectedGraph.tsx
+++ b/ui/components/DirectedGraph.tsx
@@ -20,7 +20,9 @@ type Props<N> = {
 };
 
 const SliderFlex = styled(Flex)`
+  padding-top: ${(props) => props.theme.spacing.base};
   min-height: 400px;
+  min-width: 60px;
   height: 25%;
   width: 5%;
 `;
@@ -79,7 +81,6 @@ function DirectedGraph<T>({
     <Flex className={className}>
       <svg width={width} height={height} ref={svgRef} />
       <SliderFlex column align>
-        <Spacer padding="base" />
         <Slider
           onChange={(e, value: number) => setZoomPercent(value)}
           defaultValue={20}
@@ -119,7 +120,7 @@ export default styled(DirectedGraph)`
     width: 6px;
   }
   .MuiSlider-vertical .MuiSlider-thumb {
-    margin-left: -8px;
+    margin-left: -9px;
   }
   .MuiSlider-thumb {
     width: 24px;

--- a/ui/components/EventsTable.tsx
+++ b/ui/components/EventsTable.tsx
@@ -48,7 +48,7 @@ function EventsTable({
           value: (e: Event) => <Text capitalize>{e.reason}</Text>,
           label: "Reason",
         },
-        { value: "message", label: "Message" },
+        { value: "message", label: "Message", maxWidth: 200 },
         { value: "component", label: "Component" },
         {
           label: "Timestamp",

--- a/ui/components/EventsTable.tsx
+++ b/ui/components/EventsTable.tsx
@@ -48,7 +48,7 @@ function EventsTable({
           value: (e: Event) => <Text capitalize>{e.reason}</Text>,
           label: "Reason",
         },
-        { value: "message", label: "Message", maxWidth: 200 },
+        { value: "message", label: "Message", maxWidth: 600 },
         { value: "component", label: "Component" },
         {
           label: "Timestamp",

--- a/ui/components/GitRepositoryDetail.tsx
+++ b/ui/components/GitRepositoryDetail.tsx
@@ -4,7 +4,10 @@ import Link from "../components/Link";
 import SourceDetail from "../components/SourceDetail";
 import Timestamp from "../components/Timestamp";
 import { GitRepository, SourceRefSourceKind } from "../lib/api/core/types.pb";
+<<<<<<< HEAD
 import { convertGitURLToGitProvider } from "../lib/utils";
+=======
+>>>>>>> 88a7001a (source detail makeover - removes title bar from page)
 
 type Props = {
   className?: string;
@@ -20,6 +23,7 @@ function GitRepositoryDetail({ name, namespace, className }: Props) {
       namespace={namespace}
       type={SourceRefSourceKind.GitRepository}
       info={(s: GitRepository) => [
+        ["Type", SourceRefSourceKind.GitRepository],
         [
           "URL",
           <Link newTab href={convertGitURLToGitProvider(s.url)}>

--- a/ui/components/GitRepositoryDetail.tsx
+++ b/ui/components/GitRepositoryDetail.tsx
@@ -4,10 +4,7 @@ import Link from "../components/Link";
 import SourceDetail from "../components/SourceDetail";
 import Timestamp from "../components/Timestamp";
 import { GitRepository, SourceRefSourceKind } from "../lib/api/core/types.pb";
-<<<<<<< HEAD
 import { convertGitURLToGitProvider } from "../lib/utils";
-=======
->>>>>>> 88a7001a (source detail makeover - removes title bar from page)
 
 type Props = {
   className?: string;

--- a/ui/components/HelmChartDetail.tsx
+++ b/ui/components/HelmChartDetail.tsx
@@ -19,6 +19,7 @@ function HelmChartDetail({ name, namespace, className }: Props) {
       type={SourceRefSourceKind.HelmChart}
       className={className}
       info={(ch: HelmChart) => [
+        ["Type", SourceRefSourceKind.HelmChart],
         ["Chart", ch?.chart],
         ["Ref", ch?.sourceRef?.name],
         ["Last Updated", <Timestamp time={ch?.lastUpdatedAt} />],
@@ -30,4 +31,6 @@ function HelmChartDetail({ name, namespace, className }: Props) {
   );
 }
 
-export default styled(HelmChartDetail).attrs({ className: HelmChartDetail.name })``;
+export default styled(HelmChartDetail).attrs({
+  className: HelmChartDetail.name,
+})``;

--- a/ui/components/HelmReleaseDetail.tsx
+++ b/ui/components/HelmReleaseDetail.tsx
@@ -11,7 +11,6 @@ import {
 import Alert from "./Alert";
 import EventsTable from "./EventsTable";
 import Flex from "./Flex";
-import Heading from "./Heading";
 import InfoList from "./InfoList";
 import Interval from "./Interval";
 import PageStatus from "./PageStatus";
@@ -32,28 +31,34 @@ const Info = styled.div`
 `;
 
 const TabContent = styled.div`
-  margin-top: 52px;
+  margin-top: ${(props) => props.theme.spacing.medium};
+  width: 100%;
+  height: 100%;
 `;
 
-function helmChartLink(helmRelease : HelmRelease) {
+function helmChartLink(helmRelease: HelmRelease) {
   if (helmRelease.helmChartName === "") {
-    return (<SourceLink
-      sourceRef={{
-        kind: SourceRefSourceKind.HelmChart,
+    return (
+      <SourceLink
+        sourceRef={{
+          kind: SourceRefSourceKind.HelmChart,
           name: helmRelease?.helmChart.chart,
-      }}
-      />)
+        }}
+      />
+    );
   }
 
-  const [ns, name] = helmRelease.helmChartName.split("/")
+  const [ns, name] = helmRelease.helmChartName.split("/");
 
-  return (<SourceLink
-    sourceRef={{
-      kind: SourceRefSourceKind.HelmChart,
+  return (
+    <SourceLink
+      sourceRef={{
+        kind: SourceRefSourceKind.HelmChart,
         name: name,
         namespace: ns,
-    }}
-    />)
+      }}
+    />
+  );
 }
 
 function HelmReleaseDetail({ name, helmRelease, className }: Props) {
@@ -73,36 +78,27 @@ function HelmReleaseDetail({ name, helmRelease, className }: Props) {
   };
 
   return (
-    <div className={className}>
-      <Flex wide between>
-        <Info>
-          <Heading level={2}>{helmRelease?.namespace}</Heading>
-          <InfoList
-            items={[
-              [
-                "Source",
-                helmChartLink(helmRelease),
-              ],
-              ["Chart", helmRelease?.helmChart.chart],
-              ["Cluster", helmRelease?.clusterName],
-              ["Interval", <Interval interval={helmRelease?.interval} />],
-            ]}
-          />
-        </Info>
-        <PageStatus
-          conditions={helmRelease?.conditions}
-          suspended={helmRelease?.suspended}
+    <Flex wide tall column className={className}>
+      {sync.isError && (
+        <Alert
+          severity="error"
+          message={sync.error.message}
+          title="Sync Error"
         />
-      </Flex>
-      <Flex wide>
-        {sync.isError && (
-          <Alert
-            severity="error"
-            message={sync.error.message}
-            title="Sync Error"
-          />
-        )}
-      </Flex>
+      )}
+      <PageStatus
+        conditions={helmRelease?.conditions}
+        suspended={helmRelease?.suspended}
+      />
+      <InfoList
+        items={[
+          ["Namespace", helmRelease?.namespace],
+          ["Source", helmChartLink(helmRelease)],
+          ["Chart", helmRelease?.helmChart.chart],
+          ["Cluster", helmRelease?.clusterName],
+          ["Interval", <Interval interval={helmRelease?.interval} />],
+        ]}
+      />
       <SyncButton onClick={handleSyncClicked} loading={sync.isLoading} />
       <TabContent>
         <SubRouterTabs rootPath={`${path}/details`}>
@@ -125,7 +121,7 @@ function HelmReleaseDetail({ name, helmRelease, className }: Props) {
           </RouterTab>
         </SubRouterTabs>
       </TabContent>
-    </div>
+    </Flex>
   );
 }
 

--- a/ui/components/HelmReleaseDetail.tsx
+++ b/ui/components/HelmReleaseDetail.tsx
@@ -26,10 +26,6 @@ type Props = {
   className?: string;
 };
 
-const Info = styled.div`
-  padding-bottom: 32px;
-`;
-
 const TabContent = styled.div`
   margin-top: ${(props) => props.theme.spacing.medium};
   width: 100%;

--- a/ui/components/HelmRepositoryDetail.tsx
+++ b/ui/components/HelmRepositoryDetail.tsx
@@ -21,6 +21,7 @@ function HelmRepositoryDetail({ name, namespace, className }: Props) {
       type={SourceRefSourceKind.HelmRepository}
       // Guard against an undefined repo with a default empty object
       info={(hr: HelmRepository = {}) => [
+        ["Type", SourceRefSourceKind.HelmRepository],
         [
           "URL",
           <Link newTab href={hr.url}>

--- a/ui/components/InfoList.tsx
+++ b/ui/components/InfoList.tsx
@@ -29,6 +29,9 @@ const InfoList = styled(
   tbody tr td:first-child {
     min-width: 200px;
   }
+  td {
+    word-break: break-all;
+  }
   tr {
     height: 16px;
   }

--- a/ui/components/InfoList.tsx
+++ b/ui/components/InfoList.tsx
@@ -25,6 +25,7 @@ const InfoList = styled(
     );
   }
 )`
+  padding: ${(props) => props.theme.spacing.medium} 0px;
   tbody tr td:first-child {
     min-width: 200px;
   }

--- a/ui/components/KustomizationDetail.tsx
+++ b/ui/components/KustomizationDetail.tsx
@@ -7,7 +7,6 @@ import { AutomationKind, Kustomization } from "../lib/api/core/types.pb";
 import Alert from "./Alert";
 import EventsTable from "./EventsTable";
 import Flex from "./Flex";
-import Heading from "./Heading";
 import InfoList from "./InfoList";
 import Interval from "./Interval";
 import PageStatus from "./PageStatus";
@@ -23,12 +22,8 @@ type Props = {
   className?: string;
 };
 
-const Info = styled.div`
-  margin-bottom: 16px;
-`;
-
 const TabContent = styled(Flex)`
-  margin-top: 52px;
+  margin-top: ${(props) => props.theme.spacing.medium};
   width: 100%;
   height: 100%;
 `;
@@ -51,38 +46,32 @@ function KustomizationDetail({ kustomization, className }: Props) {
   };
 
   return (
-    <Flex wide tall column align className={className}>
-      <Flex wide between>
-        <Info>
-          <Heading level={2}>{kustomization?.namespace}</Heading>
-          <InfoList
-            items={[
-              ["Source", <SourceLink sourceRef={kustomization?.sourceRef} />],
-              ["Applied Revision", kustomization?.lastAppliedRevision],
-              ["Cluster", kustomization?.clusterName],
-              ["Path", kustomization?.path],
-              ["Interval", <Interval interval={kustomization?.interval} />],
-              [
-                "Last Updated At",
-                <Timestamp time={kustomization?.lastHandledReconciledAt} />,
-              ],
-            ]}
-          />
-        </Info>
-        <PageStatus
-          conditions={kustomization?.conditions}
-          suspended={kustomization?.suspended}
+    <Flex wide tall column className={className}>
+      {sync.isError && (
+        <Alert
+          severity="error"
+          message={sync.error.message}
+          title="Sync Error"
         />
-      </Flex>
-      <Flex wide>
-        {sync.isError && (
-          <Alert
-            severity="error"
-            message={sync.error.message}
-            title="Sync Error"
-          />
-        )}
-      </Flex>
+      )}
+      <PageStatus
+        conditions={kustomization?.conditions}
+        suspended={kustomization?.suspended}
+      />
+      <InfoList
+        items={[
+          ["Namespace", kustomization?.namespace],
+          ["Source", <SourceLink sourceRef={kustomization?.sourceRef} />],
+          ["Applied Revision", kustomization?.lastAppliedRevision],
+          ["Cluster", kustomization?.clusterName],
+          ["Path", kustomization?.path],
+          ["Interval", <Interval interval={kustomization?.interval} />],
+          [
+            "Last Updated At",
+            <Timestamp time={kustomization?.lastHandledReconciledAt} />,
+          ],
+        ]}
+      />
       <SyncButton onClick={handleSyncClicked} loading={sync.isLoading} />
       <TabContent>
         <SubRouterTabs rootPath={`${path}/details`}>

--- a/ui/components/Layout.tsx
+++ b/ui/components/Layout.tsx
@@ -57,7 +57,7 @@ const StyleLinkTab = styled(LinkTab)`
 
 const AppContainer = styled.div`
   width: 100%;
-  min-width: 1024px;
+  min-width: 768px;
   max-width: 100vw;
   min-height: 100vh;
   margin: 0 auto;
@@ -119,15 +119,21 @@ const ContentContainer = styled.div`
   overflow: hidden;
 `;
 
-const Main = styled(Flex)``;
+const Main = styled(Flex)`
+  padding-top: 80px;
+`;
 
 const TopToolBar = styled(Flex)`
+  position: fixed;
   background-color: ${(props) => props.theme.colors.primary};
   height: 80px;
+  min-width: 768px;
   ${UserSettings} {
     justify-self: flex-end;
     margin-left: auto;
   }
+  //puts it over nav text (must be an mui thing)
+  z-index: 2;
 `;
 
 function Layout({ className, children }: Props) {

--- a/ui/components/Page.tsx
+++ b/ui/components/Page.tsx
@@ -68,7 +68,6 @@ function Page({ children, loading, error, className }: PageProps) {
       <Children column wide tall start>
         {children}
       </Children>
-
       {settings.renderFooter && <Footer />}
     </Content>
   );

--- a/ui/components/Page.tsx
+++ b/ui/components/Page.tsx
@@ -1,6 +1,5 @@
 import _ from "lodash";
 import React from "react";
-import { useIsFetching } from "react-query";
 import styled from "styled-components";
 import useCommon from "../hooks/common";
 import { PageRoute, RequestError } from "../lib/types";
@@ -8,9 +7,7 @@ import Alert from "./Alert";
 import Flex from "./Flex";
 import Footer from "./Footer";
 import LoadingPage from "./LoadingPage";
-import PollingIndicator from "./PollingIndicator";
 import Spacer from "./Spacer";
-import Text from "./Text";
 
 export type PageProps = {
   className?: string;
@@ -39,11 +36,6 @@ export const Content = styled(Flex)`
 
 const Children = styled(Flex)``;
 
-export const TitleBar = styled(Flex)`
-  //matches nav tabs
-  line-height: 1.75;
-`;
-
 function Errors({ error }) {
   const arr = _.isArray(error) ? error : [error];
   return (
@@ -59,16 +51,8 @@ function Errors({ error }) {
   );
 }
 
-function Page({
-  children,
-  title,
-  actions,
-  loading,
-  error,
-  className,
-}: PageProps) {
+function Page({ children, loading, error, className }: PageProps) {
   const { settings } = useCommon();
-  const fetching = useIsFetching();
 
   if (loading) {
     return (
@@ -80,16 +64,6 @@ function Page({
 
   return (
     <Content wide tall start column className={className}>
-      <TitleBar wide start between>
-        <Flex align>
-          <Text semiBold size="large">
-            {title}
-          </Text>
-          <Spacer padding="small" />
-          <PollingIndicator loading={fetching > 0} />
-        </Flex>
-        {actions}
-      </TitleBar>
       {error && <Errors error={error} />}
       <Children column wide tall start>
         {children}

--- a/ui/components/PageStatus.tsx
+++ b/ui/components/PageStatus.tsx
@@ -17,38 +17,26 @@ function PageStatus({ conditions, suspended, className }: StatusProps) {
   const ok = suspended ? false : computeReady(conditions);
   const msg = suspended ? "Suspended" : computeMessage(conditions);
   return (
-    <div className={`${className}${!ok ? " error-border" : ""}`}>
-      <Flex align>
-        <Icon
-          type={
-            suspended
-              ? IconType.SuspendedIcon
-              : ok
-              ? IconType.CheckCircleIcon
-              : IconType.FailedIcon
-          }
-          color={ok ? "success" : "alert"}
-          size="medium"
-        />
-        <Spacer padding="xs" />
-        <Text color="neutral30">{msg}</Text>
-      </Flex>
-    </div>
+    <Flex align className={className}>
+      <Icon
+        type={
+          suspended
+            ? IconType.SuspendedIcon
+            : ok
+            ? IconType.CheckCircleIcon
+            : IconType.FailedIcon
+        }
+        color={ok ? "success" : "alert"}
+        size="medium"
+      />
+      <Spacer padding="xs" />
+      <Text color="neutral30">{msg}</Text>
+    </Flex>
   );
 }
 export default styled(PageStatus).attrs({ className: PageStatus.name })`
-  position: relative;
-  max-width: 45%;
-  bottom: ${(props) => props.theme.spacing.large};
-  padding: ${(props) => props.theme.spacing.small};
+  //matches nav
+  line-height: 1.75;
+
   color: ${(props) => props.theme.colors.neutral30};
-  overflow: hidden;
-  &.error-border {
-    border: 1px solid ${(props) => props.theme.colors.neutral20};
-    border-radius: 10px;
-  }
-  span {
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
 `;

--- a/ui/components/ReconciledObjectsTable.tsx
+++ b/ui/components/ReconciledObjectsTable.tsx
@@ -59,6 +59,7 @@ function ReconciledObjectsTable({
           {
             value: "name",
             label: "Name",
+            maxWidth: 200,
           },
           {
             label: "Type",

--- a/ui/components/ReconciledObjectsTable.tsx
+++ b/ui/components/ReconciledObjectsTable.tsx
@@ -59,7 +59,7 @@ function ReconciledObjectsTable({
           {
             value: "name",
             label: "Name",
-            maxWidth: 200,
+            maxWidth: 600,
           },
           {
             label: "Type",
@@ -91,7 +91,7 @@ function ReconciledObjectsTable({
             value: (u: UnstructuredObject) => _.first(u.conditions)?.message,
             sortType: SortType.string,
             sortValue: ({ conditions }) => computeMessage(conditions),
-            maxWidth: 200,
+            maxWidth: 600,
           },
         ]}
         rows={objs}

--- a/ui/components/ReconciledObjectsTable.tsx
+++ b/ui/components/ReconciledObjectsTable.tsx
@@ -79,6 +79,7 @@ function ReconciledObjectsTable({
                 <KubeStatusIndicator
                   conditions={u.conditions}
                   suspended={u.suspended}
+                  short
                 />
               ) : null,
             sortType: SortType.number,
@@ -89,6 +90,7 @@ function ReconciledObjectsTable({
             value: (u: UnstructuredObject) => _.first(u.conditions)?.message,
             sortType: SortType.string,
             sortValue: ({ conditions }) => computeMessage(conditions),
+            maxWidth: 200,
           },
         ]}
         rows={objs}

--- a/ui/components/SourceDetail.tsx
+++ b/ui/components/SourceDetail.tsx
@@ -73,7 +73,7 @@ function SourceDetail({ className, name, info, type }: Props) {
         <Alert severity="error" title="Error" message={error.message} />
       )}
       <SubRouterTabs rootPath={`${path}/automations`}>
-        <RouterTab name="Relevant Automations" path={`${path}/automations`}>
+        <RouterTab name="Automations" path={`${path}/automations`}>
           <AutomationsTable automations={relevantAutomations} hideSource />
         </RouterTab>
         <RouterTab name="Events" path={`${path}/events`}>

--- a/ui/components/SourceDetail.tsx
+++ b/ui/components/SourceDetail.tsx
@@ -9,7 +9,6 @@ import Alert from "./Alert";
 import AutomationsTable from "./AutomationsTable";
 import EventsTable from "./EventsTable";
 import Flex from "./Flex";
-import Heading from "./Heading";
 import InfoList, { InfoField } from "./InfoList";
 import Link from "./Link";
 import LoadingPage from "./LoadingPage";
@@ -61,17 +60,12 @@ function SourceDetail({ className, name, info, type }: Props) {
   });
 
   return (
-    <Flex wide tall column align className={className}>
-      <Flex wide between>
-        <div>
-          <Heading level={2}>{s.type}</Heading>
-          <InfoList items={items} />
-        </div>
-        <PageStatus conditions={s.conditions} suspended={s.suspended} />
-      </Flex>
+    <Flex wide tall column className={className}>
       {error && (
         <Alert severity="error" title="Error" message={error.message} />
       )}
+      <PageStatus conditions={s.conditions} suspended={s.suspended} />
+      <InfoList items={items} />
       <SubRouterTabs rootPath={`${path}/automations`}>
         <RouterTab name="Automations" path={`${path}/automations`}>
           <AutomationsTable automations={relevantAutomations} hideSource />
@@ -92,11 +86,10 @@ function SourceDetail({ className, name, info, type }: Props) {
 }
 
 export default styled(SourceDetail).attrs({ className: SourceDetail.name })`
-  padding-top: ${(props) => props.theme.spacing.xs};
   width: 100%;
 
   ${InfoList} {
-    margin-bottom: 60px;
+    margin-bottom: ${(props) => props.theme.spacing.medium};
   }
 
   .MuiTabs-root ${Link} .active-tab {

--- a/ui/components/SourceLink.tsx
+++ b/ui/components/SourceLink.tsx
@@ -7,9 +7,10 @@ import Link from "./Link";
 type Props = {
   className?: string;
   sourceRef?: SourceRef;
+  short?: boolean;
 };
 
-function SourceLink({ className, sourceRef }: Props) {
+function SourceLink({ className, sourceRef, short }: Props) {
   if (!sourceRef) {
     return <div />;
   }
@@ -18,7 +19,7 @@ function SourceLink({ className, sourceRef }: Props) {
       className={className}
       to={formatSourceURL(sourceRef.kind, sourceRef.name, sourceRef.namespace)}
     >
-      {sourceRef.kind}/{sourceRef.name}
+      {!short && sourceRef.kind}/{sourceRef.name}
     </Link>
   );
 }

--- a/ui/components/SourceLink.tsx
+++ b/ui/components/SourceLink.tsx
@@ -19,7 +19,8 @@ function SourceLink({ className, sourceRef, short }: Props) {
       className={className}
       to={formatSourceURL(sourceRef.kind, sourceRef.name, sourceRef.namespace)}
     >
-      {!short && sourceRef.kind}/{sourceRef.name}
+      {!short && sourceRef.kind + "/"}
+      {sourceRef.name}
     </Link>
   );
 }

--- a/ui/components/SourcesTable.tsx
+++ b/ui/components/SourcesTable.tsx
@@ -77,6 +77,7 @@ function SourcesTable({ className, sources }: Props) {
         {
           label: "Message",
           value: (s) => computeMessage(s.conditions),
+          maxWidth: 200,
         },
         {
           label: "Cluster",

--- a/ui/components/SourcesTable.tsx
+++ b/ui/components/SourcesTable.tsx
@@ -59,6 +59,7 @@ function SourcesTable({ className, sources }: Props) {
           sortType: SortType.string,
           sortValue: (s: Source) => s.name || "",
           textSearchable: true,
+          maxWidth: 200,
         },
         { label: "Type", value: "type" },
         { label: "Namespace", value: "namespace" },
@@ -117,6 +118,7 @@ function SourcesTable({ className, sources }: Props) {
               text
             );
           },
+          maxWidth: 200,
         },
         {
           label: "Reference",

--- a/ui/components/SourcesTable.tsx
+++ b/ui/components/SourcesTable.tsx
@@ -59,7 +59,7 @@ function SourcesTable({ className, sources }: Props) {
           sortType: SortType.string,
           sortValue: (s: Source) => s.name || "",
           textSearchable: true,
-          maxWidth: 200,
+          maxWidth: 600,
         },
         { label: "Type", value: "type" },
         { label: "Namespace", value: "namespace" },
@@ -78,7 +78,7 @@ function SourcesTable({ className, sources }: Props) {
         {
           label: "Message",
           value: (s) => computeMessage(s.conditions),
-          maxWidth: 200,
+          maxWidth: 600,
         },
         {
           label: "Cluster",
@@ -118,7 +118,7 @@ function SourcesTable({ className, sources }: Props) {
               text
             );
           },
-          maxWidth: 200,
+          maxWidth: 600,
         },
         {
           label: "Reference",

--- a/ui/components/__tests__/__snapshots__/DataTable.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/DataTable.test.tsx.snap
@@ -110,8 +110,6 @@ exports[`DataTable snapshots renders 1`] = `
   font-weight: 600;
   color: #737373;
   margin: 0px;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .c0 .MuiTableRow-root {
@@ -130,11 +128,8 @@ exports[`DataTable snapshots renders 1`] = `
 }
 
 .c0 td {
-  word-break: break-all;
   word-wrap: break-word;
   white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
 }
 
 <div

--- a/ui/components/__tests__/__snapshots__/DataTable.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/DataTable.test.tsx.snap
@@ -110,6 +110,7 @@ exports[`DataTable snapshots renders 1`] = `
   font-weight: 600;
   color: #737373;
   margin: 0px;
+  white-space: nowrap;
 }
 
 .c0 .MuiTableRow-root {
@@ -128,8 +129,9 @@ exports[`DataTable snapshots renders 1`] = `
 }
 
 .c0 td {
-  word-wrap: break-word;
   white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 <div

--- a/ui/components/__tests__/__snapshots__/Page.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/Page.test.tsx.snap
@@ -34,10 +34,6 @@ exports[`Page snapshots default 1`] = `
   -ms-flex-align: start;
   align-items: start;
   width: 100%;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
-  justify-content: flex-start;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
@@ -45,39 +41,6 @@ exports[`Page snapshots default 1`] = `
 }
 
 .c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c9 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: start;
-  -webkit-box-align: start;
-  -ms-flex-align: start;
-  align-items: start;
-  width: 100%;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-}
-
-.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -93,14 +56,6 @@ exports[`Page snapshots default 1`] = `
 
 .c6 {
   font-family: 'proxima-nova',Helvetica,Arial,sans-serif;
-  font-size: 20px;
-  font-weight: 600;
-  text-transform: none;
-  font-style: normal;
-}
-
-.c12 {
-  font-family: 'proxima-nova',Helvetica,Arial,sans-serif;
   font-size: 16px;
   font-weight: 400;
   text-transform: none;
@@ -108,7 +63,7 @@ exports[`Page snapshots default 1`] = `
   color: #737373;
 }
 
-.c15 {
+.c9 {
   font-family: 'proxima-nova',Helvetica,Arial,sans-serif;
   font-size: 16px;
   font-weight: 400;
@@ -117,47 +72,25 @@ exports[`Page snapshots default 1`] = `
   color: #00b3ec;
 }
 
-.c14 {
+.c8 {
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c14.title-bar-button {
+.c8.title-bar-button {
   width: 250px;
 }
 
 .c7 {
-  padding: 12px;
-}
-
-.c13 {
   padding: 4px;
 }
 
-.c16 {
+.c10 {
   padding-right: 24px;
 }
 
-.c10 {
+.c4 {
   color: #737373;
-}
-
-.c8 {
-  padding-left: 8px;
-}
-
-.c8 .MuiCircularProgress-root {
-  -webkit-transition: opacity 2s;
-  transition: opacity 2s;
-  margin-bottom: 0;
-}
-
-.c8 .MuiCircularProgress-root.in {
-  opacity: 1;
-}
-
-.c8 .MuiCircularProgress-root.out {
-  opacity: 0;
 }
 
 .c1 {
@@ -174,10 +107,6 @@ exports[`Page snapshots default 1`] = `
   overflow: hidden;
 }
 
-.c4 {
-  line-height: 1.75;
-}
-
 .c2 .MuiAlert-root {
   width: 100%;
 }
@@ -186,76 +115,32 @@ exports[`Page snapshots default 1`] = `
   className="c0 c1 c2"
 >
   <div
-    className="c3 c4"
+    className="c0"
+  />
+  <footer
+    className="c3 c4 Footer"
   >
     <div
       className="c5"
     >
       <span
         className="c6"
-        size="large"
-      />
-      <div
-        className="c7"
-      />
-      <div
-        className="c5 c8"
-      >
-        <div
-          className="MuiCircularProgress-root out MuiCircularProgress-colorPrimary MuiCircularProgress-indeterminate"
-          role="progressbar"
-          style={
-            Object {
-              "height": "16px",
-              "width": "16px",
-            }
-          }
-        >
-          <svg
-            className="MuiCircularProgress-svg"
-            viewBox="22 22 44 44"
-          >
-            <circle
-              className="MuiCircularProgress-circle MuiCircularProgress-circleIndeterminate"
-              cx={44}
-              cy={44}
-              fill="none"
-              r={20.2}
-              strokeWidth={3.6}
-              style={Object {}}
-            />
-          </svg>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    className="c0"
-  />
-  <footer
-    className="c9 c10 Footer"
-  >
-    <div
-      className="c11"
-    >
-      <span
-        className="c12"
         color="neutral30"
         size="normal"
       >
         Need help? Contact us at
       </span>
       <div
-        className="c13"
+        className="c7"
       />
       <a
-        className="c14"
+        className="c8"
         href="mailto:support@weave.works"
         rel="noreferrer"
         target="_blank"
       >
         <span
-          className="c15"
+          className="c9"
           color="primary"
           size="normal"
         >
@@ -264,13 +149,13 @@ exports[`Page snapshots default 1`] = `
       </a>
     </div>
     <div
-      className="c11 c16"
+      className="c5 c10"
     >
       <div
-        className="c13"
+        className="c7"
       />
       <span
-        className="c12"
+        className="c6"
         color="neutral30"
         size="normal"
       >

--- a/ui/pages/v2/Automations.tsx
+++ b/ui/pages/v2/Automations.tsx
@@ -12,12 +12,7 @@ function Automations({ className }: Props) {
   const { data: automations, error, isLoading } = useListAutomations();
 
   return (
-    <Page
-      error={error}
-      loading={isLoading}
-      title="Applications"
-      className={className}
-    >
+    <Page error={error} loading={isLoading} className={className}>
       <AutomationsTable automations={automations} />
     </Page>
   );

--- a/ui/pages/v2/BucketDetail.tsx
+++ b/ui/pages/v2/BucketDetail.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import styled from "styled-components";
-import Page from "../../components/Page";
 import BucketDetailComponent from "../../components/BucketDetail";
+import Page from "../../components/Page";
 
 type Props = {
   className?: string;
@@ -11,11 +11,8 @@ type Props = {
 
 function BucketDetail({ className, name, namespace }: Props) {
   return (
-    <Page error={null} className={className} title={name}>
-      <BucketDetailComponent
-        name={name}
-        namespace={namespace}
-      />
+    <Page error={null} className={className}>
+      <BucketDetailComponent name={name} namespace={namespace} />
     </Page>
   );
 }

--- a/ui/pages/v2/FluxRuntime.tsx
+++ b/ui/pages/v2/FluxRuntime.tsx
@@ -1,8 +1,8 @@
 import * as React from "react";
 import styled from "styled-components";
+import FluxRuntimeComponent from "../../components/FluxRuntime";
 import Page from "../../components/Page";
 import Spacer from "../../components/Spacer";
-import FluxRuntimeComponent from "../../components/FluxRuntime";
 import { useListFluxRuntimeObjects } from "../../hooks/flux";
 
 type Props = {
@@ -13,12 +13,7 @@ function FluxRuntime({ className }: Props) {
   const { data, isLoading, error } = useListFluxRuntimeObjects();
 
   return (
-    <Page
-      title="Flux Runtime"
-      loading={isLoading}
-      error={error}
-      className={className}
-    >
+    <Page loading={isLoading} error={error} className={className}>
       <Spacer padding="xs" />
       <FluxRuntimeComponent deployments={data?.deployments} />
     </Page>

--- a/ui/pages/v2/FluxRuntime.tsx
+++ b/ui/pages/v2/FluxRuntime.tsx
@@ -2,7 +2,6 @@ import * as React from "react";
 import styled from "styled-components";
 import FluxRuntimeComponent from "../../components/FluxRuntime";
 import Page from "../../components/Page";
-import Spacer from "../../components/Spacer";
 import { useListFluxRuntimeObjects } from "../../hooks/flux";
 
 type Props = {
@@ -14,7 +13,6 @@ function FluxRuntime({ className }: Props) {
 
   return (
     <Page loading={isLoading} error={error} className={className}>
-      <Spacer padding="xs" />
       <FluxRuntimeComponent deployments={data?.deployments} />
     </Page>
   );

--- a/ui/pages/v2/GitRepositoryDetail.tsx
+++ b/ui/pages/v2/GitRepositoryDetail.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import styled from "styled-components";
-import Page from "../../components/Page";
 import GitRepositoryDetailComponent from "../../components/GitRepositoryDetail";
+import Page from "../../components/Page";
 
 type Props = {
   className?: string;
@@ -11,11 +11,8 @@ type Props = {
 
 function GitRepositoryDetail({ className, name, namespace }: Props) {
   return (
-    <Page error={null} className={className} title={name}>
-      <GitRepositoryDetailComponent
-        name={name}
-        namespace={namespace}
-      />
+    <Page error={null} className={className}>
+      <GitRepositoryDetailComponent name={name} namespace={namespace} />
     </Page>
   );
 }

--- a/ui/pages/v2/HelmChartDetail.tsx
+++ b/ui/pages/v2/HelmChartDetail.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import styled from "styled-components";
-import Page from "../../components/Page";
 import HelmChartDetailComponent from "../../components/HelmChartDetail";
+import Page from "../../components/Page";
 
 type Props = {
   className?: string;
@@ -11,11 +11,8 @@ type Props = {
 
 function HelmChartDetail({ className, name, namespace }: Props) {
   return (
-    <Page error={null} className={className} title={name}>
-      <HelmChartDetailComponent
-        name={name}
-        namespace={namespace}
-      />
+    <Page error={null} className={className}>
+      <HelmChartDetailComponent name={name} namespace={namespace} />
     </Page>
   );
 }

--- a/ui/pages/v2/HelmReleasePage.tsx
+++ b/ui/pages/v2/HelmReleasePage.tsx
@@ -20,7 +20,7 @@ function HelmReleasePage({ className, name, namespace, clusterName }: Props) {
   const helmRelease = data?.helmRelease;
 
   return (
-    <Page loading={isLoading} error={error} className={className} title={name}>
+    <Page loading={isLoading} error={error} className={className}>
       <HelmReleaseComponent
         helmRelease={helmRelease}
         name={name}

--- a/ui/pages/v2/HelmRepositoryDetail.tsx
+++ b/ui/pages/v2/HelmRepositoryDetail.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import styled from "styled-components";
-import Page from "../../components/Page";
 import HelmRepositoryDetailComponent from "../../components/HelmRepositoryDetail";
+import Page from "../../components/Page";
 
 type Props = {
   className?: string;
@@ -11,11 +11,8 @@ type Props = {
 
 function HelmRepositoryDetail({ className, name, namespace }: Props) {
   return (
-    <Page error={null} className={className} title={name}>
-      <HelmRepositoryDetailComponent
-        name={name}
-        namespace={namespace}
-      />
+    <Page error={null} className={className}>
+      <HelmRepositoryDetailComponent name={name} namespace={namespace} />
     </Page>
   );
 }

--- a/ui/pages/v2/KustomizationPage.tsx
+++ b/ui/pages/v2/KustomizationPage.tsx
@@ -19,7 +19,7 @@ function KustomizationPage({ className, name, namespace, clusterName }: Props) {
   );
   const kustomization = data?.kustomization;
   return (
-    <Page loading={isLoading} error={error} className={className} title={name}>
+    <Page loading={isLoading} error={error} className={className}>
       <KustomizationComponent kustomization={kustomization} />
     </Page>
   );

--- a/ui/pages/v2/Sources.tsx
+++ b/ui/pages/v2/Sources.tsx
@@ -11,12 +11,7 @@ type Props = {
 function SourcesList({ className }: Props) {
   const { data: sources, error, isLoading } = useListSources();
   return (
-    <Page
-      title="Sources"
-      error={error}
-      loading={isLoading}
-      className={className}
-    >
+    <Page error={error} loading={isLoading} className={className}>
       <SourcesTable sources={sources} />
     </Page>
   );


### PR DESCRIPTION
Here's the big list of changes:

A `maxWidth` prop has been added to the `Field` type, allowing longer data table cells (message, name) to wrap. Additionally, the `SourceLink` component has a `short` prop in order to cut the url down inside the data table. One downside of these changes is that it becomes unclear that the table is scrollable/there are additional columns. 
<img width="1042" alt="image" src="https://user-images.githubusercontent.com/65822698/165389881-6d4ae306-5d0b-4a8f-a4c3-7d800b40043e.png">

The title bar in layout has been removed. Adjustments to the details pages make those look great, but the top level pages look a little empty at the top to me. This is all in service of decreasing the min-width of the app to 768px.

main page: 
<img width="1277" alt="image" src="https://user-images.githubusercontent.com/65822698/165390518-3db0af53-4eda-42d5-af15-7d3ce8849708.png">

detail page:
<img width="1277" alt="image" src="https://user-images.githubusercontent.com/65822698/165390625-e23a70a4-717a-4bed-94bf-e66c1cfc869f.png">

The top bar is now set to `position: fixed`. I also set the nav content to fixed but it looked clunky - I want to figure out how to add some kind of delay there or make the entire white bar scroll.
<img width="1278" alt="image" src="https://user-images.githubusercontent.com/65822698/165390743-be16e718-d141-4411-825c-6990ba44c6f3.png">

Status message in `ReconciledObjectsTable` repeated what's in the message column. Made it consistent with other status indicators and it now displays the `readyText` instead (Ready, Not Ready, Suspended).

Changed the name of the "Relevant Automations" tab to just "Automations".
