### PR TITLE
fix: Weave GitOps username is hard-coded

### DIFF
--- a/charts/gitops-server/Chart.yaml
+++ b/charts/gitops-server/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.2
+version: 2.0.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/gitops-server/templates/admin-user-creds.yaml
+++ b/charts/gitops-server/templates/admin-user-creds.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.adminUser.create }}
+{{- if .Values.adminUser.createSecret }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cluster-user-auth
+  namespace: flux-system
+type: Opaque
+data:
+  {{- with .Values.adminUser }}
+  username: {{ .username | b64enc | quote }}
+  password: {{ .passwordHash | required "passwordHash must be set!" | b64enc | quote }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/gitops-server/templates/admin-user-roles.yaml
+++ b/charts/gitops-server/templates/admin-user-roles.yaml
@@ -1,0 +1,53 @@
+{{- if .Values.adminUser.create }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: wego-admin-role
+  namespace: flux-system
+rules:
+  - apiGroups: [""]
+    resources: ["secrets", "pods" ]
+    verbs: [ "get", "list" ]
+  - apiGroups: ["apps"]
+    resources: [ "deployments", "replicasets"]
+    verbs: [ "get", "list" ]
+  - apiGroups: ["kustomize.toolkit.fluxcd.io"]
+    resources: [ "kustomizations" ]
+    verbs: [ "get", "list", "patch" ]
+  - apiGroups: ["helm.toolkit.fluxcd.io"]
+    resources: [ "helmreleases" ]
+    verbs: [ "get", "list", "patch" ]
+  - apiGroups: ["source.toolkit.fluxcd.io"]
+    resources: [ "buckets", "helmcharts", "gitrepositories", "helmrepositories" ]
+    verbs: [ "get", "list", "patch" ]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "watch", "list"]
+{{- if .Values.adminUser.createClusterRole }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: wego-admin-cluster-role
+rules:
+  - apiGroups: [""]
+    resources: ["secrets", "pods" ]
+    verbs: [ "get", "list" ]
+  - apiGroups: ["apps"]
+    resources: [ "deployments", "replicasets"]
+    verbs: [ "get", "list" ]
+  - apiGroups: ["kustomize.toolkit.fluxcd.io"]
+    resources: [ "kustomizations" ]
+    verbs: [ "get", "list", "patch" ]
+  - apiGroups: ["helm.toolkit.fluxcd.io"]
+    resources: [ "helmreleases" ]
+    verbs: [ "get", "list", "patch" ]
+  - apiGroups: ["source.toolkit.fluxcd.io"]
+    resources: [ "buckets", "helmcharts", "gitrepositories", "helmrepositories" ]
+    verbs: [ "get", "list", "patch" ]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "watch", "list"]
+{{- end }}
+{{- end }}

--- a/charts/gitops-server/templates/admin-user.yaml
+++ b/charts/gitops-server/templates/admin-user.yaml
@@ -13,7 +13,7 @@ metadata:
   namespace: flux-system
 subjects:
   - kind: User
-    name: wego-admin
+    name: {{ .Values.adminUser.username }}
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: Role
@@ -52,7 +52,7 @@ metadata:
   name: wego-test-user-read-resources-cr
 subjects:
 - kind: User
-  name: wego-admin
+  name: {{ .Values.adminUser.username }}
   apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole

--- a/charts/gitops-server/templates/custom-admin-user.yaml
+++ b/charts/gitops-server/templates/custom-admin-user.yaml
@@ -1,19 +1,13 @@
 {{- if .Values.adminUser.create }}
-# This should not be used in production. It is for testing & demo purposes only
-# FIXME issues #1789, #1787, #1671
-# the contents of this file are dependent upon the outcome of several
-# discussions around usage of the admin user. Once those are resolved the
-# configuration here should be brought into line with those outcomes (e.g.
-# names(paces) made configurable, permissions set).
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: wego-test-user-read-resources
+  name: {{ .Values.adminUser.username }}-user-read-resources
   namespace: flux-system
 subjects:
   - kind: User
-    name: wego-admin
+    name: {{ .Values.adminUser.username }}
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: Role
@@ -24,10 +18,10 @@ roleRef:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: wego-test-user-read-resources-cr
+  name: {{ .Values.adminUser.username }}-user-read-resources-cr
 subjects:
 - kind: User
-  name: wego-admin
+  name: {{ .Values.adminUser.username }}
   apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole

--- a/pkg/server/auth/server.go
+++ b/pkg/server/auth/server.go
@@ -312,7 +312,7 @@ func (s *AuthServer) SignIn() http.HandlerFunc {
 			return
 		}
 
-		signed, err := s.tokenSignerVerifier.Sign()
+		signed, err := s.tokenSignerVerifier.Sign(loginRequest.Username)
 		if err != nil {
 			s.Log.Error(err, "Failed to create and sign token")
 			rw.WriteHeader(http.StatusInternalServerError)

--- a/pkg/server/auth/token_signer_verifier.go
+++ b/pkg/server/auth/token_signer_verifier.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v4"
-	"github.com/weaveworks/weave-gitops/api/v1alpha1"
 )
 
 type AdminClaims struct {
@@ -15,7 +14,7 @@ type AdminClaims struct {
 }
 
 type TokenSigner interface {
-	Sign() (string, error)
+	Sign(subject string) (string, error)
 }
 
 type TokenVerifier interface {
@@ -48,13 +47,13 @@ func NewHMACTokenSignerVerifier(expireAfter time.Duration) (*HMACTokenSignerVeri
 	}, nil
 }
 
-func (sv *HMACTokenSignerVerifier) Sign() (string, error) {
+func (sv *HMACTokenSignerVerifier) Sign(subject string) (string, error) {
 	claims := AdminClaims{
 		StandardClaims: jwt.StandardClaims{
 			IssuedAt:  time.Now().UTC().Unix(),
 			ExpiresAt: time.Now().Add(sv.expireAfter).UTC().Unix(),
 			NotBefore: time.Now().UTC().Unix(),
-			Subject:   v1alpha1.DefaultClaimsSubject,
+			Subject:   subject,
 		},
 	}
 


### PR DESCRIPTION
Create addition RoleBinding and ClusterRoleBinding based on the
username, and keep the original `wego-admin` there to maintain backward
compatibility.

`DevMode` with Tilt still uses `wego-admin` as a hard-coded user,
potentially we can even remove the `DevUser` maybe.

`DevMode` is used only to set `DevUser` on `HMACTokenSignerVerifier` and
the user is used only return with a static claim on `Verify()`.

Additional changes:
* Split up the admin-user.yaml into logical parts like
  * Credentials as they will be created only once.
  * Role and ClustreRole as they will be created only once
  * Two files for RoleBinding and ClusterRoleBinding (as described above)



Fixes #2001