### PR TITLE
Deploy new chart and docs for new release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -149,7 +149,7 @@ jobs:
         run: |
           curl --request PUT \
             --url https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/merge \
-            --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+            --header 'authorization: Bearer ${{ secrets.WEAVE_GITOPS_BOT_ACCESS_TOKEN }}' \
             --header 'content-type: application/json' \
             --data '{
                 "merge_method": "merge"

--- a/charts/gitops-server/Chart.yaml
+++ b/charts/gitops-server/Chart.yaml
@@ -10,10 +10,12 @@ description: Weave Gitops is a set of tools and services to aid your interaction
 # a dependency of application charts to inject those utilities and functions into the rendering
 # pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
+
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 version: 2.0.2
+
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/tools/update-docs.sh
+++ b/tools/update-docs.sh
@@ -11,7 +11,7 @@ yarn install
 sed -i
 ex - installation.mdx << EOS
 /download\/
-%s,download/\([^/]*\)/,download/${GITOPS_VERSION}/,
+%s,download/\([^/]*\)/,download/v${GITOPS_VERSION}/,
 /Current Version
 .,+3! ${WEAVE_GITOPS_BINARY} version
 wq!

--- a/website/docs/installation.mdx
+++ b/website/docs/installation.mdx
@@ -72,7 +72,7 @@ Windows support is a [planned enhancement](https://github.com/weaveworks/weave-g
 To install the `gitops` CLI, please follow the following steps:
 
 ```console
-curl --silent --location "https://github.com/weaveworks/weave-gitops/releases/download/0.8.0/gitops-$(uname)-$(uname -m).tar.gz" | tar xz -C /tmp
+curl --silent --location "https://github.com/weaveworks/weave-gitops/releases/download/v0.8.0/gitops-$(uname)-$(uname -m).tar.gz" | tar xz -C /tmp
 sudo mv /tmp/gitops /usr/local/bin
 gitops version
 ```

--- a/website/versioned_docs/version-0.8.0/installation.mdx
+++ b/website/versioned_docs/version-0.8.0/installation.mdx
@@ -72,7 +72,7 @@ Windows support is a [planned enhancement](https://github.com/weaveworks/weave-g
 To install the `gitops` CLI, please follow the following steps:
 
 ```console
-curl --silent --location "https://github.com/weaveworks/weave-gitops/releases/download/0.8.0/gitops-$(uname)-$(uname -m).tar.gz" | tar xz -C /tmp
+curl --silent --location "https://github.com/weaveworks/weave-gitops/releases/download/v0.8.0/gitops-$(uname)-$(uname -m).tar.gz" | tar xz -C /tmp
 sudo mv /tmp/gitops /usr/local/bin
 gitops version
 ```


### PR DESCRIPTION
I had a bug in my release merge step - it wasn't triggering a deploy of docs & helm chart, because it wasn't using an external github token, and github actions can't trigger other actions through its actions.

This adds some newlines to the chart to get that deployed, and I found a bug in the CLI installation instructions (again!) which I fixed the cause of and then I fixed the docs.