### PR TITLE
Tilt: Fixed default value for local dev

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -4,9 +4,7 @@
 allow_k8s_contexts('wego-dev')
 
 # Support IMAGE_REPO env so that we can run Tilt with a remote cluster
-image_repository = os.getenv('IMAGE_REPO')
-if image_repository == "":
-    image_repository = "localhost:5001/weaveworks/wego-app"
+image_repository = os.getenv('IMAGE_REPO', 'localhost:5001/weaveworks/wego-app')
 
 load('ext://restart_process', 'docker_build_with_restart')
 


### PR DESCRIPTION
Fix bug in our local tiltfile.

os.getenv returns a NoneType as a default value not an empty string so our
docker registry wasn't being populated by default.
