### PR TITLE
Link to Flux resources in the details table for Kustomizations and Helm Releases

### DIFF
--- a/ui/components/AutomationsTable.tsx
+++ b/ui/components/AutomationsTable.tsx
@@ -5,7 +5,7 @@ import { Automation } from "../hooks/automations";
 import { FluxObjectKind, HelmRelease } from "../lib/api/core/types.pb";
 import { formatURL } from "../lib/nav";
 import { V2Routes } from "../lib/types";
-import { statusSortHelper, displayKind } from "../lib/utils";
+import { statusSortHelper, removeKind } from "../lib/utils";
 import { Field, SortType } from "./DataTable";
 import {
   filterConfigForStatus,
@@ -26,7 +26,7 @@ type Props = {
 
 function AutomationsTable({ className, automations, hideSource }: Props) {
   automations = automations.map((a) => {
-    return { ...a, type: displayKind(a.kind) };
+    return { ...a, type: removeKind(a.kind) };
   });
   const filterConfig = {
     ...filterConfigForString(automations, "type"),

--- a/ui/components/BucketDetail.tsx
+++ b/ui/components/BucketDetail.tsx
@@ -4,7 +4,7 @@ import Interval from "../components/Interval";
 import SourceDetail from "../components/SourceDetail";
 import Timestamp from "../components/Timestamp";
 import { Bucket, FluxObjectKind } from "../lib/api/core/types.pb";
-import { displayKind } from "../lib/utils";
+import { removeKind } from "../lib/utils";
 
 type Props = {
   className?: string;
@@ -23,7 +23,7 @@ function BucketDetail({ name, namespace, className, clusterName }: Props) {
       type={FluxObjectKind.KindBucket}
       // Guard against an undefined bucket with a default empty object
       info={(b: Bucket = {}) => [
-        ["Type", displayKind(FluxObjectKind.KindBucket)],
+        ["Type", removeKind(FluxObjectKind.KindBucket)],
         ["Endpoint", b.endpoint],
         ["Bucket Name", b.name],
         ["Last Updated", <Timestamp time={b.lastUpdatedAt} />],

--- a/ui/components/GitRepositoryDetail.tsx
+++ b/ui/components/GitRepositoryDetail.tsx
@@ -4,7 +4,7 @@ import Link from "../components/Link";
 import SourceDetail from "../components/SourceDetail";
 import Timestamp from "../components/Timestamp";
 import { FluxObjectKind, GitRepository } from "../lib/api/core/types.pb";
-import { convertGitURLToGitProvider, displayKind } from "../lib/utils";
+import { convertGitURLToGitProvider, removeKind } from "../lib/utils";
 
 type Props = {
   className?: string;
@@ -13,7 +13,12 @@ type Props = {
   clusterName: string;
 };
 
-function GitRepositoryDetail({ name, namespace, className, clusterName }: Props) {
+function GitRepositoryDetail({
+  name,
+  namespace,
+  className,
+  clusterName,
+}: Props) {
   return (
     <SourceDetail
       className={className}
@@ -22,7 +27,7 @@ function GitRepositoryDetail({ name, namespace, className, clusterName }: Props)
       clusterName={clusterName}
       type={FluxObjectKind.KindGitRepository}
       info={(s: GitRepository) => [
-        ["Type", displayKind(FluxObjectKind.KindGitRepository)],
+        ["Type", removeKind(FluxObjectKind.KindGitRepository)],
         [
           "URL",
           <Link newTab href={convertGitURLToGitProvider(s.url)}>

--- a/ui/components/HelmChartDetail.tsx
+++ b/ui/components/HelmChartDetail.tsx
@@ -3,7 +3,7 @@ import styled from "styled-components";
 import Interval from "../components/Interval";
 import SourceDetail from "../components/SourceDetail";
 import Timestamp from "../components/Timestamp";
-import { displayKind } from "../lib/utils";
+import { removeKind } from "../lib/utils";
 import { FluxObjectKind, HelmChart } from "../lib/api/core/types.pb";
 
 type Props = {
@@ -22,7 +22,7 @@ function HelmChartDetail({ name, namespace, className, clusterName }: Props) {
       className={className}
       clusterName={clusterName}
       info={(ch: HelmChart) => [
-        ["Type", displayKind(FluxObjectKind.KindHelmChart)],
+        ["Type", removeKind(FluxObjectKind.KindHelmChart)],
         ["Chart", ch?.chart],
         ["Ref", ch?.sourceRef?.name],
         ["Last Updated", <Timestamp time={ch?.lastUpdatedAt} />],

--- a/ui/components/HelmRepositoryDetail.tsx
+++ b/ui/components/HelmRepositoryDetail.tsx
@@ -4,7 +4,7 @@ import Interval from "../components/Interval";
 import Link from "../components/Link";
 import SourceDetail from "../components/SourceDetail";
 import Timestamp from "../components/Timestamp";
-import { displayKind } from "../lib/utils";
+import { removeKind } from "../lib/utils";
 import { FluxObjectKind, HelmRepository } from "../lib/api/core/types.pb";
 
 type Props = {
@@ -14,7 +14,12 @@ type Props = {
   clusterName: string;
 };
 
-function HelmRepositoryDetail({ name, namespace, className, clusterName }: Props) {
+function HelmRepositoryDetail({
+  name,
+  namespace,
+  className,
+  clusterName,
+}: Props) {
   return (
     <SourceDetail
       className={className}
@@ -24,7 +29,7 @@ function HelmRepositoryDetail({ name, namespace, className, clusterName }: Props
       type={FluxObjectKind.KindHelmRepository}
       // Guard against an undefined repo with a default empty object
       info={(hr: HelmRepository = {}) => [
-        ["Type", displayKind(FluxObjectKind.KindHelmRepository)],
+        ["Type", removeKind(FluxObjectKind.KindHelmRepository)],
         [
           "URL",
           <Link newTab href={hr.url}>

--- a/ui/components/ReconciledObjectsTable.tsx
+++ b/ui/components/ReconciledObjectsTable.tsx
@@ -28,6 +28,19 @@ export interface ReconciledVisualizationProps {
   clusterName: string;
 }
 
+const kindsFrom = [
+  FluxObjectKind.KindKustomization,
+  FluxObjectKind.KindHelmRelease,
+];
+
+const kindsTo = [
+  FluxObjectKind.KindKustomization,
+  FluxObjectKind.KindHelmRelease,
+  FluxObjectKind.KindGitRepository,
+  FluxObjectKind.KindHelmRepository,
+  FluxObjectKind.KindBucket,
+];
+
 function ReconciledObjectsTable({
   className,
   automationName,
@@ -53,20 +66,7 @@ function ReconciledObjectsTable({
     ...filterConfigForStatus(objs),
   };
 
-  const kindsFrom = [
-    FluxObjectKind.KindKustomization,
-    FluxObjectKind.KindHelmRelease,
-  ];
-
   const shouldDisplayLinks = kindsFrom.includes(automationKind);
-
-  const kindsTo = [
-    FluxObjectKind.KindKustomization,
-    FluxObjectKind.KindHelmRelease,
-    FluxObjectKind.KindGitRepository,
-    FluxObjectKind.KindHelmRepository,
-    FluxObjectKind.KindBucket,
-  ];
 
   return (
     <RequestStateHandler loading={isLoading} error={error}>

--- a/ui/components/ReconciledObjectsTable.tsx
+++ b/ui/components/ReconciledObjectsTable.tsx
@@ -7,7 +7,7 @@ import {
   GroupVersionKind,
   UnstructuredObject,
 } from "../lib/api/core/types.pb";
-import { formatURL, sourceTypeToRoute } from "../lib/nav";
+import { formatURL, objectTypeToRoute } from "../lib/nav";
 import { NoNamespace } from "../lib/types";
 import { addKind, statusSortHelper } from "../lib/utils";
 import { SortType } from "./DataTable";
@@ -58,7 +58,7 @@ function ReconciledObjectsTable({
     FluxObjectKind.KindHelmRelease,
   ];
 
-  const shouldAddLinks = kindsFrom.includes(automationKind);
+  const shouldDisplayLinks = kindsFrom.includes(automationKind);
 
   const kindsTo = [
     FluxObjectKind.KindKustomization,
@@ -78,9 +78,9 @@ function ReconciledObjectsTable({
             value: (u: UnstructuredObject) => {
               const kind = FluxObjectKind[addKind(u.groupVersionKind.kind)];
 
-              return shouldAddLinks && kind && kindsTo.includes(kind) ? (
+              return shouldDisplayLinks && kind && kindsTo.includes(kind) ? (
                 <Link
-                  to={formatURL(sourceTypeToRoute(kind), {
+                  to={formatURL(objectTypeToRoute(kind), {
                     name: u.name,
                     namespace: u.namespace,
                     clusterName: u.clusterName,
@@ -89,7 +89,7 @@ function ReconciledObjectsTable({
                   {u.name}
                 </Link>
               ) : (
-                "name"
+                u.name
               );
             },
             label: "Name",

--- a/ui/components/ReconciledObjectsTable.tsx
+++ b/ui/components/ReconciledObjectsTable.tsx
@@ -9,7 +9,7 @@ import {
 } from "../lib/api/core/types.pb";
 import { formatURL, sourceTypeToRoute } from "../lib/nav";
 import { NoNamespace } from "../lib/types";
-import { statusSortHelper } from "../lib/utils";
+import { addKind, statusSortHelper } from "../lib/utils";
 import { SortType } from "./DataTable";
 import FilterableTable, {
   filterConfigForStatus,
@@ -76,7 +76,7 @@ function ReconciledObjectsTable({
         fields={[
           {
             value: (u: UnstructuredObject) => {
-              const kind = FluxObjectKind[`Kind${u.groupVersionKind.kind}`];
+              const kind = FluxObjectKind[addKind(u.groupVersionKind.kind)];
 
               return shouldAddLinks &&
                 kind &&

--- a/ui/components/ReconciledObjectsTable.tsx
+++ b/ui/components/ReconciledObjectsTable.tsx
@@ -53,14 +53,14 @@ function ReconciledObjectsTable({
     ...filterConfigForStatus(objs),
   };
 
-  const kindsToAddLinksFrom = [
+  const kindsFrom = [
     FluxObjectKind.KindKustomization,
     FluxObjectKind.KindHelmRelease,
   ];
 
-  const shouldAddLinks = kindsToAddLinksFrom.includes(automationKind);
+  const shouldAddLinks = kindsFrom.includes(automationKind);
 
-  const kindsToAddLinksTo = [
+  const kindsTo = [
     FluxObjectKind.KindKustomization,
     FluxObjectKind.KindHelmRelease,
     FluxObjectKind.KindGitRepository,
@@ -78,9 +78,7 @@ function ReconciledObjectsTable({
             value: (u: UnstructuredObject) => {
               const kind = FluxObjectKind[addKind(u.groupVersionKind.kind)];
 
-              return shouldAddLinks &&
-                kind &&
-                kindsToAddLinksTo.includes(kind) ? (
+              return shouldAddLinks && kind && kindsTo.includes(kind) ? (
                 <Link
                   to={formatURL(sourceTypeToRoute(kind), {
                     name: u.name,

--- a/ui/components/ReconciliationGraph.tsx
+++ b/ui/components/ReconciliationGraph.tsx
@@ -9,7 +9,7 @@ import {
   UnstructuredObject,
 } from "../lib/api/core/types.pb";
 import images from "../lib/images";
-import { displayKind } from "../lib/utils";
+import { removeKind } from "../lib/utils";
 import DirectedGraph from "./DirectedGraph";
 import Flex from "./Flex";
 import { computeReady } from "./KubeStatusIndicator";
@@ -140,7 +140,7 @@ function ReconciliationGraph({
           <NodeHtml
             object={{
               ...u,
-              groupVersionKind: { kind: displayKind(automationKind) },
+              groupVersionKind: { kind: removeKind(automationKind) },
             }}
           />
         ),
@@ -150,12 +150,12 @@ function ReconciliationGraph({
       id: sourceId,
       data: {
         ...source,
-        kind: displayKind(source.kind),
+        kind: removeKind(source.kind),
       },
       label: (s: ObjectRef) =>
         renderToString(
           <NodeHtml
-            object={{ ...s, groupVersionKind: { kind: displayKind(s.kind) } }}
+            object={{ ...s, groupVersionKind: { kind: removeKind(s.kind) } }}
           />
         ),
     },

--- a/ui/components/SourceLink.tsx
+++ b/ui/components/SourceLink.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import styled from "styled-components";
 import { ObjectRef } from "../lib/api/core/types.pb";
-import { displayKind } from "../lib/utils";
+import { removeKind } from "../lib/utils";
 import { formatSourceURL } from "../lib/nav";
 import Link from "./Link";
 
@@ -19,9 +19,14 @@ function SourceLink({ className, sourceRef, clusterName, short }: Props) {
   return (
     <Link
       className={className}
-      to={formatSourceURL(sourceRef.kind, sourceRef.name, sourceRef.namespace, clusterName)}
+      to={formatSourceURL(
+        sourceRef.kind,
+        sourceRef.name,
+        sourceRef.namespace,
+        clusterName
+      )}
     >
-      {!short && displayKind(sourceRef.kind) + "/"}
+      {!short && removeKind(sourceRef.kind) + "/"}
       {sourceRef.name}
     </Link>
   );

--- a/ui/components/SourcesTable.tsx
+++ b/ui/components/SourcesTable.tsx
@@ -11,7 +11,7 @@ import { showInterval } from "../lib/time";
 import { Source } from "../lib/types";
 import {
   convertGitURLToGitProvider,
-  displayKind,
+  removeKind,
   statusSortHelper,
 } from "../lib/utils";
 import { SortType } from "./DataTable";
@@ -33,7 +33,7 @@ type Props = {
 function SourcesTable({ className, sources }: Props) {
   const [filterDialogOpen, setFilterDialog] = React.useState(false);
   sources = sources.map((s) => {
-    return { ...s, type: displayKind(s.kind) };
+    return { ...s, type: removeKind(s.kind) };
   });
 
   const initialFilterState = {

--- a/ui/components/SourcesTable.tsx
+++ b/ui/components/SourcesTable.tsx
@@ -6,7 +6,7 @@ import {
   GitRepository,
   HelmRepository,
 } from "../lib/api/core/types.pb";
-import { formatURL, sourceTypeToRoute } from "../lib/nav";
+import { formatURL, objectTypeToRoute } from "../lib/nav";
 import { showInterval } from "../lib/time";
 import { Source } from "../lib/types";
 import {
@@ -55,7 +55,7 @@ function SourcesTable({ className, sources }: Props) {
           label: "Name",
           value: (s: Source) => (
             <Link
-              to={formatURL(sourceTypeToRoute(s.kind), {
+              to={formatURL(objectTypeToRoute(s.kind), {
                 name: s?.name,
                 namespace: s?.namespace,
                 clusterName: s?.clusterName,

--- a/ui/lib/nav.ts
+++ b/ui/lib/nav.ts
@@ -52,10 +52,10 @@ export const formatSourceURL = (
   namespace: string = NoNamespace,
   clusterName: string
 ) => {
-  return formatURL(sourceTypeToRoute(kind), { name, namespace, clusterName });
+  return formatURL(objectTypeToRoute(kind), { name, namespace, clusterName });
 };
 
-export function sourceTypeToRoute(t: FluxObjectKind): V2Routes {
+export function objectTypeToRoute(t: FluxObjectKind): V2Routes {
   switch (t) {
     case FluxObjectKind.KindGitRepository:
       return V2Routes.GitRepo;
@@ -68,6 +68,12 @@ export function sourceTypeToRoute(t: FluxObjectKind): V2Routes {
 
     case FluxObjectKind.KindHelmChart:
       return V2Routes.HelmChart;
+
+    case FluxObjectKind.KindKustomization:
+      return V2Routes.Kustomization;
+
+    case FluxObjectKind.KindHelmRelease:
+      return V2Routes.HelmRelease;
 
     default:
       break;

--- a/ui/lib/utils.ts
+++ b/ui/lib/utils.ts
@@ -4,8 +4,6 @@ import { computeReady } from "../components/KubeStatusIndicator";
 import { Condition, HelmRelease, Kustomization } from "./api/core/types.pb";
 import { PageRoute } from "./types";
 
-const KIND_PREFIX = "Kind";
-
 export function notifySuccess(message: string) {
   toast["success"](message);
 }
@@ -66,16 +64,18 @@ export function automationLastUpdated(a: Kustomization | HelmRelease): string {
   return _.get(_.find(a?.conditions, { type: "Ready" }), "timestamp");
 }
 
+const kindPrefix = "Kind";
+
 export function addKind(kind: string): string {
-  if (!kind.startsWith(KIND_PREFIX)) {
-    return `${KIND_PREFIX}${kind}`;
+  if (!kind.startsWith(kindPrefix)) {
+    return `${kindPrefix}${kind}`;
   }
   return kind;
 }
 
 export function removeKind(kind: string): string {
-  if (kind.startsWith(KIND_PREFIX)) {
-    return kind.slice(KIND_PREFIX.length);
+  if (kind.startsWith(kindPrefix)) {
+    return kind.slice(kindPrefix.length);
   }
   return kind;
 }

--- a/ui/lib/utils.ts
+++ b/ui/lib/utils.ts
@@ -4,6 +4,8 @@ import { computeReady } from "../components/KubeStatusIndicator";
 import { Condition, HelmRelease, Kustomization } from "./api/core/types.pb";
 import { PageRoute } from "./types";
 
+const KIND_PREFIX = "Kind";
+
 export function notifySuccess(message: string) {
   toast["success"](message);
 }
@@ -64,9 +66,16 @@ export function automationLastUpdated(a: Kustomization | HelmRelease): string {
   return _.get(_.find(a?.conditions, { type: "Ready" }), "timestamp");
 }
 
-export function displayKind(kind: string): string {
-  if (kind.startsWith("Kind")) {
-    return kind.slice(4);
+export function addKind(kind: string): string {
+  if (!kind.startsWith(KIND_PREFIX)) {
+    return `${KIND_PREFIX}${kind}`;
+  }
+  return kind;
+}
+
+export function removeKind(kind: string): string {
+  if (kind.startsWith(KIND_PREFIX)) {
+    return kind.slice(KIND_PREFIX.length);
   }
   return kind;
 }


### PR DESCRIPTION
Closes #2250

Adds links from a ReconciledObjectsTable name column cells on Kustomization or HelmRelease details page (checking the `automationKind` prop) to object detail pages for objects of types:

- Kustomization
- Helm Release
- Git Repository
- Helm Repository
- Bucket

If an object to which the row corresponds is not of a type above, the name of the object is displayed as plain text without a link.

Also renamed the `displayKind` function (which removes `Kind` prefix) to `removeKind` and added the `addKind` function for mapping `groupVersionKind.kind` string to `FluxObjectKind` enum values.

Renamed function `sourceTypeToRoute` to `objectTypeToRoute` and added mapping for `Kustomization` and `HelmRelease` to it.