### PR TITLE
Replace `npm ci` with `npm i` in releases

### DIFF
--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -40,7 +40,7 @@ jobs:
         run: |
           jq '.version = "'$GITOPS_VERSION'"' < package.json > package-new.json
           mv package-new.json package.json
-          npm ci
+          npm install
           npm run test -- -u
           git commit -am "Update javascript library version to $GITOPS_VERSION"
 


### PR DESCRIPTION
This is a follow-up to f3e7230ff - that commit made sure that `npm ci`
    stopped changing the lock file (as expected from that command), but
    that means that when running `npm i` right now, package-lock.json
    doesn't change, which means the lock file's version doesn't change.