### PR TITLE
Support multiline text and auto-wrap long lines in message table cells

### DIFF
--- a/ui/components/AutomationsTable.tsx
+++ b/ui/components/AutomationsTable.tsx
@@ -25,7 +25,9 @@ type Props = {
 };
 
 function AutomationsTable({ className, automations, hideSource }: Props) {
-  automations = automations.map((a) => { return { ...a, type: displayKind(a.kind) } });
+  automations = automations.map((a) => {
+    return { ...a, type: displayKind(a.kind) };
+  });
   const filterConfig = {
     ...filterConfigForString(automations, "type"),
     ...filterConfigForString(automations, "namespace"),
@@ -147,4 +149,10 @@ function AutomationsTable({ className, automations, hideSource }: Props) {
 
 export default styled(AutomationsTable).attrs({
   className: AutomationsTable.name,
-})``;
+})`
+  td:nth-child(7) {
+    white-space: pre-wrap;
+    overflow-wrap: break-word;
+    word-wrap: break-word;
+  }
+`;

--- a/ui/components/EventsTable.tsx
+++ b/ui/components/EventsTable.tsx
@@ -16,13 +16,8 @@ type Props = {
   involvedObject: ObjectRef;
 };
 
-function EventsTable({
-  className,
-  involvedObject,
-}: Props) {
-  const { data, isLoading, error } = useListFluxEvents(
-    involvedObject
-  );
+function EventsTable({ className, involvedObject }: Props) {
+  const { data, isLoading, error } = useListFluxEvents(involvedObject);
 
   if (isLoading) {
     return (
@@ -63,5 +58,11 @@ function EventsTable({
 export default styled(EventsTable).attrs({ className: EventsTable.name })`
   td {
     max-width: 1024px;
+
+    &:nth-child(2) {
+      white-space: pre-wrap;
+      overflow-wrap: break-word;
+      word-wrap: break-word;
+    }
   }
 `;

--- a/ui/components/ReconciledObjectsTable.tsx
+++ b/ui/components/ReconciledObjectsTable.tsx
@@ -16,6 +16,7 @@ import FilterableTable, {
 } from "./FilterableTable";
 import KubeStatusIndicator, { computeMessage } from "./KubeStatusIndicator";
 import RequestStateHandler from "./RequestStateHandler";
+
 export interface ReconciledVisualizationProps {
   className?: string;
   automationName: string;
@@ -102,4 +103,10 @@ function ReconciledObjectsTable({
 
 export default styled(ReconciledObjectsTable).attrs({
   className: ReconciledObjectsTable.name,
-})``;
+})`
+  td:nth-child(5) {
+    white-space: pre-wrap;
+    overflow-wrap: break-word;
+    word-wrap: break-word;
+  }
+`;

--- a/ui/components/SourcesTable.tsx
+++ b/ui/components/SourcesTable.tsx
@@ -152,4 +152,10 @@ function SourcesTable({ className, sources }: Props) {
   );
 }
 
-export default styled(SourcesTable).attrs({ className: SourcesTable.name })``;
+export default styled(SourcesTable).attrs({ className: SourcesTable.name })`
+  td:nth-child(5) {
+    white-space: pre-wrap;
+    overflow-wrap: break-word;
+    word-wrap: break-word;
+  }
+`;


### PR DESCRIPTION
Closes #2239 

Adds preserving newlines and auto-wrapping long lines of text for all table cells which contain messages.

Using `nth-child` for styling individual table cells based on @jpellizzari 's suggestion.

Code was autoformatted on save with Prettier.