### PR TITLE
server: Start logging all requests, and fix specifying log levels to application

### DIFF
--- a/cmd/gitops-server/cmd/cmd.go
+++ b/cmd/gitops-server/cmd/cmd.go
@@ -28,6 +28,7 @@ import (
 	"github.com/weaveworks/weave-gitops/pkg/kube"
 	"github.com/weaveworks/weave-gitops/pkg/server"
 	"github.com/weaveworks/weave-gitops/pkg/server/auth"
+	"github.com/weaveworks/weave-gitops/pkg/server/middleware"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
@@ -211,7 +212,7 @@ func runCmd(cmd *cobra.Command, args []string) error {
 
 	srv := &http.Server{
 		Addr:    addr,
-		Handler: mux,
+		Handler: middleware.WithLogging(log, mux),
 	}
 
 	go func() {

--- a/core/logger/logger.go
+++ b/core/logger/logger.go
@@ -18,13 +18,13 @@ const (
 // Levels are in order of decreasing verbosity and increasing importance
 const (
 	// LogLevelDebug = -1
-	LogLevelDebug int = int(zap.DebugLevel)
+	LogLevelDebug int = -int(zap.DebugLevel)
 	// LogLevelInfo = 0
-	LogLevelInfo int = int(zap.InfoLevel)
+	LogLevelInfo int = -int(zap.InfoLevel)
 	// LogLevelWarn = 1
-	LogLevelWarn int = int(zap.WarnLevel)
+	LogLevelWarn int = -int(zap.WarnLevel)
 	// LogLevelError = 2
-	LogLevelError int = int(zap.ErrorLevel)
+	LogLevelError int = -int(zap.ErrorLevel)
 )
 
 // New returns a new Logger instance

--- a/pkg/server/handler.go
+++ b/pkg/server/handler.go
@@ -37,16 +37,14 @@ type Config struct {
 
 func NewHandlers(ctx context.Context, log logr.Logger, cfg *Config) (http.Handler, error) {
 	mux := runtime.NewServeMux(middleware.WithGrpcErrorLogging(log))
-	httpHandler := middleware.WithLogging(log, mux)
-
-	if AuthEnabled() {
-		httpHandler = clustersmngr.WithClustersClient(cfg.CoreServerConfig.ClientsFactory, httpHandler)
-		httpHandler = auth.WithAPIAuth(httpHandler, cfg.AuthServer, PublicRoutes)
-	}
 
 	if err := core.Hydrate(ctx, mux, cfg.CoreServerConfig); err != nil {
 		return nil, fmt.Errorf("could not start up core servers: %w", err)
 	}
+
+	httpHandler := clustersmngr.WithClustersClient(cfg.CoreServerConfig.ClientsFactory, mux)
+
+	httpHandler = auth.WithAPIAuth(httpHandler, cfg.AuthServer, PublicRoutes)
 
 	return httpHandler, nil
 }

--- a/pkg/server/middleware/middleware.go
+++ b/pkg/server/middleware/middleware.go
@@ -43,14 +43,13 @@ func WithGrpcErrorLogging(log logr.Logger) runtime.ServeMuxOption {
 }
 
 // WithLogging adds basic logging for HTTP requests.
-// Note that this accepts a grpc-gateway ServeMux instead of an http.Handler.
-func WithLogging(log logr.Logger, mux *runtime.ServeMux) http.Handler {
+func WithLogging(log logr.Logger, h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		recorder := &statusRecorder{
 			ResponseWriter: w,
 			Status:         200,
 		}
-		mux.ServeHTTP(recorder, r)
+		h.ServeHTTP(recorder, r)
 
 		l := log.WithValues("uri", r.RequestURI, "status", recorder.Status)
 


### PR DESCRIPTION
This changes 2 things: it starts to log all requests rather than just ones to `/v1/`, and makes it work to specify log levels in your config.

The log handler is now attached to the top HTTP server instead of just to the core handler, so you can see _all_ requests being served. Only non-OK requests are logged at above DEBUG level, so it shouldn't cause a massive increase in log sizes, but it does mean you can debug e.g. OIDC logins properly.

The log level specification is now correct - HTTP errors were logged as debug, debug messages were logged as errors, because zap and logr disagree on whether a bigger numuber is more important or more voluminous. This flips them so it works.