### PR TITLE
Provide the correct source namespace in automations

### DIFF
--- a/core/server/types/helmrelease.go
+++ b/core/server/types/helmrelease.go
@@ -20,6 +20,13 @@ func HelmReleaseToProto(helmrelease *v2beta1.HelmRelease, clusterName string, in
 		chartInterval = durationToInterval(*helmrelease.Spec.Chart.Spec.Interval)
 	}
 
+	var sourceNamespace string
+	if helmrelease.Spec.Chart.Spec.SourceRef.Namespace != "" {
+		sourceNamespace = helmrelease.Spec.Chart.Spec.SourceRef.Namespace
+	} else {
+		sourceNamespace = helmrelease.Namespace
+	}
+
 	return &pb.HelmRelease{
 		Name:        helmrelease.Name,
 		ReleaseName: helmrelease.Spec.ReleaseName,
@@ -29,10 +36,10 @@ func HelmReleaseToProto(helmrelease *v2beta1.HelmRelease, clusterName string, in
 			Chart:     helmrelease.Spec.Chart.Spec.Chart,
 			Version:   helmrelease.Spec.Chart.Spec.Version,
 			Name:      fmt.Sprintf("%s-%s", helmrelease.Namespace, helmrelease.Name),
-			Namespace: helmrelease.Namespace,
+			Namespace: sourceNamespace,
 			Interval:  chartInterval,
 			SourceRef: &pb.SourceRef{
-				Namespace: helmrelease.Spec.Chart.Spec.SourceRef.Namespace,
+				Namespace: sourceNamespace,
 				Name:      helmrelease.Spec.Chart.Spec.SourceRef.Name,
 				Kind:      getSourceKind(helmrelease.Spec.Chart.Spec.SourceRef.Kind),
 			},

--- a/core/server/types/helmrepository_test.go
+++ b/core/server/types/helmrepository_test.go
@@ -1,0 +1,138 @@
+package types
+
+import (
+	"testing"
+	"time"
+
+	"github.com/fluxcd/helm-controller/api/v2beta1"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/format"
+	pb "github.com/weaveworks/weave-gitops/pkg/api/core"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestHelmRepository(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	format.UseStringerRepresentation = true // Makes the representation more compact
+
+	d123, err := time.ParseDuration("1h2m3s")
+	g.Expect(err).NotTo(HaveOccurred())
+	d321, err := time.ParseDuration("3h2m1s")
+	g.Expect(err).NotTo(HaveOccurred())
+
+	tests := []struct {
+		name        string
+		clusterName string
+		state       v2beta1.HelmRelease
+		result      *pb.HelmRelease
+	}{
+		{
+			"empty",
+			"Default",
+			v2beta1.HelmRelease{},
+			&pb.HelmRelease{
+				HelmChart: &pb.HelmChart{
+					Name: "-",
+					SourceRef: &pb.SourceRef{
+						Kind: -1, // This is invalid?
+					},
+				},
+				Interval:    &pb.Interval{},
+				Inventory:   []*pb.GroupVersionKind{},
+				Conditions:  []*pb.Condition{},
+				ClusterName: "Default",
+			},
+		},
+		{
+			"same-ns",
+			"Default",
+			v2beta1.HelmRelease{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "some-chart",
+					Namespace: "namespace-of-all-objects",
+				},
+				Spec: v2beta1.HelmReleaseSpec{
+					Chart: v2beta1.HelmChartTemplate{
+						Spec: v2beta1.HelmChartTemplateSpec{
+							SourceRef: v2beta1.CrossNamespaceObjectReference{
+								Name: "source-object",
+								Kind: "GitRepository",
+							},
+						},
+					},
+				},
+			},
+			&pb.HelmRelease{
+				Name:      "some-chart",
+				Namespace: "namespace-of-all-objects",
+				HelmChart: &pb.HelmChart{
+					Name:      "namespace-of-all-objects-some-chart",
+					Namespace: "namespace-of-all-objects",
+					SourceRef: &pb.SourceRef{
+						Name:      "source-object",
+						Namespace: "namespace-of-all-objects",
+						Kind:      pb.FluxObjectKind_KindGitRepository,
+					},
+				},
+				Interval:    &pb.Interval{},
+				Inventory:   []*pb.GroupVersionKind{},
+				Conditions:  []*pb.Condition{},
+				ClusterName: "Default",
+			},
+		},
+		{
+			"cross-ns",
+			"Default",
+			v2beta1.HelmRelease{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "some-chart",
+					Namespace: "namespace-of-object",
+				},
+				Spec: v2beta1.HelmReleaseSpec{
+					Interval: metav1.Duration{Duration: d123},
+					Chart: v2beta1.HelmChartTemplate{
+						Spec: v2beta1.HelmChartTemplateSpec{
+							Chart:    "chart-name",
+							Version:  "semver-version",
+							Interval: &metav1.Duration{Duration: d321},
+							SourceRef: v2beta1.CrossNamespaceObjectReference{
+								Kind:      "HelmRepository",
+								Name:      "some-helm-repository",
+								Namespace: "namespace-of-source",
+							},
+						},
+					},
+				},
+			},
+			&pb.HelmRelease{
+				Name:      "some-chart",
+				Namespace: "namespace-of-object",
+				HelmChart: &pb.HelmChart{
+					Name:      "namespace-of-object-some-chart",
+					Namespace: "namespace-of-source",
+					SourceRef: &pb.SourceRef{
+						Name:      "some-helm-repository",
+						Namespace: "namespace-of-source",
+						Kind:      pb.FluxObjectKind_KindHelmRepository,
+					},
+					Chart:    "chart-name",
+					Version:  "semver-version",
+					Interval: &pb.Interval{Hours: 3, Minutes: 2, Seconds: 1},
+				},
+				Interval:    &pb.Interval{Hours: 1, Minutes: 2, Seconds: 3},
+				Inventory:   []*pb.GroupVersionKind{},
+				Conditions:  []*pb.Condition{},
+				ClusterName: "Default",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := HelmReleaseToProto(&tt.state, tt.clusterName, []*pb.GroupVersionKind{})
+
+			g.Expect(res).To(Equal(tt.result))
+		})
+	}
+}

--- a/core/server/types/kustomization.go
+++ b/core/server/types/kustomization.go
@@ -27,6 +27,13 @@ func KustomizationToProto(kustomization *kustomizev1.Kustomization, clusterName 
 		return nil, fmt.Errorf("coverting kustomization to proto: %w", err)
 	}
 
+	var sourceNamespace string
+	if kustomization.Spec.SourceRef.Namespace != "" {
+		sourceNamespace = kustomization.Spec.SourceRef.Namespace
+	} else {
+		sourceNamespace = kustomization.Namespace
+	}
+
 	return &pb.Kustomization{
 		Name:      kustomization.Name,
 		Namespace: kustomization.Namespace,
@@ -34,7 +41,7 @@ func KustomizationToProto(kustomization *kustomizev1.Kustomization, clusterName 
 		SourceRef: &pb.SourceRef{
 			Kind:      kind,
 			Name:      kustomization.Spec.SourceRef.Name,
-			Namespace: kustomization.Spec.SourceRef.Namespace,
+			Namespace: sourceNamespace,
 		},
 		Interval:              durationToInterval(kustomization.Spec.Interval),
 		Conditions:            mapConditions(kustomization.Status.Conditions),

--- a/core/server/types/kustomization_test.go
+++ b/core/server/types/kustomization_test.go
@@ -1,0 +1,185 @@
+package types
+
+import (
+	"testing"
+	"time"
+
+	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1beta2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/format"
+	pb "github.com/weaveworks/weave-gitops/pkg/api/core"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestKustomization(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	format.UseStringerRepresentation = true // Makes the representation more compact
+
+	d, err := time.ParseDuration("1h2m3s")
+	g.Expect(err).NotTo(HaveOccurred())
+
+	tests := []struct {
+		name        string
+		clusterName string
+		state       kustomizev1.Kustomization
+		result      *pb.Kustomization
+	}{
+		{
+			"empty",
+			"Default",
+			kustomizev1.Kustomization{},
+			&pb.Kustomization{
+				SourceRef:   &pb.SourceRef{},
+				Interval:    &pb.Interval{},
+				Conditions:  []*pb.Condition{},
+				ClusterName: "Default",
+			},
+		},
+		{
+			"same-ns",
+			"Default",
+			kustomizev1.Kustomization{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "some-object",
+					Namespace: "namespace-of-all-objects",
+				},
+				Spec: kustomizev1.KustomizationSpec{
+					Interval: metav1.Duration{Duration: d},
+					SourceRef: kustomizev1.CrossNamespaceSourceReference{
+						Kind:      "GitRepository",
+						Name:      "some-git-repository",
+						Namespace: "", // Flux won't put the namespace here if it's the same as the object
+					},
+				},
+			},
+			&pb.Kustomization{
+				Name:      "some-object",
+				Namespace: "namespace-of-all-objects",
+				SourceRef: &pb.SourceRef{
+					Kind:      pb.FluxObjectKind_KindGitRepository,
+					Name:      "some-git-repository",
+					Namespace: "namespace-of-all-objects",
+				},
+				Interval:    &pb.Interval{Hours: 1, Minutes: 2, Seconds: 3},
+				Conditions:  []*pb.Condition{},
+				ClusterName: "Default",
+			},
+		},
+		{
+			"cross-ns",
+			"Default",
+			kustomizev1.Kustomization{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "some-object",
+					Namespace: "namespace-of-object",
+				},
+				Spec: kustomizev1.KustomizationSpec{
+					Interval: metav1.Duration{Duration: d},
+					SourceRef: kustomizev1.CrossNamespaceSourceReference{
+						Kind:      "HelmRepository",
+						Name:      "some-helm-repository",
+						Namespace: "namespace-of-source",
+					},
+				},
+			},
+			&pb.Kustomization{
+				Name:      "some-object",
+				Namespace: "namespace-of-object",
+				SourceRef: &pb.SourceRef{
+					Kind:      pb.FluxObjectKind_KindHelmRepository,
+					Name:      "some-helm-repository",
+					Namespace: "namespace-of-source",
+				},
+				Interval:    &pb.Interval{Hours: 1, Minutes: 2, Seconds: 3},
+				Conditions:  []*pb.Condition{},
+				ClusterName: "Default",
+			},
+		},
+		{
+			"all-fields",
+			"Default",
+			kustomizev1.Kustomization{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "some-object",
+					Namespace: "namespace-of-object",
+				},
+				Spec: kustomizev1.KustomizationSpec{
+					Path:     "./my-cluster",
+					Interval: metav1.Duration{Duration: d},
+					SourceRef: kustomizev1.CrossNamespaceSourceReference{
+						Kind:      "Bucket",
+						Name:      "some-bucket",
+						Namespace: "namespace-of-source",
+					},
+					Suspend: true,
+				},
+				Status: kustomizev1.KustomizationStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               "Ready",
+							Status:             metav1.ConditionTrue,
+							Reason:             "InstallSucceeded",
+							Message:            "Release reconciliation succeeded",
+							LastTransitionTime: metav1.Time{Time: time.Date(2022, time.January, 1, 1, 1, 1, 0, time.UTC)},
+						},
+					},
+					LastAppliedRevision:   "what even is a bucket revision?",
+					LastAttemptedRevision: "the one before",
+					Inventory: &kustomizev1.ResourceInventory{
+						Entries: []kustomizev1.ResourceRef{
+							{
+								ID:      "flux-system_helm-controller_apps_Deployment",
+								Version: "v1",
+							},
+							{
+								ID:      "flux-system_kustomize-controller_apps_Deployment",
+								Version: "v1",
+							},
+						},
+					},
+				},
+			},
+			&pb.Kustomization{
+				Namespace: "namespace-of-object",
+				Name:      "some-object",
+				Path:      "./my-cluster",
+				SourceRef: &pb.SourceRef{
+					Kind:      pb.FluxObjectKind_KindBucket,
+					Name:      "some-bucket",
+					Namespace: "namespace-of-source",
+				},
+				Interval: &pb.Interval{Hours: 1, Minutes: 2, Seconds: 3},
+				Conditions: []*pb.Condition{
+					{
+						Type:      "Ready",
+						Status:    "True",
+						Reason:    "InstallSucceeded",
+						Message:   "Release reconciliation succeeded",
+						Timestamp: "2022-01-01T01:01:01Z",
+					},
+				},
+				LastAppliedRevision:   "what even is a bucket revision?",
+				LastAttemptedRevision: "the one before",
+				Inventory: []*pb.GroupVersionKind{
+					{
+						Group:   "apps",
+						Kind:    "Deployment",
+						Version: "v1",
+					},
+				},
+				Suspended:   true,
+				ClusterName: "Default",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := KustomizationToProto(&tt.state, tt.clusterName)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			g.Expect(res).To(Equal(tt.result))
+		})
+	}
+}

--- a/ui/components/AutomationsTable.tsx
+++ b/ui/components/AutomationsTable.tsx
@@ -71,15 +71,19 @@ function AutomationsTable({ className, automations, hideSource }: Props) {
     {
       label: "Source",
       value: (a: Automation) => {
-        let sourceKind;
-        let sourceName;
+        let sourceKind: FluxObjectKind;
+        let sourceName: string;
+        let sourceNamespace: string;
 
         if (a.kind === FluxObjectKind.KindKustomization) {
           sourceKind = a.sourceRef?.kind;
           sourceName = a.sourceRef?.name;
+          sourceNamespace = a.sourceRef?.namespace;
         } else {
+          const hr = a as HelmRelease;
           sourceKind = FluxObjectKind.KindHelmChart;
-          sourceName = (a as HelmRelease).helmChart.name;
+          sourceName = hr.helmChart.name;
+          sourceNamespace = hr.helmChart.namespace;
         }
 
         return (
@@ -88,7 +92,7 @@ function AutomationsTable({ className, automations, hideSource }: Props) {
             sourceRef={{
               kind: sourceKind,
               name: sourceName,
-              namespace: a.sourceRef?.namespace,
+              namespace: sourceNamespace,
             }}
           />
         );


### PR DESCRIPTION
This is 2 commits: a small one that makes sure that the source namespace is always set correctly, and a big one that adds some pretty verbose test code.

The setting source namespace correctly bit is about making sure that the backend always sets a namespace - in flux, a sourceref doesn't have a namespace set if the automation is in the same namespace as the source (see e.g. https://fluxcd.io/docs/components/kustomize/api/#kustomize.toolkit.fluxcd.io/v1beta2.CrossNamespaceSourceReference ). However, that's a faff to remember, so this just sets them always in the protobuf message, so the frontend doesn't need to care.

Finally, this adds some tests to the type conversion code. It's a lot more verbose than the actual type conversion code, as it's intended more as regression testing - the actual HTTP endpoints pretty much just reads from k8s and calls this code, so we want to be able to save weird k8s state so we can see that we're doing something sensible with it. I'm not altogether convinced that everything we do now is sensible, but at least it won't be changed by accident.