### PR TITLE
Fix the template for TFTemplate

### DIFF
--- a/cmd/gitops/add/terraform/cmd.go
+++ b/cmd/gitops/add/terraform/cmd.go
@@ -92,7 +92,7 @@ func addTerraformCmdRunE(endpoint *string, client *resty.Client) func(*cobra.Com
 		params := templates.CreatePullRequestFromTemplateParams{
 			GitProviderToken: token,
 			TemplateName:     flags.Template,
-			TemplateKind:     templates.TFTemplateKind,
+			TemplateKind:     templates.GitopsTemplateKind,
 			ParameterValues:  vals,
 			RepositoryURL:    flags.RepositoryURL,
 			HeadBranch:       flags.HeadBranch,

--- a/pkg/adapters/http.go
+++ b/pkg/adapters/http.go
@@ -248,7 +248,7 @@ func (c *HTTPClient) CreatePullRequestFromTemplate(params templates.CreatePullRe
 	)
 
 	endpoint = "v1/clusters"
-	if params.TemplateKind == templates.TFTemplateKind {
+	if params.TemplateKind == templates.GitopsTemplateKind {
 		endpoint = "v1/tfcontrollers"
 	}
 

--- a/pkg/templates/templates.go
+++ b/pkg/templates/templates.go
@@ -12,7 +12,7 @@ const (
 	CAPITemplateKind = "CAPITemplate"
 
 	// TF template
-	TFTemplateKind = "TFTemplate"
+	GitopsTemplateKind = "GitopsTemplate"
 )
 
 type CreatePullRequestFromTemplateParams struct {

--- a/pkg/templates/templates_test.go
+++ b/pkg/templates/templates_test.go
@@ -111,7 +111,7 @@ func TestCreatePullRequestFromTemplate_Terraform(t *testing.T) {
 
 			c, err := adapters.NewHttpClient(testutils.BaseURI, client, os.Stdout)
 			assert.NoError(t, err)
-			result, err := c.CreatePullRequestFromTemplate(templates.CreatePullRequestFromTemplateParams{TemplateKind: templates.TFTemplateKind})
+			result, err := c.CreatePullRequestFromTemplate(templates.CreatePullRequestFromTemplateParams{TemplateKind: templates.GitopsTemplateKind})
 			tt.assertFunc(t, result, err)
 		})
 	}


### PR DESCRIPTION
The template name changed on the last commit, but we didn't reflect that in this PR.

This is a fix to change that to the more recent name of the template.