### PR TITLE
fix: Timestamp column is empty on Event list pages

### DIFF
--- a/core/server/events.go
+++ b/core/server/events.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"fmt"
+	"time"
 
 	pb "github.com/weaveworks/weave-gitops/pkg/api/core"
 	"google.golang.org/grpc/codes"
@@ -42,7 +43,7 @@ func (cs *coreServer) ListFluxEvents(ctx context.Context, msg *pb.ListFluxEvents
 			Name:      e.ObjectMeta.Name,
 			Reason:    e.Reason,
 			Message:   e.Message,
-			Timestamp: e.LastTimestamp.String(),
+			Timestamp: e.LastTimestamp.Format(time.RFC3339),
 			Host:      e.Source.Host,
 		})
 	}

--- a/ui/components/Timestamp.tsx
+++ b/ui/components/Timestamp.tsx
@@ -8,7 +8,8 @@ type Props = {
 };
 
 function Timestamp({ className, time }: Props) {
-  const t = DateTime.fromJSDate(new Date(time));
+  const t = DateTime.fromISO(time);
+
   return <span className={className}>{t.toRelative()}</span>;
 }
 


### PR DESCRIPTION
For some reason, Go formats strings weird with `String()`

```go
# https://github.com/golang/go/blob/master/src/time/format.go
func (t Time) String() string {
  s := t.Format("2006-01-02 15:04:05.999999999 -0700 MST")
```

Fixing by using `Format()` and use RFC3339, that can be parsed on client
side too.

Closes #2034