### PR TITLE
Fix getting a helm release's inventory when using targetNamespace

### DIFF
--- a/core/server/helm_release.go
+++ b/core/server/helm_release.go
@@ -80,15 +80,9 @@ func (cs *coreServer) GetHelmRelease(ctx context.Context, msg *pb.GetHelmRelease
 }
 
 func getHelmReleaseInventory(ctx context.Context, helmRelease v2beta1.HelmRelease, c clustersmngr.Client, cluster string) ([]*pb.GroupVersionKind, error) {
-	storageNamespace := helmRelease.GetNamespace()
-	if helmRelease.Spec.StorageNamespace != "" {
-		storageNamespace = helmRelease.Spec.StorageNamespace
-	}
+	storageNamespace := helmRelease.GetStorageNamespace()
 
-	storageName := helmRelease.GetName()
-	if helmRelease.Spec.ReleaseName != "" {
-		storageName = helmRelease.Spec.ReleaseName
-	}
+	storageName := helmRelease.GetReleaseName()
 
 	storageVersion := helmRelease.Status.LastReleaseRevision
 	if storageVersion < 1 {


### PR DESCRIPTION
This just uses flux's built-in methods to use the correct
namespace/release name, instead of us trying to get it right
ourselves.

This fixes #2132.

I've tested this by creating objects with various combinations of `targetNamespace`, `storageNamespace` and `releaseName` to see that it failed before and is succeeding now. There are no automated tests however, given that the logic now lives in flux.