### PR TITLE
add username and apssword cli auth to enterprise endpoint

### DIFF
--- a/cmd/gitops/add/clusters/cmd.go
+++ b/cmd/gitops/add/clusters/cmd.go
@@ -67,7 +67,6 @@ gitops add cluster --from-template <template-name> \
 
 func getClusterCmdPreRunE(endpoint *string, client *resty.Client) func(*cobra.Command, []string) error {
 	return func(c *cobra.Command, s []string) error {
-
 		if *endpoint == "" {
 			return cmderrors.ErrNoWGEEndpoint
 		}
@@ -84,6 +83,7 @@ func getClusterCmdRunE(endpoint, username, password *string, client *resty.Clien
 		}
 
 		vals := make(map[string]string)
+
 		for _, v := range flags.ParameterValues {
 			kv := strings.SplitN(v, "=", 2)
 			if len(kv) == 2 {

--- a/cmd/gitops/add/cmd.go
+++ b/cmd/gitops/add/cmd.go
@@ -8,7 +8,7 @@ import (
 	"github.com/weaveworks/weave-gitops/cmd/gitops/add/terraform"
 )
 
-func GetCommand(endpoint *string, client *resty.Client) *cobra.Command {
+func GetCommand(endpoint, username, password *string, client *resty.Client) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "add",
 		Short: "Add a new Weave GitOps resource",
@@ -17,9 +17,9 @@ func GetCommand(endpoint *string, client *resty.Client) *cobra.Command {
 gitops add cluster`,
 	}
 
-	cmd.AddCommand(clusters.ClusterCommand(endpoint, client))
-	cmd.AddCommand(profiles.AddCommand(endpoint, client))
-	cmd.AddCommand(terraform.AddCommand(endpoint, client))
+	cmd.AddCommand(clusters.ClusterCommand(endpoint, username, password, client))
+	cmd.AddCommand(profiles.AddCommand(endpoint, username, password, client))
+	cmd.AddCommand(terraform.AddCommand(endpoint, username, password, client))
 
 	return cmd
 }

--- a/cmd/gitops/add/profiles/cmd.go
+++ b/cmd/gitops/add/profiles/cmd.go
@@ -55,7 +55,6 @@ func AddCommand(endpoint, username, password *string, client *resty.Client) *cob
 
 func addProfileCmdPreRunE(endpoint *string, client *resty.Client) func(*cobra.Command, []string) error {
 	return func(c *cobra.Command, s []string) error {
-
 		if *endpoint == "" {
 			return cmderrors.ErrNoWGEEndpoint
 		}

--- a/cmd/gitops/add/terraform/cmd.go
+++ b/cmd/gitops/add/terraform/cmd.go
@@ -28,7 +28,7 @@ type terraformCommandFlags struct {
 
 var flags terraformCommandFlags
 
-func AddCommand(endpoint *string, client *resty.Client) *cobra.Command {
+func AddCommand(endpoint, username, password *string, client *resty.Client) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "terraform",
 		Short: "Add a new Terraform resource using a TF template",
@@ -39,7 +39,7 @@ gitops add terraform --from-template <template-name> --set key=val
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		PreRunE:       addTerraformCmdPreRunE(endpoint, client),
-		RunE:          addTerraformCmdRunE(endpoint, client),
+		RunE:          addTerraformCmdRunE(endpoint, username, password, client),
 	}
 
 	cmd.Flags().StringVar(&flags.RepositoryURL, "url", "", "URL of remote repository to create the pull request")
@@ -59,9 +59,9 @@ func addTerraformCmdPreRunE(endpoint *string, client *resty.Client) func(*cobra.
 	}
 }
 
-func addTerraformCmdRunE(endpoint *string, client *resty.Client) func(*cobra.Command, []string) error {
+func addTerraformCmdRunE(endpoint, username, password *string, client *resty.Client) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
-		r, err := adapters.NewHttpClient(*endpoint, client, os.Stdout)
+		r, err := adapters.NewHttpClient(*endpoint, *username, *password, client, os.Stdout)
 		if err != nil {
 			return err
 		}

--- a/cmd/gitops/delete/clusters/cmd.go
+++ b/cmd/gitops/delete/clusters/cmd.go
@@ -25,7 +25,7 @@ type clustersDeleteFlags struct {
 
 var flags clustersDeleteFlags
 
-func ClusterCommand(endpoint *string, client *resty.Client) *cobra.Command {
+func ClusterCommand(endpoint, username, password *string, client *resty.Client) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "cluster",
 		Aliases: []string{"clusters"},
@@ -37,7 +37,7 @@ gitops delete cluster <cluster-name>
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		PreRunE:       getClusterCmdPreRunE(endpoint, client),
-		RunE:          getClusterCmdRunE(endpoint, client),
+		RunE:          getClusterCmdRunE(endpoint, username, password, client),
 		Args:          cobra.MinimumNArgs(1),
 	}
 
@@ -53,6 +53,7 @@ gitops delete cluster <cluster-name>
 
 func getClusterCmdPreRunE(endpoint *string, client *resty.Client) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
+
 		if *endpoint == "" {
 			return cmderrors.ErrNoWGEEndpoint
 		}
@@ -61,9 +62,9 @@ func getClusterCmdPreRunE(endpoint *string, client *resty.Client) func(*cobra.Co
 	}
 }
 
-func getClusterCmdRunE(endpoint *string, client *resty.Client) func(*cobra.Command, []string) error {
+func getClusterCmdRunE(endpoint, username, password *string, client *resty.Client) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
-		r, err := adapters.NewHttpClient(*endpoint, client, os.Stdout)
+		r, err := adapters.NewHttpClient(*endpoint, *username, *password, client, os.Stdout)
 		if err != nil {
 			return err
 		}

--- a/cmd/gitops/delete/clusters/cmd.go
+++ b/cmd/gitops/delete/clusters/cmd.go
@@ -53,7 +53,6 @@ gitops delete cluster <cluster-name>
 
 func getClusterCmdPreRunE(endpoint *string, client *resty.Client) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
-
 		if *endpoint == "" {
 			return cmderrors.ErrNoWGEEndpoint
 		}

--- a/cmd/gitops/delete/cmd.go
+++ b/cmd/gitops/delete/cmd.go
@@ -6,7 +6,7 @@ import (
 	"github.com/weaveworks/weave-gitops/cmd/gitops/delete/clusters"
 )
 
-func DeleteCommand(endpoint *string, client *resty.Client) *cobra.Command {
+func DeleteCommand(endpoint, username, password *string, client *resty.Client) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "delete",
 		Short: "Delete one or many Weave GitOps resources",
@@ -15,7 +15,7 @@ func DeleteCommand(endpoint *string, client *resty.Client) *cobra.Command {
 gitops delete cluster <cluster-name>`,
 	}
 
-	cmd.AddCommand(clusters.ClusterCommand(endpoint, client))
+	cmd.AddCommand(clusters.ClusterCommand(endpoint, username, password, client))
 
 	return cmd
 }

--- a/cmd/gitops/get/clusters/cmd.go
+++ b/cmd/gitops/get/clusters/cmd.go
@@ -18,7 +18,7 @@ type clustersGetFlags struct {
 
 var clustersGetCmdFlags clustersGetFlags
 
-func ClusterCommand(endpoint *string, client *resty.Client) *cobra.Command {
+func ClusterCommand(endpoint, username, password *string, client *resty.Client) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "cluster",
 		Aliases: []string{"clusters"},
@@ -35,7 +35,7 @@ gitops get cluster <cluster-name> --kubeconfig`,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		PreRunE:       getClusterCmdPreRunE(endpoint, client),
-		RunE:          getClusterCmdRunE(endpoint, client),
+		RunE:          getClusterCmdRunE(endpoint, username, password, client),
 	}
 
 	cmd.PersistentFlags().BoolVar(&clustersGetCmdFlags.Kubeconfig, "kubeconfig", false, "Returns the Kubeconfig of the workload cluster")
@@ -45,6 +45,7 @@ gitops get cluster <cluster-name> --kubeconfig`,
 
 func getClusterCmdPreRunE(endpoint *string, client *resty.Client) func(*cobra.Command, []string) error {
 	return func(c *cobra.Command, s []string) error {
+
 		if *endpoint == "" {
 			return cmderrors.ErrNoWGEEndpoint
 		}
@@ -53,9 +54,9 @@ func getClusterCmdPreRunE(endpoint *string, client *resty.Client) func(*cobra.Co
 	}
 }
 
-func getClusterCmdRunE(endpoint *string, client *resty.Client) func(*cobra.Command, []string) error {
+func getClusterCmdRunE(endpoint, username, password *string, client *resty.Client) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
-		r, err := adapters.NewHttpClient(*endpoint, client, os.Stdout)
+		r, err := adapters.NewHttpClient(*endpoint, *username, *password, client, os.Stdout)
 		if err != nil {
 			return err
 		}

--- a/cmd/gitops/get/clusters/cmd.go
+++ b/cmd/gitops/get/clusters/cmd.go
@@ -45,7 +45,6 @@ gitops get cluster <cluster-name> --kubeconfig`,
 
 func getClusterCmdPreRunE(endpoint *string, client *resty.Client) func(*cobra.Command, []string) error {
 	return func(c *cobra.Command, s []string) error {
-
 		if *endpoint == "" {
 			return cmderrors.ErrNoWGEEndpoint
 		}

--- a/cmd/gitops/get/clusters/cmd_test.go
+++ b/cmd/gitops/get/clusters/cmd_test.go
@@ -40,7 +40,7 @@ func TestGetCluster(t *testing.T) {
 				"--kubeconfig",
 				"--endpoint", "not_a_valid_url",
 			},
-			errString: "parse \"not_a_valid_url\": invalid URI for request",
+			errString: "failed to parse endpoint: parse \"not_a_valid_url\": invalid URI for request",
 		},
 		{
 			name: "no endpoint",

--- a/cmd/gitops/get/cmd.go
+++ b/cmd/gitops/get/cmd.go
@@ -9,7 +9,7 @@ import (
 	"github.com/weaveworks/weave-gitops/cmd/gitops/get/templates"
 )
 
-func GetCommand(endpoint *string, client *resty.Client) *cobra.Command {
+func GetCommand(endpoint, username, password *string, client *resty.Client) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "get",
 		Short: "Display one or many Weave GitOps resources",
@@ -24,10 +24,10 @@ gitops get credentials
 gitops get clusters`,
 	}
 
-	cmd.AddCommand(templates.TemplateCommand(endpoint, client))
-	cmd.AddCommand(credentials.CredentialCommand(endpoint, client))
-	cmd.AddCommand(clusters.ClusterCommand(endpoint, client))
-	cmd.AddCommand(profiles.ProfilesCommand(endpoint, client))
+	cmd.AddCommand(templates.TemplateCommand(endpoint, username, password, client))
+	cmd.AddCommand(credentials.CredentialCommand(endpoint, username, password, client))
+	cmd.AddCommand(clusters.ClusterCommand(endpoint, username, password, client))
+	cmd.AddCommand(profiles.ProfilesCommand(endpoint, username, password, client))
 
 	return cmd
 }

--- a/cmd/gitops/get/credentials/cmd.go
+++ b/cmd/gitops/get/credentials/cmd.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/cli-runtime/pkg/printers"
 )
 
-func CredentialCommand(endpoint *string, client *resty.Client) *cobra.Command {
+func CredentialCommand(endpoint, username, password *string, client *resty.Client) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "credential",
 		Aliases: []string{"credentials"},
@@ -23,7 +23,7 @@ gitops get credentials
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		PreRunE:       getCredentialCmdPreRunE(endpoint, client),
-		RunE:          getCredentialCmdRunE(endpoint, client),
+		RunE:          getCredentialCmdRunE(endpoint, username, password, client),
 	}
 
 	return cmd
@@ -31,6 +31,7 @@ gitops get credentials
 
 func getCredentialCmdPreRunE(endpoint *string, client *resty.Client) func(*cobra.Command, []string) error {
 	return func(c *cobra.Command, s []string) error {
+
 		if *endpoint == "" {
 			return cmderrors.ErrNoWGEEndpoint
 		}
@@ -39,13 +40,12 @@ func getCredentialCmdPreRunE(endpoint *string, client *resty.Client) func(*cobra
 	}
 }
 
-func getCredentialCmdRunE(endpoint *string, client *resty.Client) func(*cobra.Command, []string) error {
+func getCredentialCmdRunE(endpoint, username, password *string, client *resty.Client) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
-		r, err := adapters.NewHttpClient(*endpoint, client, os.Stdout)
+		r, err := adapters.NewHttpClient(*endpoint, *username, *password, client, os.Stdout)
 		if err != nil {
 			return err
 		}
-
 		w := printers.GetNewTabWriter(os.Stdout)
 		defer w.Flush()
 

--- a/cmd/gitops/get/credentials/cmd.go
+++ b/cmd/gitops/get/credentials/cmd.go
@@ -31,7 +31,6 @@ gitops get credentials
 
 func getCredentialCmdPreRunE(endpoint *string, client *resty.Client) func(*cobra.Command, []string) error {
 	return func(c *cobra.Command, s []string) error {
-
 		if *endpoint == "" {
 			return cmderrors.ErrNoWGEEndpoint
 		}
@@ -46,7 +45,9 @@ func getCredentialCmdRunE(endpoint, username, password *string, client *resty.Cl
 		if err != nil {
 			return err
 		}
+
 		w := printers.GetNewTabWriter(os.Stdout)
+
 		defer w.Flush()
 
 		return capi.GetCredentials(r, w)

--- a/cmd/gitops/get/profiles/cmd.go
+++ b/cmd/gitops/get/profiles/cmd.go
@@ -34,7 +34,6 @@ func ProfilesCommand(endpoint, username, password *string, client *resty.Client)
 
 func getProfilesCmdPreRunE(endpoint *string, client *resty.Client) func(*cobra.Command, []string) error {
 	return func(c *cobra.Command, s []string) error {
-
 		if *endpoint == "" {
 			return cmderrors.ErrNoWGEEndpoint
 		}

--- a/cmd/gitops/get/profiles/cmd.go
+++ b/cmd/gitops/get/profiles/cmd.go
@@ -13,7 +13,7 @@ import (
 	"k8s.io/cli-runtime/pkg/printers"
 )
 
-func ProfilesCommand(endpoint *string, client *resty.Client) *cobra.Command {
+func ProfilesCommand(endpoint, username, password *string, client *resty.Client) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "profile",
 		Aliases:       []string{"profiles"},
@@ -26,7 +26,7 @@ func ProfilesCommand(endpoint *string, client *resty.Client) *cobra.Command {
 	gitops get profiles
 	`,
 		PreRunE: getProfilesCmdPreRunE(endpoint, client),
-		RunE:    getProfilesCmdRunE(endpoint, client),
+		RunE:    getProfilesCmdRunE(endpoint, username, password, client),
 	}
 
 	return cmd
@@ -34,6 +34,7 @@ func ProfilesCommand(endpoint *string, client *resty.Client) *cobra.Command {
 
 func getProfilesCmdPreRunE(endpoint *string, client *resty.Client) func(*cobra.Command, []string) error {
 	return func(c *cobra.Command, s []string) error {
+
 		if *endpoint == "" {
 			return cmderrors.ErrNoWGEEndpoint
 		}
@@ -42,9 +43,9 @@ func getProfilesCmdPreRunE(endpoint *string, client *resty.Client) func(*cobra.C
 	}
 }
 
-func getProfilesCmdRunE(endpoint *string, client *resty.Client) func(*cobra.Command, []string) error {
+func getProfilesCmdRunE(endpoint, username, password *string, client *resty.Client) func(*cobra.Command, []string) error {
 	return func(c *cobra.Command, s []string) error {
-		r, err := adapters.NewHttpClient(*endpoint, client, os.Stdout)
+		r, err := adapters.NewHttpClient(*endpoint, *username, *password, client, os.Stdout)
 		if err != nil {
 			return err
 		}

--- a/cmd/gitops/get/templates/cmd.go
+++ b/cmd/gitops/get/templates/cmd.go
@@ -57,6 +57,7 @@ gitops get template <template-name> --list-parameters
 	cmd.Flags().BoolVar(&flags.ListTemplateParameters, "list-parameters", false, "Show parameters of CAPI template")
 	cmd.Flags().BoolVar(&flags.ListTemplateProfiles, "list-profiles", false, "Show profiles of CAPI template")
 	cmd.Flags().StringVar(&flags.Provider, "provider", "", fmt.Sprintf("Filter templates by provider. Supported providers: %s", strings.Join(providers, " ")))
+
 	return cmd
 }
 
@@ -80,6 +81,7 @@ func getTemplateCmdRunE(endpoint, username, password *string, client *resty.Clie
 		if err != nil {
 			return err
 		}
+
 		w := printers.GetNewTabWriter(os.Stdout)
 		defer w.Flush()
 

--- a/cmd/gitops/get/templates/cmd.go
+++ b/cmd/gitops/get/templates/cmd.go
@@ -32,7 +32,7 @@ var providers = []string{
 	"vsphere",
 }
 
-func TemplateCommand(endpoint *string, client *resty.Client) *cobra.Command {
+func TemplateCommand(endpoint, username, password *string, client *resty.Client) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "template",
 		Aliases: []string{"templates"},
@@ -50,14 +50,13 @@ gitops get template <template-name> --list-parameters
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		PreRunE:       getTemplateCmdPreRunE(endpoint, client),
-		RunE:          getTemplateCmdRunE(endpoint, client),
+		RunE:          getTemplateCmdRunE(endpoint, username, password, client),
 		Args:          cobra.MaximumNArgs(1),
 	}
 
 	cmd.Flags().BoolVar(&flags.ListTemplateParameters, "list-parameters", false, "Show parameters of CAPI template")
 	cmd.Flags().BoolVar(&flags.ListTemplateProfiles, "list-profiles", false, "Show profiles of CAPI template")
 	cmd.Flags().StringVar(&flags.Provider, "provider", "", fmt.Sprintf("Filter templates by provider. Supported providers: %s", strings.Join(providers, " ")))
-
 	return cmd
 }
 
@@ -75,13 +74,12 @@ func getTemplateCmdPreRunE(endpoint *string, client *resty.Client) func(*cobra.C
 	}
 }
 
-func getTemplateCmdRunE(endpoint *string, client *resty.Client) func(*cobra.Command, []string) error {
+func getTemplateCmdRunE(endpoint, username, password *string, client *resty.Client) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
-		r, err := adapters.NewHttpClient(*endpoint, client, os.Stdout)
+		r, err := adapters.NewHttpClient(*endpoint, *username, *password, client, os.Stdout)
 		if err != nil {
 			return err
 		}
-
 		w := printers.GetNewTabWriter(os.Stdout)
 		defer w.Flush()
 

--- a/cmd/gitops/root/cmd.go
+++ b/cmd/gitops/root/cmd.go
@@ -29,6 +29,8 @@ var options struct {
 	overrideInCluster     bool
 	gitHostTypes          map[string]string
 	insecureSkipTlsVerify bool
+	username              string
+	password              string
 }
 
 // Only want AutomaticEnv to be called once!
@@ -79,6 +81,7 @@ func RootCmd(client *resty.Client) *cobra.Command {
 			if options.overrideInCluster {
 				kube.InClusterConfig = func() (*rest.Config, error) { return nil, rest.ErrNotInCluster }
 			}
+
 			if options.insecureSkipTlsVerify {
 				client.SetTLSClientConfig(&tls.Config{InsecureSkipVerify: true})
 			}
@@ -87,6 +90,8 @@ func RootCmd(client *resty.Client) *cobra.Command {
 
 	rootCmd.PersistentFlags().String("namespace", wego.DefaultNamespace, "The namespace scope for this operation")
 	rootCmd.PersistentFlags().StringVarP(&options.endpoint, "endpoint", "e", os.Getenv("WEAVE_GITOPS_ENTERPRISE_API_URL"), "The Weave GitOps Enterprise HTTP API endpoint")
+	rootCmd.PersistentFlags().StringVarP(&options.username, "username", "u", os.Getenv("WEAVE_GITOPS_USERNAME"), "The Weave GitOps Enterprise HTTP API endpoint")
+	rootCmd.PersistentFlags().StringVarP(&options.password, "password", "p", os.Getenv("WEAVE_GITOPS_PASSWORD"), "The Weave GitOps Enterprise HTTP API endpoint")
 	rootCmd.PersistentFlags().BoolVar(&options.overrideInCluster, "override-in-cluster", false, "override running in cluster check")
 	rootCmd.PersistentFlags().StringToStringVar(&options.gitHostTypes, "git-host-types", map[string]string{}, "Specify which custom domains are running what (github or gitlab)")
 	rootCmd.PersistentFlags().BoolVar(&options.insecureSkipTlsVerify, "insecure-skip-tls-verify", false, "If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure")
@@ -94,10 +99,10 @@ func RootCmd(client *resty.Client) *cobra.Command {
 	cobra.CheckErr(rootCmd.PersistentFlags().MarkHidden("git-host-types"))
 
 	rootCmd.AddCommand(version.Cmd)
-	rootCmd.AddCommand(get.GetCommand(&options.endpoint, client))
-	rootCmd.AddCommand(add.GetCommand(&options.endpoint, client))
-	rootCmd.AddCommand(update.UpdateCommand(&options.endpoint, client))
-	rootCmd.AddCommand(delete.DeleteCommand(&options.endpoint, client))
+	rootCmd.AddCommand(get.GetCommand(&options.endpoint, &options.username, &options.password, client))
+	rootCmd.AddCommand(add.GetCommand(&options.endpoint, &options.username, &options.password, client))
+	rootCmd.AddCommand(update.UpdateCommand(&options.endpoint, &options.username, &options.password, client))
+	rootCmd.AddCommand(delete.DeleteCommand(&options.endpoint, &options.username, &options.password, client))
 	rootCmd.AddCommand(upgrade.Cmd)
 	rootCmd.AddCommand(docs.Cmd)
 	rootCmd.AddCommand(check.Cmd)

--- a/cmd/gitops/root/cmd.go
+++ b/cmd/gitops/root/cmd.go
@@ -39,7 +39,7 @@ func init() {
 	//   config-repo => GITOPS_CONFIG_REPO
 	replacer := strings.NewReplacer("-", "_")
 	viper.SetEnvKeyReplacer(replacer)
-	viper.SetEnvPrefix("GITOPS")
+	viper.SetEnvPrefix("WEAVE_GITOPS")
 
 	viper.AutomaticEnv()
 }
@@ -85,13 +85,25 @@ func RootCmd(client *resty.Client) *cobra.Command {
 			if options.insecureSkipTlsVerify {
 				client.SetTLSClientConfig(&tls.Config{InsecureSkipVerify: true})
 			}
+
+			err = cmd.Flags().Set("username", viper.GetString("username"))
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+				os.Exit(1)
+			}
+
+			err = cmd.Flags().Set("password", viper.GetString("password"))
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+				os.Exit(1)
+			}
 		},
 	}
 
 	rootCmd.PersistentFlags().String("namespace", wego.DefaultNamespace, "The namespace scope for this operation")
 	rootCmd.PersistentFlags().StringVarP(&options.endpoint, "endpoint", "e", os.Getenv("WEAVE_GITOPS_ENTERPRISE_API_URL"), "The Weave GitOps Enterprise HTTP API endpoint")
-	rootCmd.PersistentFlags().StringVarP(&options.username, "username", "u", os.Getenv("WEAVE_GITOPS_USERNAME"), "The Weave GitOps Enterprise HTTP API endpoint")
-	rootCmd.PersistentFlags().StringVarP(&options.password, "password", "p", os.Getenv("WEAVE_GITOPS_PASSWORD"), "The Weave GitOps Enterprise HTTP API endpoint")
+	rootCmd.PersistentFlags().StringVarP(&options.username, "username", "u", "", "The Weave GitOps Enterprise username for authentication can be set with `WEAVE_GITOPS_USERNAME` environment variable")
+	rootCmd.PersistentFlags().StringVarP(&options.password, "password", "p", "", "The Weave GitOps Enterprise password for authentication can be set with `WEAVE_GITOPS_PASSWORD` environment variable")
 	rootCmd.PersistentFlags().BoolVar(&options.overrideInCluster, "override-in-cluster", false, "override running in cluster check")
 	rootCmd.PersistentFlags().StringToStringVar(&options.gitHostTypes, "git-host-types", map[string]string{}, "Specify which custom domains are running what (github or gitlab)")
 	rootCmd.PersistentFlags().BoolVar(&options.insecureSkipTlsVerify, "insecure-skip-tls-verify", false, "If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure")

--- a/cmd/gitops/update/cmd.go
+++ b/cmd/gitops/update/cmd.go
@@ -1,13 +1,13 @@
 package update
 
 import (
+	"github.com/go-resty/resty/v2"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/update/profiles"
 
-	"github.com/go-resty/resty/v2"
 	"github.com/spf13/cobra"
 )
 
-func UpdateCommand(endpoint *string, client *resty.Client) *cobra.Command {
+func UpdateCommand(endpoint, username, password *string, client *resty.Client) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "update",
 		Short: "Update a Weave GitOps resource",
@@ -17,7 +17,7 @@ func UpdateCommand(endpoint *string, client *resty.Client) *cobra.Command {
 		`,
 	}
 
-	cmd.AddCommand(profiles.UpdateCommand(endpoint, client))
+	cmd.AddCommand(profiles.UpdateCommand(endpoint, username, password, client))
 
 	return cmd
 }

--- a/cmd/gitops/update/profiles/profiles.go
+++ b/cmd/gitops/update/profiles/profiles.go
@@ -54,7 +54,6 @@ func UpdateCommand(endpoint, username, password *string, client *resty.Client) *
 
 func updateProfileCmdPreRunE(endpoint *string, client *resty.Client) func(*cobra.Command, []string) error {
 	return func(c *cobra.Command, s []string) error {
-
 		if *endpoint == "" {
 			return cmderrors.ErrNoWGEEndpoint
 		}
@@ -65,11 +64,11 @@ func updateProfileCmdPreRunE(endpoint *string, client *resty.Client) func(*cobra
 
 func updateProfileCmdRunE(endpoint, username, password *string, client *resty.Client) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
-
 		log := internal.NewCLILogger(os.Stdout)
 		fluxClient := flux.New(&runner.CLIRunner{})
 		factory := services.NewFactory(fluxClient, internal.Logr())
 		providerClient := internal.NewGitProviderClient(os.Stdout, os.LookupEnv, log)
+
 		r, err := adapters.NewHttpClient(*endpoint, *username, *password, client, os.Stdout)
 		if err != nil {
 			return err

--- a/cmd/gitops/update/profiles/profiles.go
+++ b/cmd/gitops/update/profiles/profiles.go
@@ -21,7 +21,7 @@ import (
 var opts profiles.Options
 
 // UpdateCommand provides support for updating a profile that is installed on a cluster.
-func UpdateCommand(endpoint *string, client *resty.Client) *cobra.Command {
+func UpdateCommand(endpoint, username, password *string, client *resty.Client) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "profile",
 		Short:         "Update a profile installation",
@@ -32,7 +32,7 @@ func UpdateCommand(endpoint *string, client *resty.Client) *cobra.Command {
 	gitops update profile --name=podinfo --cluster=prod --config-repo=ssh://git@github.com/owner/config-repo.git  --version=1.0.0
 		`,
 		PreRunE: updateProfileCmdPreRunE(endpoint, client),
-		RunE:    updateProfileCmdRunE(endpoint, client),
+		RunE:    updateProfileCmdRunE(endpoint, username, password, client),
 	}
 
 	cmd.Flags().StringVar(&opts.Name, "name", "", "Name of the profile")
@@ -54,6 +54,7 @@ func UpdateCommand(endpoint *string, client *resty.Client) *cobra.Command {
 
 func updateProfileCmdPreRunE(endpoint *string, client *resty.Client) func(*cobra.Command, []string) error {
 	return func(c *cobra.Command, s []string) error {
+
 		if *endpoint == "" {
 			return cmderrors.ErrNoWGEEndpoint
 		}
@@ -62,14 +63,14 @@ func updateProfileCmdPreRunE(endpoint *string, client *resty.Client) func(*cobra
 	}
 }
 
-func updateProfileCmdRunE(endpoint *string, client *resty.Client) func(*cobra.Command, []string) error {
+func updateProfileCmdRunE(endpoint, username, password *string, client *resty.Client) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
+
 		log := internal.NewCLILogger(os.Stdout)
 		fluxClient := flux.New(&runner.CLIRunner{})
 		factory := services.NewFactory(fluxClient, internal.Logr())
 		providerClient := internal.NewGitProviderClient(os.Stdout, os.LookupEnv, log)
-
-		r, err := adapters.NewHttpClient(*endpoint, client, os.Stdout)
+		r, err := adapters.NewHttpClient(*endpoint, *username, *password, client, os.Stdout)
 		if err != nil {
 			return err
 		}

--- a/pkg/adapters/http.go
+++ b/pkg/adapters/http.go
@@ -2,6 +2,7 @@ package adapters
 
 import (
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -17,6 +18,7 @@ import (
 const (
 	expiredHeaderName          = "Entitlement-Expired-Message"
 	gitProviderTokenHeaderName = "Git-Provider-Token"
+	auth_cookie_name           = "id_token"
 )
 
 // An HTTP client of the cluster service.
@@ -32,10 +34,10 @@ type ServiceError struct {
 
 // NewHttpClient creates a new HTTP client of the cluster service.
 // The endpoint is expected to be an absolute HTTP URI.
-func NewHttpClient(endpoint string, client *resty.Client, out io.Writer) (*HTTPClient, error) {
+func NewHttpClient(endpoint, username, password string, client *resty.Client, out io.Writer) (*HTTPClient, error) {
 	u, err := url.ParseRequestURI(endpoint)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to parse endpoint: %w", err)
 	}
 
 	client = client.SetHostURL(u.String()).
@@ -51,10 +53,57 @@ func NewHttpClient(endpoint string, client *resty.Client, out io.Writer) (*HTTPC
 			return nil
 		})
 
-	return &HTTPClient{
+	httpClient := &HTTPClient{
 		baseURI: u,
 		client:  client,
-	}, nil
+	}
+
+	if username != "" && password != "" {
+		err = httpClient.signIn(username, password)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return httpClient, nil
+}
+
+func getAuthCookie(cookies []*http.Cookie) (*http.Cookie, error) {
+	for i := range cookies {
+		if cookies[i].Name == auth_cookie_name {
+			return cookies[i], nil
+		}
+	}
+	return nil, errors.New("unable to find token in auth response")
+}
+
+func (c *HTTPClient) signIn(username, password string) error {
+	endpoint := "oauth2/sign_in"
+
+	type SignInBody struct {
+		Username string `json:"username"`
+		Password string `json:"password"`
+	}
+
+	res, err := c.client.R().
+		SetBody(SignInBody{Username: username, Password: password}).
+		Post(endpoint)
+
+	if err != nil {
+		return fmt.Errorf("unable to sign in from %q: %w", res.Request.URL, err)
+	}
+
+	if res.StatusCode() != http.StatusOK {
+		return fmt.Errorf("response status for POST %q was %d", res.Request.URL, res.StatusCode())
+	}
+
+	cookie, err := getAuthCookie(res.Cookies())
+	if err != nil {
+		return err
+	}
+	c.client.SetCookie(cookie)
+	return nil
+
 }
 
 // Source returns the endpoint of the cluster service.

--- a/pkg/adapters/http.go
+++ b/pkg/adapters/http.go
@@ -74,6 +74,7 @@ func getAuthCookie(cookies []*http.Cookie) (*http.Cookie, error) {
 			return cookies[i], nil
 		}
 	}
+
 	return nil, errors.New("unable to find token in auth response")
 }
 
@@ -101,9 +102,10 @@ func (c *HTTPClient) signIn(username, password string) error {
 	if err != nil {
 		return err
 	}
-	c.client.SetCookie(cookie)
-	return nil
 
+	c.client.SetCookie(cookie)
+
+	return nil
 }
 
 // Source returns the endpoint of the cluster service.

--- a/pkg/adapters/http_test.go
+++ b/pkg/adapters/http_test.go
@@ -69,7 +69,7 @@ func TestRetrieveTemplates(t *testing.T) {
 			defer httpmock.DeactivateAndReset()
 			httpmock.RegisterResponder("GET", testutils.BaseURI+"/v1/templates", tt.responder)
 
-			r, err := adapters.NewHttpClient(testutils.BaseURI, client, os.Stdout)
+			r, err := adapters.NewHttpClient(testutils.BaseURI, "", "", client, os.Stdout)
 			assert.NoError(t, err)
 			ts, err := r.RetrieveTemplates()
 			tt.assertFunc(t, ts, err)
@@ -119,7 +119,7 @@ func TestRetrieveTemplatesByProvider(t *testing.T) {
 			defer httpmock.DeactivateAndReset()
 			httpmock.RegisterResponder("GET", testutils.BaseURI+"/v1/templates", tt.responder)
 
-			r, err := adapters.NewHttpClient(testutils.BaseURI, client, os.Stdout)
+			r, err := adapters.NewHttpClient(testutils.BaseURI, "", "", client, os.Stdout)
 			assert.NoError(t, err)
 			ts, err := r.RetrieveTemplates()
 			tt.assertFunc(t, ts, err)
@@ -169,7 +169,7 @@ func TestRetrieveTemplateParameters(t *testing.T) {
 			defer httpmock.DeactivateAndReset()
 			httpmock.RegisterResponder("GET", testutils.BaseURI+"/v1/templates/cluster-template/params", tt.responder)
 
-			r, err := adapters.NewHttpClient(testutils.BaseURI, client, os.Stdout)
+			r, err := adapters.NewHttpClient(testutils.BaseURI, "", "", client, os.Stdout)
 			assert.NoError(t, err)
 			ts, err := r.RetrieveTemplateParameters("cluster-template")
 			tt.assertFunc(t, ts, err)
@@ -263,7 +263,7 @@ spec:
 			defer httpmock.DeactivateAndReset()
 			httpmock.RegisterResponder("POST", testutils.BaseURI+"/v1/templates/cluster-template/render", tt.responder)
 
-			r, err := adapters.NewHttpClient(testutils.BaseURI, client, os.Stdout)
+			r, err := adapters.NewHttpClient(testutils.BaseURI, "", "", client, os.Stdout)
 			assert.NoError(t, err)
 			result, err := r.RenderTemplateWithParameters("cluster-template", nil, capi.Credentials{})
 			tt.assertFunc(t, result, err)
@@ -322,7 +322,7 @@ func TestRetrieveCredentials(t *testing.T) {
 			defer httpmock.DeactivateAndReset()
 			httpmock.RegisterResponder("GET", testutils.BaseURI+"/v1/credentials", tt.responder)
 
-			r, err := adapters.NewHttpClient(testutils.BaseURI, client, os.Stdout)
+			r, err := adapters.NewHttpClient(testutils.BaseURI, "", "", client, os.Stdout)
 			assert.NoError(t, err)
 			creds, err := r.RetrieveCredentials()
 			tt.assertFunc(t, creds, err)
@@ -358,7 +358,7 @@ func TestRetrieveCredentialsByName(t *testing.T) {
 			defer httpmock.DeactivateAndReset()
 			httpmock.RegisterResponder("GET", testutils.BaseURI+"/v1/credentials", tt.responder)
 
-			r, err := adapters.NewHttpClient(testutils.BaseURI, client, os.Stdout)
+			r, err := adapters.NewHttpClient(testutils.BaseURI, "", "", client, os.Stdout)
 			assert.NoError(t, err)
 			creds, err := r.RetrieveCredentialsByName("aws-creds")
 			tt.assertFunc(t, creds, err)
@@ -427,7 +427,7 @@ func TestRetrieveClusters(t *testing.T) {
 			defer httpmock.DeactivateAndReset()
 			httpmock.RegisterResponder("GET", testutils.BaseURI+"/gitops/api/clusters", tt.responder)
 
-			r, err := adapters.NewHttpClient(testutils.BaseURI, client, os.Stdout)
+			r, err := adapters.NewHttpClient(testutils.BaseURI, "", "", client, os.Stdout)
 			assert.NoError(t, err)
 			cs, err := r.RetrieveClusters()
 			tt.assertFunc(t, cs, err)
@@ -478,7 +478,7 @@ func TestGetClusterKubeconfig(t *testing.T) {
 			defer httpmock.DeactivateAndReset()
 			httpmock.RegisterResponder("GET", testutils.BaseURI+"/v1/clusters/dev/kubeconfig", tt.responder)
 
-			r, err := adapters.NewHttpClient(testutils.BaseURI, client, os.Stdout)
+			r, err := adapters.NewHttpClient(testutils.BaseURI, "", "", client, os.Stdout)
 			assert.NoError(t, err)
 			k, err := r.GetClusterKubeconfig("dev")
 			tt.assertFunc(t, k, err)
@@ -529,7 +529,7 @@ func TestDeleteClusters(t *testing.T) {
 			defer httpmock.DeactivateAndReset()
 			httpmock.RegisterResponder("DELETE", testutils.BaseURI+"/v1/clusters", tt.responder)
 
-			c, err := adapters.NewHttpClient(testutils.BaseURI, client, os.Stdout)
+			c, err := adapters.NewHttpClient(testutils.BaseURI, "", "", client, os.Stdout)
 			assert.NoError(t, err)
 			result, err := c.DeleteClusters(clusters.DeleteClustersParams{})
 			tt.assertFunc(t, result, err)
@@ -548,7 +548,7 @@ func TestEntitlementExpiredHeader(t *testing.T) {
 	httpmock.RegisterResponder("GET", testutils.BaseURI+"/v1/templates", httpmock.ResponderFromResponse(response))
 
 	var buf bytes.Buffer
-	c, err := adapters.NewHttpClient(testutils.BaseURI, client, &buf)
+	c, err := adapters.NewHttpClient(testutils.BaseURI, "", "", client, &buf)
 	assert.NoError(t, err)
 	_, err = c.RetrieveTemplates()
 	assert.NoError(t, err)
@@ -610,10 +610,62 @@ func TestRetrieveTemplateProfiles(t *testing.T) {
 			defer httpmock.DeactivateAndReset()
 			httpmock.RegisterResponder("GET", testutils.BaseURI+"/v1/templates/cluster-template/profiles", tt.responder)
 
-			r, err := adapters.NewHttpClient(testutils.BaseURI, client, os.Stdout)
+			r, err := adapters.NewHttpClient(testutils.BaseURI, "", "", client, os.Stdout)
 			assert.NoError(t, err)
 			tps, err := r.RetrieveTemplateProfiles("cluster-template")
 			tt.assertFunc(t, tps, err)
+		})
+	}
+}
+
+func TestSignin(t *testing.T) {
+	tests := []struct {
+		name       string
+		responder  httpmock.Responder
+		assertFunc func(t *testing.T, client *resty.Client, err error)
+	}{
+		{
+			name: "sign in successful",
+			responder: func(*http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: 200,
+					Header: map[string][]string{
+						"Set-Cookie": {
+							"id_token=value",
+						},
+					},
+				}, nil
+			},
+			assertFunc: func(t *testing.T, client *resty.Client, err error) {
+				assert.NotEmpty(t, client.Cookies)
+				assert.Equal(t, client.Cookies[0].Name, "id_token")
+			},
+		},
+		{
+			name:      "error returned",
+			responder: httpmock.NewErrorResponder(errors.New("oops")),
+			assertFunc: func(t *testing.T, client *resty.Client, err error) {
+				assert.Equal(t, err.Error(), "unable to sign in from \"https://weave.works/api/oauth2/sign_in\": Post \"https://weave.works/api/oauth2/sign_in\": oops")
+			},
+		},
+		{
+			name:      "unexpected status code",
+			responder: httpmock.NewStringResponder(http.StatusBadRequest, ""),
+			assertFunc: func(t *testing.T, client *resty.Client, err error) {
+				assert.Equal(t, err.Error(), "response status for POST \"https://weave.works/api/oauth2/sign_in\" was 400")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := resty.New()
+			httpmock.ActivateNonDefault(client.GetClient())
+			defer httpmock.DeactivateAndReset()
+			httpmock.RegisterResponder("POST", testutils.BaseURI+"/oauth2/sign_in", tt.responder)
+
+			_, err := adapters.NewHttpClient(testutils.BaseURI, "username", "pass", client, os.Stdout)
+			tt.assertFunc(t, client, err)
 		})
 	}
 }

--- a/pkg/templates/templates_test.go
+++ b/pkg/templates/templates_test.go
@@ -57,7 +57,7 @@ func TestCreatePullRequestFromTemplate_CAPI(t *testing.T) {
 			defer httpmock.DeactivateAndReset()
 			httpmock.RegisterResponder("POST", testutils.BaseURI+"/v1/clusters", tt.responder)
 
-			c, err := adapters.NewHttpClient(testutils.BaseURI, client, os.Stdout)
+			c, err := adapters.NewHttpClient(testutils.BaseURI, "", "", client, os.Stdout)
 			assert.NoError(t, err)
 
 			result, err := c.CreatePullRequestFromTemplate(templates.CreatePullRequestFromTemplateParams{TemplateKind: templates.CAPITemplateKind})
@@ -109,7 +109,7 @@ func TestCreatePullRequestFromTemplate_Terraform(t *testing.T) {
 			defer httpmock.DeactivateAndReset()
 			httpmock.RegisterResponder("POST", testutils.BaseURI+"/v1/tfcontrollers", tt.responder)
 
-			c, err := adapters.NewHttpClient(testutils.BaseURI, client, os.Stdout)
+			c, err := adapters.NewHttpClient(testutils.BaseURI, "", "", client, os.Stdout)
 			assert.NoError(t, err)
 			result, err := c.CreatePullRequestFromTemplate(templates.CreatePullRequestFromTemplateParams{TemplateKind: templates.GitopsTemplateKind})
 			tt.assertFunc(t, result, err)


### PR DESCRIPTION

<!-- Describe what has changed in this PR -->
**What changed?**
Added functionality to specify username and password through command line(not recommended) or env variable

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**
To add basic authentication against WGE for local development using kind clusters

<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**
Allow passing username and password to all command that contacts WGE endpoints. If they are specified the args are used to sign in before applying the command

<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**
Added unit tests and tested against a local WGE instance

<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**


<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
