### PR TITLE
Use 'viewSecretsResourceNames' no 'viewSecrets' in dev values.yaml

### DIFF
--- a/charts/gitops-server/Chart.yaml
+++ b/charts/gitops-server/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.5
+version: 2.0.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/gitops-server/templates/role.yaml
+++ b/charts/gitops-server/templates/role.yaml
@@ -20,11 +20,13 @@ rules:
     resources: [ "secrets" ]
     verbs: [ "get", "list" ]
     {{- if and .Values.rbac.viewSecrets .Values.rbac.viewSecretsResourceNames }}
-    {{- fail "You've supplied both rbac.viewSecrets and rbac.viewSecretsResourceName. Please only use rbac.viewSecretsResourceName" }}
+    {{- fail "You've supplied both rbac.viewSecrets and rbac.viewSecretsResourceNames. Please only use rbac.viewSecretsResourceNames" }}
     {{- end }}
-    {{- with .Values.rbac.viewSecrets }}
+    # or should return the first non-falsy result
+    {{- with (or .Values.rbac.viewSecretsResourceNames .Values.rbac.viewSecrets) }}
     resourceNames: {{ . | toJson }}
     {{- end }}
+
   # The service account needs to read namespaces to know where it can query
   - apiGroups: [ "" ]
     resources: [ "namespaces" ]

--- a/tools/helm-values-dev.yaml
+++ b/tools/helm-values-dev.yaml
@@ -7,7 +7,7 @@ image:
 logLevel: debug
 
 rbac:
-  viewSecrets: ["cluster-user-auth", "oidc-auth"]
+  viewSecretsResourceNames: ["cluster-user-auth", "oidc-auth"]
 
 adminUser:
   create: true

--- a/website/docs/configuration/service-account-permissions.mdx
+++ b/website/docs/configuration/service-account-permissions.mdx
@@ -23,7 +23,7 @@ rules:
 - apiGroups: [""]
   resources: [ "secrets" ]
   verbs: [ "get", "list" ]
-  resourceNames:                  # set by rbac.viewSecrets
+  resourceNames:                  # set by rbac.viewSecretsResourceNames
     - "cluster-user-auth"
     - "oidc-auth"
 # The service account needs to read namespaces to know where it can query
@@ -45,7 +45,7 @@ These allow the pod to do three things:
 |-----------------------------------|---------------------------------------------------------------------|--------------------------------------|
 | `rbac.impersonationResources`     | Which resource types the service account can impersonate            | `["users", "groups"]`                |
 | `rbac.impersonationResourceNames` | Specific users, groups or services account that can be impersonated | `[]`                                 |
-| `rbac.viewSecrets`                | Specific secrets that can be read                                   | `["cluster-user-auth", "oidc-auth"]` |
+| `rbac.viewSecretsResourceNames`   | Specific secrets that can be read                                   | `["cluster-user-auth", "oidc-auth"]` |
 
 
 ## Impersonation
@@ -117,6 +117,6 @@ authenticate users.
 
 ### Configuring secrets
 
-The `rbac.viewSecrets` value allows the operator to change which secrets the
+The `rbac.viewSecretsResourceNames` value allows the operator to change which secrets the
 application can read. This is mostly so that, if the static user is not
 configured, that secret can be removed; or if the secret to be used is re-named.


### PR DESCRIPTION
This was causing the error `Execution error at (weave-gitops/tempaltes/role.yaml:23:8). You've supplioed both rbac.viewSecrets and rbac.viewSecretsResourceName. please only use rbac.viewSecretsResourceName" failed`

<!-- Describe what has changed in this PR -->
**What changed?**

Set the correct values in `tools/helm-values-dev.yaml`

**How did you validate the change?**

Tested locally & checked helm output e.g.:
```console
$  helm template -f tools/helm-values-dev.yaml test charts/gitops-server
```
works vs on main:
```console
$ helm template -f tools/helm-values-dev.yaml test charts/gitops-server
Error: execution error at (weave-gitops/templates/role.yaml:23:8): You've supplied both rbac.viewSecrets and rbac.viewSecretsResourceName. Please only use rbac.viewSecretsResourceName

Use --debug flag to render out invalid YAML
```
