### PR TITLE
release: Don't try to update non-existing CLI installation steps

### DIFF
--- a/tools/update-docs.sh
+++ b/tools/update-docs.sh
@@ -8,14 +8,6 @@ WEAVE_GITOPS_DOC_REPO=$2
 
 cd $WEAVE_GITOPS_DOC_REPO/docs
 yarn install
-# update version information
-ex - installation.mdx << EOS
-/download\/
-%s,download/\([^/]*\)/,download/v${GITOPS_VERSION}/,
-/Current Version
-.,+3! ${WEAVE_GITOPS_BINARY} version
-wq!
-EOS
 # create CLI reference
 git rm -f --ignore-unmatch references/cli-reference.md
 git rm -f --ignore-unmatch references/cli-reference/*.md


### PR DESCRIPTION
The CLI installation instructions have been deleted, so we can't
update the release number any longer.
