### PR TITLE
Collection of minor auth changes

### DIFF
--- a/cmd/gitops-server/cmd/cmd.go
+++ b/cmd/gitops-server/cmd/cmd.go
@@ -93,7 +93,7 @@ func NewCommand() *cobra.Command {
 	cmd.Flags().StringVar(&options.OIDC.ClientID, "oidc-client-id", "", "The client ID for the OpenID Connect client")
 	cmd.Flags().StringVar(&options.OIDC.ClientSecret, "oidc-client-secret", "", "The client secret to use with OpenID Connect issuer")
 	cmd.Flags().StringVar(&options.OIDC.RedirectURL, "oidc-redirect-url", "", "The OAuth2 redirect URL")
-	cmd.Flags().DurationVar(&options.OIDC.TokenDuration, "oidc-token-duration", time.Hour, "The duration of the ID token. It should be set in the format: number + time unit (s,m,h) e.g., 20m")
+	cmd.Flags().DurationVar(&options.OIDC.TokenDuration, "oidc-token-duration", auth.DefaultIDTokenDuration, "The duration of the ID token. It should be set in the format: number + time unit (s,m,h) e.g., 20m")
 
 	cmd.Flags().BoolVar(&options.DevMode, "dev-mode", false, "Enables development mode")
 	cmd.Flags().StringVar(&options.DevUser, "dev-user", v1alpha1.DefaultClaimsSubject, "Sets development User")

--- a/pkg/server/auth/auth.go
+++ b/pkg/server/auth/auth.go
@@ -84,9 +84,8 @@ func WithAPIAuth(next http.Handler, srv *AuthServer, publicRoutes []string) http
 	multi := MultiAuthPrincipal{adminAuth}
 
 	if srv.oidcEnabled() {
-		headerAuth := NewJWTAuthorizationHeaderPrincipalGetter(srv.Log, srv.verifier())
 		cookieAuth := NewJWTCookiePrincipalGetter(srv.Log, srv.verifier(), IDTokenCookieName)
-		multi = append(multi, headerAuth, cookieAuth)
+		multi = append(multi, cookieAuth)
 	}
 
 	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {

--- a/pkg/server/auth/auth_test.go
+++ b/pkg/server/auth/auth_test.go
@@ -124,7 +124,7 @@ func TestOauth2FlowRedirectsToOIDCIssuerForUnauthenticatedRequests(t *testing.T)
 
 	g.Expect(res).To(HaveHTTPStatus(http.StatusSeeOther))
 
-	authCodeURL := fmt.Sprintf("%s?client_id=%s&redirect_uri=%s&response_type=code&scope=%s", m.AuthorizationEndpoint(), fake.ClientID, url.QueryEscape(redirectURL), strings.Join([]string{"profile", oidc.ScopeOpenID, oidc.ScopeOfflineAccess, "email"}, "+"))
+	authCodeURL := fmt.Sprintf("%s?client_id=%s&redirect_uri=%s&response_type=code&scope=%s", m.AuthorizationEndpoint(), fake.ClientID, url.QueryEscape(redirectURL), strings.Join([]string{"profile", oidc.ScopeOpenID, "email"}, "+"))
 	g.Expect(res.Result().Header.Get("Location")).To(ContainSubstring(authCodeURL))
 }
 

--- a/pkg/server/auth/jwt.go
+++ b/pkg/server/auth/jwt.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"strings"
 
 	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/go-logr/logr"
@@ -43,45 +42,6 @@ func (pg *JWTCookiePrincipalGetter) Principal(r *http.Request) (*UserPrincipal, 
 	}
 
 	return parseJWTToken(r.Context(), pg.verifier, cookie.Value)
-}
-
-// JWTAuthorizationHeaderPrincipalGetter inspects the Authorization
-// header (bearer token) for a JWT token and returns a principal
-// object.
-type JWTAuthorizationHeaderPrincipalGetter struct {
-	log      logr.Logger
-	verifier *oidc.IDTokenVerifier
-}
-
-func NewJWTAuthorizationHeaderPrincipalGetter(log logr.Logger, verifier *oidc.IDTokenVerifier) PrincipalGetter {
-	return &JWTAuthorizationHeaderPrincipalGetter{
-		log:      log,
-		verifier: verifier,
-	}
-}
-
-func (pg *JWTAuthorizationHeaderPrincipalGetter) Principal(r *http.Request) (*UserPrincipal, error) {
-	pg.log.Info("attempt to read token from auth header")
-
-	header := r.Header.Get("Authorization")
-	if header == "" {
-		return nil, nil
-	}
-
-	return parseJWTToken(r.Context(), pg.verifier, extractToken(header))
-}
-
-func extractToken(s string) string {
-	parts := strings.Split(s, " ")
-	if len(parts) != 2 {
-		return ""
-	}
-
-	if strings.TrimSpace(parts[0]) != "Bearer" {
-		return ""
-	}
-
-	return strings.TrimSpace(parts[1])
 }
 
 func parseJWTToken(ctx context.Context, verifier *oidc.IDTokenVerifier, rawIDToken string) (*UserPrincipal, error) {

--- a/pkg/server/auth/jwt_test.go
+++ b/pkg/server/auth/jwt_test.go
@@ -44,34 +44,6 @@ func TestJWTCookiePrincipalGetter(t *testing.T) {
 	}
 }
 
-func TestJWTAuthorizationHeaderPrincipalGetter(t *testing.T) {
-	privKey := testutils.MakeRSAPrivateKey(t)
-	authTests := []struct {
-		name          string
-		authorization string
-		want          *auth.UserPrincipal
-	}{
-		{"JWT ID Token", "Bearer " + testutils.MakeJWToken(t, privKey, "example@example.com"), &auth.UserPrincipal{ID: "example@example.com", Groups: []string{"testing"}}},
-		{"no auth header value", "", nil},
-	}
-
-	srv := testutils.MakeKeysetServer(t, privKey)
-	keySet := oidc.NewRemoteKeySet(oidc.ClientContext(context.TODO(), srv.Client()), srv.URL)
-	verifier := oidc.NewVerifier("http://127.0.0.1:5556/dex", keySet, &oidc.Config{ClientID: "test-service"})
-
-	for _, tt := range authTests {
-		t.Run(tt.name, func(t *testing.T) {
-			principal, err := auth.NewJWTAuthorizationHeaderPrincipalGetter(logr.Discard(), verifier).Principal(makeAuthenticatedRequest(tt.authorization))
-			if err != nil {
-				t.Fatal(err)
-			}
-			if diff := cmp.Diff(tt.want, principal); diff != "" {
-				t.Fatalf("failed to get principal:\n%s", diff)
-			}
-		})
-	}
-}
-
 func makeCookieRequest(cookieName, token string) *http.Request {
 	req := httptest.NewRequest("GET", "http://example.com/", nil)
 	if token != "" {
@@ -79,15 +51,6 @@ func makeCookieRequest(cookieName, token string) *http.Request {
 			Name:  cookieName,
 			Value: token,
 		})
-	}
-
-	return req
-}
-
-func makeAuthenticatedRequest(token string) *http.Request {
-	req := httptest.NewRequest("GET", "http://example.com/", nil)
-	if token != "" {
-		req.Header.Set("Authorization", token)
 	}
 
 	return req

--- a/pkg/server/auth/server.go
+++ b/pkg/server/auth/server.go
@@ -439,7 +439,7 @@ func (c *AuthServer) createCookie(name, value string, expires time.Duration) *ht
 		Path:     "/",
 		Expires:  time.Now().UTC().Add(expires),
 		HttpOnly: true,
-		Secure:   false,
+		Secure:   true,
 	}
 
 	return cookie

--- a/pkg/server/auth/server.go
+++ b/pkg/server/auth/server.go
@@ -134,11 +134,6 @@ func (s *AuthServer) oauth2Config(scopes []string) *oauth2.Config {
 		scopes = append(scopes, oidc.ScopeOpenID)
 	}
 
-	// Request "offline_access" scope for refresh tokens.
-	if !contains(scopes, oidc.ScopeOfflineAccess) {
-		scopes = append(scopes, oidc.ScopeOfflineAccess)
-	}
-
 	// Request "email" scope to get user's email address.
 	if !contains(scopes, scopeEmail) {
 		scopes = append(scopes, scopeEmail)
@@ -416,7 +411,7 @@ func (c *AuthServer) startAuthFlow(rw http.ResponseWriter, r *http.Request) {
 	state := base64.StdEncoding.EncodeToString(b)
 
 	var scopes []string
-	// "openid", "offline_access", "email" and "groups" scopes added by default
+	// "openid", "email" and "groups" scopes added by default
 	scopes = append(scopes, scopeProfile)
 	authCodeUrl := c.oauth2Config(scopes).AuthCodeURL(state)
 


### PR DESCRIPTION
- feat: Set Secure flag on cookies

- ref: Remove JWTAuthorizationHeaderPrincipalGetter

    Currently we don't make any requests from the UI using the auth header,
    just the cookie is used for now.
    We can add it back when we need it.

-  feat: Reduce State cookie TTL to 5 mins

    Also remove setting the RefreshToken cookie. We don't do anything with
    that token right now, and need to do some work around how we handle a
    user who is no longer authenticated.

- refactor: Remove offline auth scope

Closes #1949 