### PR TITLE
chore(ci): Skip CI runs if no code changes

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,10 +1,16 @@
 on:
   push:
     paths-ignore:
-      - "doc/**"
+      - 'doc/**'
+      - 'website/**'
+      - '*.md'
     branches:
       - main
   pull_request:
+    paths-ignore:
+      - 'doc/**'
+      - 'website/**'
+      - '*.md'
     branches:
       - main
   workflow_dispatch:


### PR DESCRIPTION
The issue says whitelist, but I think blacklisting is much better. With
whilelisting items would prevent future code to be scanned if we add new
root directories or move/rename existing ones, for example moving
internal Go code under `internal/` (to make it clear they are not
intended to be reused in external tools).

Ignored glob patterns:
  - `doc/**` (everything under `doc/`)
  - `website/**` (everything under `website/`)
  - `*.md` (all markdown files in the of the repo)

Closes #2061