### PR TITLE
ci: Fix check to see that chart version was bumped

### DIFF
--- a/.github/workflows/chart.yaml
+++ b/.github/workflows/chart.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Find old version
         id: old_version
         run: |
-          git checkout ${{ github.event.pull_request.head.sha }}
+          git checkout ${{ github.event.pull_request.base.sha }}
           OLD_VERSION=$(yq e '.version' charts/gitops-server/Chart.yaml)
           echo "::set-output name=version::$OLD_VERSION"
       - name: Alert about the need to change chart version


### PR DESCRIPTION
This fixes a typo - `head` is the latest commit (just like e.g. git
show HEAD), `base` is the base branch (which is also what github calls
it when you open a PR). So in effect, the code was comparing the most
recent version to itself and somehow kept finding that the version was
the same.