### PR TITLE
Put tsconfig & parcelrc into UI build dockerfile

### DIFF
--- a/gitops-server.dockerfile
+++ b/gitops-server.dockerfile
@@ -6,6 +6,8 @@ WORKDIR /home/app
 USER node
 COPY --chown=node:node package*.json /home/app/
 COPY --chown=node:node Makefile /home/app/
+COPY --chown=node:node tsconfig.json /home/app/
+COPY --chown=node:node .parcelrc /home/app/
 RUN make node_modules
 COPY --chown=node:node ui /home/app/ui
 RUN make ui


### PR DESCRIPTION
I _think_ this might have been the cause of the frontend being
compiled differently when built with the docker file compared to when
doing it outside - tsconfig specifies flags that sound like they could
affect the compiler output.

A reasonable response to this would be "should we stop trying to
enumerate all the files, because this sounds fragile?" to which my
response would be, yes, but, I really don't want to bust the js cache
because go code changed, so, no, I'm gonna continue doing it this way
for now.