### PR TITLE
Pass in right source when automation is helm release

### DIFF
--- a/ui/components/AutomationDetail.tsx
+++ b/ui/components/AutomationDetail.tsx
@@ -4,7 +4,7 @@ import styled from "styled-components";
 import { AppContext } from "../contexts/AppContext";
 import { Automation, useSyncAutomation } from "../hooks/automations";
 import { AutomationKind } from "../lib/api/core/types.pb";
-import {AutomationType} from "../lib/types";
+import { AutomationType } from "../lib/types";
 import Alert from "./Alert";
 import EventsTable from "./EventsTable";
 import Flex from "./Flex";
@@ -82,12 +82,12 @@ function AutomationDetail({ automation, className, info }: Props) {
           </RouterTab>
           <RouterTab name="Graph" path={`${path}/graph`}>
             <ReconciliationGraph
-              automationKind={AutomationKind.KustomizationAutomation}
+              automationKind={automation?.type === AutomationType.Kustomization ? AutomationKind.KustomizationAutomation: AutomationKind.HelmReleaseAutomation}
               automationName={automation?.name}
               kinds={automation?.inventory}
               parentObject={automation}
               clusterName={automation?.clusterName}
-              source={automation?.sourceRef}
+              source={automation?.type === AutomationType.Kustomization ? automation?.sourceRef: automation?.helmChart.sourceRef}
             />
           </RouterTab>
         </SubRouterTabs>


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes #2160 

<!-- Describe what has changed in this PR -->
**What changed?**
- We are now passing in the helm chart source to the `ReconciliationGraph` component if the automation is a HelmRelease.

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**
- This was causing the UI to brake

<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**


<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**
- Locally using a kustomize app and and helm release app, make sure the graph works for both.

<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**


<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**

It looks like this now:
<img width="779" alt="image" src="https://user-images.githubusercontent.com/3892786/168166466-3435c3cc-0085-469d-ba0f-eec65cfdbe42.png">
