### PR TITLE
Handle empty filter dialog options + adjust font sizes

### DIFF
--- a/ui/components/DataTable.tsx
+++ b/ui/components/DataTable.tsx
@@ -234,7 +234,7 @@ export const DataTable = styled(UnstyledDataTable)`
   overflow-x: auto;
   h2 {
     padding: ${(props) => props.theme.spacing.xs};
-    font-size: 18px;
+    font-size: 14px;
     font-weight: 600;
     color: ${(props) => props.theme.colors.neutral30};
     margin: 0px;

--- a/ui/components/FilterDialog.tsx
+++ b/ui/components/FilterDialog.tsx
@@ -60,9 +60,11 @@ const FilterSection = ({ header, options, formState, onSectionSelect }) => {
     <ListItem>
       <List>
         <ListItem>
-          <ListItemIcon>
-            <Checkbox checked={all} onChange={handleChange} id={header} />
-          </ListItemIcon>
+          {options[0] && (
+            <ListItemIcon>
+              <Checkbox checked={all} onChange={handleChange} id={header} />
+            </ListItemIcon>
+          )}
           <Text capitalize size="small" color="neutral30" semiBold>
             {convertHeaders(header)}
           </Text>

--- a/ui/components/FilterDialog.tsx
+++ b/ui/components/FilterDialog.tsx
@@ -70,19 +70,20 @@ const FilterSection = ({ header, options, formState, onSectionSelect }) => {
           </Text>
         </ListItem>
         {_.map(options, (option: string, index: number) => {
-          return (
-            <ListItem key={index}>
-              <ListItemIcon>
-                <FormCheckbox
-                  label=""
-                  name={`${header}${filterSeparator}${option}`}
-                />
-              </ListItemIcon>
-              <Text color="neutral40" size="small">
-                {_.toString(option)}
-              </Text>
-            </ListItem>
-          );
+          if (option)
+            return (
+              <ListItem key={index}>
+                <ListItemIcon>
+                  <FormCheckbox
+                    label=""
+                    name={`${header}${filterSeparator}${option}`}
+                  />
+                </ListItemIcon>
+                <Text color="neutral40" size="small">
+                  {_.toString(option)}
+                </Text>
+              </ListItem>
+            );
         })}
       </List>
     </ListItem>

--- a/ui/components/Text.tsx
+++ b/ui/components/Text.tsx
@@ -40,7 +40,7 @@ const Text = styled.span<TextProps>`
 `;
 
 Text.defaultProps = {
-  size: "normal",
+  size: "medium",
 };
 
 export default Text;

--- a/ui/components/__tests__/__snapshots__/Breadcrumbs.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/Breadcrumbs.test.tsx.snap
@@ -10,9 +10,9 @@ exports[`snapshots renders 1`] = `
     onClick={[Function]}
   >
     <span
-      className="sc-gsDKAQ izdIGU"
+      className="sc-gsDKAQ iZjEZq"
       color="primary"
-      size="normal"
+      size="medium"
     >
       Applications
     </span>
@@ -30,9 +30,9 @@ exports[`snapshots renders child route 1`] = `
     onClick={[Function]}
   >
     <span
-      className="sc-gsDKAQ izdIGU"
+      className="sc-gsDKAQ iZjEZq"
       color="primary"
-      size="normal"
+      size="medium"
     >
       Applications
     </span>
@@ -57,9 +57,9 @@ exports[`snapshots renders child route 1`] = `
     onClick={[Function]}
   >
     <span
-      className="sc-gsDKAQ eouEkA"
+      className="sc-gsDKAQ eOAACW"
       color="primary"
-      size="normal"
+      size="medium"
     >
       flux
     </span>
@@ -77,9 +77,9 @@ exports[`snapshots renders on the root page 1`] = `
     onClick={[Function]}
   >
     <span
-      className="sc-gsDKAQ izdIGU"
+      className="sc-gsDKAQ iZjEZq"
       color="primary"
-      size="normal"
+      size="medium"
     />
   </a>
   <div
@@ -102,9 +102,9 @@ exports[`snapshots renders on the root page 1`] = `
     onClick={[Function]}
   >
     <span
-      className="sc-gsDKAQ eouEkA"
+      className="sc-gsDKAQ eOAACW"
       color="primary"
-      size="normal"
+      size="medium"
     />
   </a>
 </div>

--- a/ui/components/__tests__/__snapshots__/DataTable.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/DataTable.test.tsx.snap
@@ -35,7 +35,7 @@ exports[`DataTable snapshots renders 1`] = `
 
 .c8 {
   font-family: 'proxima-nova',Helvetica,Arial,sans-serif;
-  font-size: 16px;
+  font-size: 14px;
   font-weight: 400;
   text-transform: none;
   font-style: normal;
@@ -106,7 +106,7 @@ exports[`DataTable snapshots renders 1`] = `
 
 .c0 h2 {
   padding: 8px;
-  font-size: 18px;
+  font-size: 14px;
   font-weight: 600;
   color: #737373;
   margin: 0px;
@@ -368,7 +368,7 @@ exports[`DataTable snapshots renders 1`] = `
           >
             <span
               className="c7 c8"
-              size="normal"
+              size="medium"
             >
               <a
                 href="/some_url"
@@ -383,7 +383,7 @@ exports[`DataTable snapshots renders 1`] = `
           >
             <span
               className="c7 c8"
-              size="normal"
+              size="medium"
             >
               Ready
             </span>
@@ -394,7 +394,7 @@ exports[`DataTable snapshots renders 1`] = `
           >
             <span
               className="c7 c8"
-              size="normal"
+              size="medium"
             >
               2004-01-02T15:04:05-0700
             </span>
@@ -405,7 +405,7 @@ exports[`DataTable snapshots renders 1`] = `
           >
             <span
               className="c7 c8"
-              size="normal"
+              size="medium"
             >
               3000
             </span>
@@ -421,7 +421,7 @@ exports[`DataTable snapshots renders 1`] = `
           >
             <span
               className="c7 c8"
-              size="normal"
+              size="medium"
             >
               <a
                 href="/some_url"
@@ -436,7 +436,7 @@ exports[`DataTable snapshots renders 1`] = `
           >
             <span
               className="c7 c8"
-              size="normal"
+              size="medium"
             />
           </td>
           <td
@@ -445,7 +445,7 @@ exports[`DataTable snapshots renders 1`] = `
           >
             <span
               className="c7 c8"
-              size="normal"
+              size="medium"
             >
               2006-01-02T15:04:05-0700
             </span>
@@ -456,7 +456,7 @@ exports[`DataTable snapshots renders 1`] = `
           >
             <span
               className="c7 c8"
-              size="normal"
+              size="medium"
             >
               2000
             </span>
@@ -472,7 +472,7 @@ exports[`DataTable snapshots renders 1`] = `
           >
             <span
               className="c7 c8"
-              size="normal"
+              size="medium"
             >
               <a
                 href="/some_url"
@@ -487,7 +487,7 @@ exports[`DataTable snapshots renders 1`] = `
           >
             <span
               className="c7 c8"
-              size="normal"
+              size="medium"
             />
           </td>
           <td
@@ -496,7 +496,7 @@ exports[`DataTable snapshots renders 1`] = `
           >
             <span
               className="c7 c8"
-              size="normal"
+              size="medium"
             >
               2005-01-02T15:04:05-0700
             </span>
@@ -507,7 +507,7 @@ exports[`DataTable snapshots renders 1`] = `
           >
             <span
               className="c7 c8"
-              size="normal"
+              size="medium"
             >
               1000
             </span>

--- a/ui/components/__tests__/__snapshots__/Footer.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/Footer.test.tsx.snap
@@ -36,7 +36,7 @@ exports[`Footer snapshots default 1`] = `
 
 .c3 {
   font-family: 'proxima-nova',Helvetica,Arial,sans-serif;
-  font-size: 16px;
+  font-size: 14px;
   font-weight: 400;
   text-transform: none;
   font-style: normal;
@@ -45,7 +45,7 @@ exports[`Footer snapshots default 1`] = `
 
 .c6 {
   font-family: 'proxima-nova',Helvetica,Arial,sans-serif;
-  font-size: 16px;
+  font-size: 14px;
   font-weight: 400;
   text-transform: none;
   font-style: normal;
@@ -168,7 +168,7 @@ exports[`Footer snapshots no api version 1`] = `
 
 .c3 {
   font-family: 'proxima-nova',Helvetica,Arial,sans-serif;
-  font-size: 16px;
+  font-size: 14px;
   font-weight: 400;
   text-transform: none;
   font-style: normal;
@@ -177,7 +177,7 @@ exports[`Footer snapshots no api version 1`] = `
 
 .c6 {
   font-family: 'proxima-nova',Helvetica,Arial,sans-serif;
-  font-size: 16px;
+  font-size: 14px;
   font-weight: 400;
   text-transform: none;
   font-style: normal;

--- a/ui/components/__tests__/__snapshots__/KubeStatusIndicator.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/KubeStatusIndicator.test.tsx.snap
@@ -35,7 +35,7 @@ exports[`KubeStatusIndicator snapshots renders error 1`] = `
 
 .c6 {
   font-family: 'proxima-nova',Helvetica,Arial,sans-serif;
-  font-size: 16px;
+  font-size: 14px;
   font-weight: 800;
   text-transform: none;
   font-style: normal;
@@ -79,7 +79,7 @@ exports[`KubeStatusIndicator snapshots renders error 1`] = `
     />
     <span
       className="c5 c6"
-      size="normal"
+      size="medium"
     >
       There was a problem
     </span>
@@ -122,7 +122,7 @@ exports[`KubeStatusIndicator snapshots renders success 1`] = `
 
 .c6 {
   font-family: 'proxima-nova',Helvetica,Arial,sans-serif;
-  font-size: 16px;
+  font-size: 14px;
   font-weight: 800;
   text-transform: none;
   font-style: normal;
@@ -166,7 +166,7 @@ exports[`KubeStatusIndicator snapshots renders success 1`] = `
     />
     <span
       className="c5 c6"
-      size="normal"
+      size="medium"
     >
       Applied revision: main/a3a54ef4a87f8963b14915639f032aa6ec1b8161
     </span>

--- a/ui/components/__tests__/__snapshots__/Logo.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/Logo.test.tsx.snap
@@ -35,7 +35,7 @@ exports[`Logo snapshots renders 1`] = `
 
 .c3 {
   font-family: 'proxima-nova',Helvetica,Arial,sans-serif;
-  font-size: 16px;
+  font-size: 14px;
   font-weight: 400;
   text-transform: none;
   font-style: normal;
@@ -71,7 +71,7 @@ exports[`Logo snapshots renders 1`] = `
     <span
       className="c3"
       color="primary"
-      size="normal"
+      size="medium"
     >
       <div
         className="c4"

--- a/ui/components/__tests__/__snapshots__/Page.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/Page.test.tsx.snap
@@ -56,7 +56,7 @@ exports[`Page snapshots default 1`] = `
 
 .c6 {
   font-family: 'proxima-nova',Helvetica,Arial,sans-serif;
-  font-size: 16px;
+  font-size: 14px;
   font-weight: 400;
   text-transform: none;
   font-style: normal;
@@ -65,7 +65,7 @@ exports[`Page snapshots default 1`] = `
 
 .c9 {
   font-family: 'proxima-nova',Helvetica,Arial,sans-serif;
-  font-size: 16px;
+  font-size: 14px;
   font-weight: 400;
   text-transform: none;
   font-style: normal;
@@ -127,7 +127,7 @@ exports[`Page snapshots default 1`] = `
       <span
         className="c6"
         color="neutral30"
-        size="normal"
+        size="medium"
       >
         Need help? Contact us at
       </span>
@@ -143,7 +143,7 @@ exports[`Page snapshots default 1`] = `
         <span
           className="c9"
           color="primary"
-          size="normal"
+          size="medium"
         >
           support@weave.works
         </span>
@@ -158,7 +158,7 @@ exports[`Page snapshots default 1`] = `
       <span
         className="c6"
         color="neutral30"
-        size="normal"
+        size="medium"
       >
         © 2022 Weaveworks
       </span>

--- a/ui/components/__tests__/__snapshots__/Text.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/Text.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Text snapshots bold 1`] = `
 .c0 {
   font-family: 'proxima-nova',Helvetica,Arial,sans-serif;
-  font-size: 16px;
+  font-size: 14px;
   font-weight: 800;
   text-transform: none;
   font-style: normal;
@@ -11,7 +11,7 @@ exports[`Text snapshots bold 1`] = `
 
 <span
   className="c0"
-  size="normal"
+  size="medium"
 >
   some text
 </span>
@@ -20,7 +20,7 @@ exports[`Text snapshots bold 1`] = `
 exports[`Text snapshots normal 1`] = `
 .c0 {
   font-family: 'proxima-nova',Helvetica,Arial,sans-serif;
-  font-size: 16px;
+  font-size: 14px;
   font-weight: 400;
   text-transform: none;
   font-style: normal;
@@ -28,7 +28,7 @@ exports[`Text snapshots normal 1`] = `
 
 <span
   className="c0"
-  size="normal"
+  size="medium"
 >
   some text
 </span>
@@ -37,7 +37,7 @@ exports[`Text snapshots normal 1`] = `
 exports[`Text snapshots with color 1`] = `
 .c0 {
   font-family: 'proxima-nova',Helvetica,Arial,sans-serif;
-  font-size: 16px;
+  font-size: 14px;
   font-weight: 400;
   text-transform: none;
   font-style: normal;
@@ -47,7 +47,7 @@ exports[`Text snapshots with color 1`] = `
 <span
   className="c0"
   color="success"
-  size="normal"
+  size="medium"
 >
   some text
 </span>

--- a/ui/lib/theme.ts
+++ b/ui/lib/theme.ts
@@ -15,9 +15,9 @@ export const theme: DefaultTheme = {
     huge: "48px",
     extraLarge: "32px",
     large: "20px",
-    normal: "16px",
-    small: "14px",
-    tiny: "12px",
+    medium: "14px",
+    small: "12px",
+    tiny: "10px",
   },
   colors: {
     black: "#1a1a1a",
@@ -84,7 +84,7 @@ export const GlobalStyle = createGlobalStyle`
   
   body {
     font-family: ${(props) => props.theme.fontFamilies.regular};
-    font-size: ${(props) => props.theme.fontSizes.normal};
+    font-size: ${(props) => props.theme.fontSizes.medium};
     color: ${(props) => props.theme.colors.black};
     padding: 0;
     margin: 0;

--- a/ui/typedefs/styled.d.ts
+++ b/ui/typedefs/styled.d.ts
@@ -33,7 +33,7 @@ export namespace fontSizes {
   const huge: string;
   const extraLarge: string;
   const large: string;
-  const normal: string;
+  const medium: string;
   const small: string;
   const tiny: string;
 }


### PR DESCRIPTION
Closes #2164

Filter dialog should not render a checkbox on categories with no options (from #2147) :
![image](https://user-images.githubusercontent.com/65822698/169877759-f1e13f34-b45b-4d1a-af7b-5243af8f800c.png)

Also adjusts global font sizes according to #2164
