### PR TITLE
dev: Add MANUAL_MODE env var to tiltfile

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -3,6 +3,9 @@
 # Allow a K8s context named wego-dev, in addition to the local cluster
 allow_k8s_contexts('wego-dev')
 
+if os.getenv('MANUAL_MODE'):
+   trigger_mode(TRIGGER_MODE_MANUAL)
+
 # Support IMAGE_REPO env so that we can run Tilt with a remote cluster
 image_repository = os.getenv('IMAGE_REPO', 'localhost:5001/weaveworks/wego-app')
 

--- a/doc/development-process.md
+++ b/doc/development-process.md
@@ -61,9 +61,10 @@ Then we install flux on it.
 
 `$ flux install`
 
-Then we bring up tilt.
+Then we bring up tilt, without auto-restart enabled (see [the FAQ
+entry below](#the-server-keeps-restarting-and-its-annoying)).
 
-`$ tilt up`
+`$ MANUAL_MODE=true tilt up`
 
 Then we make our node_modules, this will take a little while.
 
@@ -158,5 +159,23 @@ Then we bring up tilt, passing it the flag `FAST_AND_FURIOUSER`. This tells our 
 
 Goto login with username: dev, password:dev at http://localhost:9001/sign_in
 
-Woop! It's working? Probably. Maybe. Or you may need to faff around with resolving build steps when you did `make all`. 
+Woop! It's working? Probably. Maybe. Or you may need to faff around with resolving build steps when you did `make all`.
 Good luck!
+
+## Tips & tricks
+
+### The server keeps restarting and it's annoying
+
+Tilt has a feature where it automatically restarts the pod whenever
+you save a changed file. This might give you a few seconds of nothing
+working, over and over.
+
+Depending on your setup, that might be more annoying than helpful -
+for instance, if you're doing frontend development outside of docker,
+then the frontend is already being restarted on its own, so anything
+tilt does is just getting in your way. If you disable auto-restart,
+then any time you want to re-deploy the k8s pod, you have to open the
+tilt UI and click on the spinny icon.
+
+`tilt up` starts tilt with auto-reload enabled. To disable, instead
+start it with `MANUAL_MODE=true tilt up`.


### PR DESCRIPTION
This is primarily useful for frontend development through npm start,
where it stops the backend pod ever restarting, which means fewer
times waiting for the requests to start working again.

Hopefully the changes to development-process.md explains this in enough details to get everybody started.