### PR TITLE
Using k3s as envtest

### DIFF
--- a/core/clustersmngr/suite_test.go
+++ b/core/clustersmngr/suite_test.go
@@ -15,7 +15,6 @@ func TestMain(m *testing.M) {
 
 	var err error
 	k8sEnv, err = testutils.StartK8sTestEnvironment([]string{
-		"../../manifests/crds",
 		"../../tools/testcrds",
 	})
 

--- a/core/server/kustomization_test.go
+++ b/core/server/kustomization_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/weaveworks/weave-gitops/core/clustersmngr"
 	pb "github.com/weaveworks/weave-gitops/pkg/api/core"
 	"github.com/weaveworks/weave-gitops/pkg/kube"
+	"github.com/weaveworks/weave-gitops/pkg/testutils"
 )
 
 func TestListKustomizations(t *testing.T) {
@@ -80,6 +81,8 @@ func TestListKustomizations_inMultipleNamespaces(t *testing.T) {
 func TestListKustomizationPagination(t *testing.T) {
 	g := NewGomegaWithT(t)
 
+	testutils.CleanupAllResources(g, &kustomizev1.Kustomization{})
+
 	ctx := context.Background()
 	c, _ := makeGRPCServer(k8sEnv.Rest, t)
 
@@ -87,8 +90,6 @@ func TestListKustomizationPagination(t *testing.T) {
 		Scheme: kube.CreateScheme(),
 	})
 	g.Expect(err).NotTo(HaveOccurred())
-
-	existingKust := existingKustomizationCount(g)
 
 	ns1 := newNamespace(ctx, k, g)
 
@@ -110,7 +111,7 @@ func TestListKustomizationPagination(t *testing.T) {
 		},
 	})
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(res.Kustomizations).To(HaveLen(existingKust + 2))
+	g.Expect(res.Kustomizations).To(HaveLen(2))
 
 	res, err = c.ListKustomizations(ctx, &pb.ListKustomizationsRequest{
 		Pagination: &pb.Pagination{

--- a/core/server/suite_test.go
+++ b/core/server/suite_test.go
@@ -29,7 +29,6 @@ func TestMain(m *testing.M) {
 
 	var err error
 	k8sEnv, err = testutils.StartK8sTestEnvironment([]string{
-		"../../manifests/crds",
 		"../../tools/testcrds",
 	})
 

--- a/pkg/kube/kube_suite_test.go
+++ b/pkg/kube/kube_suite_test.go
@@ -26,7 +26,6 @@ var cleanupK8s func()
 var _ = BeforeSuite(func() {
 	var err error
 	k8sTestEnv, err = testutils.StartK8sTestEnvironment([]string{
-		"../../manifests/crds",
 		"../../tools/testcrds",
 	})
 	Expect(err).NotTo(HaveOccurred())

--- a/pkg/kube/kubehttp.go
+++ b/pkg/kube/kubehttp.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 
+	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -21,7 +22,7 @@ import (
 )
 
 func CreateScheme() *apiruntime.Scheme {
-	scheme := apiruntime.NewScheme()
+	scheme := scheme.Scheme
 	_ = sourcev1.AddToScheme(scheme)
 	_ = kustomizev2.AddToScheme(scheme)
 	_ = helmv2.AddToScheme(scheme)

--- a/pkg/server/server_suite_test.go
+++ b/pkg/server/server_suite_test.go
@@ -60,7 +60,6 @@ var _ = BeforeSuite(func() {
 
 	var err error
 	env, err = testutils.StartK8sTestEnvironment([]string{
-		"../../manifests/crds",
 		"../../tools/testcrds",
 	})
 	Expect(err).NotTo(HaveOccurred())

--- a/pkg/testutils/cluster_utils.go
+++ b/pkg/testutils/cluster_utils.go
@@ -1,0 +1,42 @@
+package testutils
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/docker/go-connections/nat"
+)
+
+// Helper function to wait for the cluster to become healthy.
+func waitForCluster(url string, retries int, interval time.Duration) bool {
+	var counter int
+
+	for {
+		counter++
+
+		res, err := http.Get(url)
+		if err == nil && res.StatusCode == http.StatusOK {
+			return true
+		}
+
+		if counter >= retries {
+			return false
+		}
+
+		time.Sleep(interval)
+	}
+}
+
+// Helper function to lookup the port mapped for a container.
+func getContainerPort(ports nat.PortMap, port nat.Port) (string, error) {
+	for key, bindings := range ports {
+		if key == port {
+			for _, binding := range bindings {
+				return binding.HostPort, nil
+			}
+		}
+	}
+
+	return "", fmt.Errorf("failed to find port: %s", port)
+}

--- a/pkg/testutils/k3s.go
+++ b/pkg/testutils/k3s.go
@@ -1,0 +1,211 @@
+package testutils
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/mount"
+	"github.com/docker/docker/client"
+	"github.com/docker/go-connections/nat"
+	"golang.org/x/net/context"
+	crenvtest "sigs.k8s.io/controller-runtime/pkg/envtest"
+)
+
+const (
+	// DefaultImage which will be used if non is provided.
+	DefaultImage = "docker.io/rancher/k3s:v1.22.9-rc4-k3s1"
+	// InsecurePort assigned to the K3s cluster.
+	InsecurePort = "6443"
+	// BindAddress assigned to the K3s cluster.
+	BindAddress = "0.0.0.0"
+	// K3sConfigFileName is the name of the k3s config file.
+	K3sConfigFileName = "k3s-test-kubeconfig.yaml"
+)
+
+// Environment which will back the Kubebuilder testsuite.
+type Environment struct {
+	// Image which will be used for spinning up K3s.
+	Image string
+	// CRDDirectoryPaths for preloading CustomResourceDefinitions.
+	// This is field name was taken from the controller-runtime envtest package
+	// for compatibility reasons.
+	CRDDirectoryPaths []string
+	// Internal container identifier.
+	id string
+}
+
+func getCallerDir() string {
+	_, file, _, _ := runtime.Caller(3)
+
+	base := filepath.Base(file)
+
+	return strings.TrimRight(file, base)
+}
+
+// Start the test environment.
+func (e *Environment) Start() (*rest.Config, error) {
+	ctx := context.Background()
+
+	if e.Image == "" {
+		e.Image = DefaultImage
+	}
+
+	cli, err := client.NewEnvClient()
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = cli.ImagePull(ctx, e.Image, types.ImagePullOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	natPort, err := nat.NewPort("tcp", InsecurePort)
+	if err != nil {
+		return nil, err
+	}
+
+	k3sOutFilesDir := getCallerDir()
+
+	containerConfig := &container.Config{
+		Image: e.Image,
+		Cmd: []string{
+			"server",
+			"--disable=traefik", "--disable=coredns", "--disable=servicelb", "--disable=local-storage", "--disable=metrics-server",
+			"--disable-scheduler", "--disable-cloud-controller", "--disable-kube-proxy", "--disable-network-policy",
+			"-o", "/output/" + K3sConfigFileName,
+		},
+		ExposedPorts: nat.PortSet{
+			natPort: {},
+		},
+		Volumes: map[string]struct{}{
+			fmt.Sprintf("%s:/output/", k3sOutFilesDir): {},
+		},
+	}
+
+	containerHostConfig := &container.HostConfig{
+		Privileged: true,
+		PortBindings: map[nat.Port][]nat.PortBinding{
+			natPort: {
+				{
+					HostIP: BindAddress,
+				},
+			},
+		},
+		Mounts: []mount.Mount{
+			{Source: k3sOutFilesDir, Target: "/output", Type: mount.TypeBind},
+		},
+	}
+
+	resp, err := cli.ContainerCreate(ctx, containerConfig, containerHostConfig, nil, nil, "")
+	if err != nil {
+		return nil, err
+	}
+
+	e.id = resp.ID
+
+	err = cli.ContainerStart(ctx, resp.ID, types.ContainerStartOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	var config *rest.Config
+
+	if err := wait.PollImmediate(1*time.Second, 10*time.Second, func() (bool, error) {
+		inspect, err := cli.ContainerInspect(ctx, resp.ID)
+		if err != nil {
+			return false, err
+		}
+
+		port, err := getContainerPort(inspect.NetworkSettings.Ports, natPort)
+		if err != nil {
+			fmt.Println(err)
+			return false, nil
+		}
+
+		config, err = clusterConfigFromPath(filepath.Join(k3sOutFilesDir, K3sConfigFileName))
+		if err != nil {
+			fmt.Println(err)
+			return false, nil
+		}
+
+		config.Host = fmt.Sprintf("https://localhost:%s", port)
+
+		kc, err := kclient.New(config, kclient.Options{})
+		if err != nil {
+			fmt.Println(err)
+			return false, nil
+		}
+
+		crds := apiextensionsv1.CustomResourceDefinitionList{}
+		if err := kc.List(ctx, &crds); err != nil {
+			fmt.Println(err)
+			return false, nil
+		}
+
+		return true, nil
+	}); err != nil {
+		return nil, err
+	}
+
+	_, err = crenvtest.InstallCRDs(config, envtest.CRDInstallOptions{
+		Paths: e.CRDDirectoryPaths,
+		// Scheme:             kube.CreateScheme(),
+		ErrorIfPathMissing: true,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed installing crds: %w", err)
+	}
+
+	return config, nil
+}
+
+// Stop the test environment.
+func (e *Environment) Stop() error {
+	ctx := context.Background()
+
+	_ = os.Remove(filepath.Join(getCallerDir(), K3sConfigFileName))
+
+	cli, err := client.NewEnvClient()
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("Removing k3s test container:", e.id)
+
+	err = cli.ContainerStop(ctx, e.id, nil)
+	if err != nil {
+		return err
+	}
+
+	return cli.ContainerRemove(ctx, e.id, types.ContainerRemoveOptions{
+		RemoveVolumes: true,
+		Force:         true,
+	})
+}
+
+func clusterConfigFromPath(path string) (*rest.Config, error) {
+	cfgLoadingRules := &clientcmd.ClientConfigLoadingRules{
+		ExplicitPath: path,
+	}
+
+	config, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(cfgLoadingRules, nil).ClientConfig()
+	if err != nil {
+		return nil, fmt.Errorf("could not create rest config: %w", err)
+	}
+
+	return config, nil
+}

--- a/pkg/testutils/testutils.go
+++ b/pkg/testutils/testutils.go
@@ -14,13 +14,16 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/onsi/gomega"
 	"github.com/weaveworks/weave-gitops/pkg/kube"
 	"github.com/weaveworks/weave-gitops/pkg/vendorfakes/fakelogr"
+	"golang.org/x/net/context"
 	"gopkg.in/square/go-jose.v2"
 	"gopkg.in/square/go-jose.v2/jwt"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/envtest"
 
 	kustomizev2 "github.com/fluxcd/kustomize-controller/api/v1beta2"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1beta1"
@@ -30,6 +33,7 @@ import (
 	"k8s.io/client-go/discovery"
 	memory "k8s.io/client-go/discovery/cached"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/restmapper"
 )
@@ -53,12 +57,17 @@ func StartK8sTestEnvironment(crdPaths []string) (*K8sTestEnv, error) {
 		return k8sEnv, nil
 	}
 
-	testEnv := &envtest.Environment{
+	testEnv := Environment{
 		CRDDirectoryPaths: crdPaths,
-		CRDInstallOptions: envtest.CRDInstallOptions{
-			CleanUpAfterUse: false,
-		},
 	}
+
+	// testEnv := &envtest.Environment{
+	// 	CRDDirectoryPaths: crdPaths,
+	// 	CRDInstallOptions: envtest.CRDInstallOptions{
+	// 		CleanUpAfterUse:    false,
+	// 		ErrorIfPathMissing: true,
+	// 	},
+	// }
 
 	var err error
 	cfg, err := testEnv.Start()
@@ -105,8 +114,13 @@ func StartK8sTestEnvironment(crdPaths []string) (*K8sTestEnv, error) {
 		return nil, fmt.Errorf("failed to initialize dynamic client: %s", err)
 	}
 
+	kc, err := client.New(cfg, client.Options{Scheme: kube.CreateScheme()})
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize client: %s", err)
+	}
+
 	k8sEnv = &K8sTestEnv{
-		Client:     k8sManager.GetClient(),
+		Client:     kc,
 		DynClient:  dyn,
 		RestMapper: mapper,
 		Rest:       cfg,
@@ -119,6 +133,76 @@ func StartK8sTestEnvironment(crdPaths []string) (*K8sTestEnv, error) {
 	}
 
 	return k8sEnv, nil
+}
+
+func CleanupAllResources(g *gomega.GomegaWithT, obj client.Object) {
+	ctx := context.Background()
+
+	nss := &corev1.NamespaceList{}
+	g.Expect(k8sEnv.Client.List(ctx, nss)).To(gomega.Succeed())
+
+	for _, ns := range nss.Items {
+		g.Expect(k8sEnv.Client.DeleteAllOf(ctx, obj, client.InNamespace(ns.Name))).To(gomega.Succeed())
+	}
+}
+
+func DeleteNamespace(g *gomega.GomegaWithT, ns *corev1.Namespace) {
+	// Code borrowed from controller-runtime: https://github.com/kubernetes-sigs/controller-runtime/blob/eb39b8eb28cfe920fa2450eb38f814fc9e8003e8/pkg/client/client_test.go#L51
+	clientset, err := kubernetes.NewForConfig(k8sEnv.Rest)
+	g.Expect(err).To(gomega.BeNil())
+
+	ctx := context.Background()
+
+	ns, err = clientset.CoreV1().Namespaces().Get(ctx, ns.Name, metav1.GetOptions{})
+	if err != nil {
+		return
+	}
+
+	err = clientset.CoreV1().Namespaces().Delete(ctx, ns.Name, metav1.DeleteOptions{})
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	// finalize if necessary
+	pos := -1
+	finalizers := ns.Spec.Finalizers
+
+	for i, fin := range finalizers {
+		if fin == "kubernetes" {
+			pos = i
+			break
+		}
+	}
+
+	if pos == -1 {
+		// no need to finalize
+		return
+	}
+
+	// re-get in order to finalize
+	ns, err = clientset.CoreV1().Namespaces().Get(ctx, ns.Name, metav1.GetOptions{})
+	if err != nil {
+		return
+	}
+
+	ns.Spec.Finalizers = append(finalizers[:pos], finalizers[pos+1:]...)
+	_, err = clientset.CoreV1().Namespaces().Finalize(ctx, ns, metav1.UpdateOptions{})
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+WAIT_LOOP:
+	for i := 0; i < 10; i++ {
+		ns, err = clientset.CoreV1().Namespaces().Get(ctx, ns.Name, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			// success!
+			return
+		}
+		select {
+		case <-ctx.Done():
+			break WAIT_LOOP
+			// failed to delete in time, see failure below
+		case <-time.After(100 * time.Millisecond):
+			// do nothing, try again
+		}
+	}
+	g.Fail(fmt.Sprintf("timed out waiting for namespace %q to be deleted", ns.Name))
 }
 
 // MakeFakeLogr returns an API compliant logr object that can be used for unit testing.


### PR DESCRIPTION
This is a Spike on using a real cluster instead of `envtest`. The initial push for it was that we were unable to clean up resources on our tests but it turned out we actually can. 

Deleting things like `kustomization` happens normally, in the case of Namespaces there is a special way to do it, the function for it has been added to this PR. I got it from the `controller-runtime` source code.

I have no intent on merging it since we don't need to use anything different than what we have it already.

I'm pushing it anyway to have it as a reference if we ever need to do something like this in the future.