### PR TITLE
Upgrade go, golangci-lint

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.17.5]
+        go-version: [1.18.X]
     steps:
       - uses: actions/checkout@v2
       - name: Go modules cache
@@ -89,7 +89,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.17.5]
+        go-version: [1.18.X]
     steps:
       - uses: actions/checkout@v2
       - name: Setup Go
@@ -227,7 +227,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.5
+        go-version: 1.18.X
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Clean

--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.5
+          go-version: 1.18.X
       - name: Setup Node.js
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.5
+          go-version: 1.18.X
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ To set up a development environment for the CLI
 
 ### To use an existing environment
 
-1. Install go v1.17
+1. Install go v1.18
 1. Install [buf](https://github.com/bufbuild/buf)
 1. Run `make all` to install dependencies and build binaries and assets
 1. Start a `kind` cluster like so: `KIND_CLUSTER_NAME=<some name> ./tools/kind-with-registry.sh`
@@ -139,7 +139,7 @@ And some tools that are installed by the `tools/download-deps.sh` script:
 
 ### To use a bootstrapped, ready made environment
 
-1. Install go v1.17
+1. Install go v1.18
 2. Install [buf](https://github.com/bufbuild/buf)
 3. Run `make all` to install dependencies and build binaries and assets
 4. Run `make cluster-dev` which should install and bring up everything and then start `tilt` to take over monitoring
@@ -188,7 +188,7 @@ For VSCode, use these editor configuration flags:
 
 To set up a development environment for the UI
 
-1. Install go v1.17
+1. Install go v1.18
 2. Install Node.js version 16.13.2
 3. Make sure your `$GOPATH` is added to your `$PATH` in your bashrc or zshrc file, then install reflex for automated server builds: go get github.com/cespare/reflex
 4. Go through the Weave GitOps getting started docs here: https://docs.gitops.weave.works/docs/getting-started/

--- a/gitops-server.dockerfile
+++ b/gitops-server.dockerfile
@@ -11,7 +11,7 @@ COPY --chown=node:node ui /home/app/ui
 RUN make ui
 
 # Go build
-FROM golang:1.17 AS go-build
+FROM golang:1.18 AS go-build
 
 # Add known_hosts entries for GitHub and GitLab
 RUN mkdir ~/.ssh

--- a/gitops.dockerfile
+++ b/gitops.dockerfile
@@ -5,7 +5,7 @@ ARG FLUX_CLI=ghcr.io/fluxcd/flux-cli:v$FLUX_VERSION
 FROM $FLUX_CLI as flux
 
 # Go build
-FROM golang:1.17 AS go-build
+FROM golang:1.18 AS go-build
 
 # Add known_hosts entries for GitHub and GitLab
 RUN mkdir ~/.ssh

--- a/go.mod
+++ b/go.mod
@@ -231,7 +231,7 @@ require (
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/sys v0.0.0-20220319134239-a9b59b0215f8 // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
-	golang.org/x/text v0.3.7 // indirect
+	golang.org/x/text v0.3.7
 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect
 	golang.org/x/tools v0.1.9 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect

--- a/pkg/services/profiles/add.go
+++ b/pkg/services/profiles/add.go
@@ -3,11 +3,12 @@ package profiles
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/weaveworks/weave-gitops/pkg/git"
 	"github.com/weaveworks/weave-gitops/pkg/gitproviders"
 	"github.com/weaveworks/weave-gitops/pkg/helm"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 
 	"github.com/fluxcd/go-git-providers/gitprovider"
 	helmv2beta1 "github.com/fluxcd/helm-controller/api/v2beta1"
@@ -94,12 +95,14 @@ func prInfo(opts Options, action, defaultBranch string, commitFile gitprovider.C
 		title = opts.Title
 	}
 
-	description := fmt.Sprintf("%s manifest for %s profile", strings.Title(action), opts.Name)
+	titleCaser := cases.Title(language.AmericanEnglish)
+
+	description := fmt.Sprintf("%s manifest for %s profile", titleCaser.String(action), opts.Name)
 	if opts.Description != "" {
 		description = opts.Description
 	}
 
-	commitMessage := fmt.Sprintf("%s profile manifests", strings.Title(action))
+	commitMessage := fmt.Sprintf("%s profile manifests", titleCaser.String(action))
 	if opts.Message != "" {
 		commitMessage = opts.Message
 	}

--- a/tools/download-deps.sh
+++ b/tools/download-deps.sh
@@ -130,7 +130,7 @@ for tool in $tools; do
 done
 
 echo "Installing golangci-lint"
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$(go env GOPATH)"/bin v1.44.0
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$(go env GOPATH)"/bin v1.45.2
 
 if [ -z ${SKIP_MKCERT_INSTALLATION+x} ];
 then


### PR DESCRIPTION
Upgrade go to 1.18.

It turns out golangci-lint only started to support go 1.18 in 1.45, so
I upgraded that, too.

That triggered a new lint - to replace `strings.Title` with a text
title caser because the old module is deprecated.

This fixes #2090