### PR TITLE
Kustomizations and Helm Releases display images in tables

### DIFF
--- a/ui/components/ReconciledObjectsTable.tsx
+++ b/ui/components/ReconciledObjectsTable.tsx
@@ -143,8 +143,11 @@ function ReconciledObjectsTable({
 export default styled(ReconciledObjectsTable).attrs({
   className: ReconciledObjectsTable.name,
 })`
-  td:nth-child(5) {
+  td:nth-child(5),
+  td:nth-child(6) {
     white-space: pre-wrap;
+  }
+  td:nth-child(5) {
     overflow-wrap: break-word;
     word-wrap: break-word;
   }

--- a/ui/components/ReconciledObjectsTable.tsx
+++ b/ui/components/ReconciledObjectsTable.tsx
@@ -9,7 +9,7 @@ import {
 } from "../lib/api/core/types.pb";
 import { formatURL, objectTypeToRoute } from "../lib/nav";
 import { NoNamespace } from "../lib/types";
-import { addKind, imageString, statusSortHelper } from "../lib/utils";
+import { addKind, makeImageString, statusSortHelper } from "../lib/utils";
 import { SortType } from "./DataTable";
 import FilterableTable, {
   filterConfigForStatus,
@@ -129,9 +129,9 @@ function ReconciledObjectsTable({
           },
           {
             label: "Images",
-            value: (u: UnstructuredObject) => imageString(u.images),
+            value: (u: UnstructuredObject) => makeImageString(u.images),
             sortType: SortType.string,
-            sortValue: (u: UnstructuredObject) => imageString(u.images),
+            sortValue: (u: UnstructuredObject) => makeImageString(u.images),
           },
         ]}
         rows={objs}

--- a/ui/components/ReconciledObjectsTable.tsx
+++ b/ui/components/ReconciledObjectsTable.tsx
@@ -9,7 +9,7 @@ import {
 } from "../lib/api/core/types.pb";
 import { formatURL, objectTypeToRoute } from "../lib/nav";
 import { NoNamespace } from "../lib/types";
-import { addKind, statusSortHelper } from "../lib/utils";
+import { addKind, imageString, statusSortHelper } from "../lib/utils";
 import { SortType } from "./DataTable";
 import FilterableTable, {
   filterConfigForStatus,
@@ -126,6 +126,12 @@ function ReconciledObjectsTable({
             sortType: SortType.string,
             sortValue: ({ conditions }) => computeMessage(conditions),
             maxWidth: 600,
+          },
+          {
+            label: "Images",
+            value: (u: UnstructuredObject) => imageString(u.images),
+            sortType: SortType.string,
+            sortValue: (u: UnstructuredObject) => imageString(u.images),
           },
         ]}
         rows={objs}

--- a/ui/lib/utils.ts
+++ b/ui/lib/utils.ts
@@ -79,3 +79,13 @@ export function removeKind(kind: string): string {
   }
   return kind;
 }
+
+export function imageString(images: string[]) {
+  let imageString = "";
+  if (!images[0]) imageString = "-";
+  else imageString += images[0];
+  if (images[1]) {
+    for (let i = 1; i < images.length; i++) imageString += `\n${images[i]}`;
+  }
+  return imageString;
+}

--- a/ui/lib/utils.ts
+++ b/ui/lib/utils.ts
@@ -80,9 +80,9 @@ export function removeKind(kind: string): string {
   return kind;
 }
 
-export function imageString(images: string[]) {
+export function makeImageString(images: string[]) {
   let imageString = "";
-  if (!images[0]) imageString = "-";
+  if (!images[0]) return "-";
   else imageString += images[0];
   if (images[1]) {
     for (let i = 1; i < images.length; i++) imageString += `\n${images[i]}`;


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes #2032 

<!-- Describe what has changed in this PR -->
The ReconciledObjectsTable now displays container images across multiple lines
<img width="1350" alt="image" src="https://user-images.githubusercontent.com/65822698/172448817-f0cce6f3-f915-4409-a28e-e304296e7cc5.png">
