### PR TITLE
Don't start the helm watcher as part of core

### DIFF
--- a/cmd/gitops-server/cmd/cmd.go
+++ b/cmd/gitops-server/cmd/cmd.go
@@ -25,8 +25,6 @@ import (
 	"github.com/weaveworks/weave-gitops/core/logger"
 	"github.com/weaveworks/weave-gitops/core/nsaccess"
 	core "github.com/weaveworks/weave-gitops/core/server"
-	"github.com/weaveworks/weave-gitops/pkg/helm/watcher"
-	"github.com/weaveworks/weave-gitops/pkg/helm/watcher/cache"
 	"github.com/weaveworks/weave-gitops/pkg/kube"
 	"github.com/weaveworks/weave-gitops/pkg/server"
 	"github.com/weaveworks/weave-gitops/pkg/server/auth"
@@ -46,10 +44,6 @@ type Options struct {
 	Host                          string
 	HelmRepoNamespace             string
 	HelmRepoName                  string
-	ProfileCacheLocation          string
-	WatcherMetricsBindAddress     string
-	WatcherHealthzBindAddress     string
-	WatcherPort                   int
 	Path                          string
 	LogLevel                      string
 	OIDC                          auth.OIDCConfig
@@ -76,13 +70,7 @@ func NewCommand() *cobra.Command {
 	cmd.Flags().StringVar(&options.Host, "host", server.DefaultHost, "UI host")
 	cmd.Flags().StringVar(&options.Port, "port", server.DefaultPort, "UI port")
 	cmd.Flags().StringVar(&options.Path, "path", "", "Path url")
-	cmd.Flags().StringVar(&options.HelmRepoNamespace, "helm-repo-namespace", "default", "the namespace of the Helm Repository resource to scan for profiles")
-	cmd.Flags().StringVar(&options.HelmRepoName, "helm-repo-name", "weaveworks-charts", "the name of the Helm Repository resource to scan for profiles")
-	cmd.Flags().StringVar(&options.ProfileCacheLocation, "profile-cache-location", "/tmp/helm-cache", "the location where the cache Profile data lives")
-	cmd.Flags().StringVar(&options.WatcherHealthzBindAddress, "watcher-healthz-bind-address", ":9981", "bind address for the healthz service of the watcher")
-	cmd.Flags().StringVar(&options.WatcherMetricsBindAddress, "watcher-metrics-bind-address", ":9980", "bind address for the metrics service of the watcher")
 	cmd.Flags().StringVar(&options.NotificationControllerAddress, "notification-controller-address", "", "the address of the notification-controller running in the cluster")
-	cmd.Flags().IntVar(&options.WatcherPort, "watcher-port", 9443, "the port on which the watcher is running")
 
 	cmd.Flags().StringVar(&options.TLSCertFile, "tls-cert-file", "", "filename for the TLS certificate, in-memory generated if omitted")
 	cmd.Flags().StringVar(&options.TLSKeyFile, "tls-private-key-file", "", "filename for the TLS key, in-memory generated if omitted")
@@ -133,35 +121,6 @@ func runCmd(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("could not create kube http client: %w", err)
 	}
-
-	profileCache, err := cache.NewCache(options.ProfileCacheLocation)
-	if err != nil {
-		return fmt.Errorf("failed to create cacher: %w", err)
-	}
-
-	if options.NotificationControllerAddress == "" {
-		namespace, _ := cmd.Flags().GetString("namespace")
-		options.NotificationControllerAddress = fmt.Sprintf("http://notification-controller.%s.svc.cluster.local./", namespace)
-	}
-
-	profileWatcher, err := watcher.NewWatcher(watcher.Options{
-		KubeClient:                    rawClient,
-		Cache:                         profileCache,
-		MetricsBindAddress:            options.WatcherMetricsBindAddress,
-		HealthzBindAddress:            options.WatcherHealthzBindAddress,
-		NotificationControllerAddress: options.NotificationControllerAddress,
-		WatcherPort:                   options.WatcherPort,
-	})
-	if err != nil {
-		return fmt.Errorf("failed to start the watcher: %w", err)
-	}
-
-	go func() {
-		if err := profileWatcher.StartWatcher(log); err != nil {
-			log.Error(err, "failed to start profile watcher")
-			os.Exit(1)
-		}
-	}()
 
 	var authServer *auth.AuthServer
 
@@ -220,15 +179,9 @@ func runCmd(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("could not create http client: %w", err)
 	}
 
-	profilesConfig := server.NewProfilesConfig(kube.ClusterConfig{
-		DefaultConfig: rest,
-		ClusterName:   clusterName,
-	}, profileCache, options.HelmRepoNamespace, options.HelmRepoName)
-
 	appAndProfilesHandlers, err := server.NewHandlers(ctx, log,
 		&server.Config{
 			AppConfig:        appConfig,
-			ProfilesConfig:   profilesConfig,
 			CoreServerConfig: coreConfig,
 			AuthServer:       authServer,
 		},

--- a/pkg/server/handler.go
+++ b/pkg/server/handler.go
@@ -11,7 +11,6 @@ import (
 	"github.com/weaveworks/weave-gitops/core/clustersmngr"
 	core "github.com/weaveworks/weave-gitops/core/server"
 	pbapp "github.com/weaveworks/weave-gitops/pkg/api/applications"
-	pbprofiles "github.com/weaveworks/weave-gitops/pkg/api/profiles"
 	"github.com/weaveworks/weave-gitops/pkg/server/auth"
 	"github.com/weaveworks/weave-gitops/pkg/server/middleware"
 )
@@ -33,7 +32,6 @@ func AuthEnabled() bool {
 type Config struct {
 	AppConfig        *ApplicationsConfig
 	AppOptions       []ApplicationsOption
-	ProfilesConfig   ProfilesConfig
 	CoreServerConfig core.CoreServerConfig
 	AuthServer       *auth.AuthServer
 }
@@ -50,12 +48,6 @@ func NewHandlers(ctx context.Context, log logr.Logger, cfg *Config) (http.Handle
 	appsSrv := NewApplicationsServer(cfg.AppConfig, cfg.AppOptions...)
 	if err := pbapp.RegisterApplicationsHandlerServer(ctx, mux, appsSrv); err != nil {
 		return nil, fmt.Errorf("could not register application: %w", err)
-	}
-
-	profilesSrv := NewProfilesServer(log, cfg.ProfilesConfig)
-
-	if err := pbprofiles.RegisterProfilesHandlerServer(ctx, mux, profilesSrv); err != nil {
-		return nil, fmt.Errorf("could not register profiles: %w", err)
 	}
 
 	if err := core.Hydrate(ctx, mux, cfg.CoreServerConfig); err != nil {


### PR DESCRIPTION
This was making gitops crash completely when you a install flux that
has the wrong API version of source.toolkit.fluxcd.io (spoiler: the
version just changed, see #1967).

This isn't a core feature anyway, so we can just disable it.

This doesn't make gitops _work_, it'll just start and find nothing.