### PR TITLE
release: Thread release notes into the PR, too

### DIFF
--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -70,7 +70,20 @@ jobs:
 
           git commit -am "Update helm chart to $NEW_CHART_VERSION to use gitops $GITOPS_VERSION"
         if: ${{ !contains(github.event.inputs.version, '-') }}
-
+      - name: Set tag for building changelog
+        run: |
+          git config user.name weave-gitops-bot
+          git config user.email weave-gitops-bot@weave.works
+          git tag -a ${{ github.event.inputs.version }} -m ${{ github.event.inputs.version }}
+          # Do not push tag - we'll push it when approved
+      - name: Build Changelog
+        id: github_release
+        uses: mikepenz/release-changelog-builder-action@v3
+        with:
+          configuration: "${{ github.workspace }}/.github/changelog/changelog_configuration.json"
+          ignorePreReleases: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create Pull Request
         id: create-pull-request
         uses: peter-evans/create-pull-request@v4
@@ -81,6 +94,27 @@ jobs:
           branch: ${{ env.BRANCH }}
           base: main
           title: "Updates for ${{ env.GITOPS_VERSION }}"
-          body: "Update version references to ${{ env.GITOPS_VERSION }}"
+          body: |
+           Breaking changes: Describe any breaking changes here, or delete this block
+
+           Action required: Describe any user facing actions here, or delete this block.
+
+           Features and improvements: Describe any user facing changes here, or delete this block.
+
+           Examples of user facing changes:
+             - API changes
+             - Bug fixes
+             - Any changes in behaviour
+             - Changes requiring upgrade notices or deprecation warning
+           ${{ steps.github_release.outputs.changelog }}
           token: ${{ secrets.WEAVE_GITOPS_BOT_ACCESS_TOKEN }}
           labels: "exclude from release notes"
+      - name: "Comment on pull request"
+        run: |
+          curl --request POST \
+            --url https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.create-pull-request.outputs.pull-request-number }}/comments \
+            --header 'authorization: Bearer ${{ secrets.WEAVE_GITOPS_BOT_ACCESS_TOKEN }}' \
+            --header 'content-type: application/json' \
+            --data '{
+                "body": "To change the release notes, edit the pull request description. As soon as you approve the PR, the release will start, and will be automatically merged when finished"
+              }'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -59,18 +59,14 @@ jobs:
         run: make all
       - name: Check Git State
         run: git diff --no-ext-diff --exit-code
-      - name: Build Changelog
-        id: github_release
-        uses: mikepenz/release-changelog-builder-action@v1
-        with:
-          configuration: "${{ github.workspace }}/.github/changelog/changelog_configuration.json"
-          outputFile: "${{ runner.temp }}/changelog.md"
-          ignorePreReleases: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Include brew publishing
         run: cat .goreleaser.brew.yml >> .goreleaser.yml
         if: ${{ !contains(github.event.pull_request.head.ref, '-') }}
+      - name: Store changelog
+        run: |
+          echo > ${{ runner.temp }}/changelog.md <<END_OF_CHANGELOG
+          ${{ github.event.pull_request.body }}
+          END_OF_CHANGELOG
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v1
         with:


### PR DESCRIPTION
This puts the release notes into the PR body, so it can be edited
before the release happens. This lets us work on general advice on
e.g. breaking changes, without having to edit the release after it's
already been published. While not massively awful to have to make a
    manual change, we ought to want to auto-publish the release to
    e.g. social networks or even email, which means it's better to publish
    the right thing in the first place.