### PR TITLE
docs: "fix" (?) update-docs, restore _category_.json

### DIFF
--- a/tools/update-docs.sh
+++ b/tools/update-docs.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -exo pipefail
 # Note that GITOPS_VERSION and ALGOLIA_API_KEY environment variables must be set
 # before running this script
 
@@ -8,7 +9,6 @@ WEAVE_GITOPS_DOC_REPO=$2
 cd $WEAVE_GITOPS_DOC_REPO/docs
 yarn install
 # update version information
-sed -i
 ex - installation.mdx << EOS
 /download\/
 %s,download/\([^/]*\)/,download/v${GITOPS_VERSION}/,
@@ -18,10 +18,9 @@ wq!
 EOS
 # create CLI reference
 git rm -f --ignore-unmatch cli-reference.md
-git rm -rf --ignore-unmatch cli-reference
+git rm -f --ignore-unmatch cli-reference/*.md
 mkdir -p cli-reference
 cd cli-reference
-git checkout _category_.json
 ${WEAVE_GITOPS_BINARY} docs
 git add *.md
 # create versioned docs

--- a/website/docs/cli-reference/_category_.json
+++ b/website/docs/cli-reference/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "CLI Reference",
+  "position": 8
+}


### PR DESCRIPTION
The script was deleting all CLI files, trying to restore one file, and
apparently failed, and then apparently decided to ignore the mistake
and just continue.

First, don't do that. Just delete the markdown files.

Second, always fail on errors. Why wouldn't you?

Third, because this is run in CI, turn on tracing of commands so we
can see what it failed doing.

Fourth, restore the deleted file.
