### PR TITLE
Remove offline_access from OIDC token requests

### DIFF
--- a/pkg/server/auth/auth.go
+++ b/pkg/server/auth/auth.go
@@ -17,9 +17,6 @@ const (
 	// IDTokenCookieName is the name of the cookie that holds the ID Token once
 	// the user has authenticated successfully with the OIDC Provider.
 	IDTokenCookieName = "id_token"
-	// RefreshTokenCookieName is the name of the cookie that holds the refresh
-	// token.
-	RefreshTokenCookieName = "refresh_token"
 	// ScopeProfile is the "profile" scope
 	scopeProfile = "profile"
 	// ScopeEmail is the "email" scope

--- a/pkg/server/auth/auth_test.go
+++ b/pkg/server/auth/auth_test.go
@@ -124,7 +124,7 @@ func TestOauth2FlowRedirectsToOIDCIssuerForUnauthenticatedRequests(t *testing.T)
 
 	g.Expect(res).To(HaveHTTPStatus(http.StatusSeeOther))
 
-	authCodeURL := fmt.Sprintf("%s?client_id=%s&redirect_uri=%s&response_type=code&scope=%s", m.AuthorizationEndpoint(), fake.ClientID, url.QueryEscape(redirectURL), strings.Join([]string{"profile", oidc.ScopeOpenID, oidc.ScopeOfflineAccess, "email"}, "+"))
+	authCodeURL := fmt.Sprintf("%s?client_id=%s&redirect_uri=%s&response_type=code&scope=%s", m.AuthorizationEndpoint(), fake.ClientID, url.QueryEscape(redirectURL), strings.Join([]string{"profile", oidc.ScopeOpenID, "email"}, "+"))
 	g.Expect(res.Result().Header.Get("Location")).To(ContainSubstring(authCodeURL))
 }
 

--- a/pkg/server/auth/server.go
+++ b/pkg/server/auth/server.go
@@ -134,11 +134,6 @@ func (s *AuthServer) oauth2Config(scopes []string) *oauth2.Config {
 		scopes = append(scopes, oidc.ScopeOpenID)
 	}
 
-	// Request "offline_access" scope for refresh tokens.
-	if !contains(scopes, oidc.ScopeOfflineAccess) {
-		scopes = append(scopes, oidc.ScopeOfflineAccess)
-	}
-
 	// Request "email" scope to get user's email address.
 	if !contains(scopes, scopeEmail) {
 		scopes = append(scopes, scopeEmail)
@@ -253,12 +248,6 @@ func (s *AuthServer) Callback() http.HandlerFunc {
 
 		// Issue ID token cookie
 		http.SetCookie(rw, s.createCookie(IDTokenCookieName, rawIDToken))
-
-		// Some OIDC providers may not include a refresh token
-		if token.RefreshToken != "" {
-			// Issue refresh token cookie
-			http.SetCookie(rw, s.createCookie(RefreshTokenCookieName, token.RefreshToken))
-		}
 
 		// Clear state cookie
 		http.SetCookie(rw, s.clearCookie(StateCookieName))
@@ -416,7 +405,7 @@ func (c *AuthServer) startAuthFlow(rw http.ResponseWriter, r *http.Request) {
 	state := base64.StdEncoding.EncodeToString(b)
 
 	var scopes []string
-	// "openid", "offline_access", "email" and "groups" scopes added by default
+	// "openid", "email" and "groups" scopes added by default
 	scopes = append(scopes, scopeProfile)
 	authCodeUrl := c.oauth2Config(scopes).AuthCodeURL(state)
 


### PR DESCRIPTION
We don't support using refresh_tokens, so stop requesting them.