### PR TITLE
ui: Fix a couple of problems displaying & linking to objects

### DIFF
--- a/ui/components/AutomationsTable.tsx
+++ b/ui/components/AutomationsTable.tsx
@@ -37,7 +37,7 @@ function AutomationsTable({ className, automations, hideSource }: Props) {
       label: "Name",
       value: (k) => {
         const route =
-          k.type === FluxObjectKind.KindKustomization
+          k.kind === FluxObjectKind.KindKustomization
             ? V2Routes.Kustomization
             : V2Routes.HelmRelease;
         return (

--- a/ui/hooks/sources.ts
+++ b/ui/hooks/sources.ts
@@ -37,19 +37,19 @@ export function useListSources(
         return [
           ..._.map(repos, (r) => ({
             ...r,
-            type: FluxObjectKind.KindGitRepository,
+            kind: FluxObjectKind.KindGitRepository,
           })),
           ..._.map(hrs, (c) => ({
             ...c,
-            type: FluxObjectKind.KindHelmRepository,
+            kind: FluxObjectKind.KindHelmRepository,
           })),
           ..._.map(buckets, (b) => ({
             ...b,
-            type: FluxObjectKind.KindBucket,
+            kind: FluxObjectKind.KindBucket,
           })),
           ..._.map(charts, (ch) => ({
             ...ch,
-            type: FluxObjectKind.KindHelmChart,
+            kind: FluxObjectKind.KindHelmChart,
           })),
         ];
       });


### PR DESCRIPTION
This makes links to kustomizations from the Automation table work again.

This also fixes opening the details page about sources.

This closes #2162, as the type property is no more.