### PR TITLE
Stop using logrus

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,6 @@ Usage:
 
 Examples:
 
-  # Get verbose output for any gitops command
-  gitops [command] -v, --verbose
-
   # Get help for gitops add cluster command
   gitops add cluster -h
   gitops help add cluster
@@ -90,7 +87,6 @@ Flags:
   -h, --help                       help for gitops
       --insecure-skip-tls-verify   If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --namespace string           The namespace scope for this operation (default "flux-system")
-  -v, --verbose                    Enable verbose output
 
 Use "gitops [command] --help" for more information about a command.
 ```

--- a/cmd/gitops/version/cmd.go
+++ b/cmd/gitops/version/cmd.go
@@ -2,9 +2,10 @@ package version
 
 import (
 	"fmt"
+	"os"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/weaveworks/go-checkpoint"
+	"github.com/weaveworks/weave-gitops/cmd/internal"
 
 	"github.com/spf13/cobra"
 )
@@ -33,9 +34,11 @@ func runCmd(cmd *cobra.Command, args []string) {
 
 // CheckVersion looks to see if there is a newer version of the software available
 func CheckVersion(p *checkpoint.CheckParams) {
+	log := internal.NewCLILogger(os.Stdout)
 	checkResponse, err := checkpoint.Check(p)
+
 	if err == nil && checkResponse.Outdated {
-		log.Infof("gitops version %s is available; please update at %s",
+		log.Printf("gitops version %s is available; please update at %s\n",
 			checkResponse.CurrentVersion, checkResponse.CurrentDownloadURL)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,6 @@ require (
 	github.com/onsi/gomega v1.18.1
 	github.com/ory/go-acc v0.2.6
 	github.com/pkg/errors v0.9.1
-	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.3.0
 	github.com/spf13/viper v1.10.0
 	github.com/stretchr/testify v1.7.1
@@ -65,6 +64,7 @@ require (
 require (
 	github.com/chai2010/gettext-go v0.0.0-20160711120539-c6fed771bfd5 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/sirupsen/logrus v1.8.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	sigs.k8s.io/kustomize/api v0.10.1 // indirect
 )


### PR DESCRIPTION
We were apparently using logrus to
 a) print that there is a new version of gitops available
 b) error & exit if viper failed to the point where we can't start
 c) set verbose logs

Now, there's no logs to make verbose, so remove that. Error & exit is
perfectly supported by the built-in log module. And as for printing
that there's a new version available, we can just use the same custom
log framework every other log line in this binary uses.

Logrus is still an indirect dependency, but at least our code is more
consistent.