### PR TITLE
Refactor table URL filtering for testability

### DIFF
--- a/ui/components/AutomationDetail.tsx
+++ b/ui/components/AutomationDetail.tsx
@@ -86,6 +86,7 @@ function AutomationDetail({ automation, className, info }: Props) {
               kinds={automation?.inventory}
               parentObject={automation}
               clusterName={automation?.clusterName}
+              source={automation?.sourceRef}
             />
           </RouterTab>
         </SubRouterTabs>

--- a/ui/components/AutomationsTable.tsx
+++ b/ui/components/AutomationsTable.tsx
@@ -1,5 +1,6 @@
 import _ from "lodash";
 import * as React from "react";
+import { useHistory } from "react-router-dom";
 import styled from "styled-components";
 import { Automation } from "../hooks/automations";
 import { HelmRelease, SourceRefSourceKind } from "../lib/api/core/types.pb";
@@ -24,7 +25,9 @@ type Props = {
 };
 
 function AutomationsTable({ className, automations, hideSource }: Props) {
-  const initialFilterState = {
+  const history = useHistory();
+
+  const filterConfig = {
     ...filterConfigForString(automations, "type"),
     ...filterConfigForString(automations, "namespace"),
     ...filterConfigForString(automations, "clusterName"),
@@ -131,8 +134,9 @@ function AutomationsTable({ className, automations, hideSource }: Props) {
 
   return (
     <FilterableTable
+      // initialSelections={parseFilterStateFromURL(history)}
       fields={fields}
-      filters={initialFilterState}
+      filters={filterConfig}
       rows={automations}
       className={className}
     />

--- a/ui/components/AutomationsTable.tsx
+++ b/ui/components/AutomationsTable.tsx
@@ -8,7 +8,7 @@ import { formatURL } from "../lib/nav";
 import { AutomationType, V2Routes } from "../lib/types";
 import { statusSortHelper } from "../lib/utils";
 import { Field, SortType } from "./DataTable";
-import FilterableTable, {
+import {
   filterConfigForStatus,
   filterConfigForString,
 } from "./FilterableTable";
@@ -16,6 +16,7 @@ import KubeStatusIndicator, { computeMessage } from "./KubeStatusIndicator";
 import Link from "./Link";
 import SourceLink from "./SourceLink";
 import Timestamp from "./Timestamp";
+import URLAddressableTable from "./URLAddressableTable";
 
 type Props = {
   className?: string;
@@ -133,8 +134,7 @@ function AutomationsTable({ className, automations, hideSource }: Props) {
   if (hideSource) fields = _.filter(fields, (f) => f.label !== "Source");
 
   return (
-    <FilterableTable
-      // initialSelections={parseFilterStateFromURL(history)}
+    <URLAddressableTable
       fields={fields}
       filters={filterConfig}
       rows={automations}

--- a/ui/components/DataTable.tsx
+++ b/ui/components/DataTable.tsx
@@ -101,6 +101,49 @@ export const sortWithType = (rows: Row[], sort: Field) => {
   });
 };
 
+type labelProps = {
+  field: Field;
+  sort: Field;
+  reverseSort: boolean;
+  setSort: (field: Field) => void;
+  setReverseSort: (b: boolean) => void;
+};
+
+function SortableLabel({
+  field,
+  sort,
+  setReverseSort,
+  setSort,
+  reverseSort,
+}: labelProps) {
+  return (
+    <Flex align start>
+      <TableButton
+        color="inherit"
+        variant="text"
+        onClick={() => {
+          setReverseSort(sort === field ? !reverseSort : false);
+          setSort(field);
+        }}
+      >
+        <h2 className={sort.label === field.label ? "selected" : ""}>
+          {field.label}
+        </h2>
+      </TableButton>
+      <Spacer padding="xxs" />
+      {sort.label === field.label ? (
+        <Icon
+          type={IconType.ArrowUpwardIcon}
+          size="base"
+          className={reverseSort ? "upward" : "downward"}
+        />
+      ) : (
+        <div style={{ width: "16px" }} />
+      )}
+    </Flex>
+  );
+}
+
 /** Form DataTable */
 function UnstyledDataTable({
   className,
@@ -116,38 +159,6 @@ function UnstyledDataTable({
 
   if (reverseSort) {
     sorted.reverse();
-  }
-
-  type labelProps = {
-    field: Field;
-  };
-  function SortableLabel({ field }: labelProps) {
-    return (
-      <Flex align start>
-        <TableButton
-          color="inherit"
-          variant="text"
-          onClick={() => {
-            setReverseSort(sort === field ? !reverseSort : false);
-            setSort(field);
-          }}
-        >
-          <h2 className={sort.label === field.label ? "selected" : ""}>
-            {field.label}
-          </h2>
-        </TableButton>
-        <Spacer padding="xxs" />
-        {sort.label === field.label ? (
-          <Icon
-            type={IconType.ArrowUpwardIcon}
-            size="base"
-            className={reverseSort ? "upward" : "downward"}
-          />
-        ) : (
-          <div style={{ width: "16px" }} />
-        )}
-      </Flex>
-    );
   }
 
   const r = _.map(sorted, (r, i) => (
@@ -178,7 +189,13 @@ function UnstyledDataTable({
                   {typeof f.labelRenderer === "function" ? (
                     f.labelRenderer(r)
                   ) : (
-                    <SortableLabel field={f} />
+                    <SortableLabel
+                      sort={sort}
+                      reverseSort={reverseSort}
+                      setReverseSort={(isReverse) => setReverseSort(isReverse)}
+                      setSort={setSort}
+                      field={f}
+                    />
                   )}
                 </TableCell>
               ))}

--- a/ui/components/FilterDialog.tsx
+++ b/ui/components/FilterDialog.tsx
@@ -8,7 +8,7 @@ import FormCheckbox from "./FormCheckbox";
 import Text from "./Text";
 
 export type FilterConfig = { [key: string]: string[] };
-export type DialogFormState = { [inputName: string]: boolean };
+export type FilterSelections = { [inputName: string]: boolean };
 
 const SlideContainer = styled.div`
   position: relative;
@@ -35,22 +35,6 @@ const SlideContent = styled.div`
 `;
 
 export const filterSeparator = ":";
-
-export function initialFormState(cfg: FilterConfig) {
-  const allFilters = _.reduce(
-    cfg,
-    (r, vals, k) => {
-      _.each(vals, (v) => {
-        r[`${k}${filterSeparator}${v}`] = false;
-      });
-
-      return r;
-    },
-    {}
-  );
-
-  return allFilters;
-}
 
 const FilterSection = ({ header, options, formState, onSectionSelect }) => {
   const [all, setAll] = React.useState(false);
@@ -107,14 +91,14 @@ const FilterSection = ({ header, options, formState, onSectionSelect }) => {
 export interface Props {
   className?: string;
   /** the setState function for `activeFilters` */
-  onFilterSelect: (val: FilterConfig, state: DialogFormState) => void;
+  onFilterSelect: (val: FilterConfig, state: FilterSelections) => void;
   /** Object containing column headers + corresponding filter options */
   filterList: FilterConfig;
-  formState: DialogFormState;
+  formState: FilterSelections;
   open?: boolean;
 }
 
-export function formStateToFilters(values: DialogFormState): FilterConfig {
+export function selectionsToFilters(values: FilterSelections): FilterConfig {
   const out = {};
   _.each(values, (v, k) => {
     const [key, val] = k.split(filterSeparator);
@@ -149,13 +133,13 @@ function UnstyledFilterDialog({
   const onSectionSelect = (object: sectionSelectObject) => {
     if (onFilterSelect) {
       const next = { ...formState, ...object };
-      onFilterSelect(formStateToFilters(next), next);
+      onFilterSelect(selectionsToFilters(next), next);
     }
   };
   const onFormChange = (name: string, value: any) => {
     if (onFilterSelect) {
       const next = { ...formState, [name]: value };
-      onFilterSelect(formStateToFilters(next), next);
+      onFilterSelect(selectionsToFilters(next), next);
     }
   };
 

--- a/ui/components/FilterableTable.tsx
+++ b/ui/components/FilterableTable.tsx
@@ -16,7 +16,7 @@ import Icon, { IconType } from "./Icon";
 import { computeReady } from "./KubeStatusIndicator";
 import SearchField from "./SearchField";
 
-type Props = {
+export type FilterableTableProps = {
   className?: string;
   fields: Field[];
   rows: any[];
@@ -210,7 +210,7 @@ function FilterableTable({
   dialogOpen,
   initialSelections,
   onFilterChange,
-}: Props) {
+}: FilterableTableProps) {
   const [filterDialogOpen, setFilterDialogOpen] = React.useState(dialogOpen);
   const [filterState, setFilterState] = React.useState<State>({
     filters: applySelections(filters, initialSelections),

--- a/ui/components/SourcesTable.tsx
+++ b/ui/components/SourcesTable.tsx
@@ -12,13 +12,14 @@ import { showInterval } from "../lib/time";
 import { Source } from "../lib/types";
 import { convertGitURLToGitProvider, statusSortHelper } from "../lib/utils";
 import { SortType } from "./DataTable";
-import FilterableTable, {
+import {
   filterConfigForStatus,
   filterConfigForString,
 } from "./FilterableTable";
 import KubeStatusIndicator, { computeMessage } from "./KubeStatusIndicator";
 import Link from "./Link";
 import Timestamp from "./Timestamp";
+import URLAddressableTable from "./URLAddressableTable";
 
 type Props = {
   className?: string;
@@ -37,7 +38,7 @@ function SourcesTable({ className, sources }: Props) {
   };
 
   return (
-    <FilterableTable
+    <URLAddressableTable
       className={className}
       filters={initialFilterState}
       rows={sources}

--- a/ui/components/URLAddressableTable.tsx
+++ b/ui/components/URLAddressableTable.tsx
@@ -1,0 +1,34 @@
+import * as React from "react";
+import { useHistory, useLocation } from "react-router-dom";
+import styled from "styled-components";
+import FilterableTable, {
+  FilterableTableProps,
+  filterSelectionsToQueryString,
+  parseFilterStateFromURL,
+} from "./FilterableTable";
+import { FilterSelections } from "./FilterDialog";
+
+type Props = FilterableTableProps;
+
+function URLAddressableTable({ initialSelections, ...rest }: Props) {
+  const history = useHistory();
+  const location = useLocation();
+  const search = location.search;
+
+  const handleFilterChange = (sel: FilterSelections) => {
+    const filterQuery = filterSelectionsToQueryString(sel);
+    history.replace({ ...location, search: filterQuery });
+  };
+
+  return (
+    <FilterableTable
+      onFilterChange={handleFilterChange}
+      initialSelections={initialSelections || parseFilterStateFromURL(search)}
+      {...rest}
+    />
+  );
+}
+
+export default styled(URLAddressableTable).attrs({
+  className: URLAddressableTable.name,
+})``;

--- a/ui/components/__tests__/FilterDialog.test.tsx
+++ b/ui/components/__tests__/FilterDialog.test.tsx
@@ -2,7 +2,8 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import "jest-styled-components";
 import React from "react";
 import { withTheme } from "../../lib/test-utils";
-import FilterDialog, { initialFormState } from "../FilterDialog";
+import { initialFormState } from "../FilterableTable";
+import FilterDialog from "../FilterDialog";
 
 describe("FilterDialog", () => {
   const setActiveFilters = jest.fn();

--- a/ui/components/__tests__/FilterableTable.test.tsx
+++ b/ui/components/__tests__/FilterableTable.test.tsx
@@ -543,4 +543,28 @@ describe("FilterableTable", () => {
     expect(tableRows).toHaveLength(1);
     expect(tableRows[0].innerHTML).toContain(row.name);
   });
+  it("adds an initial filter selection state", () => {
+    const initialFilterConfig = {
+      ...filterConfigForString(rows, "type"),
+    };
+
+    render(
+      withTheme(
+        withContext(
+          <FilterableTable
+            fields={fields}
+            rows={rows}
+            initialSelections={{ "type:foo": true }}
+            filters={initialFilterConfig}
+            dialogOpen
+          />,
+          "/applications",
+          {}
+        )
+      )
+    );
+    const tableRows = document.querySelectorAll("tbody tr");
+    expect(tableRows).toHaveLength(2);
+    expect(tableRows[0].innerHTML).toContain("foo");
+  });
 });


### PR DESCRIPTION
Re-work the DataTable URL logic to make it easily testable.

This also sneaks in a change to add the source to the ReconciliationGraph as I was pairing with @joshri  and I forgot to switch branches. It is in it's own commit, so keeping it in the PR.