### PR TITLE
Continue processing and updating the clustermngr caches onError

### DIFF
--- a/core/clustersmngr/factory.go
+++ b/core/clustersmngr/factory.go
@@ -88,7 +88,7 @@ func (cf *clientsFactory) watchClusters(ctx context.Context) {
 
 	if err := wait.PollImmediateInfinite(watchClustersFrequency, func() (bool, error) {
 		if err := cf.UpdateClusters(ctx); err != nil {
-			return false, err
+			cf.log.Error(err, "Failed to update clusters")
 		}
 
 		return false, nil
@@ -114,7 +114,7 @@ func (cf *clientsFactory) watchNamespaces(ctx context.Context) {
 
 	if err := wait.PollImmediateInfinite(watchNamespaceFrequency, func() (bool, error) {
 		if err := cf.UpdateNamespaces(ctx); err != nil {
-			return false, err
+			cf.log.Error(err, "Failed to update namespaces")
 		}
 
 		return false, nil

--- a/core/clustersmngr/factory.go
+++ b/core/clustersmngr/factory.go
@@ -19,7 +19,7 @@ import (
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
 
 const (
-	userNamespaceTTL        = 1 * time.Hour
+	userNamespaceTTL        = 30 * time.Second
 	watchClustersFrequency  = 30 * time.Second
 	watchNamespaceFrequency = 30 * time.Second
 )

--- a/core/clustersmngr/factory.go
+++ b/core/clustersmngr/factory.go
@@ -19,7 +19,9 @@ import (
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
 
 const (
-	userNamespaceTTL        = 30 * time.Second
+	userNamespaceTTL = 30 * time.Second
+	// How often we need to stop the world and remove outdated records.
+	userNamespaceResolution = 30 * time.Second
 	watchClustersFrequency  = 30 * time.Second
 	watchNamespaceFrequency = 30 * time.Second
 )
@@ -68,7 +70,7 @@ func NewClientFactory(fetcher ClusterFetcher, nsChecker nsaccess.Checker, logger
 		nsChecker:           nsChecker,
 		clusters:            &Clusters{},
 		clustersNamespaces:  &ClustersNamespaces{},
-		usersNamespaces:     &UsersNamespaces{Cache: ttlcache.New(24 * time.Hour)},
+		usersNamespaces:     &UsersNamespaces{Cache: ttlcache.New(userNamespaceResolution)},
 		log:                 logger,
 		initialClustersLoad: make(chan bool),
 	}


### PR DESCRIPTION
- Right now we bail out if there's an error connecting to a leaf cluster
- This then requires a restart of the server to continue trying

We also tweak the userNamespace cache. This was previously 1h.
- When provisioning clusters the RBAC takes a minute to be configured
- We cache the permissions in an incomplete state for up to an hour
- This makes provisioning new clusters a bit awkward
- TODO: Follow up issue to discuss options

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**

During cluster provisioning we run into many transitory errors like "cannot connect to cluster", we want to be resilient to these rough patches.

**How did you validate the change?**

Tested in a MC environment