### PR TITLE
Export node module as esm

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,12 @@
   "version": "0.10.2-rc.1",
   "description": "Weave GitOps core",
   "module": "index.js",
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./index.js"
+    }
+  },
   "targets": {
     "default": {
       "distDir": "bin/dist",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@weaveworks/weave-gitops",
   "version": "0.10.2-rc.1",
   "description": "Weave GitOps core",
+  "module": "index.js",
   "targets": {
     "default": {
       "distDir": "bin/dist",
@@ -11,7 +12,8 @@
     "lib": {
       "includeNodeModules": false,
       "isLibrary": true,
-      "outputFormat": "commonjs",
+      "optimize": false,
+      "outputFormat": "esmodule",
       "distDir": "dist",
       "source": "ui/index.ts",
       "sourceMap": false

--- a/ui/components/Button.tsx
+++ b/ui/components/Button.tsx
@@ -1,10 +1,6 @@
 // eslint-disable-next-line
-import {
-  CircularProgress,
-  PropTypes,
-  Button as MaterialButton,
-  ButtonProps,
-} from "@material-ui/core";
+import { CircularProgress, PropTypes } from "@material-ui/core";
+import MaterialButton, { ButtonProps } from "@material-ui/core/Button/Button";
 import * as React from "react";
 import styled, { useTheme } from "styled-components";
 

--- a/ui/components/Button.tsx
+++ b/ui/components/Button.tsx
@@ -1,6 +1,10 @@
 // eslint-disable-next-line
-import { CircularProgress, PropTypes } from "@material-ui/core";
-import MaterialButton, { ButtonProps } from "@material-ui/core/Button/Button";
+import {
+  CircularProgress,
+  PropTypes,
+  Button as MaterialButton,
+  ButtonProps,
+} from "@material-ui/core";
 import * as React from "react";
 import styled, { useTheme } from "styled-components";
 

--- a/ui/index.ts
+++ b/ui/index.ts
@@ -57,7 +57,6 @@ import { Core as coreClient } from "./lib/api/core/core.pb";
 import { Kind } from "./lib/api/core/types.pb";
 import { formatURL } from "./lib/nav";
 import {
-  Automation,
   Bucket,
   GitRepository,
   HelmChart,

--- a/ui/index.ts
+++ b/ui/index.ts
@@ -81,7 +81,6 @@ export {
   Auth,
   AuthCheck,
   AuthContextProvider,
-  Automation,
   AutomationsTable,
   Bucket,
   BucketDetail,

--- a/ui/lib/images.ts
+++ b/ui/lib/images.ts
@@ -1,16 +1,16 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import bg from "data-url:../images/bg-circles.png";
-import failedSrc from "data-url:../images/failed.svg";
-import fluxIconHoverSrc from "data-url:../images/flux-icon-hover.svg";
-import fluxIconSrc from "data-url:../images/flux-icon.svg";
-import logoSrc from "data-url:../images/logo.svg";
-import reconcileSrc from "data-url:../images/reconcile.svg";
-import signInWheel from "data-url:../images/SignInWheel.svg";
-import successSrc from "data-url:../images/success.svg";
-import suspendedSrc from "data-url:../images/suspended.svg";
-import weaveLogo from "data-url:../images/WeaveLogo.svg";
+import bg from "../images/bg-circles.png";
+import failedSrc from "../images/failed.svg";
+import fluxIconHoverSrc from "../images/flux-icon-hover.svg";
+import fluxIconSrc from "../images/flux-icon.svg";
+import logoSrc from "../images/logo.svg";
+import reconcileSrc from "../images/reconcile.svg";
+import signInWheel from "../images/SignInWheel.svg";
+import successSrc from "../images/success.svg";
+import suspendedSrc from "../images/suspended.svg";
+import weaveLogo from "../images/WeaveLogo.svg";
 
 export default {
   bg,

--- a/ui/pages/SignIn.tsx
+++ b/ui/pages/SignIn.tsx
@@ -1,5 +1,6 @@
 import { Divider, IconButton, Input, InputAdornment } from "@material-ui/core";
-import { Visibility, VisibilityOff } from "@material-ui/icons";
+import Visibility from "@material-ui/icons/Visibility";
+import VisibilityOff from "@material-ui/icons/VisibilityOff";
 import * as React from "react";
 import styled from "styled-components";
 import Alert from "../components/Alert";


### PR DESCRIPTION
Closes #1916 

Makes https://github.com/weaveworks/weave-gitops/pull/1917 irrelevant.

Has better support by consuming tooling to "pass through" assets like svgs


