### PR TITLE
Use ready condition for automations table timestamp

### DIFF
--- a/ui/components/AutomationsTable.tsx
+++ b/ui/components/AutomationsTable.tsx
@@ -2,10 +2,7 @@ import _ from "lodash";
 import * as React from "react";
 import styled from "styled-components";
 import { Automation } from "../hooks/automations";
-import {
-  HelmRelease,
-  SourceRefSourceKind,
-} from "../lib/api/core/types.pb";
+import { HelmRelease, SourceRefSourceKind } from "../lib/api/core/types.pb";
 import { formatURL } from "../lib/nav";
 import { AutomationType, V2Routes } from "../lib/types";
 import { statusSortHelper } from "../lib/utils";
@@ -122,8 +119,10 @@ function AutomationsTable({ className, automations, hideSource }: Props) {
     },
     {
       label: "Last Updated",
-      value: () => (
-        <Timestamp time={""} />
+      value: (a: Automation) => (
+        <Timestamp
+          time={_.get(_.find(a.conditions, { type: "Ready" }), "timestamp")}
+        />
       ),
     },
   ];

--- a/ui/components/HelmReleaseDetail.tsx
+++ b/ui/components/HelmReleaseDetail.tsx
@@ -2,10 +2,12 @@ import * as React from "react";
 import styled from "styled-components";
 import { HelmRelease, SourceRefSourceKind } from "../lib/api/core/types.pb";
 import { AutomationType } from "../lib/types";
+import { automationLastUpdated } from "../lib/utils";
 import Alert from "./Alert";
 import AutomationDetail from "./AutomationDetail";
 import Interval from "./Interval";
 import SourceLink from "./SourceLink";
+import Timestamp from "./Timestamp";
 
 type Props = {
   name: string;
@@ -49,6 +51,10 @@ function HelmReleaseDetail({ helmRelease, className }: Props) {
         ["Chart", helmRelease?.helmChart.chart],
         ["Cluster", helmRelease?.clusterName],
         ["Interval", <Interval interval={helmRelease?.interval} />],
+        [
+          "Last Updated",
+          <Timestamp time={automationLastUpdated(helmRelease)} />,
+        ],
       ]}
     />
   );

--- a/ui/components/KustomizationDetail.tsx
+++ b/ui/components/KustomizationDetail.tsx
@@ -2,10 +2,12 @@ import * as React from "react";
 import styled from "styled-components";
 import { Kustomization } from "../lib/api/core/types.pb";
 import { AutomationType } from "../lib/types";
+import { automationLastUpdated } from "../lib/utils";
 import Alert from "./Alert";
 import AutomationDetail from "./AutomationDetail";
 import Interval from "./Interval";
 import SourceLink from "./SourceLink";
+import Timestamp from "./Timestamp";
 
 type Props = {
   kustomization?: Kustomization;
@@ -15,6 +17,7 @@ type Props = {
 function KustomizationDetail({ kustomization, className }: Props) {
   return (
     <AutomationDetail
+      className={className}
       automation={{
         ...kustomization,
         type: AutomationType.Kustomization,
@@ -24,7 +27,12 @@ function KustomizationDetail({ kustomization, className }: Props) {
         ["Applied Revision", kustomization?.lastAppliedRevision],
         ["Cluster", kustomization?.clusterName],
         ["Path", kustomization?.path],
+
         ["Interval", <Interval interval={kustomization?.interval} />],
+        [
+          "Last Updated",
+          <Timestamp time={automationLastUpdated(kustomization)} />,
+        ],
       ]}
     />
   );

--- a/ui/lib/utils.ts
+++ b/ui/lib/utils.ts
@@ -1,6 +1,7 @@
+import _ from "lodash";
 import { toast } from "react-toastify";
 import { computeReady } from "../components/KubeStatusIndicator";
-import { Condition } from "./api/core/types.pb";
+import { Condition, HelmRelease, Kustomization } from "./api/core/types.pb";
 import { PageRoute } from "./types";
 
 export function notifySuccess(message: string) {
@@ -57,4 +58,8 @@ export function statusSortHelper({ suspended, conditions }: Statusable) {
   if (suspended) return 2;
   if (computeReady(conditions)) return 3;
   else return 1;
+}
+
+export function automationLastUpdated(a: Kustomization | HelmRelease): string {
+  return _.get(_.find(a?.conditions, { type: "Ready" }), "timestamp");
 }


### PR DESCRIPTION
Closes #2063 

Populate last updated from the `type:Ready` condition in the automations table and detail screens:

![Screenshot from 2022-05-11 10-35-21](https://user-images.githubusercontent.com/2802257/167913755-67c156ab-1b33-4b9f-82a7-7ab4485b98bb.png)
![Screenshot from 2022-05-11 10-43-12](https://user-images.githubusercontent.com/2802257/167913766-5e3d1b0e-462d-44d7-ae47-e13e5a92f537.png)

