### PR TITLE
Dynamically pass in the right automation kind

### DIFF
--- a/ui/components/AutomationDetail.tsx
+++ b/ui/components/AutomationDetail.tsx
@@ -4,6 +4,7 @@ import styled from "styled-components";
 import { AppContext } from "../contexts/AppContext";
 import { Automation, useSyncAutomation } from "../hooks/automations";
 import { AutomationKind } from "../lib/api/core/types.pb";
+import {AutomationType} from "../lib/types";
 import Alert from "./Alert";
 import EventsTable from "./EventsTable";
 import Flex from "./Flex";
@@ -62,7 +63,7 @@ function AutomationDetail({ automation, className, info }: Props) {
         <SubRouterTabs rootPath={`${path}/details`}>
           <RouterTab name="Details" path={`${path}/details`}>
             <ReconciledObjectsTable
-              automationKind={AutomationKind.KustomizationAutomation}
+              automationKind={automation?.type === AutomationType.Kustomization ? AutomationKind.KustomizationAutomation: AutomationKind.HelmReleaseAutomation}
               automationName={automation?.name}
               namespace={automation?.namespace}
               kinds={automation?.inventory}


### PR DESCRIPTION
 <!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes #2016 

<!-- Describe what has changed in this PR -->
**What changed?**
- Removed hardcoded kustomization kind value when hitting reconciled objects end point. This is now calculated dynamically based on the automation type.

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**
- When hitting the reconciled objects end point, the parameter `automation kind` always had the value `Kustomization` even though the automation selected was a helm release.

<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**


<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**
- Manually and local using tilt

<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**


<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
