### PR TITLE
update `get clusters` to use the new endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,3 +112,4 @@ Need help or want to contribute? Please see the links below.
 ## License scan details
 
 [![FOSSA Status](https://app.fossa.com/api/projects/custom%2B19155%2Fgithub.com%2Fweaveworks%2Fweave-gitops.svg?type=large)](https://app.fossa.com/reports/005da7c4-1f10-4889-9432-8b97c2084e41)
+

--- a/pkg/adapters/http.go
+++ b/pkg/adapters/http.go
@@ -40,7 +40,7 @@ func NewHttpClient(endpoint, username, password string, client *resty.Client, ou
 		return nil, fmt.Errorf("failed to parse endpoint: %w", err)
 	}
 
-	client = client.SetDebug(true).SetHostURL(u.String()).
+	client = client.SetHostURL(u.String()).
 		OnAfterResponse(func(c *resty.Client, r *resty.Response) error {
 			if r.StatusCode() >= http.StatusInternalServerError {
 				fmt.Fprintf(out, "Server error: %s\n", r.Body())

--- a/pkg/adapters/http.go
+++ b/pkg/adapters/http.go
@@ -401,7 +401,7 @@ func (c *HTTPClient) RetrieveCredentialsByName(name string) (capi.Credentials, e
 
 // RetrieveClusters returns the list of all clusters from the cluster service.
 func (c *HTTPClient) RetrieveClusters() ([]clusters.Cluster, error) {
-	endpoint := "gitops/api/clusters"
+	endpoint := "/v1/clusters"
 
 	type ClusterView struct {
 		Name        string               `json:"name"`

--- a/pkg/adapters/http_test.go
+++ b/pkg/adapters/http_test.go
@@ -408,14 +408,14 @@ func TestRetrieveClusters(t *testing.T) {
 			name:      "error returned",
 			responder: httpmock.NewErrorResponder(errors.New("oops")),
 			assertFunc: func(t *testing.T, cs []clusters.Cluster, err error) {
-				assert.EqualError(t, err, "unable to GET clusters from \"https://weave.works/api/gitops/api/clusters\": Get \"https://weave.works/api/gitops/api/clusters\": oops")
+				assert.EqualError(t, err, "unable to GET clusters from \"https://weave.works/api/v1/clusters\": Get \"https://weave.works/api/v1/clusters\": oops")
 			},
 		},
 		{
 			name:      "unexpected status code",
 			responder: httpmock.NewStringResponder(http.StatusBadRequest, ""),
 			assertFunc: func(t *testing.T, cs []clusters.Cluster, err error) {
-				assert.EqualError(t, err, "response status for GET \"https://weave.works/api/gitops/api/clusters\" was 400")
+				assert.EqualError(t, err, "response status for GET \"https://weave.works/api/v1/clusters\" was 400")
 			},
 		},
 	}
@@ -425,7 +425,7 @@ func TestRetrieveClusters(t *testing.T) {
 			client := resty.New()
 			httpmock.ActivateNonDefault(client.GetClient())
 			defer httpmock.DeactivateAndReset()
-			httpmock.RegisterResponder("GET", testutils.BaseURI+"/gitops/api/clusters", tt.responder)
+			httpmock.RegisterResponder("GET", testutils.BaseURI+"/v1/clusters", tt.responder)
 
 			r, err := adapters.NewHttpClient(testutils.BaseURI, "", "", client, os.Stdout)
 			assert.NoError(t, err)

--- a/pkg/adapters/http_test.go
+++ b/pkg/adapters/http_test.go
@@ -378,27 +378,33 @@ func TestRetrieveClusters(t *testing.T) {
 			assertFunc: func(t *testing.T, cs []clusters.Cluster, err error) {
 				assert.ElementsMatch(t, cs, []clusters.Cluster{
 					{
-						Name:   "cluster-a",
-						Status: "pullRequestCreated",
-						PullRequest: clusters.PullRequest{
-							Type: "",
-							Url:  "https://github.com/org/repo/pull/1",
+						Name: "cluster-a",
+						Conditions: []clusters.Condition{
+							{
+								Type:    "Ready",
+								Status:  "True",
+								Message: "Cluster Found",
+							},
 						},
 					},
 					{
-						Name:   "cluster-b",
-						Status: "pullRequestCreated",
-						PullRequest: clusters.PullRequest{
-							Type: "",
-							Url:  "https://github.com/org/repo/pull/2",
+						Name: "cluster-b",
+						Conditions: []clusters.Condition{
+							{
+								Type:    "Ready",
+								Status:  "True",
+								Message: "Cluster Found",
+							},
 						},
 					},
 					{
-						Name:   "cluster-c",
-						Status: "pullRequestCreated",
-						PullRequest: clusters.PullRequest{
-							Type: "",
-							Url:  "https://github.com/org/repo/pull/3",
+						Name: "cluster-c",
+						Conditions: []clusters.Condition{
+							{
+								Type:    "Ready",
+								Status:  "True",
+								Message: "Cluster Found",
+							},
 						},
 					},
 				})

--- a/pkg/adapters/testdata/clusters.json
+++ b/pkg/adapters/testdata/clusters.json
@@ -1,40 +1,64 @@
 {
-    "clusters": [
+    "gitopsClusters": [
      {
-      "id": 1,
-      "name": "cluster-a",
-      "type": "",
-      "token": "111",
-      "ingressUrl": "",
-      "status": "pullRequestCreated",
-      "updatedAt": "0001-01-01T00:00:00Z",
-      "pullRequest": {
-       "url": "https://github.com/org/repo/pull/1"
+        "id": 1,
+        "name": "cluster-a",
+        "namespace": "default",
+        "annotations": {
+           "capi.weave.works/bootstrapped": "yes"
+         },
+         "labels": {
+            "kustomize.toolkit.fluxcd.io/name": "flux-system",
+            "kustomize.toolkit.fluxcd.io/namespace": "flux-system",
+            "weave.works/capi": "bootstrap"
+         },
+         "conditions": [
+            {
+               "type": "Ready",
+               "status": "True",
+               "Message": "Cluster Found"
+            }
+         ]
+      },
+      {
+         "id": 1,
+         "name": "cluster-b",
+         "namespace": "default",
+         "annotations": {
+            "capi.weave.works/bootstrapped": "yes"
+         },
+         "labels": {
+            "kustomize.toolkit.fluxcd.io/name": "flux-system",
+            "kustomize.toolkit.fluxcd.io/namespace": "flux-system",
+            "weave.works/capi": "bootstrap"
+         },
+         "conditions": [
+            {
+               "type": "Ready",
+               "status": "True",
+               "Message": "Cluster Found"
+            }
+         ]
+      },
+      {
+         "id": 1,
+         "name": "cluster-c",
+         "namespace": "default",
+         "annotations": {
+            "capi.weave.works/bootstrapped": "yes"
+         },
+         "labels": {
+            "kustomize.toolkit.fluxcd.io/name": "flux-system",
+            "kustomize.toolkit.fluxcd.io/namespace": "flux-system",
+            "weave.works/capi": "bootstrap"
+         },
+         "conditions": [
+            {
+               "type": "Ready",
+               "status": "True",
+               "Message": "Cluster Found"
+            }
+         ]
       }
-     },
-     {
-        "id": 1,
-        "name": "cluster-b",
-        "type": "",
-        "token": "222",
-        "ingressUrl": "",
-        "status": "pullRequestCreated",
-        "updatedAt": "0001-01-01T00:00:00Z",
-        "pullRequest": {
-         "url": "https://github.com/org/repo/pull/2"
-        }
-       },
-       {
-        "id": 1,
-        "name": "cluster-c",
-        "type": "",
-        "token": "333",
-        "ingressUrl": "",
-        "status": "pullRequestCreated",
-        "updatedAt": "0001-01-01T00:00:00Z",
-        "pullRequest": {
-         "url": "https://github.com/org/repo/pull/3"
-        }
-       }
-    ]
-   }
+   ]
+}

--- a/pkg/clusters/clusters.go
+++ b/pkg/clusters/clusters.go
@@ -15,14 +15,14 @@ type ClustersRetriever interface {
 }
 
 type Cluster struct {
-	Name        string      `json:"name"`
-	Status      string      `json:"status"`
-	PullRequest PullRequest `json:"pullRequest"`
+	Name       string      `json:"name"`
+	Conditions []Condition `json:"conditions"`
 }
 
-type PullRequest struct {
-	Type string `json:"type"`
-	Url  string `json:"url"`
+type Condition struct {
+	Type    string `json:"type"`
+	Status  string `json:"status"`
+	Message string `json:"message"`
 }
 
 // GetClusters uses a ClustersRetriever adapter to show
@@ -107,17 +107,19 @@ type DeleteClustersParams struct {
 }
 
 func printCluster(c Cluster, w io.Writer) {
-	if c.Status == "pullRequestCreated" && c.PullRequest.Type == "create" {
-		c.Status = "Creation PR"
-	} else if c.PullRequest.Type == "delete" {
-		c.Status = "Deletion PR"
+	var status, message string
+
+	// wip
+	for _, condition := range c.Conditions {
+		if condition.Type == "Ready" {
+			if condition.Status == "True" {
+				status = condition.Type
+			}
+
+			message = condition.Message
+		}
 	}
 
-	if c.Status == "Creation PR" || c.Status == "Deletion PR" {
-		fmt.Fprintf(w, "%s\t%s\t%s", c.Name, c.Status, c.PullRequest.Url)
-		fmt.Fprintln(w, "")
-	} else {
-		fmt.Fprintf(w, "%s\t%s", c.Name, c.Status)
-		fmt.Fprintln(w, "")
-	}
+	fmt.Fprintf(w, "%s\t%s\t%s", c.Name, status, message)
+	fmt.Fprintln(w, "")
 }

--- a/pkg/clusters/clusters.go
+++ b/pkg/clusters/clusters.go
@@ -109,11 +109,12 @@ type DeleteClustersParams struct {
 func printCluster(c Cluster, w io.Writer) {
 	var status, message string
 
-	// wip
 	for _, condition := range c.Conditions {
 		if condition.Type == "Ready" {
 			if condition.Status == "True" {
 				status = condition.Type
+			} else {
+				status = "Not Ready"
 			}
 
 			message = condition.Message

--- a/pkg/clusters/clusters_test.go
+++ b/pkg/clusters/clusters_test.go
@@ -26,62 +26,32 @@ func TestGetClusters(t *testing.T) {
 			name: "clusters exist",
 			cs: []clusters.Cluster{
 				{
-					Name:   "cluster-a",
-					Status: "status-a",
+					Name: "cluster-a",
+					Conditions: []clusters.Condition{
+						{
+							Type:    "Ready",
+							Status:  "True",
+							Message: "Cluster Found",
+						},
+					},
 				},
 				{
-					Name:   "cluster-b",
-					Status: "status-b",
+					Name: "cluster-b",
+					Conditions: []clusters.Condition{
+						{
+							Type:    "Ready",
+							Status:  "True",
+							Message: "Cluster Found",
+						},
+					},
 				},
 			},
-			expected: "NAME\tSTATUS\tSTATUS_MESSAGE\ncluster-a\tstatus-a\ncluster-b\tstatus-b\n",
+			expected: "NAME\tSTATUS\tSTATUS_MESSAGE\ncluster-a\tReady\tCluster Found\ncluster-b\tReady\tCluster Found\n",
 		},
 		{
 			name:             "error retrieving clusters",
 			err:              fmt.Errorf("oops something went wrong"),
 			expectedErrorStr: "unable to retrieve clusters from \"In-memory fake\": oops something went wrong",
-		},
-		{
-			name: "different status for creation and deletion PR",
-			cs: []clusters.Cluster{
-				{
-					Name:   "cluster-a",
-					Status: "pullRequestCreated",
-					PullRequest: clusters.PullRequest{
-						Type: "create",
-					},
-				},
-				{
-					Name:   "cluster-b",
-					Status: "pullRequestCreated",
-					PullRequest: clusters.PullRequest{
-						Type: "delete",
-					},
-				},
-			},
-			expected: "NAME\tSTATUS\tSTATUS_MESSAGE\ncluster-a\tCreation PR\t\ncluster-b\tDeletion PR\t\n",
-		},
-		{
-			name: "PR URL column",
-			cs: []clusters.Cluster{
-				{
-					Name:   "cluster-a",
-					Status: "pullRequestCreated",
-					PullRequest: clusters.PullRequest{
-						Type: "create",
-						Url:  "https://github.com/org/repo/pull/1",
-					},
-				},
-				{
-					Name:   "cluster-b",
-					Status: "foo",
-					PullRequest: clusters.PullRequest{
-						Type: "create",
-						Url:  "https://github.com/org/repo/pull/1",
-					},
-				},
-			},
-			expected: "NAME\tSTATUS\tSTATUS_MESSAGE\ncluster-a\tCreation PR\thttps://github.com/org/repo/pull/1\ncluster-b\tfoo\n",
 		},
 	}
 
@@ -116,8 +86,13 @@ func TestGetClusterByName(t *testing.T) {
 			clusterName: "cluster-a",
 			cs: []clusters.Cluster{
 				{
-					Name:   "cluster-a",
-					Status: "status-a",
+					Name: "cluster-a",
+					Conditions: []clusters.Condition{
+						{
+							Type:   "ready",
+							Status: "True",
+						},
+					},
 				},
 			},
 			expected: "NAME\tSTATUS\tSTATUS_MESSAGE\ncluster-a\tstatus-a\n",
@@ -127,11 +102,12 @@ func TestGetClusterByName(t *testing.T) {
 			clusterName: "cluster-a",
 			cs: []clusters.Cluster{
 				{
-					Name:   "cluster-a",
-					Status: "pullRequestCreated",
-					PullRequest: clusters.PullRequest{
-						Type: "create",
-						Url:  "https://github.com/org/repo/pull/1",
+					Name: "cluster-a",
+					Conditions: []clusters.Condition{
+						{
+							Type:   "ready",
+							Status: "True",
+						},
 					},
 				},
 			},

--- a/pkg/clusters/clusters_test.go
+++ b/pkg/clusters/clusters_test.go
@@ -40,13 +40,13 @@ func TestGetClusters(t *testing.T) {
 					Conditions: []clusters.Condition{
 						{
 							Type:    "Ready",
-							Status:  "True",
-							Message: "Cluster Found",
+							Status:  "False",
+							Message: "failed to get CAPI cluster",
 						},
 					},
 				},
 			},
-			expected: "NAME\tSTATUS\tSTATUS_MESSAGE\ncluster-a\tReady\tCluster Found\ncluster-b\tReady\tCluster Found\n",
+			expected: "NAME\tSTATUS\tSTATUS_MESSAGE\ncluster-a\tReady\tCluster Found\ncluster-b\tNot Ready\tfailed to get CAPI cluster\n",
 		},
 		{
 			name:             "error retrieving clusters",
@@ -89,29 +89,30 @@ func TestGetClusterByName(t *testing.T) {
 					Name: "cluster-a",
 					Conditions: []clusters.Condition{
 						{
-							Type:   "ready",
+							Type:   "Ready",
 							Status: "True",
 						},
 					},
 				},
 			},
-			expected: "NAME\tSTATUS\tSTATUS_MESSAGE\ncluster-a\tstatus-a\n",
+			expected: "NAME\tSTATUS\tSTATUS_MESSAGE\ncluster-a\tReady\t\n",
 		},
 		{
-			name:        "Print cluster PR url",
+			name:        "not ready cluster",
 			clusterName: "cluster-a",
 			cs: []clusters.Cluster{
 				{
 					Name: "cluster-a",
 					Conditions: []clusters.Condition{
 						{
-							Type:   "ready",
-							Status: "True",
+							Type:    "Ready",
+							Status:  "False",
+							Message: "failed to get CAPI cluster",
 						},
 					},
 				},
 			},
-			expected: "NAME\tSTATUS\tSTATUS_MESSAGE\ncluster-a\tCreation PR\thttps://github.com/org/repo/pull/1\n",
+			expected: "NAME\tSTATUS\tSTATUS_MESSAGE\ncluster-a\tNot Ready\tfailed to get CAPI cluster\n",
 		},
 	}
 


### PR DESCRIPTION
Closes #weaveworks/weave-gitops-enterprise#869

**What changed?**
Updated `RetrieveClusters()` to use `/v1/clusters` endpoint for listing clusters

**Why was this change made?**
Endpoint changed in EE 

**How did you validate the change?**
Manually tested it + unit tests