### PR TITLE
Waiting the initial load of clusters

### DIFF
--- a/core/clustersmngr/factory.go
+++ b/core/clustersmngr/factory.go
@@ -74,12 +74,16 @@ func (cf *clientsFactory) Start(ctx context.Context) {
 }
 
 func (cf *clientsFactory) watchClusters(ctx context.Context) {
+	if err := cf.UpdateClusters(ctx); err != nil {
+		cf.log.Error(err, "failed updating clusters")
+	}
+
+	cf.initialClustersLoad <- true
+
 	if err := wait.PollImmediateInfinite(watchClustersFrequency, func() (bool, error) {
 		if err := cf.UpdateClusters(ctx); err != nil {
 			return false, err
 		}
-
-		cf.initialClustersLoad <- true
 
 		return false, nil
 	}); err != nil {


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes

<!-- Describe what has changed in this PR -->
**What changed?**
Waits for the initial load of clusters. Since we fire both, namespaces and clusters go routines to watch for changes, the namespace one can execute before the initial load of clusters, resulting in a empty namespace list for about 30 seconds until the next time it runs.

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**


<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**


<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**


<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**


<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
