### PR TITLE
Auto-update UI snapshots

### DIFF
--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -41,6 +41,7 @@ jobs:
           jq '.version = "'$GITOPS_VERSION'"' < package.json > package-new.json
           mv package-new.json package.json
           npm ci
+          npm run test -- -u
           git commit -am "Update javascript library version to $GITOPS_VERSION"
 
       - name: Update Chart

--- a/ui/components/__tests__/FilterableTable.test.tsx
+++ b/ui/components/__tests__/FilterableTable.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, prettyDOM, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import "jest-styled-components";
 import _ from "lodash";
 import React from "react";

--- a/ui/components/__tests__/__snapshots__/Footer.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/Footer.test.tsx.snap
@@ -240,7 +240,7 @@ exports[`Footer snapshots no api version 1`] = `
   >
     <a
       class="c5"
-      href="https://github.com/weaveworks/weave-gitops/releases/tag/v0.8.1-rc.4"
+      href="https://github.com/weaveworks/weave-gitops/releases/tag/v0.8.1-rc.5"
       rel="noreferrer"
       target="_blank"
     >
@@ -248,7 +248,7 @@ exports[`Footer snapshots no api version 1`] = `
         class="c6"
         color="primary"
       >
-        v0.8.1-rc.4
+        v0.8.1-rc.5
       </span>
     </a>
     <div


### PR DESCRIPTION
We have a UI snapshot that contains a release number, so we need to
    re-generate the UI snapshots whenever we update the JS version.

The reason I found this out was that I _did_ change the version number without re-generating the UI snapshots, so this also re-generates the UI snapshots.