### PR TITLE
Removed extra port mappings from kind config in installation guide

### DIFF
--- a/website/docs/cluster-management/cluster-api-providers.mdx
+++ b/website/docs/cluster-management/cluster-api-providers.mdx
@@ -12,7 +12,7 @@ import TierLabel from "../_components/TierLabel";
 
 ## Creating leaf clusters
 
-To enable leaf cluster creation, Weave Gitops leverages the Cluster-API (CAPI) providers for [AWS](https://cluster-api-aws.sigs.k8s.io/getting-started.html) or [Docker](https://cluster-api.sigs.k8s.io/user/quick-start.html).
+To enable leaf cluster creation, Weave GitOps leverages the Cluster-API (CAPI) providers for [AWS](https://cluster-api-aws.sigs.k8s.io/getting-started.html) or [Docker](https://cluster-api.sigs.k8s.io/user/quick-start.html).
 In this section we cover the steps to deploy the providers on a Kubernetes cluster that is running the Weave GitOps.
 
 CAPI provides declarative APIs, controllers, and tooling to manage the lifecycle of Kubernetes clusters, across
@@ -35,6 +35,6 @@ After having configured `kubectl`, to deploy the CAPA components, follow the ste
 
 ## Docker provider (CAPD)
 
-The Docker infrastructure provider is a reference implementation and is a practical way of testing the Weave Gitops cluster creation feature. It is not intended for production clusters. As CAPD will start docker containers in the host nodes of the management cluster, note that if you are using it with a `kind` cluster you'll need to mount the docker socket as described in the [Install and/or configure a kubernetes cluster](https://cluster-api-aws.sigs.k8s.io/getting-started.html#install-andor-configure-a-kubernetes-cluster) kind section.
+The Docker infrastructure provider is a reference implementation and is a practical way of testing the Weave GitOps cluster creation feature. It is not intended for production clusters. As CAPD will start docker containers in the host nodes of the management cluster, note that if you are using it with a `kind` cluster you'll need to mount the docker socket as described in the [Install and/or configure a kubernetes cluster](https://cluster-api-aws.sigs.k8s.io/getting-started.html#install-andor-configure-a-kubernetes-cluster) kind section.
 
 Similar to the AWS provider case, configure `kubectl` to use the management cluster, and to deploy the CAPD components follow the steps at https://cluster-api-aws.sigs.k8s.io/getting-started.html#install-clusterctl.

--- a/website/docs/cluster-management/managing-existing-clusters.mdx
+++ b/website/docs/cluster-management/managing-existing-clusters.mdx
@@ -10,12 +10,12 @@ import TierLabel from "../_components/TierLabel";
 
 ## How to: Connect a cluster {#how-to-connect-a-cluster}
 
-To connect a cluster to Weave Gitops, first navigate to the `Clusters` section of the UI and click on the `Connect a cluster` button. You will then be presented with a form to add the details of the leaf cluster being connected.
+To connect a cluster to Weave GitOps, first navigate to the `Clusters` section of the UI and click on the `Connect a cluster` button. You will then be presented with a form to add the details of the leaf cluster being connected.
 
 - Name: this is the name of the leaf cluster. This is a required field.
 - Ingress URL: this is the publicly accessible HTTP(S) endpoint of the leaf cluster. This is an optional field.
 
-Click on the `Save & next` button to persist these details. You will then be presented with a `kubectl` command that you can run to install an agent on your leaf cluster. The agent is responsible for inspecting the leaf cluster and sending back leaf information to the Weave Gitops server. It will not make any changes to your cluster.
+Click on the `Save & next` button to persist these details. You will then be presented with a `kubectl` command that you can run to install an agent on your leaf cluster. The agent is responsible for inspecting the leaf cluster and sending back leaf information to the Weave GitOps server. It will not make any changes to your cluster.
 
 Ensure that your current kubeconfig context is setup to use the leaf cluster. Then copy the command and run it.
 

--- a/website/docs/cluster-management/provider-identities.mdx
+++ b/website/docs/cluster-management/provider-identities.mdx
@@ -52,7 +52,7 @@ spec:
         cluster.x-k8s.io/ns: "testlabel"
 ```
 
-We can select ask Weave Gitops to use the `test-account` when creating the cluster by using the _Infrastructure provider credentials_ dropdown on the _Create new cluster with template_ page:
+We can select ask Weave GitOps to use the `test-account` when creating the cluster by using the _Infrastructure provider credentials_ dropdown on the _Create new cluster with template_ page:
 
 ![Identity Selection](./img/identity-selection.png)
 

--- a/website/docs/enterprise/intro.md
+++ b/website/docs/enterprise/intro.md
@@ -3,9 +3,9 @@ title: Introduction
 sidebar_position: 0
 ---
 
-## Weave Gitops Enterprise
+## Weave GitOps Enterprise
 
-Weave Gitops Enterprise (WGE) provides ops teams with an easy way to assess the
+Weave GitOps Enterprise (WGE) provides ops teams with an easy way to assess the
 health of multiple clusters in a single place. It shows cluster information such as
 Kubernetes version and number of nodes and provides details about the GitOps operations
 on those clusters, such as Git repositories and recent commits. Additionally, it

--- a/website/docs/installation.mdx
+++ b/website/docs/installation.mdx
@@ -14,7 +14,7 @@ This section details the steps required to install Weave GitOps on a Kubernetes 
 ### Pre-requisites
 
 #### Kubernetes Cluster
-This version of Weave Gitops is tested against the following Kubernetes releases:
+This version of Weave GitOps is tested against the following Kubernetes releases:
 * 1.20
 * 1.21
 * 1.22
@@ -25,7 +25,7 @@ Note that the version of [Flux](https://fluxcd.io/docs/installation/#prerequisit
 #### Install Flux
 Weave GitOps is an extension to Flux and therefore requires that Flux 0.29 or later has already been installed on your Kubernetes cluster. Full documentation is avilable at: [https://fluxcd.io/docs/installation/](https://fluxcd.io/docs/installation/).
 
-This version of Weave Gitops is tested against the following Flux releases:
+This version of Weave GitOps is tested against the following Flux releases:
 * 0.29
 
 ### Install the Helm Chart
@@ -65,7 +65,7 @@ There are many other values you can configure - for more information, see [our v
 
 ## Installing Weave GitOps Enterprise<TierLabel tiers="enterprise" />
 
-Weave Gitops Enterprise (WGE) provides ops teams with an easy way to assess the
+Weave GitOps Enterprise (WGE) provides ops teams with an easy way to assess the
 health of multiple clusters in a single place. It shows cluster information such as
 Kubernetes version and number of nodes and provides details about the GitOps operations
 on those clusters, such as Git repositories and recent commits. Additionally, it
@@ -92,7 +92,7 @@ To get you started in this document we'll cover:
 - `kind` as our management cluster with the _CAPD_ provider
 - **EKS** as our management cluster with the _CAPA_ provider
 
-However Weave Gitops Enterprise supports any combination of management cluster and CAPI provider.
+However Weave GitOps Enterprise supports any combination of management cluster and CAPI provider.
 
 <Tabs groupId="infrastructure" default>
 <TabItem value="kind" label="kind">
@@ -352,7 +352,7 @@ Commit and push all the files
 
 ```
 git add clusters/management/weave-gitops-enterprise.yaml
-git commit -m "Deploy Weave Gitops Enterprise"
+git commit -m "Deploy Weave GitOps Enterprise"
 git push
 ```
 

--- a/website/docs/installation.mdx
+++ b/website/docs/installation.mdx
@@ -108,15 +108,6 @@ nodes:
     extraMounts:
       - hostPath: /var/run/docker.sock
         containerPath: /var/run/docker.sock
-    extraPortMappings:
-      - containerPort: 30080
-        hostPort: 30080
-        listenAddress: "0.0.0.0" # Optional, defaults to "0.0.0.0"
-        protocol: tcp # Optional, defaults to tcp
-      - containerPort: 31490
-        hostPort: 31490
-        listenAddress: "0.0.0.0" # Optional, defaults to "0.0.0.0"
-        protocol: tcp # Optional, defaults to tcp
 ```
 
 - The `extraMounts` are for the Docker CAPI provider (CAPD) to be able to talk to the host docker

--- a/website/versioned_docs/version-0.8.0/cluster-management/cluster-api-providers.mdx
+++ b/website/versioned_docs/version-0.8.0/cluster-management/cluster-api-providers.mdx
@@ -12,7 +12,7 @@ import TierLabel from "../_components/TierLabel";
 
 ## Creating leaf clusters
 
-To enable leaf cluster creation, Weave Gitops leverages the Cluster-API (CAPI) providers for [AWS](https://cluster-api-aws.sigs.k8s.io/getting-started.html) or [Docker](https://cluster-api.sigs.k8s.io/user/quick-start.html).
+To enable leaf cluster creation, Weave GitOps leverages the Cluster-API (CAPI) providers for [AWS](https://cluster-api-aws.sigs.k8s.io/getting-started.html) or [Docker](https://cluster-api.sigs.k8s.io/user/quick-start.html).
 In this section we cover the steps to deploy the providers on a Kubernetes cluster that is running the Weave GitOps.
 
 CAPI provides declarative APIs, controllers, and tooling to manage the lifecycle of Kubernetes clusters, across
@@ -35,6 +35,6 @@ After having configured `kubectl`, to deploy the CAPA components, follow the ste
 
 ## Docker provider (CAPD)
 
-The Docker infrastructure provider is a reference implementation and is a practical way of testing the Weave Gitops cluster creation feature. It is not intended for production clusters. As CAPD will start docker containers in the host nodes of the management cluster, note that if you are using it with a `kind` cluster you'll need to mount the docker socket as described in the [Install and/or configure a kubernetes cluster](https://cluster-api-aws.sigs.k8s.io/getting-started.html#install-andor-configure-a-kubernetes-cluster) kind section.
+The Docker infrastructure provider is a reference implementation and is a practical way of testing the Weave GitOps cluster creation feature. It is not intended for production clusters. As CAPD will start docker containers in the host nodes of the management cluster, note that if you are using it with a `kind` cluster you'll need to mount the docker socket as described in the [Install and/or configure a kubernetes cluster](https://cluster-api-aws.sigs.k8s.io/getting-started.html#install-andor-configure-a-kubernetes-cluster) kind section.
 
 Similar to the AWS provider case, configure `kubectl` to use the management cluster, and to deploy the CAPD components follow the steps at https://cluster-api-aws.sigs.k8s.io/getting-started.html#install-clusterctl.

--- a/website/versioned_docs/version-0.8.0/cluster-management/managing-existing-clusters.mdx
+++ b/website/versioned_docs/version-0.8.0/cluster-management/managing-existing-clusters.mdx
@@ -10,12 +10,12 @@ import TierLabel from "../_components/TierLabel";
 
 ## How to: Connect a cluster {#how-to-connect-a-cluster}
 
-To connect a cluster to Weave Gitops, first navigate to the `Clusters` section of the UI and click on the `Connect a cluster` button. You will then be presented with a form to add the details of the leaf cluster being connected.
+To connect a cluster to Weave GitOps, first navigate to the `Clusters` section of the UI and click on the `Connect a cluster` button. You will then be presented with a form to add the details of the leaf cluster being connected.
 
 - Name: this is the name of the leaf cluster. This is a required field.
 - Ingress URL: this is the publicly accessible HTTP(S) endpoint of the leaf cluster. This is an optional field.
 
-Click on the `Save & next` button to persist these details. You will then be presented with a `kubectl` command that you can run to install an agent on your leaf cluster. The agent is responsible for inspecting the leaf cluster and sending back leaf information to the Weave Gitops server. It will not make any changes to your cluster.
+Click on the `Save & next` button to persist these details. You will then be presented with a `kubectl` command that you can run to install an agent on your leaf cluster. The agent is responsible for inspecting the leaf cluster and sending back leaf information to the Weave GitOps server. It will not make any changes to your cluster.
 
 Ensure that your current kubeconfig context is setup to use the leaf cluster. Then copy the command and run it.
 

--- a/website/versioned_docs/version-0.8.0/cluster-management/provider-identities.mdx
+++ b/website/versioned_docs/version-0.8.0/cluster-management/provider-identities.mdx
@@ -52,7 +52,7 @@ spec:
         cluster.x-k8s.io/ns: "testlabel"
 ```
 
-We can select ask Weave Gitops to use the `test-account` when creating the cluster by using the _Infrastructure provider credentials_ dropdown on the _Create new cluster with template_ page:
+We can select ask Weave GitOps to use the `test-account` when creating the cluster by using the _Infrastructure provider credentials_ dropdown on the _Create new cluster with template_ page:
 
 ![Identity Selection](./img/identity-selection.png)
 

--- a/website/versioned_docs/version-0.8.0/enterprise/intro.md
+++ b/website/versioned_docs/version-0.8.0/enterprise/intro.md
@@ -3,9 +3,9 @@ title: Introduction
 sidebar_position: 0
 ---
 
-## Weave Gitops Enterprise
+## Weave GitOps Enterprise
 
-Weave Gitops Enterprise (WGE) provides ops teams with an easy way to assess the
+Weave GitOps Enterprise (WGE) provides ops teams with an easy way to assess the
 health of multiple clusters in a single place. It shows cluster information such as
 Kubernetes version and number of nodes and provides details about the GitOps operations
 on those clusters, such as Git repositories and recent commits. Additionally, it

--- a/website/versioned_docs/version-0.8.0/installation.mdx
+++ b/website/versioned_docs/version-0.8.0/installation.mdx
@@ -107,15 +107,6 @@ nodes:
     extraMounts:
       - hostPath: /var/run/docker.sock
         containerPath: /var/run/docker.sock
-    extraPortMappings:
-      - containerPort: 30080
-        hostPort: 30080
-        listenAddress: "0.0.0.0" # Optional, defaults to "0.0.0.0"
-        protocol: tcp # Optional, defaults to tcp
-      - containerPort: 31490
-        hostPort: 31490
-        listenAddress: "0.0.0.0" # Optional, defaults to "0.0.0.0"
-        protocol: tcp # Optional, defaults to tcp
 ```
 
 Fire up cluster

--- a/website/versioned_docs/version-0.8.0/installation.mdx
+++ b/website/versioned_docs/version-0.8.0/installation.mdx
@@ -14,7 +14,7 @@ This section details the steps required to install Weave GitOps on a Kubernetes 
 ### Pre-requisites
 
 #### Kubernetes Cluster
-This version of Weave Gitops is tested against the following Kubernetes releases:
+This version of Weave GitOps is tested against the following Kubernetes releases:
 * 1.20
 * 1.21
 * 1.22
@@ -25,7 +25,7 @@ Note that the version of [Flux](https://fluxcd.io/docs/installation/#prerequisit
 #### Install Flux
 Weave GitOps is an extension to Flux and therefore requires that Flux 0.29 or later has already been installed on your Kubernetes cluster. Full documentation is avilable at: [https://fluxcd.io/docs/installation/](https://fluxcd.io/docs/installation/).
 
-This version of Weave Gitops is tested against the following Flux releases:
+This version of Weave GitOps is tested against the following Flux releases:
 * 0.29
 
 ### Install the Helm Chart
@@ -64,7 +64,7 @@ spec:
 
 ## Installing Weave GitOps Enterprise<TierLabel tiers="enterprise" />
 
-Weave Gitops Enterprise (WGE) provides ops teams with an easy way to assess the
+Weave GitOps Enterprise (WGE) provides ops teams with an easy way to assess the
 health of multiple clusters in a single place. It shows cluster information such as
 Kubernetes version and number of nodes and provides details about the GitOps operations
 on those clusters, such as Git repositories and recent commits. Additionally, it
@@ -91,7 +91,7 @@ To get you started in this document we'll cover:
 - `kind` as our management cluster with the _CAPD_ provider
 - **EKS** as our management cluster with the _CAPA_ provider
 
-However Weave Gitops Enterprise supports any combination of management cluster and CAPI provider.
+However Weave GitOps Enterprise supports any combination of management cluster and CAPI provider.
 
 <Tabs groupId="infrastructure" default>
 <TabItem value="kind" label="kind">
@@ -313,7 +313,7 @@ Commit and push all the files
 
 ```
 git add clusters/management/weave-gitops-enterprise.yaml
-git commit -m "Deploy Weave Gitops Enterprise"
+git commit -m "Deploy Weave GitOps Enterprise"
 git push
 ```
 


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes

<!-- Describe what has changed in this PR -->
**What changed?**
Updated docs

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**
The kind config in the installation guide for Weave GitOps Enterprise included port mappings that the rest of the guide did not use.

<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**
N/A

<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**
Viewed docs locally

<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**
N/A


<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
N/A
