### PR TITLE
Add number lines to yaml tab

### DIFF
--- a/ui/components/YamlView.tsx
+++ b/ui/components/YamlView.tsx
@@ -7,8 +7,6 @@ type Props = {
 };
 
 function YamlView({ yaml, className }: Props) {
-  console.log(yaml.split("\n"));
-
   return (
     <pre className={className}>
       {yaml.split("\n").map((yaml, index) => (

--- a/ui/components/YamlView.tsx
+++ b/ui/components/YamlView.tsx
@@ -41,6 +41,7 @@ export default styled(YamlView).attrs({
   }
 
   code::before {
+    width: 24px;
     color: ${(props) => props.theme.colors.primary10};
     content: counter(listing);
     display: inline-block;

--- a/ui/components/YamlView.tsx
+++ b/ui/components/YamlView.tsx
@@ -4,14 +4,16 @@ import styled from "styled-components";
 type Props = {
   className?: string;
   yaml: string;
-}
+};
 
 function YamlView({ yaml, className }: Props) {
+  console.log(yaml.split("\n"));
+
   return (
     <pre className={className}>
-      <code>
-        {yaml}
-      </code>
+      {yaml.split("\n").map((yaml, index) => (
+        <code key={index}>{yaml}</code>
+      ))}
     </pre>
   );
 }
@@ -19,6 +21,35 @@ function YamlView({ yaml, className }: Props) {
 export default styled(YamlView).attrs({
   className: YamlView.name,
 })`
-  font-size: ${props => props.theme.fontSizes.small};
+  width: calc(100% - ${(props) => props.theme.spacing.medium});
+  font-size: ${(props) => props.theme.fontSizes.small};
+  border: 1px solid ${(props) => props.theme.colors.neutral20};
+  border-radius: 8px;
+  padding: ${(props) => props.theme.spacing.small};
   white-space: break-spaces;
+  pre {
+    white-space: pre-wrap;
+  }
+
+  pre::before {
+    counter-reset: listing;
+  }
+
+  code {
+    counter-increment: listing;
+    text-align: left;
+    float: left;
+    clear: left;
+  }
+
+  code::before {
+    color: ${(props) => props.theme.colors.primary10};
+    content: counter(listing);
+    display: inline-block;
+    float: left;
+    height: auto;
+    padding-left: auto;
+    margin-right: ${(props) => props.theme.spacing.small};
+    text-align: right;
+  }
 `;

--- a/ui/components/YamlView.tsx
+++ b/ui/components/YamlView.tsx
@@ -41,7 +41,7 @@ export default styled(YamlView).attrs({
   }
 
   code::before {
-    width: 24px;
+    width: 28px;
     color: ${(props) => props.theme.colors.primary10};
     content: counter(listing);
     display: inline-block;

--- a/ui/components/YamlView.tsx
+++ b/ui/components/YamlView.tsx
@@ -26,7 +26,7 @@ export default styled(YamlView).attrs({
   border: 1px solid ${(props) => props.theme.colors.neutral20};
   border-radius: 8px;
   padding: ${(props) => props.theme.spacing.small};
-  white-space: break-spaces;
+  overflow: scroll;
   pre {
     white-space: pre-wrap;
   }


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes #2229 

<!-- Describe what has changed in this PR -->
Adds a counter to the yaml view with CSS, based on this stack overflow post: https://stackoverflow.com/questions/41306797/html-how-to-add-line-numbers-to-a-source-code-block

The wrapping was getting a bit crazy, so I changed the view to `overflow: scroll` as well.
<img width="1347" alt="image" src="https://user-images.githubusercontent.com/65822698/172241670-3040d12a-18d2-4458-aa1d-05506ee00c73.png">
