### PR TITLE
Fix loading icon size inside buttons

### DIFF
--- a/ui/components/Button.tsx
+++ b/ui/components/Button.tsx
@@ -2,7 +2,7 @@
 import { CircularProgress, PropTypes } from "@material-ui/core";
 import MaterialButton, { ButtonProps } from "@material-ui/core/Button/Button";
 import * as React from "react";
-import styled from "styled-components";
+import styled, { useTheme } from "styled-components";
 
 /** Button Properties */
 export interface Props extends ButtonProps {
@@ -21,10 +21,17 @@ const defaultProps = {
 
 /** Form Button */
 function UnstyledButton({ loading, ...props }: Props) {
+  const theme = useTheme();
   return (
     <MaterialButton
       disabled={loading}
-      startIcon={loading ? <CircularProgress size={14} /> : props.startIcon}
+      startIcon={
+        loading ? (
+          <CircularProgress size={theme.fontSizes.medium} />
+        ) : (
+          props.startIcon
+        )
+      }
       disableElevation={true}
       {...defaultProps}
       {...props}

--- a/ui/components/Button.tsx
+++ b/ui/components/Button.tsx
@@ -24,7 +24,7 @@ function UnstyledButton({ loading, ...props }: Props) {
   return (
     <MaterialButton
       disabled={loading}
-      startIcon={loading ? <CircularProgress size={16} /> : props.startIcon}
+      startIcon={loading ? <CircularProgress size={14} /> : props.startIcon}
       disableElevation={true}
       {...defaultProps}
       {...props}


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes #2228 

<!-- Describe what has changed in this PR -->
When font sizes were changed recently, the loading icon on buttons became too large, which would adjust button size when it appeared. It wasn't tied to the theme so I didn't catch it, but now it is with the `useTheme` hook from styled components. Hooray!

