### PR TITLE
2269 Format metadata keys; 2301 Sort metadata key/value pairs by key

### DIFF
--- a/ui/components/InfoList.tsx
+++ b/ui/components/InfoList.tsx
@@ -11,7 +11,7 @@ const InfoList = styled(
       <table className={className}>
         <tbody>
           {_.map(items, ([k, v], index) => (
-            <tr key={`key ${index}`}>
+            <tr key={`item ${index}`}>
               <td>
                 <Text capitalize semiBold color="neutral30">
                   {k}:

--- a/ui/components/InfoList.tsx
+++ b/ui/components/InfoList.tsx
@@ -10,8 +10,8 @@ const InfoList = styled(
     return (
       <table className={className}>
         <tbody>
-          {_.map(items, ([k, v]) => (
-            <tr key={k}>
+          {_.map(items, ([k, v], index) => (
+            <tr key={`key ${index}`}>
               <td>
                 <Text capitalize semiBold color="neutral30">
                   {k}:

--- a/ui/components/Metadata.tsx
+++ b/ui/components/Metadata.tsx
@@ -22,6 +22,8 @@ function Metadata({ metadata, className }: Props) {
     metadataCopy[i] = metadata[i].slice();
   }
 
+  metadataCopy.sort((a, b) => a[0].localeCompare(b[0]));
+
   metadataCopy.forEach((pair) => {
     pair[0] = formatMetadataKey(pair[0]);
 

--- a/ui/components/Metadata.tsx
+++ b/ui/components/Metadata.tsx
@@ -16,9 +16,9 @@ function Metadata({ metadata, className }: Props) {
     return <></>;
   }
 
-  let metadataCopy = [];
+  const metadataCopy = [];
 
-  for (var i = 0; i < metadata.length; i++) {
+  for (let i = 0; i < metadata.length; i++) {
     metadataCopy[i] = metadata[i].slice();
   }
 

--- a/ui/components/Metadata.tsx
+++ b/ui/components/Metadata.tsx
@@ -8,7 +8,7 @@ import Text from "./Text";
 
 type Props = {
   className?: string;
-  metadata: [string, string][] | undefined;
+  metadata?: [string, string][];
 };
 
 function Metadata({ metadata, className }: Props) {

--- a/ui/components/Metadata.tsx
+++ b/ui/components/Metadata.tsx
@@ -8,7 +8,7 @@ import Text from "./Text";
 
 type Props = {
   className?: string;
-  metadata: any;
+  metadata: [string, string][] | undefined;
 };
 
 function Metadata({ metadata, className }: Props) {
@@ -21,8 +21,6 @@ function Metadata({ metadata, className }: Props) {
   for (var i = 0; i < metadata.length; i++) {
     metadataCopy[i] = metadata[i].slice();
   }
-
-  console.log(metadataCopy);
 
   metadataCopy.forEach((pair) => {
     pair[0] = formatMetadataKey(pair[0]);

--- a/ui/components/Metadata.tsx
+++ b/ui/components/Metadata.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import styled from "styled-components";
-import { isHTTP } from "../lib/utils";
+import { formatMetadataKey, isHTTP } from "../lib/utils";
 import Flex from "./Flex";
 import InfoList from "./InfoList";
 import Link from "./Link";
@@ -16,7 +16,17 @@ function Metadata({ metadata, className }: Props) {
     return <></>;
   }
 
-  metadata.forEach((pair) => {
+  let metadataCopy = [];
+
+  for (var i = 0; i < metadata.length; i++) {
+    metadataCopy[i] = metadata[i].slice();
+  }
+
+  console.log(metadataCopy);
+
+  metadataCopy.forEach((pair) => {
+    pair[0] = formatMetadataKey(pair[0]);
+
     const data = pair[1];
     if (isHTTP(data))
       pair[1] = (
@@ -31,7 +41,7 @@ function Metadata({ metadata, className }: Props) {
       <Text size="large" color="neutral30">
         Metadata
       </Text>
-      <InfoList items={metadata} />
+      <InfoList items={metadataCopy} />
     </Flex>
   );
 }

--- a/ui/components/__tests__/Metadata.test.tsx
+++ b/ui/components/__tests__/Metadata.test.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import renderer from "react-test-renderer";
+import { withTheme } from "../../lib/test-utils";
+import Metadata from "../Metadata";
+
+describe("snapshots", () => {
+  it("renders with data", () => {
+    const tree = renderer
+      .create(
+        withTheme(
+          <Metadata
+            metadata={[
+              ["CreatedBy", "Value 4"],
+              ["Version", "some version"],
+              ["created-by", "Value 2"],
+              ["createdBy", "Value 3"],
+              ["description", "Value 1"],
+              ["html", "<p><b>html</b></p>"],
+              ["link-to-google", "https://google.com"],
+              ["multi-lines", "This is first line\nThis is second line\n"],
+            ]}
+          />
+        )
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+  it("renders nothing without data", () => {
+    const tree = renderer.create(withTheme(<Metadata />)).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/ui/components/__tests__/__snapshots__/Metadata.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/Metadata.test.tsx.snap
@@ -1,0 +1,158 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`snapshots renders nothing without data 1`] = `null`;
+
+exports[`snapshots renders with data 1`] = `
+<div
+  className="sc-bdvvtL jFYFyX sc-gKclnd thVwy Metadata"
+>
+  <span
+    className="sc-gsDKAQ iLgApi"
+    color="neutral30"
+    size="large"
+  >
+    Metadata
+  </span>
+  <table
+    className="sc-eCImPb heNLgc"
+  >
+    <tbody>
+      <tr>
+        <td>
+          <span
+            className="sc-gsDKAQ jYnRIx"
+            color="neutral30"
+            size="medium"
+          >
+            Created By
+            :
+          </span>
+        </td>
+        <td>
+          Value 2
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <span
+            className="sc-gsDKAQ jYnRIx"
+            color="neutral30"
+            size="medium"
+          >
+            CreatedBy
+            :
+          </span>
+        </td>
+        <td>
+          Value 3
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <span
+            className="sc-gsDKAQ jYnRIx"
+            color="neutral30"
+            size="medium"
+          >
+            CreatedBy
+            :
+          </span>
+        </td>
+        <td>
+          Value 4
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <span
+            className="sc-gsDKAQ jYnRIx"
+            color="neutral30"
+            size="medium"
+          >
+            Description
+            :
+          </span>
+        </td>
+        <td>
+          Value 1
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <span
+            className="sc-gsDKAQ jYnRIx"
+            color="neutral30"
+            size="medium"
+          >
+            Html
+            :
+          </span>
+        </td>
+        <td>
+          &lt;p&gt;&lt;b&gt;html&lt;/b&gt;&lt;/p&gt;
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <span
+            className="sc-gsDKAQ jYnRIx"
+            color="neutral30"
+            size="medium"
+          >
+            Link To Google
+            :
+          </span>
+        </td>
+        <td>
+          <a
+            className="sc-jRQBWg itTnfW"
+            href="https://google.com"
+            rel="noreferrer"
+            target="_blank"
+          >
+            <span
+              className="sc-gsDKAQ eOAACW"
+              color="primary"
+              size="medium"
+            >
+              https://google.com
+            </span>
+          </a>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <span
+            className="sc-gsDKAQ jYnRIx"
+            color="neutral30"
+            size="medium"
+          >
+            Multi Lines
+            :
+          </span>
+        </td>
+        <td>
+          This is first line
+This is second line
+
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <span
+            className="sc-gsDKAQ jYnRIx"
+            color="neutral30"
+            size="medium"
+          >
+            Version
+            :
+          </span>
+        </td>
+        <td>
+          some version
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;

--- a/ui/lib/__tests__/utils.test.ts
+++ b/ui/lib/__tests__/utils.test.ts
@@ -66,12 +66,12 @@ describe("utils lib", () => {
     const pageTitle = "Page Title";
     const appName = "App Name";
 
-    it("returns correct page title with appName", () => {
+    it("returns correct page title with app name", () => {
       expect(pageTitleWithAppName(pageTitle, appName)).toEqual(
         `${pageTitle} for ${appName}`
       );
     });
-    it("returns correct page title without appName", () => {
+    it("returns correct page title without app name", () => {
       expect(pageTitleWithAppName(pageTitle)).toEqual(pageTitle);
     });
   });
@@ -135,7 +135,7 @@ describe("utils lib", () => {
     });
   });
   describe("addKind", () => {
-    it("adds prefix if string does not start with Kind", () => {
+    it("adds the prefix if string does not start with Kind", () => {
       expect(addKind("HelmRelease")).toEqual("KindHelmRelease");
     });
     it("does not add prefix if string starts with Kind", () => {
@@ -143,10 +143,10 @@ describe("utils lib", () => {
     });
   });
   describe("removeKind", () => {
-    it("removes prefix if string starts with Kind", () => {
+    it("removes the prefix if string starts with Kind", () => {
       expect(removeKind("KindHelmRelease")).toEqual("HelmRelease");
     });
-    it("does not remove prefix if string does not start with Kind", () => {
+    it("does not remove the prefix if string does not start with Kind", () => {
       expect(removeKind("GitRepository")).toEqual("GitRepository");
     });
   });
@@ -154,7 +154,7 @@ describe("utils lib", () => {
     it("returns a hyphen if the first image string is empty", () => {
       expect(makeImageString([""])).toEqual("-");
     });
-    it("returns the first string if the first string is not empty", () => {
+    it("returns the first string if the first string is the only string available and it is not empty", () => {
       expect(makeImageString(["image string 1"])).toEqual("image string 1");
     });
     it("returns the first string if the first string is not empty and the second string is empty", () => {

--- a/ui/lib/__tests__/utils.test.ts
+++ b/ui/lib/__tests__/utils.test.ts
@@ -1,0 +1,177 @@
+import { jest } from "@jest/globals";
+import {
+  addKind,
+  convertGitURLToGitProvider,
+  formatMetadataKey,
+  gitlabOAuthRedirectURI,
+  isHTTP,
+  makeImageString,
+  pageTitleWithAppName,
+  removeKind,
+  statusSortHelper,
+} from "../utils";
+
+describe("utils lib", () => {
+  describe("gitlabOAuthRedirectURI", () => {
+    let windowSpy;
+
+    beforeEach(() => {
+      windowSpy = jest.spyOn(window, "window", "get");
+    });
+
+    afterEach(() => {
+      windowSpy.mockRestore();
+    });
+
+    it("returns correct URL", () => {
+      windowSpy.mockImplementation(() => ({
+        location: {
+          origin: "https://example.com",
+        },
+      }));
+
+      expect(gitlabOAuthRedirectURI()).toEqual(
+        "https://example.com/oauth/gitlab"
+      );
+    });
+  });
+  describe("isHTTP", () => {
+    it("detects HTTP", () => {
+      expect(isHTTP("http://www.google.com")).toEqual(true);
+    });
+    it("detects HTTPS", () => {
+      expect(isHTTP("https://www.google.com")).toEqual(true);
+    });
+    it("detects non-HTTP string", () => {
+      expect(isHTTP("test string")).toEqual(false);
+    });
+  });
+  describe("convertGitURLToGitProvider", () => {
+    it("converts valid Git URL", () => {
+      expect(
+        convertGitURLToGitProvider(
+          "ssh://git@github.com/weaveworks/weave-gitops-clusters"
+        )
+      ).toEqual("https://github.com/weaveworks/weave-gitops-clusters");
+    });
+    it("throws error on invalid Git URL", () => {
+      const uri = "github.com/weaveworks/weave-gitops-clusters";
+
+      expect(() => {
+        convertGitURLToGitProvider(uri);
+      }).toThrow(new Error(`could not parse url "${uri}"`));
+    });
+  });
+  describe("pageTitleWithAppName", () => {
+    const pageTitle = "Page Title";
+    const appName = "App Name";
+
+    it("returns correct page title with appName", () => {
+      expect(pageTitleWithAppName(pageTitle, appName)).toEqual(
+        `${pageTitle} for ${appName}`
+      );
+    });
+    it("returns correct page title without appName", () => {
+      expect(pageTitleWithAppName(pageTitle)).toEqual(pageTitle);
+    });
+  });
+  describe("statusSortHelper", () => {
+    it("computes suspended status", () => {
+      expect(
+        statusSortHelper({
+          suspended: true,
+          conditions: [
+            {
+              message:
+                "Applied revision: main/8868a29b71c008c06549052389f3d762d5fbf821",
+              reason: "ReconciliationSucceeded",
+              status: "True",
+              timestamp: "2022-04-13 20:23:15 +0000 UTC",
+              type: "Ready",
+            },
+          ],
+        })
+      ).toEqual(2);
+    });
+    it("computes ready status", () => {
+      expect(
+        statusSortHelper({
+          suspended: false,
+          conditions: [
+            {
+              type: "Ready",
+              status: "True",
+              reason: "HealthCheckFailed",
+              message:
+                "Health check failed after 30.004470633s, timeout waiting for: [Deployment/test/backend status: 'Failed']",
+              timestamp: "2022-03-03 16:55:29 +0000 UTC",
+            },
+            {
+              type: "Healthy",
+              status: "True",
+              reason: "HealthCheckFailed",
+              message: "HealthCheckFailed",
+              timestamp: "2022-03-03 16:55:29 +0000 UTC",
+            },
+          ],
+        })
+      ).toEqual(3);
+    });
+    it("computes default status", () => {
+      expect(
+        statusSortHelper({
+          suspended: false,
+          conditions: [
+            {
+              type: "Healthy",
+              status: "False",
+              reason: "HealthCheckFailed",
+              message: "HealthCheckFailed",
+              timestamp: "2022-03-03 16:55:29 +0000 UTC",
+            },
+          ],
+        })
+      ).toEqual(1);
+    });
+  });
+  describe("addKind", () => {
+    it("adds prefix if string does not start with Kind", () => {
+      expect(addKind("HelmRelease")).toEqual("KindHelmRelease");
+    });
+    it("does not add prefix if string starts with Kind", () => {
+      expect(addKind("KindGitRepository")).toEqual("KindGitRepository");
+    });
+  });
+  describe("removeKind", () => {
+    it("removes prefix if string starts with Kind", () => {
+      expect(removeKind("KindHelmRelease")).toEqual("HelmRelease");
+    });
+    it("does not remove prefix if string does not start with Kind", () => {
+      expect(removeKind("GitRepository")).toEqual("GitRepository");
+    });
+  });
+  describe("makeImageString", () => {
+    it("returns a hyphen if the first image string is empty", () => {
+      expect(makeImageString([""])).toEqual("-");
+    });
+    it("returns the first string if the first string is not empty", () => {
+      expect(makeImageString(["image string 1"])).toEqual("image string 1");
+    });
+    it("returns the first string if the first string is not empty and the second string is empty", () => {
+      expect(makeImageString(["image string 1", ""])).toEqual("image string 1");
+    });
+    it("concatenates strings if both strings are not empty", () => {
+      expect(makeImageString(["image string 1", "image string 2"])).toEqual(
+        "image string 1\nimage string 2"
+      );
+    });
+  });
+  describe("formatMetadataKey", () => {
+    it("capitalizes words in keys if needed", () => {
+      expect(formatMetadataKey("description")).toEqual("Description");
+      expect(formatMetadataKey("created-by")).toEqual("Created By");
+      expect(formatMetadataKey("createdBy")).toEqual("CreatedBy");
+      expect(formatMetadataKey("CreatedBy")).toEqual("CreatedBy");
+    });
+  });
+});

--- a/ui/lib/utils.ts
+++ b/ui/lib/utils.ts
@@ -27,7 +27,7 @@ export function poller(cb, interval) {
   return setInterval(cb, interval);
 }
 
-export function isHTTP(uri) {
+export function isHTTP(uri: string) {
   return uri.includes("http");
 }
 

--- a/ui/lib/utils.ts
+++ b/ui/lib/utils.ts
@@ -89,3 +89,7 @@ export function makeImageString(images: string[]) {
   }
   return imageString;
 }
+
+export function formatMetadataKey(key: string) {
+  return key;
+}

--- a/ui/lib/utils.ts
+++ b/ui/lib/utils.ts
@@ -28,7 +28,7 @@ export function poller(cb, interval) {
 }
 
 export function isHTTP(uri) {
-  return uri.includes("http") || uri.includes("https");
+  return uri.includes("http");
 }
 
 export function convertGitURLToGitProvider(uri: string) {

--- a/ui/lib/utils.ts
+++ b/ui/lib/utils.ts
@@ -91,5 +91,7 @@ export function makeImageString(images: string[]) {
 }
 
 export function formatMetadataKey(key: string) {
-  return key;
+  return key
+    .replace(/-/g, " ")
+    .replace(/\w+/g, (w) => w[0].toUpperCase() + w.slice(1));
 }


### PR DESCRIPTION
Closes #2269 
Closes #2301 

- Added capitalizing words in metadata keys if needed.
- Added sorting metadata key/value pairs by key (by original key value, not formatted) alphabetically.
- Minor improvements:
-- now we are mutating a local copy of Metadata props instead of the props themselves, it is considered unsafe to mutate props in React and can lead to hard-to-detect bugs when component complexity increases.
-- if we check for the `http` substring in the `isHTTP` function we don't need to check for `https` after that.
-- instead of metadata keys the `ImageList` component now uses `item` with index as item keys, because some of the formatted keys can be the same (to prevent the duplicate key React error).
-- changed the metadata prop type to match the input type.
- Added snapshot tests for the `Metadata` component.
- Added tests for `lib/utils.ts` functions (they were just asking for it 😺 ).