### PR TITLE
Don't use quotes on flags to docker build action

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -154,10 +154,9 @@ jobs:
           tags: "${{ env.CI_CONTAINER_REPOSITORY }}/${{ matrix.docker-image }}:${{ needs.ci-generate-tag.outputs.tag }}"
           outputs: type=docker,dest=/tmp/${{ matrix.docker-image }}.tar
           file: ${{ matrix.docker-image }}.dockerfile
-          # Warning: the ' in build-args are fragile -- only use on LDFLAGS
           build-args: |
             FLUX_VERSION=${{ env.FLUX_VERSION }}
-            LDFLAGS='${{ env.LDFLAGS }}'
+            LDFLAGS=${{ env.LDFLAGS }}
             GIT_COMMIT=${{ github.sha }}
       - name: Load docker image
         run: docker load --input /tmp/${{ matrix.docker-image }}.tar


### PR DESCRIPTION
The quotes around LDFLAGS were also being passed (although this was only
obvious in the docker output rather than the command being called). The
inclusion of these quote marks meant that `go build` was ignoring the
`-ldflags` as one giant string that it didn't understand.

Removing the quotes seems to work and has hopefully fixed the problem.