### PR TITLE
change chart image to chart location

### DIFF
--- a/.github/workflows/chart.yaml
+++ b/.github/workflows/chart.yaml
@@ -14,7 +14,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  CHART_IMAGE_NAME: weaveworks/charts/weave-gitops
+  CHART_LOCATION: weaveworks/charts
 
 jobs:
   helm-verify:
@@ -77,4 +77,4 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish chart as an OCI image
         run: |
-          helm push helm-release/weave-gitops-${{ steps.new_version.outputs.version }}.tgz oci://${{ env.REGISTRY }}/${{ env.CHART_IMAGE_NAME }}  
+          helm push helm-release/weave-gitops-${{ steps.new_version.outputs.version }}.tgz oci://${{ env.REGISTRY }}/${{ env.CHART_LOCATION }}  


### PR DESCRIPTION
We had implemented chart publication to `oci://ghcr.io/weaveworks/charts/weave-gitops`, which was the wrong place.
When doing `helm push`, Helm expects the 3rd parameter to be a chart location, not a chart image name.
The correct one should be `oci://ghcr.io/weaveworks/charts`. Helm then puts the chart image name and version for us.

Re Fixes #2300 
Improves PR #2327 

Signed-off-by: Chanwit Kaewkasi <chanwit@weave.works>
