### PR TITLE
Adding testutils methods to delete resources

### DIFF
--- a/pkg/testutils/testutils.go
+++ b/pkg/testutils/testutils.go
@@ -236,7 +236,7 @@ func DeleteAllOf(g *gomega.GomegaWithT, obj client.Object) {
 }
 
 // DeleteNamespace deletes a namespace.
-// Note: deleting a namespace using function on tests wont delete the underlying resources
+// Note: deleting a namespace using this function on tests wont delete the underlying resources
 // like in a real environment would.
 func DeleteNamespace(g *gomega.GomegaWithT, ns *corev1.Namespace) {
 	// Code borrowed from controller-runtime: https://github.com/kubernetes-sigs/controller-runtime/blob/eb39b8eb28cfe920fa2450eb38f814fc9e8003e8/pkg/client/client_test.go#L51

--- a/pkg/testutils/testutils.go
+++ b/pkg/testutils/testutils.go
@@ -1,6 +1,7 @@
 package testutils
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/json"
@@ -24,12 +25,16 @@ import (
 
 	kustomizev2 "github.com/fluxcd/kustomize-controller/api/v1beta2"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1beta2"
+	"github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/discovery"
 	memory "k8s.io/client-go/discovery/cached"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/restmapper"
 )
@@ -216,4 +221,78 @@ func MakeKeysetServer(t *testing.T, key *rsa.PrivateKey) *httptest.Server {
 	t.Cleanup(ts.Close)
 
 	return ts
+}
+
+// DeleteAllOf loops through all namespaces and deletes all resources from the given type
+func DeleteAllOf(g *gomega.GomegaWithT, obj client.Object) {
+	ctx := context.Background()
+
+	nss := &corev1.NamespaceList{}
+	g.Expect(k8sEnv.Client.List(ctx, nss)).To(gomega.Succeed())
+
+	for _, ns := range nss.Items {
+		g.Expect(k8sEnv.Client.DeleteAllOf(ctx, obj, client.InNamespace(ns.Name))).To(gomega.Succeed())
+	}
+}
+
+// DeleteNamespace deletes a namespace.
+// Note: deleting a namespace using function on tests wont delete the underlying resources
+// like in a real environment would.
+func DeleteNamespace(g *gomega.GomegaWithT, ns *corev1.Namespace) {
+	// Code borrowed from controller-runtime: https://github.com/kubernetes-sigs/controller-runtime/blob/eb39b8eb28cfe920fa2450eb38f814fc9e8003e8/pkg/client/client_test.go#L51
+	clientset, err := kubernetes.NewForConfig(k8sEnv.Rest)
+	g.Expect(err).To(gomega.BeNil())
+
+	ctx := context.Background()
+
+	ns, err = clientset.CoreV1().Namespaces().Get(ctx, ns.Name, metav1.GetOptions{})
+	if err != nil {
+		return
+	}
+
+	err = clientset.CoreV1().Namespaces().Delete(ctx, ns.Name, metav1.DeleteOptions{})
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	// finalize if necessary
+	pos := -1
+	finalizers := ns.Spec.Finalizers
+
+	for i, fin := range finalizers {
+		if fin == "kubernetes" {
+			pos = i
+			break
+		}
+	}
+
+	if pos == -1 {
+		// no need to finalize
+		return
+	}
+
+	// re-get in order to finalize
+	ns, err = clientset.CoreV1().Namespaces().Get(ctx, ns.Name, metav1.GetOptions{})
+	if err != nil {
+		return
+	}
+
+	ns.Spec.Finalizers = append(finalizers[:pos], finalizers[pos+1:]...)
+	_, err = clientset.CoreV1().Namespaces().Finalize(ctx, ns, metav1.UpdateOptions{})
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+WAIT_LOOP:
+	for i := 0; i < 10; i++ {
+		ns, err = clientset.CoreV1().Namespaces().Get(ctx, ns.Name, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			// success!
+			return
+		}
+		select {
+		case <-ctx.Done():
+			break WAIT_LOOP
+			// failed to delete in time, see failure below
+		case <-time.After(100 * time.Millisecond):
+			// do nothing, try again
+		}
+	}
+	g.Fail(fmt.Sprintf("timed out waiting for namespace %q to be deleted", ns.Name))
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
While I was spiking on adding a full-blown cluster to our tests in an attempt to be able to delete resources, I realize we are actually capable of doing that right now. 

We probably were lead to believe we couldn't because we tried to delete `Namespaces`, and that is a special case that needs to be handled differently, I've found on the `controller-runtime` source code how to do it, so I added that to our repo.

Not all tests need to have a clean state, but if the ones you are working on need, make use of `testutils.DeleteAllOf` to delete all resources of a given type and `testutils.DeleteNamespace` to delete a single namespace.

