### PR TITLE
Change table filtering logic to AND between categories, and OR within…

### DIFF
--- a/ui/components/FilterableTable.tsx
+++ b/ui/components/FilterableTable.tsx
@@ -69,22 +69,22 @@ export function filterRows<T>(rows: T[], filters: FilterConfig) {
     return rows;
   }
 
-  return _.filter(rows, (r) => {
-    let ok = false;
+  return _.filter(rows, (row) => {
+    let ok = true;
 
-    _.each(filters, (vals, key) => {
+    _.each(filters, (vals, category) => {
       let value;
       //status
-      if (key === "status") {
-        if (r["suspended"]) value = "Suspended";
-        else if (computeReady(r["conditions"])) value = "Ready";
+      if (category === "status") {
+        if (row["suspended"]) value = "Suspended";
+        else if (computeReady(row["conditions"])) value = "Ready";
         else value = "Not Ready";
       }
-      //string
-      else value = r[key];
+      // strings
+      else value = row[category];
 
-      if (_.includes(vals, value)) {
-        ok = true;
+      if (!_.includes(vals, value)) {
+        ok = false;
       }
     });
 

--- a/ui/components/__tests__/FilterableTable.test.tsx
+++ b/ui/components/__tests__/FilterableTable.test.tsx
@@ -124,33 +124,54 @@ describe("FilterableTable", () => {
       const filtered = filterRows(rows, { name: ["cool", "slick"] });
       expect(filtered).toHaveLength(2);
     });
-    it("filters rows with multiple filter keys", () => {
-      const filtered = filterRows(rows, { name: ["cool"], type: ["bar"] });
-      expect(filtered).toHaveLength(2);
-      const cool = _.find(filtered, { name: "cool" });
-      const neat = _.find(filtered, { name: "neat" });
-      const slick = _.find(filtered, { name: "slick" });
-
-      expect(cool).toBeTruthy();
-      expect(neat).toBeTruthy();
-      expect(slick).toBeFalsy();
-    });
-    it("filters rows with multiple filters in multiple keys", () => {
+    it("ANDs between categories", () => {
+      const rows = [
+        { name: "a", namespace: "ns1", type: "git" },
+        { name: "b", namespace: "ns1", type: "bucket" },
+        { name: "c", namespace: "ns2", type: "git" },
+      ];
       const filtered = filterRows(rows, {
-        name: ["cool"],
-        type: ["bar", "foo"],
+        namespace: ["ns1"],
       });
-      expect(filtered).toHaveLength(3);
+      expect(filtered).toHaveLength(2);
 
       const filtered2 = filterRows(rows, {
-        name: [],
-        type: ["baz", "foo"],
+        namespace: ["ns1"],
+        type: ["git"],
       });
-      expect(filtered2).toHaveLength(3);
+      expect(filtered2).toHaveLength(1);
 
-      const neat = _.find(filtered2, { name: "neat" });
-      expect(neat).toBeFalsy();
+      const a = _.find(filtered2, { name: "a" });
+      const b = _.find(filtered2, { name: "b" });
+      const c = _.find(filtered2, { name: "c" });
+      expect(a).toBeTruthy();
+      expect(b).toBeFalsy();
+      expect(c).toBeFalsy();
     });
+  });
+  it("ANDs between categories, ORs within a category", () => {
+    const rows = [
+      { name: "a", namespace: "ns1", type: "git" },
+      { name: "b", namespace: "ns1", type: "bucket" },
+      { name: "c", namespace: "ns2", type: "git" },
+    ];
+    const filtered = filterRows(rows, {
+      namespace: ["ns1", "ns2"],
+    });
+    expect(filtered).toHaveLength(3);
+
+    const filtered2 = filterRows(rows, {
+      namespace: ["ns1"],
+      type: ["git", "bucket"],
+    });
+    expect(filtered2).toHaveLength(2);
+
+    const a2 = _.find(filtered2, { name: "a" });
+    const b2 = _.find(filtered2, { name: "b" });
+    const c2 = _.find(filtered2, { name: "c" });
+    expect(a2).toBeTruthy();
+    expect(b2).toBeTruthy();
+    expect(c2).toBeFalsy();
   });
 
   it("should show all rows", () => {


### PR DESCRIPTION
Closes https://github.com/weaveworks/weave-gitops-enterprise/issues/700

I was able to get a quick win with some sign-flipping, thanks to the solid test coverage we have here.

Some screen shots to explain the new behavior:

No filters, all rows:
![Screenshot from 2022-05-11 14-04-45](https://user-images.githubusercontent.com/2802257/167947567-7b89cc1e-8ba1-4f71-92c5-045c61d156ea.png)


`OR` filtering within a category
![Screenshot from 2022-05-11 13-59-20](https://user-images.githubusercontent.com/2802257/167946940-fc55ae31-bf1a-423a-a9b7-756318bcb165.png)

`AND` filtering; note that we have `Not Ready` selected, so only the single `Not Ready` element is appearing:

![Screenshot from 2022-05-11 13-59-25](https://user-images.githubusercontent.com/2802257/167947118-54ca5a0a-dfed-473c-9ae0-c3b72ed3abbe.png)

`AND + OR` to show "All Statuses, but only the types I specified":

![Screenshot from 2022-05-11 13-59-33](https://user-images.githubusercontent.com/2802257/167947412-d9c6ae2b-5bdb-4477-8940-83922e4a25aa.png)

