### PR TITLE
Provide auth compatibility for older images

### DIFF
--- a/charts/gitops-server/Chart.yaml
+++ b/charts/gitops-server/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.7
+version: 2.0.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/gitops-server/templates/deployment.yaml
+++ b/charts/gitops-server/templates/deployment.yaml
@@ -59,8 +59,10 @@ spec:
             httpGet:
               path: /
               port: http
-          {{- if .Values.envVars}}
           env:
+            - name: WEAVE_GITOPS_AUTH_ENABLED
+              value: "true"
+          {{- if .Values.envVars }}
           {{- with .Values.envVars }}
             {{- toYaml . | nindent 12 }}
           {{- end }}


### PR DESCRIPTION
closes #2171 

If using the "new" helm chart (post https://github.com/weaveworks/weave-gitops/pull/1983) with v0.8.0, which still expects the env var to be set.

