### PR TITLE
Adds multiline and link support to metadata

### DIFF
--- a/ui/components/InfoList.tsx
+++ b/ui/components/InfoList.tsx
@@ -25,11 +25,15 @@ const InfoList = styled(
     );
   }
 )`
+  border-spacing: 0;
   tbody tr td:first-child {
     min-width: 200px;
   }
   td {
+    padding: ${(props) => props.theme.spacing.xxs} 0;
     word-break: break-all;
+    vertical-align: top;
+    white-space: pre-wrap;
   }
   tr {
     height: 16px;

--- a/ui/components/Metadata.tsx
+++ b/ui/components/Metadata.tsx
@@ -17,10 +17,11 @@ function Metadata({ metadata, className }: Props) {
   }
 
   metadata.forEach((pair) => {
-    if (isHTTP(pair[1]))
+    const data = pair[1];
+    if (isHTTP(data))
       pair[1] = (
-        <Link newTab href={pair[1]}>
-          {pair[1]}
+        <Link newTab href={data}>
+          {data}
         </Link>
       );
   });

--- a/ui/components/Metadata.tsx
+++ b/ui/components/Metadata.tsx
@@ -1,8 +1,10 @@
 import * as React from "react";
 import styled from "styled-components";
-import Text from "./Text";
+import { isHTTP } from "../lib/utils";
 import Flex from "./Flex";
 import InfoList from "./InfoList";
+import Link from "./Link";
+import Text from "./Text";
 
 type Props = {
   className?: string;
@@ -14,9 +16,20 @@ function Metadata({ metadata, className }: Props) {
     return <></>;
   }
 
+  metadata.forEach((pair) => {
+    if (isHTTP(pair[1]))
+      pair[1] = (
+        <Link newTab href={pair[1]}>
+          {pair[1]}
+        </Link>
+      );
+  });
+
   return (
     <Flex wide column className={className}>
-      <Text size="large">Metadata</Text>
+      <Text size="large" color="neutral30">
+        Metadata
+      </Text>
       <InfoList items={metadata} />
     </Flex>
   );

--- a/ui/components/SourcesTable.tsx
+++ b/ui/components/SourcesTable.tsx
@@ -32,7 +32,7 @@ type Props = {
 
 function SourcesTable({ className, sources }: Props) {
   const [filterDialogOpen, setFilterDialog] = React.useState(false);
-  sources = sources.map((s) => {
+  sources = sources?.map((s) => {
     return { ...s, type: removeKind(s.kind) };
   });
 


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes #2224 
Closes #2280 

<!-- Describe what has changed in this PR -->
A couple styling changes allow for multiline support in metadata annotations, as well as a quick loop that supports http or https links. I wanted to put the loop into the info list component instead but we're already passing down non-strings in the pair.
<img width="1248" alt="image" src="https://user-images.githubusercontent.com/65822698/172910988-2da68b77-544f-4592-b2b4-a6fb7e56836c.png">
