### PR TITLE
Fix syncing sources

### DIFF
--- a/core/server/internal/adapters.go
+++ b/core/server/internal/adapters.go
@@ -141,7 +141,7 @@ func (obj HelmRepositoryAdapter) AsClientObject() client.Object {
 }
 
 func (o HelmRepositoryAdapter) GroupVersionKind() schema.GroupVersionKind {
-	return sourcev1.GroupVersion.WithKind(sourcev1.HelmChartKind)
+	return sourcev1.GroupVersion.WithKind(sourcev1.HelmRepositoryKind)
 }
 
 func (o HelmRepositoryAdapter) SetSuspended(suspend bool) {


### PR DESCRIPTION
This fixes two copy-paste errors, plus removes one API request that we
don't need to do.

There fixes two copy-paste errors (chart vs repository, name vs
    key).
    
This also removes a redundant extra request to read the source a
    second time - the first thing requestReconciliation does is to read
    the object again, and then use the result.
    
Finally, this does a bit of renaming for
    consistency. types.NamespacedName and client.ObjectKey are the same
    type, but we used both names, and thus we were using `name` for the
    source key, and `key` for the automation name. Use `client.ObjectKey`
    everywhere instead.


This fixes #2179.