### PR TITLE
refactor: move cli options to package, refactor command args

### DIFF
--- a/cmd/config/options.go
+++ b/cmd/config/options.go
@@ -1,0 +1,11 @@
+package config
+
+type Options struct {
+	Endpoint              string
+	OverrideInCluster     bool
+	GitHostTypes          map[string]string
+	InsecureSkipTLSVerify bool
+	Username              string
+	Password              string
+	KubeconfigLocation    string
+}

--- a/cmd/gitops/add/cmd.go
+++ b/cmd/gitops/add/cmd.go
@@ -3,12 +3,13 @@ package add
 import (
 	"github.com/go-resty/resty/v2"
 	"github.com/spf13/cobra"
+	"github.com/weaveworks/weave-gitops/cmd/config"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/add/clusters"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/add/profiles"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/add/terraform"
 )
 
-func GetCommand(endpoint, username, password *string, client *resty.Client) *cobra.Command {
+func GetCommand(opts *config.Options, client *resty.Client) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "add",
 		Short: "Add a new Weave GitOps resource",
@@ -17,9 +18,9 @@ func GetCommand(endpoint, username, password *string, client *resty.Client) *cob
 gitops add cluster`,
 	}
 
-	cmd.AddCommand(clusters.ClusterCommand(endpoint, username, password, client))
-	cmd.AddCommand(profiles.AddCommand(endpoint, username, password, client))
-	cmd.AddCommand(terraform.AddCommand(endpoint, username, password, client))
+	cmd.AddCommand(clusters.ClusterCommand(opts, client))
+	cmd.AddCommand(profiles.AddCommand(opts, client))
+	cmd.AddCommand(terraform.AddCommand(opts, client))
 
 	return cmd
 }

--- a/cmd/gitops/add/profiles/cmd.go
+++ b/cmd/gitops/add/profiles/cmd.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/go-resty/resty/v2"
 	"github.com/spf13/cobra"
+	"github.com/weaveworks/weave-gitops/cmd/config"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/cmderrors"
 	"github.com/weaveworks/weave-gitops/cmd/internal"
 	"github.com/weaveworks/weave-gitops/pkg/adapters"
@@ -19,10 +20,10 @@ import (
 	"github.com/weaveworks/weave-gitops/pkg/services/profiles"
 )
 
-var opts profiles.Options
+var profileOpts profiles.Options
 
 // AddCommand provides support for adding a profile to a cluster.
-func AddCommand(endpoint, username, password *string, client *resty.Client) *cobra.Command {
+func AddCommand(opts *config.Options, client *resty.Client) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "profile",
 		Short:         "Add a profile to a cluster",
@@ -32,16 +33,16 @@ func AddCommand(endpoint, username, password *string, client *resty.Client) *cob
 		# Add a profile to a cluster
 		gitops add profile --name=podinfo --cluster=prod --version=1.0.0 --config-repo=ssh://git@github.com/owner/config-repo.git
 		`,
-		PreRunE: addProfileCmdPreRunE(endpoint, client),
-		RunE:    addProfileCmdRunE(endpoint, username, password, client),
+		PreRunE: addProfileCmdPreRunE(&opts.Endpoint),
+		RunE:    addProfileCmdRunE(opts, client),
 	}
 
-	cmd.Flags().StringVar(&opts.Name, "name", "", "Name of the profile")
-	cmd.Flags().StringVar(&opts.Version, "version", "latest", "Version of the profile specified as semver (e.g.: 0.1.0) or as 'latest'")
-	cmd.Flags().StringVar(&opts.ConfigRepo, "config-repo", "", "URL of the external repository that contains the automation manifests")
-	cmd.Flags().StringVar(&opts.Cluster, "cluster", "", "Name of the cluster to add the profile to")
-	cmd.Flags().BoolVar(&opts.AutoMerge, "auto-merge", false, "If set, 'gitops add profile' will merge automatically into the repository's branch")
-	internal.AddPRFlags(cmd, &opts.HeadBranch, &opts.BaseBranch, &opts.Description, &opts.Message, &opts.Title)
+	cmd.Flags().StringVar(&profileOpts.Name, "name", "", "Name of the profile")
+	cmd.Flags().StringVar(&profileOpts.Version, "version", "latest", "Version of the profile specified as semver (e.g.: 0.1.0) or as 'latest'")
+	cmd.Flags().StringVar(&profileOpts.ConfigRepo, "config-repo", "", "URL of the external repository that contains the automation manifests")
+	cmd.Flags().StringVar(&profileOpts.Cluster, "cluster", "", "Name of the cluster to add the profile to")
+	cmd.Flags().BoolVar(&profileOpts.AutoMerge, "auto-merge", false, "If set, 'gitops add profile' will merge automatically into the repository's branch")
+	internal.AddPRFlags(cmd, &profileOpts.HeadBranch, &profileOpts.BaseBranch, &profileOpts.Description, &profileOpts.Message, &profileOpts.Title)
 
 	requiredFlags := []string{"name", "config-repo", "cluster"}
 	for _, f := range requiredFlags {
@@ -53,7 +54,7 @@ func AddCommand(endpoint, username, password *string, client *resty.Client) *cob
 	return cmd
 }
 
-func addProfileCmdPreRunE(endpoint *string, client *resty.Client) func(*cobra.Command, []string) error {
+func addProfileCmdPreRunE(endpoint *string) func(*cobra.Command, []string) error {
 	return func(c *cobra.Command, s []string) error {
 		if *endpoint == "" {
 			return cmderrors.ErrNoWGEEndpoint
@@ -63,23 +64,23 @@ func addProfileCmdPreRunE(endpoint *string, client *resty.Client) func(*cobra.Co
 	}
 }
 
-func addProfileCmdRunE(endpoint, username, password *string, client *resty.Client) func(*cobra.Command, []string) error {
+func addProfileCmdRunE(opts *config.Options, client *resty.Client) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		log := internal.NewCLILogger(os.Stdout)
 		fluxClient := flux.New(&runner.CLIRunner{})
 		factory := services.NewFactory(fluxClient, internal.Logr())
 		providerClient := internal.NewGitProviderClient(os.Stdout, os.LookupEnv, log)
 
-		r, err := adapters.NewHttpClient(*endpoint, *username, *password, client, os.Stdout)
+		r, err := adapters.NewHttpClient(opts.Endpoint, opts.Username, opts.Password, client, os.Stdout)
 		if err != nil {
 			return err
 		}
 
-		if err := validateOptions(opts); err != nil {
+		if err := validateOptions(profileOpts); err != nil {
 			return err
 		}
 
-		if opts.Namespace, err = cmd.Flags().GetString("namespace"); err != nil {
+		if profileOpts.Namespace, err = cmd.Flags().GetString("namespace"); err != nil {
 			return err
 		}
 
@@ -89,8 +90,8 @@ func addProfileCmdRunE(endpoint, username, password *string, client *resty.Clien
 		}
 
 		_, gitProvider, err := factory.GetGitClients(context.Background(), kubeClient, providerClient, services.GitConfigParams{
-			ConfigRepo:       opts.ConfigRepo,
-			Namespace:        opts.Namespace,
+			ConfigRepo:       profileOpts.ConfigRepo,
+			Namespace:        profileOpts.Namespace,
 			IsHelmRepository: true,
 			DryRun:           false,
 		})
@@ -98,7 +99,7 @@ func addProfileCmdRunE(endpoint, username, password *string, client *resty.Clien
 			return fmt.Errorf("failed to get git clients: %w", err)
 		}
 
-		return profiles.NewService(log).Add(context.Background(), r, gitProvider, opts)
+		return profiles.NewService(log).Add(context.Background(), r, gitProvider, profileOpts)
 	}
 }
 

--- a/cmd/gitops/add/terraform/cmd.go
+++ b/cmd/gitops/add/terraform/cmd.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-resty/resty/v2"
 	"github.com/spf13/cobra"
 
+	"github.com/weaveworks/weave-gitops/cmd/config"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/cmderrors"
 	"github.com/weaveworks/weave-gitops/cmd/internal"
 	"github.com/weaveworks/weave-gitops/pkg/adapters"
@@ -29,7 +30,7 @@ type terraformCommandFlags struct {
 
 var flags terraformCommandFlags
 
-func AddCommand(endpoint, username, password *string, client *resty.Client) *cobra.Command {
+func AddCommand(opts *config.Options, client *resty.Client) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "terraform",
 		Short: "Add a new Terraform resource using a TF template",
@@ -39,8 +40,8 @@ gitops add terraform --from-template <template-name> --set key=val
 		`,
 		SilenceUsage:  true,
 		SilenceErrors: true,
-		PreRunE:       addTerraformCmdPreRunE(endpoint, client),
-		RunE:          addTerraformCmdRunE(endpoint, username, password, client),
+		PreRunE:       addTerraformCmdPreRunE(&opts.Endpoint),
+		RunE:          addTerraformCmdRunE(opts, client),
 	}
 
 	cmd.Flags().StringVar(&flags.RepositoryURL, "url", "", "URL of remote repository to create the pull request")
@@ -50,7 +51,7 @@ gitops add terraform --from-template <template-name> --set key=val
 	return cmd
 }
 
-func addTerraformCmdPreRunE(endpoint *string, client *resty.Client) func(*cobra.Command, []string) error {
+func addTerraformCmdPreRunE(endpoint *string) func(*cobra.Command, []string) error {
 	return func(c *cobra.Command, s []string) error {
 		if *endpoint == "" {
 			return cmderrors.ErrNoWGEEndpoint
@@ -60,9 +61,9 @@ func addTerraformCmdPreRunE(endpoint *string, client *resty.Client) func(*cobra.
 	}
 }
 
-func addTerraformCmdRunE(endpoint, username, password *string, client *resty.Client) func(*cobra.Command, []string) error {
+func addTerraformCmdRunE(opts *config.Options, client *resty.Client) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
-		r, err := adapters.NewHttpClient(*endpoint, *username, *password, client, os.Stdout)
+		r, err := adapters.NewHttpClient(opts.Endpoint, opts.Username, opts.Password, client, os.Stdout)
 		if err != nil {
 			return err
 		}

--- a/cmd/gitops/delete/clusters/cmd.go
+++ b/cmd/gitops/delete/clusters/cmd.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/go-resty/resty/v2"
 	"github.com/spf13/cobra"
+	"github.com/weaveworks/weave-gitops/cmd/config"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/cmderrors"
 	"github.com/weaveworks/weave-gitops/cmd/internal"
 	"github.com/weaveworks/weave-gitops/pkg/adapters"
@@ -25,7 +26,7 @@ type clustersDeleteFlags struct {
 
 var flags clustersDeleteFlags
 
-func ClusterCommand(endpoint, username, password *string, client *resty.Client) *cobra.Command {
+func ClusterCommand(opts *config.Options, client *resty.Client) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "cluster",
 		Aliases: []string{"clusters"},
@@ -36,8 +37,8 @@ gitops delete cluster <cluster-name>
 		`,
 		SilenceUsage:  true,
 		SilenceErrors: true,
-		PreRunE:       getClusterCmdPreRunE(endpoint, client),
-		RunE:          getClusterCmdRunE(endpoint, username, password, client),
+		PreRunE:       getClusterCmdPreRunE(&opts.Endpoint),
+		RunE:          getClusterCmdRunE(opts, client),
 		Args:          cobra.MinimumNArgs(1),
 	}
 
@@ -51,7 +52,7 @@ gitops delete cluster <cluster-name>
 	return cmd
 }
 
-func getClusterCmdPreRunE(endpoint *string, client *resty.Client) func(*cobra.Command, []string) error {
+func getClusterCmdPreRunE(endpoint *string) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		if *endpoint == "" {
 			return cmderrors.ErrNoWGEEndpoint
@@ -61,9 +62,9 @@ func getClusterCmdPreRunE(endpoint *string, client *resty.Client) func(*cobra.Co
 	}
 }
 
-func getClusterCmdRunE(endpoint, username, password *string, client *resty.Client) func(*cobra.Command, []string) error {
+func getClusterCmdRunE(opts *config.Options, client *resty.Client) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
-		r, err := adapters.NewHttpClient(*endpoint, *username, *password, client, os.Stdout)
+		r, err := adapters.NewHttpClient(opts.Endpoint, opts.Username, opts.Password, client, os.Stdout)
 		if err != nil {
 			return err
 		}

--- a/cmd/gitops/delete/cmd.go
+++ b/cmd/gitops/delete/cmd.go
@@ -3,10 +3,11 @@ package delete
 import (
 	"github.com/go-resty/resty/v2"
 	"github.com/spf13/cobra"
+	"github.com/weaveworks/weave-gitops/cmd/config"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/delete/clusters"
 )
 
-func DeleteCommand(endpoint, username, password *string, client *resty.Client) *cobra.Command {
+func DeleteCommand(opts *config.Options, client *resty.Client) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "delete",
 		Short: "Delete one or many Weave GitOps resources",
@@ -15,7 +16,7 @@ func DeleteCommand(endpoint, username, password *string, client *resty.Client) *
 gitops delete cluster <cluster-name>`,
 	}
 
-	cmd.AddCommand(clusters.ClusterCommand(endpoint, username, password, client))
+	cmd.AddCommand(clusters.ClusterCommand(opts, client))
 
 	return cmd
 }

--- a/cmd/gitops/get/cmd.go
+++ b/cmd/gitops/get/cmd.go
@@ -4,6 +4,7 @@ import (
 	"github.com/go-resty/resty/v2"
 	"github.com/spf13/cobra"
 
+	"github.com/weaveworks/weave-gitops/cmd/config"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/get/clusters"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/get/credentials"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/get/profiles"
@@ -11,7 +12,7 @@ import (
 	"github.com/weaveworks/weave-gitops/cmd/gitops/get/templates/terraform"
 )
 
-func GetCommand(endpoint, username, password *string, client *resty.Client) *cobra.Command {
+func GetCommand(opts *config.Options, client *resty.Client) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "get",
 		Short: "Display one or many Weave GitOps resources",
@@ -26,14 +27,14 @@ gitops get credentials
 gitops get clusters`,
 	}
 
-	templateCommand := templates.TemplateCommand(endpoint, username, password, client)
-	terraformCommand := terraform.TerraformCommand(endpoint, username, password, client)
+	templateCommand := templates.TemplateCommand(opts, client)
+	terraformCommand := terraform.TerraformCommand(opts, client)
 	templateCommand.AddCommand(terraformCommand)
 
 	cmd.AddCommand(templateCommand)
-	cmd.AddCommand(credentials.CredentialCommand(endpoint, username, password, client))
-	cmd.AddCommand(clusters.ClusterCommand(endpoint, username, password, client))
-	cmd.AddCommand(profiles.ProfilesCommand(endpoint, username, password, client))
+	cmd.AddCommand(credentials.CredentialCommand(opts, client))
+	cmd.AddCommand(clusters.ClusterCommand(opts, client))
+	cmd.AddCommand(profiles.ProfilesCommand(opts, client))
 
 	return cmd
 }

--- a/cmd/gitops/get/credentials/cmd.go
+++ b/cmd/gitops/get/credentials/cmd.go
@@ -5,13 +5,14 @@ import (
 
 	"github.com/go-resty/resty/v2"
 	"github.com/spf13/cobra"
+	"github.com/weaveworks/weave-gitops/cmd/config"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/cmderrors"
 	"github.com/weaveworks/weave-gitops/pkg/adapters"
 	"github.com/weaveworks/weave-gitops/pkg/templates"
 	"k8s.io/cli-runtime/pkg/printers"
 )
 
-func CredentialCommand(endpoint, username, password *string, client *resty.Client) *cobra.Command {
+func CredentialCommand(opts *config.Options, client *resty.Client) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "credential",
 		Aliases: []string{"credentials"},
@@ -22,14 +23,14 @@ gitops get credentials
 		`,
 		SilenceUsage:  true,
 		SilenceErrors: true,
-		PreRunE:       getCredentialCmdPreRunE(endpoint, client),
-		RunE:          getCredentialCmdRunE(endpoint, username, password, client),
+		PreRunE:       getCredentialCmdPreRunE(&opts.Endpoint),
+		RunE:          getCredentialCmdRunE(opts, client),
 	}
 
 	return cmd
 }
 
-func getCredentialCmdPreRunE(endpoint *string, client *resty.Client) func(*cobra.Command, []string) error {
+func getCredentialCmdPreRunE(endpoint *string) func(*cobra.Command, []string) error {
 	return func(c *cobra.Command, s []string) error {
 		if *endpoint == "" {
 			return cmderrors.ErrNoWGEEndpoint
@@ -39,9 +40,9 @@ func getCredentialCmdPreRunE(endpoint *string, client *resty.Client) func(*cobra
 	}
 }
 
-func getCredentialCmdRunE(endpoint, username, password *string, client *resty.Client) func(*cobra.Command, []string) error {
+func getCredentialCmdRunE(opts *config.Options, client *resty.Client) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
-		r, err := adapters.NewHttpClient(*endpoint, *username, *password, client, os.Stdout)
+		r, err := adapters.NewHttpClient(opts.Endpoint, opts.Username, opts.Password, client, os.Stdout)
 		if err != nil {
 			return err
 		}

--- a/cmd/gitops/get/profiles/cmd.go
+++ b/cmd/gitops/get/profiles/cmd.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/go-resty/resty/v2"
 	"github.com/spf13/cobra"
+	"github.com/weaveworks/weave-gitops/cmd/config"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/cmderrors"
 	"github.com/weaveworks/weave-gitops/cmd/internal"
 	"github.com/weaveworks/weave-gitops/pkg/adapters"
@@ -13,7 +14,7 @@ import (
 	"k8s.io/cli-runtime/pkg/printers"
 )
 
-func ProfilesCommand(endpoint, username, password *string, client *resty.Client) *cobra.Command {
+func ProfilesCommand(opts *config.Options, client *resty.Client) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "profile",
 		Aliases:       []string{"profiles"},
@@ -25,14 +26,14 @@ func ProfilesCommand(endpoint, username, password *string, client *resty.Client)
 	# Get all profiles
 	gitops get profiles
 	`,
-		PreRunE: getProfilesCmdPreRunE(endpoint, client),
-		RunE:    getProfilesCmdRunE(endpoint, username, password, client),
+		PreRunE: getProfilesCmdPreRunE(&opts.Endpoint),
+		RunE:    getProfilesCmdRunE(opts, client),
 	}
 
 	return cmd
 }
 
-func getProfilesCmdPreRunE(endpoint *string, client *resty.Client) func(*cobra.Command, []string) error {
+func getProfilesCmdPreRunE(endpoint *string) func(*cobra.Command, []string) error {
 	return func(c *cobra.Command, s []string) error {
 		if *endpoint == "" {
 			return cmderrors.ErrNoWGEEndpoint
@@ -42,9 +43,9 @@ func getProfilesCmdPreRunE(endpoint *string, client *resty.Client) func(*cobra.C
 	}
 }
 
-func getProfilesCmdRunE(endpoint, username, password *string, client *resty.Client) func(*cobra.Command, []string) error {
+func getProfilesCmdRunE(opts *config.Options, client *resty.Client) func(*cobra.Command, []string) error {
 	return func(c *cobra.Command, s []string) error {
-		r, err := adapters.NewHttpClient(*endpoint, *username, *password, client, os.Stdout)
+		r, err := adapters.NewHttpClient(opts.Endpoint, opts.Username, opts.Password, client, os.Stdout)
 		if err != nil {
 			return err
 		}

--- a/cmd/gitops/get/templates/cmd.go
+++ b/cmd/gitops/get/templates/cmd.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/printers"
 
+	"github.com/weaveworks/weave-gitops/cmd/config"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/cmderrors"
 	"github.com/weaveworks/weave-gitops/pkg/adapters"
 	"github.com/weaveworks/weave-gitops/pkg/templates"
@@ -33,7 +34,7 @@ var providers = []string{
 	"vsphere",
 }
 
-func TemplateCommand(endpoint, username, password *string, client *resty.Client) *cobra.Command {
+func TemplateCommand(opts *config.Options, client *resty.Client) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "template",
 		Aliases: []string{"templates"},
@@ -50,8 +51,8 @@ gitops get template <template-name> --list-parameters
 		`,
 		SilenceUsage:  true,
 		SilenceErrors: true,
-		PreRunE:       getTemplateCmdPreRunE(endpoint, client),
-		RunE:          getTemplateCmdRunE(endpoint, username, password, client),
+		PreRunE:       getTemplateCmdPreRunE(&opts.Endpoint),
+		RunE:          getTemplateCmdRunE(opts, client),
 		Args:          cobra.MaximumNArgs(1),
 	}
 
@@ -62,7 +63,7 @@ gitops get template <template-name> --list-parameters
 	return cmd
 }
 
-func getTemplateCmdPreRunE(endpoint *string, client *resty.Client) func(*cobra.Command, []string) error {
+func getTemplateCmdPreRunE(endpoint *string) func(*cobra.Command, []string) error {
 	return func(c *cobra.Command, args []string) error {
 		if c.Flag("provider").Changed && !contains(providers, c.Flag("provider").Value.String()) {
 			return fmt.Errorf("provider %q is not valid", c.Flag("provider").Value.String())
@@ -76,9 +77,9 @@ func getTemplateCmdPreRunE(endpoint *string, client *resty.Client) func(*cobra.C
 	}
 }
 
-func getTemplateCmdRunE(endpoint, username, password *string, client *resty.Client) func(*cobra.Command, []string) error {
+func getTemplateCmdRunE(opts *config.Options, client *resty.Client) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
-		r, err := adapters.NewHttpClient(*endpoint, *username, *password, client, os.Stdout)
+		r, err := adapters.NewHttpClient(opts.Endpoint, opts.Username, opts.Password, client, os.Stdout)
 		if err != nil {
 			return err
 		}

--- a/cmd/gitops/root/cmd.go
+++ b/cmd/gitops/root/cmd.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	wego "github.com/weaveworks/weave-gitops/api/v1alpha1"
+	"github.com/weaveworks/weave-gitops/cmd/config"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/add"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/check"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/delete"
@@ -24,14 +25,7 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-var options struct {
-	endpoint              string
-	overrideInCluster     bool
-	gitHostTypes          map[string]string
-	insecureSkipTlsVerify bool
-	username              string
-	password              string
-}
+var options = &config.Options{}
 
 // Only want AutomaticEnv to be called once!
 func init() {
@@ -78,11 +72,11 @@ func RootCmd(client *resty.Client) *cobra.Command {
 				fmt.Fprintf(os.Stderr, "Error: %v\n", nserr)
 				os.Exit(1)
 			}
-			if options.overrideInCluster {
+			if options.OverrideInCluster {
 				kube.InClusterConfig = func() (*rest.Config, error) { return nil, rest.ErrNotInCluster }
 			}
 
-			if options.insecureSkipTlsVerify {
+			if options.InsecureSkipTLSVerify {
 				client.SetTLSClientConfig(&tls.Config{InsecureSkipVerify: true})
 			}
 
@@ -101,20 +95,20 @@ func RootCmd(client *resty.Client) *cobra.Command {
 	}
 
 	rootCmd.PersistentFlags().String("namespace", wego.DefaultNamespace, "The namespace scope for this operation")
-	rootCmd.PersistentFlags().StringVarP(&options.endpoint, "endpoint", "e", os.Getenv("WEAVE_GITOPS_ENTERPRISE_API_URL"), "The Weave GitOps Enterprise HTTP API endpoint")
-	rootCmd.PersistentFlags().StringVarP(&options.username, "username", "u", "", "The Weave GitOps Enterprise username for authentication can be set with `WEAVE_GITOPS_USERNAME` environment variable")
-	rootCmd.PersistentFlags().StringVarP(&options.password, "password", "p", "", "The Weave GitOps Enterprise password for authentication can be set with `WEAVE_GITOPS_PASSWORD` environment variable")
-	rootCmd.PersistentFlags().BoolVar(&options.overrideInCluster, "override-in-cluster", false, "override running in cluster check")
-	rootCmd.PersistentFlags().StringToStringVar(&options.gitHostTypes, "git-host-types", map[string]string{}, "Specify which custom domains are running what (github or gitlab)")
-	rootCmd.PersistentFlags().BoolVar(&options.insecureSkipTlsVerify, "insecure-skip-tls-verify", false, "If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure")
+	rootCmd.PersistentFlags().StringVarP(&options.Endpoint, "endpoint", "e", os.Getenv("WEAVE_GITOPS_ENTERPRISE_API_URL"), "The Weave GitOps Enterprise HTTP API endpoint")
+	rootCmd.PersistentFlags().StringVarP(&options.Username, "username", "u", "", "The Weave GitOps Enterprise username for authentication can be set with `WEAVE_GITOPS_USERNAME` environment variable")
+	rootCmd.PersistentFlags().StringVarP(&options.Password, "password", "p", "", "The Weave GitOps Enterprise password for authentication can be set with `WEAVE_GITOPS_PASSWORD` environment variable")
+	rootCmd.PersistentFlags().BoolVar(&options.OverrideInCluster, "override-in-cluster", false, "override running in cluster check")
+	rootCmd.PersistentFlags().StringToStringVar(&options.GitHostTypes, "git-host-types", map[string]string{}, "Specify which custom domains are running what (github or gitlab)")
+	rootCmd.PersistentFlags().BoolVar(&options.InsecureSkipTLSVerify, "insecure-skip-tls-verify", false, "If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure")
 	cobra.CheckErr(rootCmd.PersistentFlags().MarkHidden("override-in-cluster"))
 	cobra.CheckErr(rootCmd.PersistentFlags().MarkHidden("git-host-types"))
 
 	rootCmd.AddCommand(version.Cmd)
-	rootCmd.AddCommand(get.GetCommand(&options.endpoint, &options.username, &options.password, client))
-	rootCmd.AddCommand(add.GetCommand(&options.endpoint, &options.username, &options.password, client))
-	rootCmd.AddCommand(update.UpdateCommand(&options.endpoint, &options.username, &options.password, client))
-	rootCmd.AddCommand(delete.DeleteCommand(&options.endpoint, &options.username, &options.password, client))
+	rootCmd.AddCommand(get.GetCommand(options, client))
+	rootCmd.AddCommand(add.GetCommand(options, client))
+	rootCmd.AddCommand(update.UpdateCommand(options, client))
+	rootCmd.AddCommand(delete.DeleteCommand(options, client))
 	rootCmd.AddCommand(upgrade.Cmd)
 	rootCmd.AddCommand(docs.Cmd)
 	rootCmd.AddCommand(check.Cmd)

--- a/cmd/gitops/update/cmd.go
+++ b/cmd/gitops/update/cmd.go
@@ -2,12 +2,13 @@ package update
 
 import (
 	"github.com/go-resty/resty/v2"
+	"github.com/weaveworks/weave-gitops/cmd/config"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/update/profiles"
 
 	"github.com/spf13/cobra"
 )
 
-func UpdateCommand(endpoint, username, password *string, client *resty.Client) *cobra.Command {
+func UpdateCommand(opts *config.Options, client *resty.Client) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "update",
 		Short: "Update a Weave GitOps resource",
@@ -17,7 +18,7 @@ func UpdateCommand(endpoint, username, password *string, client *resty.Client) *
 		`,
 	}
 
-	cmd.AddCommand(profiles.UpdateCommand(endpoint, username, password, client))
+	cmd.AddCommand(profiles.UpdateCommand(opts, client))
 
 	return cmd
 }

--- a/cmd/gitops/update/profiles/profiles.go
+++ b/cmd/gitops/update/profiles/profiles.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/go-resty/resty/v2"
 	"github.com/spf13/cobra"
+	"github.com/weaveworks/weave-gitops/cmd/config"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/cmderrors"
 	"github.com/weaveworks/weave-gitops/cmd/internal"
 	"github.com/weaveworks/weave-gitops/pkg/adapters"
@@ -18,10 +19,10 @@ import (
 	"github.com/weaveworks/weave-gitops/pkg/services/profiles"
 )
 
-var opts profiles.Options
+var profileOpts profiles.Options
 
 // UpdateCommand provides support for updating a profile that is installed on a cluster.
-func UpdateCommand(endpoint, username, password *string, client *resty.Client) *cobra.Command {
+func UpdateCommand(opts *config.Options, client *resty.Client) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "profile",
 		Short:         "Update a profile installation",
@@ -31,16 +32,16 @@ func UpdateCommand(endpoint, username, password *string, client *resty.Client) *
 	# Update a profile that is installed on a cluster
 	gitops update profile --name=podinfo --cluster=prod --config-repo=ssh://git@github.com/owner/config-repo.git  --version=1.0.0
 		`,
-		PreRunE: updateProfileCmdPreRunE(endpoint, client),
-		RunE:    updateProfileCmdRunE(endpoint, username, password, client),
+		PreRunE: updateProfileCmdPreRunE(&opts.Endpoint),
+		RunE:    updateProfileCmdRunE(opts, client),
 	}
 
-	cmd.Flags().StringVar(&opts.Name, "name", "", "Name of the profile")
-	cmd.Flags().StringVar(&opts.Version, "version", "latest", "Version of the profile specified as semver (e.g.: 0.1.0) or as 'latest'")
-	cmd.Flags().StringVar(&opts.ConfigRepo, "config-repo", "", "URL of the external repository that contains the automation manifests")
-	cmd.Flags().StringVar(&opts.Cluster, "cluster", "", "Name of the cluster where the profile is installed")
-	cmd.Flags().BoolVar(&opts.AutoMerge, "auto-merge", false, "If set, 'gitops update profile' will merge automatically into the repository's branch")
-	internal.AddPRFlags(cmd, &opts.HeadBranch, &opts.BaseBranch, &opts.Description, &opts.Message, &opts.Title)
+	cmd.Flags().StringVar(&profileOpts.Name, "name", "", "Name of the profile")
+	cmd.Flags().StringVar(&profileOpts.Version, "version", "latest", "Version of the profile specified as semver (e.g.: 0.1.0) or as 'latest'")
+	cmd.Flags().StringVar(&profileOpts.ConfigRepo, "config-repo", "", "URL of the external repository that contains the automation manifests")
+	cmd.Flags().StringVar(&profileOpts.Cluster, "cluster", "", "Name of the cluster where the profile is installed")
+	cmd.Flags().BoolVar(&profileOpts.AutoMerge, "auto-merge", false, "If set, 'gitops update profile' will merge automatically into the repository's branch")
+	internal.AddPRFlags(cmd, &profileOpts.HeadBranch, &profileOpts.BaseBranch, &profileOpts.Description, &profileOpts.Message, &profileOpts.Title)
 
 	requiredFlags := []string{"name", "config-repo", "cluster", "version"}
 	for _, f := range requiredFlags {
@@ -52,7 +53,7 @@ func UpdateCommand(endpoint, username, password *string, client *resty.Client) *
 	return cmd
 }
 
-func updateProfileCmdPreRunE(endpoint *string, client *resty.Client) func(*cobra.Command, []string) error {
+func updateProfileCmdPreRunE(endpoint *string) func(*cobra.Command, []string) error {
 	return func(c *cobra.Command, s []string) error {
 		if *endpoint == "" {
 			return cmderrors.ErrNoWGEEndpoint
@@ -62,25 +63,25 @@ func updateProfileCmdPreRunE(endpoint *string, client *resty.Client) func(*cobra
 	}
 }
 
-func updateProfileCmdRunE(endpoint, username, password *string, client *resty.Client) func(*cobra.Command, []string) error {
+func updateProfileCmdRunE(opts *config.Options, client *resty.Client) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		log := internal.NewCLILogger(os.Stdout)
 		fluxClient := flux.New(&runner.CLIRunner{})
 		factory := services.NewFactory(fluxClient, internal.Logr())
 		providerClient := internal.NewGitProviderClient(os.Stdout, os.LookupEnv, log)
 
-		r, err := adapters.NewHttpClient(*endpoint, *username, *password, client, os.Stdout)
+		r, err := adapters.NewHttpClient(opts.Endpoint, opts.Username, opts.Password, client, os.Stdout)
 		if err != nil {
 			return err
 		}
 
-		if opts.Version != "latest" {
-			if _, err := semver.StrictNewVersion(opts.Version); err != nil {
-				return fmt.Errorf("error parsing --version=%s: %w", opts.Version, err)
+		if profileOpts.Version != "latest" {
+			if _, err := semver.StrictNewVersion(profileOpts.Version); err != nil {
+				return fmt.Errorf("error parsing --version=%s: %w", profileOpts.Version, err)
 			}
 		}
 
-		if opts.Namespace, err = cmd.Flags().GetString("namespace"); err != nil {
+		if profileOpts.Namespace, err = cmd.Flags().GetString("namespace"); err != nil {
 			return err
 		}
 
@@ -90,8 +91,8 @@ func updateProfileCmdRunE(endpoint, username, password *string, client *resty.Cl
 		}
 
 		_, gitProvider, err := factory.GetGitClients(context.Background(), kubeClient, providerClient, services.GitConfigParams{
-			ConfigRepo:       opts.ConfigRepo,
-			Namespace:        opts.Namespace,
+			ConfigRepo:       profileOpts.ConfigRepo,
+			Namespace:        profileOpts.Namespace,
 			IsHelmRepository: true,
 			DryRun:           false,
 		})
@@ -99,6 +100,6 @@ func updateProfileCmdRunE(endpoint, username, password *string, client *resty.Cl
 			return fmt.Errorf("failed to get git clients: %w", err)
 		}
 
-		return profiles.NewService(log).Update(context.Background(), r, gitProvider, opts)
+		return profiles.NewService(log).Update(context.Background(), r, gitProvider, profileOpts)
 	}
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Move CLI arg options out of the root package and into a separate package. Refactor the command implementations to accept the new options type instead of individual args.

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**

The args list for commands is becoming too long in many cases, and with the introduction of kubeconfig token passthru authentication coming soon it will probably get bigger. 

