### PR TITLE
Fix invalid URL caused by filters

### DIFF
--- a/ui/components/FilterableTable.tsx
+++ b/ui/components/FilterableTable.tsx
@@ -9,7 +9,7 @@ import FilterDialog, {
   FilterConfig,
   FilterSelections,
   filterSeparator,
-  selectionsToFilters
+  selectionsToFilters,
 } from "./FilterDialog";
 import Flex from "./Flex";
 import Icon, { IconType } from "./Icon";
@@ -184,7 +184,7 @@ export function filterSelectionsToQueryString(sel: FilterSelections) {
   //if there are any filters, reassign/create filter query key
   if (url) query["filters"] = url;
   //if the update leaves no filters, remove the filter query key from the object
-  else if (query['filters']) query = _.omit(query, 'filters');
+  else if (query["filters"]) query = _.omit(query, "filters");
   //this turns a parsed search into a legit query string
   return qs.stringify(query);
 }

--- a/ui/components/FilterableTable.tsx
+++ b/ui/components/FilterableTable.tsx
@@ -9,7 +9,7 @@ import FilterDialog, {
   FilterConfig,
   FilterSelections,
   filterSeparator,
-  selectionsToFilters,
+  selectionsToFilters
 } from "./FilterDialog";
 import Flex from "./Flex";
 import Icon, { IconType } from "./Icon";
@@ -150,7 +150,6 @@ export function initialFormState(cfg: FilterConfig, initialSelections?) {
     },
     {}
   );
-
   return allFilters;
 }
 
@@ -170,7 +169,6 @@ export function parseFilterStateFromURL(search: string): FilterSelections {
     });
     return next;
   }
-
   return null;
 }
 
@@ -181,12 +179,14 @@ export function filterSelectionsToQueryString(sel: FilterSelections) {
       url += `${key}_`;
     }
   });
-  const query = location.search;
-  let prefix = "";
-  if (query && !query.includes("filters") && url) prefix = "&?filters=";
-  else if (url) prefix = "?filters=";
-
-  return prefix + encodeURIComponent(url);
+  //this is an object with all the different queries as keys
+  let query = qs.parse(location.search);
+  //if there are any filters, reassign/create filter query key
+  if (url) query["filters"] = url;
+  //if the update leaves no filters, remove the filter query key from the object
+  else if (query['filters']) query = _.omit(query, 'filters');
+  //this turns a parsed search into a legit query string
+  return qs.stringify(query);
 }
 
 type State = {

--- a/ui/components/ReconciledObjectsTable.tsx
+++ b/ui/components/ReconciledObjectsTable.tsx
@@ -5,19 +5,20 @@ import { useGetReconciledObjects } from "../hooks/flux";
 import {
   FluxObjectKind,
   GroupVersionKind,
-  UnstructuredObject,
+  UnstructuredObject
 } from "../lib/api/core/types.pb";
 import { formatURL, objectTypeToRoute } from "../lib/nav";
 import { NoNamespace } from "../lib/types";
 import { addKind, makeImageString, statusSortHelper } from "../lib/utils";
 import { SortType } from "./DataTable";
-import FilterableTable, {
+import {
   filterConfigForStatus,
-  filterConfigForString,
+  filterConfigForString
 } from "./FilterableTable";
 import KubeStatusIndicator, { computeMessage } from "./KubeStatusIndicator";
 import Link from "./Link";
 import RequestStateHandler from "./RequestStateHandler";
+import URLAddressableTable from "./URLAddressableTable";
 
 export interface ReconciledVisualizationProps {
   className?: string;
@@ -70,7 +71,7 @@ function ReconciledObjectsTable({
 
   return (
     <RequestStateHandler loading={isLoading} error={error}>
-      <FilterableTable
+      <URLAddressableTable
         filters={initialFilterState}
         className={className}
         fields={[

--- a/ui/components/ReconciledObjectsTable.tsx
+++ b/ui/components/ReconciledObjectsTable.tsx
@@ -5,7 +5,7 @@ import { useGetReconciledObjects } from "../hooks/flux";
 import {
   FluxObjectKind,
   GroupVersionKind,
-  UnstructuredObject
+  UnstructuredObject,
 } from "../lib/api/core/types.pb";
 import { formatURL, objectTypeToRoute } from "../lib/nav";
 import { NoNamespace } from "../lib/types";
@@ -13,7 +13,7 @@ import { addKind, makeImageString, statusSortHelper } from "../lib/utils";
 import { SortType } from "./DataTable";
 import {
   filterConfigForStatus,
-  filterConfigForString
+  filterConfigForString,
 } from "./FilterableTable";
 import KubeStatusIndicator, { computeMessage } from "./KubeStatusIndicator";
 import Link from "./Link";

--- a/ui/components/SourceDetail.tsx
+++ b/ui/components/SourceDetail.tsx
@@ -44,7 +44,8 @@ function SourceDetail({
 }: Props) {
   const { notifySuccess } = React.useContext(AppContext);
   const { data: sources, isLoading, error } = useListSources();
-  const { data: automations, isLoading: automationsLoading } = useListAutomations();
+  const { data: automations, isLoading: automationsLoading } =
+    useListAutomations();
   const { path } = useRouteMatch();
   const { data: object } = useGetObject(
     name,

--- a/ui/components/SourceDetail.tsx
+++ b/ui/components/SourceDetail.tsx
@@ -44,7 +44,7 @@ function SourceDetail({
 }: Props) {
   const { notifySuccess } = React.useContext(AppContext);
   const { data: sources, isLoading, error } = useListSources();
-  const { data: automations } = useListAutomations();
+  const { data: automations, isLoading: automationsLoading } = useListAutomations();
   const { path } = useRouteMatch();
   const { data: object } = useGetObject(
     name,
@@ -72,7 +72,7 @@ function SourceDetail({
     kind: type,
   });
 
-  if (isLoading) {
+  if (isLoading || automationsLoading) {
     return <LoadingPage />;
   }
 

--- a/ui/components/URLAddressableTable.tsx
+++ b/ui/components/URLAddressableTable.tsx
@@ -4,7 +4,7 @@ import styled from "styled-components";
 import FilterableTable, {
   FilterableTableProps,
   filterSelectionsToQueryString,
-  parseFilterStateFromURL
+  parseFilterStateFromURL,
 } from "./FilterableTable";
 import { FilterSelections } from "./FilterDialog";
 

--- a/ui/components/URLAddressableTable.tsx
+++ b/ui/components/URLAddressableTable.tsx
@@ -4,7 +4,7 @@ import styled from "styled-components";
 import FilterableTable, {
   FilterableTableProps,
   filterSelectionsToQueryString,
-  parseFilterStateFromURL,
+  parseFilterStateFromURL
 } from "./FilterableTable";
 import { FilterSelections } from "./FilterDialog";
 

--- a/ui/components/__tests__/FilterableTable.test.tsx
+++ b/ui/components/__tests__/FilterableTable.test.tsx
@@ -9,7 +9,7 @@ import FilterableTable, {
   filterConfigForString,
   filterRows,
   filterSelectionsToQueryString,
-  parseFilterStateFromURL
+  parseFilterStateFromURL,
 } from "../FilterableTable";
 import { FilterSelections } from "../FilterDialog";
 

--- a/ui/components/__tests__/FilterableTable.test.tsx
+++ b/ui/components/__tests__/FilterableTable.test.tsx
@@ -9,7 +9,7 @@ import FilterableTable, {
   filterConfigForString,
   filterRows,
   filterSelectionsToQueryString,
-  parseFilterStateFromURL,
+  parseFilterStateFromURL
 } from "../FilterableTable";
 import { FilterSelections } from "../FilterDialog";
 
@@ -649,7 +649,7 @@ describe("FilterableTable", () => {
 
     expect(args["type:foo"]).toEqual(true);
     const queryString = filterSelectionsToQueryString(args);
-    expect(queryString).toEqual("?filters=type%3Afoo_");
+    expect(queryString).toEqual("filters=type%3Afoo_");
     expect(parseFilterStateFromURL(queryString)).toEqual({
       "type:foo": true,
     });


### PR DESCRIPTION
Closes: #2284 

Massively simplifies the `filterSelectionsToQueryString` function and fixes an error where it would replace the entire query string with just the filter part - `query-string` allows for us to isolate just the filter section of the query string and change it, then put it all back together again with `stringify()`. 

Adds a `URLAddressableTable` to the `ReconciledObjectsTable` component, meaning urls will actually show up on Kustomization or HelmReleaseDetail.

Fixes another bug I found while working on this - the table in the source detail page was using data from the `useListAutomations` hook without checking for a loading value, which would pass down no data to the filters, which would ruin the config and leave checkboxes empty. At least now we're accounting for if the hook is still running.

Definitely check out the branch and try to break everything so we can find out what else is wrong with these dang components please and thank you ❤️ 