### PR TITLE
feat: ClusterRole for default user

### DIFF
--- a/charts/gitops-server/templates/admin-user.yaml
+++ b/charts/gitops-server/templates/admin-user.yaml
@@ -44,6 +44,45 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["get", "watch", "list"]
+{{- if .Values.adminUser.createClusterRole }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: wego-test-user-read-resources-cr
+subjects:
+- kind: User
+  name: wego-admin
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: wego-admin-cluster-role
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: wego-admin-cluster-role
+rules:
+  - apiGroups: [""]
+    resources: ["secrets", "pods" ]
+    verbs: [ "get", "list" ]
+  - apiGroups: ["apps"]
+    resources: [ "deployments", "replicasets"]
+    verbs: [ "get", "list" ]
+  - apiGroups: ["kustomize.toolkit.fluxcd.io"]
+    resources: [ "kustomizations" ]
+    verbs: [ "get", "list", "patch" ]
+  - apiGroups: ["helm.toolkit.fluxcd.io"]
+    resources: [ "helmreleases" ]
+    verbs: [ "get", "list", "patch" ]
+  - apiGroups: ["source.toolkit.fluxcd.io"]
+    resources: [ "buckets", "helmcharts", "gitrepositories", "helmrepositories" ]
+    verbs: [ "get", "list", "patch" ]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "watch", "list"]
+{{- end }}
 {{- if .Values.adminUser.createSecret }}
 ---
 apiVersion: v1

--- a/charts/gitops-server/values.yaml
+++ b/charts/gitops-server/values.yaml
@@ -44,6 +44,9 @@ adminUser:
   # Whether the wego-admin user should be created.
   # If you use this make sure you add it to rbac.impersonationResourceNames.
   create: false
+  # Specifies whether the clusterRole & binding to the admin user should be created.
+  # Will be created only if adminUser.crete is enabled.
+  createClusterRole: true
   createSecret: true
   # Set the username and password, these will be stored in a secret in k8s.
   username: gitops-test-user

--- a/charts/gitops-server/values.yaml
+++ b/charts/gitops-server/values.yaml
@@ -45,7 +45,7 @@ adminUser:
   # If you use this make sure you add it to rbac.impersonationResourceNames.
   create: false
   # Specifies whether the clusterRole & binding to the admin user should be created.
-  # Will be created only if adminUser.crete is enabled.
+  # Will be created only if adminUser.create is enabled.
   createClusterRole: true
   createSecret: true
   # Set the username and password, these will be stored in a secret in k8s.

--- a/website/docs/configuration/securing-access-to-the-dashboard.mdx
+++ b/website/docs/configuration/securing-access-to-the-dashboard.mdx
@@ -158,6 +158,48 @@ rules:
     resourceNames: ["weaveworks-charts"]
 ```
 
+To access all resources in all namespaces, with the same permissions, a
+ClusterRole has to be defined and bound to the user:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: wego-admin-cluster-role
+rules:
+  - apiGroups: [""]
+    resources: ["secrets", "pods" ]
+    verbs: [ "get", "list" ]
+  - apiGroups: ["apps"]
+    resources: [ "deployments", "replicasets"]
+    verbs: [ "get", "list" ]
+  - apiGroups: ["kustomize.toolkit.fluxcd.io"]
+    resources: [ "kustomizations" ]
+    verbs: [ "get", "list", "patch" ]
+  - apiGroups: ["helm.toolkit.fluxcd.io"]
+    resources: [ "helmreleases" ]
+    verbs: [ "get", "list", "patch" ]
+  - apiGroups: ["source.toolkit.fluxcd.io"]
+    resources: [ "buckets", "helmcharts", "gitrepositories", "helmrepositories" ]
+    verbs: [ "get", "list", "patch" ]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "watch", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: wego-test-user-read-resources-cr
+subjects:
+- kind: User
+  name: wego-admin
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: wego-admin-cluster-role
+  apiGroup: rbac.authorization.k8s.io
+```
+
 The following role represents the minimal set of permissions needed to add applications from the dashboard:
 
 ```yaml title="apps-writer.yaml"


### PR DESCRIPTION
It's created by default if `adminUser.create` is true, but can be turned
off with `adminUser.createClusterRole`.

The clusterRole gets the same permissions as the role, but without namespace restrictions.

Closes #2053