### PR TITLE
remove unnecessary special character in error

### DIFF
--- a/core/clustersmngr/middleware.go
+++ b/core/clustersmngr/middleware.go
@@ -20,7 +20,7 @@ func WithClustersClient(clientsFactory ClientsFactory, next http.Handler) http.H
 		client, err := clientsFactory.GetImpersonatedClient(r.Context(), user)
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
-			fmt.Fprintln(w, "failed fetching clusters list: %w", err)
+			fmt.Fprintln(w, "failed fetching clusters list:", err)
 			return
 		}
 


### PR DESCRIPTION
Fixes weaveworks/weave-gitops-enterprise#767

**What changed?**
Removed special character from a returned error

**Why was this change made?**
`%w` in `fmt.Fprintln()` appears in the UI
