### PR TITLE
cli: Remove gitops check --pre flag

### DIFF
--- a/cmd/gitops/check/cmd.go
+++ b/cmd/gitops/check/cmd.go
@@ -8,22 +8,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	pre bool
-)
-
 var Cmd = &cobra.Command{
 	Use:   "check",
 	Short: "Validates flux compatibility",
 	Example: `
 # Validate flux and kubernetes compatibility
-gitops check --pre
+gitops check
 `,
 	RunE: runCmd,
-}
-
-func init() {
-	Cmd.Flags().BoolVarP(&pre, "pre", "p", true, "perform only the pre-installation checks")
 }
 
 func runCmd(_ *cobra.Command, _ []string) error {


### PR DESCRIPTION
It doesn't do anything at all - we always call `check.Pre()` - except
for trying to register a `-p` flag which has been stolen by
`--password` and now it crashed at startup.