### PR TITLE
Allow filter repos

### DIFF
--- a/pkg/helm/charts.go
+++ b/pkg/helm/charts.go
@@ -75,10 +75,11 @@ var defaultChartGetters = getter.Providers{
 	},
 }
 
-type ChartPredicate func(*repo.ChartVersion) bool
+// ChartPredicate is used to filter charts coming from a HelmRepository.
+type ChartPredicate func(*sourcev1.HelmRepository, *repo.ChartVersion) bool
 
 // Profiles is a predicate for scanning charts with the ProfileAnnotation.
-var Profiles = func(v *repo.ChartVersion) bool {
+var Profiles = func(_ *sourcev1.HelmRepository, v *repo.ChartVersion) bool {
 	return hasAnnotation(v.Metadata, ProfileAnnotation)
 }
 
@@ -94,7 +95,7 @@ func (h *RepoManager) ListCharts(ctx context.Context, hr *sourcev1.HelmRepositor
 
 	for name, versions := range chartRepo.Entries {
 		for _, v := range versions {
-			if pred(v) {
+			if pred(hr, v) {
 				// if already added, update the versions array
 				if p, ok := ps[name]; ok {
 					p.AvailableVersions = append(p.AvailableVersions, v.Version)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Support HelmRepository annotation for profiles.

This adds support for a new annotation on Flux HelmRepositories

      weave.works/profiles: "true"

If the annotation exists, all charts discovered in the repository are considered to be Profiles.

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**
Simplify getting profiles in from existing HelmCharts.

<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**
This is a fairly trivial change, expanding the predicate to accept the helm repository, and checking for either chart of repo annotation.

<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**

<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**


<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
