### PR TITLE
plumb parameter values through the helm chart values file

### DIFF
--- a/charts/gitops-server/Chart.yaml
+++ b/charts/gitops-server/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.3
+version: 2.0.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/gitops-server/templates/deployment.yaml
+++ b/charts/gitops-server/templates/deployment.yaml
@@ -36,9 +36,9 @@ spec:
             - "{{ .Values.logLevel }}"
             {{- if .Values.serverTLS.enable }}
             - "--tls-cert-file"
-            - {{ .Values.TLSCertFile }}
+            - "/etc/tls-volume/tls.crt"
             - "--tls-private-key-file"
-            - {{ .Values.TLSKeyFile }}
+            - "/etc/tls-volume/tls.key"
             {{- else }}
             - "--insecure"
             {{- end }}
@@ -59,35 +59,29 @@ spec:
             httpGet:
               path: /
               port: http
-          {{- if or .Values.enableLogin .Values.envVars}}
           env:
-            - name: PROFILE_CACHE_LOCATION
-              value: {{ .Values.profileCacheLocation }}
-            - name: NOTIFICATION_CONTROLLER_ADDRESS
-              value: {{ .Values.notificationControllerAddress }}
             - name: WATCHER_PORT
               value: {{ .Values.watcherPort }}
+          {{- if .Values.OIDC.enable }}
+          {{- with .Values.OIDC }}
             - name: OIDC_ISSUER_URL
-              value: {{ .Values.OIDCIssuerURL }}
+              value: {{ .issuerURL }}
             - name: OIDC_CLIENT_ID
-              value: {{ .Values.OIDCClientID }}
+              value: {{ .clientID }}
             - name: OIDC_CLIENT_SECRET
-              value: {{ .Values.OIDCClientSecret }}
+              value: {{ .clientSecret }}
             - name: OIDC_REDIRECT_URL
-              value: {{ .Values.OIDCRedirectURL }}
+              value: {{ .redirectURL }}
             - name: OIDC_TOKEN_DURATION
-              value: {{ .Values.OIDCTokenDuration }}
-            - name: DEV_MODE
-              value: {{ .Values.DEV_MODE }}
-            - name: DEV_USER
-              value: {{ .Values.DEV_USER }}
+              value: {{ .tokenDuration }}
+          {{- end }}
+          {{- end }}
           {{- if .Values.enableLogin }}
             - name: WEAVE_GITOPS_AUTH_ENABLED
               value: "true"
           {{- end }}
           {{- with .Values.envVars }}
             {{- toYaml . | nindent 12 }}
-          {{- end }}
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/gitops-server/templates/deployment.yaml
+++ b/charts/gitops-server/templates/deployment.yaml
@@ -63,10 +63,6 @@ spec:
           env:
             - name: PROFILE_CACHE_LOCATION
               value: {{ .Values.profileCacheLocation }}
-            - name: HEALTHZ_BIND_ADDRESS
-              value: {{ .Values.watcherHealthzBindAddress }}
-            - name: METRICS_BIND_ADDRESS
-              value: {{ .Values.watcherMetricsBindAddress }}
             - name: NOTIFICATION_CONTROLLER_ADDRESS
               value: {{ .Values.notificationControllerAddress }}
             - name: WATCHER_PORT

--- a/charts/gitops-server/templates/deployment.yaml
+++ b/charts/gitops-server/templates/deployment.yaml
@@ -62,20 +62,6 @@ spec:
           env:
             - name: WATCHER_PORT
               value: {{ .Values.watcherPort }}
-          {{- if .Values.OIDC.enable }}
-          {{- with .Values.OIDC }}
-            - name: OIDC_ISSUER_URL
-              value: {{ .issuerURL }}
-            - name: OIDC_CLIENT_ID
-              value: {{ .clientID }}
-            - name: OIDC_CLIENT_SECRET
-              value: {{ .clientSecret }}
-            - name: OIDC_REDIRECT_URL
-              value: {{ .redirectURL }}
-            - name: OIDC_TOKEN_DURATION
-              value: {{ .tokenDuration }}
-          {{- end }}
-          {{- end }}
           {{- if .Values.enableLogin }}
             - name: WEAVE_GITOPS_AUTH_ENABLED
               value: "true"

--- a/charts/gitops-server/templates/deployment.yaml
+++ b/charts/gitops-server/templates/deployment.yaml
@@ -36,9 +36,9 @@ spec:
             - "{{ .Values.logLevel }}"
             {{- if .Values.serverTLS.enable }}
             - "--tls-cert-file"
-            - "/etc/tls-volume/tls.crt"
+            - {{ .Values.TLSCertFile }}
             - "--tls-private-key-file"
-            - "/etc/tls-volume/tls.key"
+            - {{ .Values.TLSKeyFile }}
             {{- else }}
             - "--insecure"
             {{- end }}
@@ -49,7 +49,7 @@ spec:
           {{- end }}
           ports:
             - name: http
-              containerPort: 9001
+              containerPort: {{ .Values.port }}
               protocol: TCP
           livenessProbe:
             httpGet:
@@ -61,6 +61,30 @@ spec:
               port: http
           {{- if or .Values.enableLogin .Values.envVars}}
           env:
+            - name: PROFILE_CACHE_LOCATION
+              value: {{ .Values.profileCacheLocation }}
+            - name: HEALTHZ_BIND_ADDRESS
+              value: {{ .Values.watcherHealthzBindAddress }}
+            - name: METRICS_BIND_ADDRESS
+              value: {{ .Values.watcherMetricsBindAddress }}
+            - name: NOTIFICATION_CONTROLLER_ADDRESS
+              value: {{ .Values.notificationControllerAddress }}
+            - name: WATCHER_PORT
+              value: {{ .Values.watcherPort }}
+            - name: OIDC_ISSUER_URL
+              value: {{ .Values.OIDCIssuerURL }}
+            - name: OIDC_CLIENT_ID
+              value: {{ .Values.OIDCClientID }}
+            - name: OIDC_CLIENT_SECRET
+              value: {{ .Values.OIDCClientSecret }}
+            - name: OIDC_REDIRECT_URL
+              value: {{ .Values.OIDCRedirectURL }}
+            - name: OIDC_TOKEN_DURATION
+              value: {{ .Values.OIDCTokenDuration }}
+            - name: DEV_MODE
+              value: {{ .Values.DEV_MODE }}
+            - name: DEV_USER
+              value: {{ .Values.DEV_USER }}
           {{- if .Values.enableLogin }}
             - name: WEAVE_GITOPS_AUTH_ENABLED
               value: "true"

--- a/charts/gitops-server/values.yaml
+++ b/charts/gitops-server/values.yaml
@@ -18,25 +18,10 @@ logLevel: info
 # IP address of UI host
 host: "0.0.0.0"
 # UI port
-# The address of the notification-controller running in the cluster
-notificationControllerAddress: ""
 # The port on which the watcher is running
 watcherPort: 9443
 # Do not enforce mTLS
 MTLS: false
-
-# OIDC
-OIDC:
-  # The URL of the OpenID Connect issuer
-  issuerURL: ""
-  # The client ID for the OpenID Connect client
-  clientID: ""
-  # The client secret to use with the OpenID Connect issuer
-  clientSecret: ""
-  # The OAuth2 redirect URL
-  redirectURL: ""
-  # The duration of the ID token. It should be set in the format: number + time unit (s,m,h) e.g., 20m
-  tokenDuration: "60m"
 
 # Additional arguments to pass in
 # additionalArgs:

--- a/charts/gitops-server/values.yaml
+++ b/charts/gitops-server/values.yaml
@@ -18,15 +18,6 @@ logLevel: info
 # IP address of UI host
 host: "0.0.0.0"
 # UI port
-port: "9001"
-# The name of the Helm Repository resource to scan for profiles
-helmRepoName: "weaveworks-charts"
-# The location where the cached Profile data lives
-profileCacheLocation: "/tmp/helm-cache"
-# The bind address for the healthz service of the watcher
-watcherHealhzBindAddress: ":9981"
-# The bind address for the metrics service of the watcher
-watcherMetricsBindAddress: ":9980"
 # The address of the notification-controller running in the cluster
 notificationControllerAddress: ""
 # The port on which the watcher is running

--- a/charts/gitops-server/values.yaml
+++ b/charts/gitops-server/values.yaml
@@ -31,22 +31,21 @@ watcherMetricsBindAddress: ":9980"
 notificationControllerAddress: ""
 # The port on which the watcher is running
 watcherPort: 9443
-# Filename for the TLS certificate, in-memory generated if omitted
-TLSCertFile: "/etc/tls-volume/tls.crt"
-# Filename for the TLS key, in-memory generated if omitted
-TLSKeyFile: "/etc/tls-volume/tls.key"
 # Do not enforce mTLS
 MTLS: false
-# The URL of the OpenID Connect issuer
-OIDCIssuerURL: ""
-# The client ID for the OpenID Connect client
-OIDCClientID: ""
-# The client secret to use with the OpenID Connect issuer
-OIDCClientSecret: ""
-# The OAuth2 redirect URL
-OIDCRedirectURL: ""
-# The duration of the ID token. It should be set in the format: number + time unit (s,m,h) e.g., 20m
-OIDCTokenDuration: "60m"
+
+# OIDC
+OIDC:
+  # The URL of the OpenID Connect issuer
+  issuerURL: ""
+  # The client ID for the OpenID Connect client
+  clientID: ""
+  # The client secret to use with the OpenID Connect issuer
+  clientSecret: ""
+  # The OAuth2 redirect URL
+  redirectURL: ""
+  # The duration of the ID token. It should be set in the format: number + time unit (s,m,h) e.g., 20m
+  tokenDuration: "60m"
 
 # Additional arguments to pass in
 # additionalArgs:

--- a/charts/gitops-server/values.yaml
+++ b/charts/gitops-server/values.yaml
@@ -15,6 +15,39 @@ fullnameOverride: ""
 enableLogin: true
 # valid levels are 'debug', 'info', 'warn' and 'error'
 logLevel: info
+# IP address of UI host
+host: "0.0.0.0"
+# UI port
+port: "9001"
+# The name of the Helm Repository resource to scan for profiles
+helmRepoName: "weaveworks-charts"
+# The location where the cached Profile data lives
+profileCacheLocation: "/tmp/helm-cache"
+# The bind address for the healthz service of the watcher
+watcherHealhzBindAddress: ":9981"
+# The bind address for the metrics service of the watcher
+watcherMetricsBindAddress: ":9980"
+# The address of the notification-controller running in the cluster
+notificationControllerAddress: ""
+# The port on which the watcher is running
+watcherPort: 9443
+# Filename for the TLS certificate, in-memory generated if omitted
+TLSCertFile: "/etc/tls-volume/tls.crt"
+# Filename for the TLS key, in-memory generated if omitted
+TLSKeyFile: "/etc/tls-volume/tls.key"
+# Do not enforce mTLS
+MTLS: false
+# The URL of the OpenID Connect issuer
+OIDCIssuerURL: ""
+# The client ID for the OpenID Connect client
+OIDCClientID: ""
+# The client secret to use with the OpenID Connect issuer
+OIDCClientSecret: ""
+# The OAuth2 redirect URL
+OIDCRedirectURL: ""
+# The duration of the ID token. It should be set in the format: number + time unit (s,m,h) e.g., 20m
+OIDCTokenDuration: "60m"
+
 # Additional arguments to pass in
 # additionalArgs:
 # Any other environment variables:

--- a/cmd/gitops-server/cmd/cmd.go
+++ b/cmd/gitops-server/cmd/cmd.go
@@ -73,11 +73,7 @@ func NewCommand() *cobra.Command {
 	cmd.Flags().StringVar(&options.Path, "path", "", "Path url")
 	cmd.Flags().StringVar(&options.HelmRepoNamespace, "helm-repo-namespace", "default", "the namespace of the Helm Repository resource to scan for profiles")
 	cmd.Flags().StringVar(&options.HelmRepoName, "helm-repo-name", "weaveworks-charts", "the name of the Helm Repository resource to scan for profiles")
-	cmd.Flags().StringVar(&options.ProfileCacheLocation, "profile-cache-location", defaultedEnvVar("PROFILE_CACHE_LOCATION", "/tmp/helm-cache"), "the location where the cache Profile data lives")
-	cmd.Flags().StringVar(&options.WatcherHealthzBindAddress, "watcher-healthz-bind-address", defaultedEnvVar("HEALTHZ_BIND_ADDRESS", ":9981"), "bind address for the healthz service of the watcher")
-	cmd.Flags().StringVar(&options.WatcherMetricsBindAddress, "watcher-metrics-bind-address", defaultedEnvVar("METRICS_BIND_ADDRESS", ":9980"), "bind address for the metrics service of the watcher")
 	cmd.Flags().StringVar(&options.NotificationControllerAddress, "notification-controller-address", os.Getenv("NOTIFICATION_CONTROLLER_ADDRESS"), "the address of the notification-controller running in the cluster")
-	cmd.Flags().IntVar(&options.WatcherPort, "watcher-port", defaultedIntEnvVar("WATCHER_PORT", 9443), "the port on which the watcher is running")
 
 	cmd.Flags().StringVar(&options.TLSCertFile, "tls-cert-file", "", "filename for the TLS certificate, in-memory generated if omitted")
 	cmd.Flags().StringVar(&options.TLSKeyFile, "tls-private-key-file", "", "filename for the TLS key, in-memory generated if omitted")

--- a/cmd/gitops-server/cmd/cmd.go
+++ b/cmd/gitops-server/cmd/cmd.go
@@ -41,20 +41,19 @@ const (
 
 // Options contains all the options for the gitops-server command.
 type Options struct {
-	Port                          string
-	Host                          string
-	HelmRepoNamespace             string
-	HelmRepoName                  string
-	Path                          string
-	LogLevel                      string
-	OIDC                          auth.OIDCConfig
-	NotificationControllerAddress string
-	TLSCertFile                   string
-	TLSKeyFile                    string
-	Insecure                      bool
-	MTLS                          bool
-	DevMode                       bool
-	DevUser                       string
+	Port              string
+	Host              string
+	HelmRepoNamespace string
+	HelmRepoName      string
+	Path              string
+	LogLevel          string
+	TLSCertFile       string
+	TLSKeyFile        string
+	Insecure          bool
+	MTLS              bool
+	OIDC              auth.OIDCConfig
+	DevMode           bool
+	DevUser           string
 }
 
 var options Options
@@ -73,7 +72,6 @@ func NewCommand() *cobra.Command {
 	cmd.Flags().StringVar(&options.Path, "path", "", "Path url")
 	cmd.Flags().StringVar(&options.HelmRepoNamespace, "helm-repo-namespace", "default", "the namespace of the Helm Repository resource to scan for profiles")
 	cmd.Flags().StringVar(&options.HelmRepoName, "helm-repo-name", "weaveworks-charts", "the name of the Helm Repository resource to scan for profiles")
-	cmd.Flags().StringVar(&options.NotificationControllerAddress, "notification-controller-address", os.Getenv("NOTIFICATION_CONTROLLER_ADDRESS"), "the address of the notification-controller running in the cluster")
 
 	cmd.Flags().StringVar(&options.TLSCertFile, "tls-cert-file", "", "filename for the TLS certificate, in-memory generated if omitted")
 	cmd.Flags().StringVar(&options.TLSKeyFile, "tls-private-key-file", "", "filename for the TLS key, in-memory generated if omitted")

--- a/cmd/gitops-server/cmd/cmd.go
+++ b/cmd/gitops-server/cmd/cmd.go
@@ -86,8 +86,8 @@ func NewCommand() *cobra.Command {
 	cmd.Flags().StringVar(&options.OIDC.RedirectURL, "oidc-redirect-url", "", "The OAuth2 redirect URL")
 	cmd.Flags().DurationVar(&options.OIDC.TokenDuration, "oidc-token-duration", defaultedDurationEnvVar("OIDC_TOKEN_DURATION", time.Hour), "The duration of the ID token. It should be set in the format: number + time unit (s,m,h) e.g., 20m")
 
-	cmd.Flags().BoolVar(&options.DevMode, "dev-mode", defaultedBoolEnvVar("DEV_MODE", false), "Enables development mode")
-	cmd.Flags().StringVar(&options.DevUser, "dev-user", defaultedEnvVar("DEV_USER", v1alpha1.DefaultClaimsSubject), "Sets development User")
+	cmd.Flags().BoolVar(&options.DevMode, "dev-mode", false, "Enables development mode")
+	cmd.Flags().StringVar(&options.DevUser, "dev-user", v1alpha1.DefaultClaimsSubject, "Sets development User")
 
 	return cmd
 }

--- a/cmd/gitops-server/cmd/cmd.go
+++ b/cmd/gitops-server/cmd/cmd.go
@@ -351,18 +351,6 @@ func defaultedDurationEnvVar(name string, defaultVal time.Duration) time.Duratio
 	return defaultVal
 }
 
-func defaultedIntEnvVar(name string, defaultVal int) int {
-	val, found := os.LookupEnv(name)
-
-	if found {
-		if ival, err := strconv.Atoi(val); err == nil {
-			return ival
-		}
-	}
-
-	return defaultVal
-}
-
 func defaultedBoolEnvVar(name string, defaultVal bool) bool {
 	val, found := os.LookupEnv(name)
 

--- a/cmd/gitops-server/cmd/cmd.go
+++ b/cmd/gitops-server/cmd/cmd.go
@@ -329,16 +329,6 @@ func createRedirector(fsys fs.FS, log logr.Logger) http.HandlerFunc {
 	}
 }
 
-func defaultedEnvVar(name, defaultVal string) string {
-	val, found := os.LookupEnv(name)
-
-	if found {
-		return val
-	}
-
-	return defaultVal
-}
-
 func defaultedDurationEnvVar(name string, defaultVal time.Duration) time.Duration {
 	val, found := os.LookupEnv(name)
 


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes #1784

<!-- Describe what has changed in this PR -->
**What changed?**
All parameters for the gitops-server that make sense to pass via a values file have been added to the helm chart. The OIDC values were left out because the OIDC auth info would have to be stored in a secret which is redundant. The OIDC values are used in the code to generate a client secret and there seems to be no reason to force users to create _two_ secrets.


<!-- Tell your future self why have you made these changes -->
**Why was this change made?**
To allow full customization when installing from a helm chart

<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**
Local manual testing

<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**
No

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
No