### PR TITLE
Duplicates on detail pages table view

### DIFF
--- a/core/server/fluxruntime.go
+++ b/core/server/fluxruntime.go
@@ -126,6 +126,8 @@ func (cs *coreServer) GetReconciledObjects(ctx context.Context, msg *pb.GetRecon
 
 	result := []unstructured.Unstructured{}
 
+	checkDup := map[types.UID]bool{}
+
 	for _, gvk := range msg.Kinds {
 		listResult := unstructured.UnstructuredList{}
 
@@ -146,7 +148,14 @@ func (cs *coreServer) GetReconciledObjects(ctx context.Context, msg *pb.GetRecon
 			return nil, fmt.Errorf("listing unstructured object: %w", err)
 		}
 
-		result = append(result, listResult.Items...)
+		for _, u := range listResult.Items {
+			uid := u.GetUID()
+
+			if !checkDup[uid] {
+				result = append(result, u)
+				checkDup[uid] = true
+			}
+		}
 	}
 
 	objects := []*pb.UnstructuredObject{}


### PR DESCRIPTION
Closes #2324 

- Added de-duplicating reconciled objects by UID (based on @chanwit 's sample code).

- I haven't  been able to reproduce the same issue with child objects, so I've removed the de-duplication code I started adding for `GetChildObjects` and stored it. The current code fixes the original issue with the reconciled object table. If there is an additional issue with `GetChildObjects`, I can add the code back fast in another request.

- I thought of storing and sorting reconciled objects with the same ID within a pair to add only objects with bigger version numbers to the result (out of each pair of objects with the same UIDs), but noticed that v1beta2 objects come in first before v1beta1 objects, so there is no need to sort the objects in each pair. I hope this behavior is consistent.