### PR TITLE
Allow the oidc secret to be named other than 'oidc-auth' and improve logging

### DIFF
--- a/charts/gitops-server/Chart.yaml
+++ b/charts/gitops-server/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.11
+version: 2.1.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/gitops-server/templates/oidc-auth-secret.yaml
+++ b/charts/gitops-server/templates/oidc-auth-secret.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.oidcSecret.create -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: oidc-auth
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+data:
+  {{- with .Values.oidcSecret }}
+  clientID: {{ .clientID | required "oidcSecret.clientID must be set" | b64enc | quote }}
+  clientSecret: {{ .clientSecret | required "oidcSecret.clientSecret must be set" | b64enc | quote }}
+  issuerURL: {{ .issuerURL | required "oidcSecret.issuerURL must be set" | b64enc | quote }}
+  redirectURL: {{ .redirectURL | required "oidcSecret.redirectURL must be set" | b64enc | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/gitops-server/values.yaml
+++ b/charts/gitops-server/values.yaml
@@ -21,6 +21,17 @@ logLevel: info
 # Any other environment variables:
 # envVars:
 
+# Should the 'oidc-auth' secret be created. For a detailed
+# explanation of these attributes please see our documentation:
+# https://docs.gitops.weave.works/docs/configuration/securing-access-to-the-dashboard/#login-via-an-oidc-provider
+oidcSecret:
+  create: false
+  # clientID:
+  # clientSecret:
+  # issuerURL:
+  # redirectURL:
+
+
 serviceAccount:
   # -- Specifies whether a service account should be created
   create: true
@@ -29,6 +40,7 @@ serviceAccount:
   # -- The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""
+
 rbac:
   # -- Specifies whether the clusterRole & binding to the service account should be created
   create: true
@@ -48,6 +60,7 @@ rbac:
   #   resources: ["terraforms"]
   #   verbs: [ "get", "list", "patch" ]
   additionalRules: []
+
 adminUser:
   # -- Whether the local admin user should be created.
   # If you use this make sure you add it to `rbac.impersonationResourceNames`.
@@ -69,6 +82,7 @@ adminUser:
   # This needs to have been hashed using the bcrypt
   # algorithm. E.g. `go install github.com/bitnami/bcrypt-cli@v1.0.2 && bcrypt-cli <<< $PASSWORD`
   passwordHash:
+
 podAnnotations: {}
 podSecurityContext: {}
 # fsGroup: 2000

--- a/cmd/gitops-server/cmd/cmd.go
+++ b/cmd/gitops-server/cmd/cmd.go
@@ -133,7 +133,15 @@ func runCmd(cmd *cobra.Command, args []string) error {
 		Namespace: v1alpha1.DefaultNamespace,
 		Name:      auth.OIDCAuthSecretName,
 	}, &secret); err == nil {
+		if len(options.OIDC.ClientSecret) > 0 && len(secret.Data["clientSecret"]) > 0 {
+			log.V(logger.LogLevelWarn).Info("OIDC client configured by both CLI and secret. CLI values will be overridden.")
+		}
 		oidcConfig = auth.NewOIDCConfigFromSecret(secret)
+
+	}
+
+	if len(oidcConfig.ClientSecret) > 0 {
+		log.V(logger.LogLevelDebug).Info("OIDC config", "IssuerURL", oidcConfig.IssuerURL, "ClientID", oidcConfig.ClientID, "ClientSecretLength", len(oidcConfig.ClientSecret), "RedirectURL", oidcConfig.RedirectURL, "TokenDuration", oidcConfig.TokenDuration)
 	}
 
 	tsv, err := auth.NewHMACTokenSignerVerifier(oidcConfig.TokenDuration)

--- a/cmd/gitops-server/cmd/cmd.go
+++ b/cmd/gitops-server/cmd/cmd.go
@@ -140,7 +140,7 @@ func runCmd(cmd *cobra.Command, args []string) error {
 		Namespace: v1alpha1.DefaultNamespace,
 		Name:      options.OIDCSecret,
 	}, &secret); err == nil {
-		if len(options.OIDC.ClientSecret) > 0 && len(secret.Data["clientSecret"]) > 0 {
+		if options.OIDC.ClientSecret != "" && secret.Data["clientSecret"] != nil { // 'Data' is a byte array
 			log.V(logger.LogLevelWarn).Info("OIDC client configured by both CLI and secret. CLI values will be overridden.")
 		}
 		oidcConfig = auth.NewOIDCConfigFromSecret(secret)
@@ -148,7 +148,7 @@ func runCmd(cmd *cobra.Command, args []string) error {
 		log.V(logger.LogLevelDebug).Info("Could not read OIDC secret", "secretName", options.OIDCSecret, "error", err)
 	}
 
-	if len(oidcConfig.ClientSecret) > 0 {
+	if oidcConfig.ClientSecret != "" {
 		log.V(logger.LogLevelDebug).Info("OIDC config", "IssuerURL", oidcConfig.IssuerURL, "ClientID", oidcConfig.ClientID, "ClientSecretLength", len(oidcConfig.ClientSecret), "RedirectURL", oidcConfig.RedirectURL, "TokenDuration", oidcConfig.TokenDuration)
 	}
 

--- a/cmd/gitops-server/cmd/cmd.go
+++ b/cmd/gitops-server/cmd/cmd.go
@@ -143,6 +143,7 @@ func runCmd(cmd *cobra.Command, args []string) error {
 		if options.OIDC.ClientSecret != "" && secret.Data["clientSecret"] != nil { // 'Data' is a byte array
 			log.V(logger.LogLevelWarn).Info("OIDC client configured by both CLI and secret. CLI values will be overridden.")
 		}
+
 		oidcConfig = auth.NewOIDCConfigFromSecret(secret)
 	} else if err != nil {
 		log.V(logger.LogLevelDebug).Info("Could not read OIDC secret", "secretName", options.OIDCSecret, "error", err)

--- a/cmd/gitops-server/cmd/cmd.go
+++ b/cmd/gitops-server/cmd/cmd.go
@@ -130,6 +130,10 @@ func runCmd(cmd *cobra.Command, args []string) error {
 
 	oidcConfig := options.OIDC
 
+	if options.OIDCSecret != auth.DefaultOIDCAuthSecretName {
+		log.V(logger.LogLevelDebug).Info("Reading OIDC configuration from alternate secret", "secretName", options.OIDCSecret)
+	}
+
 	// If OIDC auth secret is found prefer that over CLI parameters
 	var secret corev1.Secret
 	if err := rawClient.Get(cmd.Context(), client.ObjectKey{
@@ -140,6 +144,8 @@ func runCmd(cmd *cobra.Command, args []string) error {
 			log.V(logger.LogLevelWarn).Info("OIDC client configured by both CLI and secret. CLI values will be overridden.")
 		}
 		oidcConfig = auth.NewOIDCConfigFromSecret(secret)
+	} else if err != nil {
+		log.V(logger.LogLevelDebug).Info("Could not read OIDC secret", "secretName", options.OIDCSecret, "error", err)
 	}
 
 	if len(oidcConfig.ClientSecret) > 0 {

--- a/core/server/featureflags.go
+++ b/core/server/featureflags.go
@@ -37,7 +37,7 @@ func (cs *coreServer) GetFeatureFlags(ctx context.Context, msg *pb.GetFeatureFla
 		flags["CLUSTER_USER_AUTH"] = "true"
 	}
 
-	flags["OIDC_AUTH"] = strconv.FormatBool(serverauth.OidcEnabled())
+	flags["OIDC_AUTH"] = strconv.FormatBool(serverauth.OIDCEnabled())
 
 	return &pb.GetFeatureFlagsResponse{
 		Flags: flags,

--- a/core/server/featureflags.go
+++ b/core/server/featureflags.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/weaveworks/weave-gitops/api/v1alpha1"
 	pb "github.com/weaveworks/weave-gitops/pkg/api/core"
@@ -36,20 +37,7 @@ func (cs *coreServer) GetFeatureFlags(ctx context.Context, msg *pb.GetFeatureFla
 		flags["CLUSTER_USER_AUTH"] = "true"
 	}
 
-	err = cl.Get(ctx, client.ObjectKey{
-		Namespace: v1alpha1.DefaultNamespace,
-		Name:      serverauth.OIDCAuthSecretName,
-	}, &secret)
-
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			flags["OIDC_AUTH"] = "false"
-		} else {
-			cs.logger.Error(err, "could not get secret for oidc")
-		}
-	} else {
-		flags["OIDC_AUTH"] = "true"
-	}
+	flags["OIDC_AUTH"] = strconv.FormatBool(serverauth.OidcEnabled())
 
 	return &pb.GetFeatureFlagsResponse{
 		Flags: flags,

--- a/core/server/featureflags_test.go
+++ b/core/server/featureflags_test.go
@@ -1,8 +1,8 @@
 package server_test
 
 import (
-	"github.com/weaveworks/weave-gitops/pkg/server/auth"
 	"context"
+	"github.com/weaveworks/weave-gitops/pkg/server/auth"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -24,18 +24,18 @@ func TestGetFeatureFlags(t *testing.T) {
 	RegisterFailHandler(Fail)
 
 	tests := []struct {
-		name     string
-		envSet   func()
-		envUnset func()
-		state    []client.Object
+		name        string
+		envSet      func()
+		envUnset    func()
+		state       []client.Object
 		oidcEnabled bool
-		result   map[string]string
+		result      map[string]string
 	}{
 		{
-			name:     "Cluster auth secret set",
-			envSet:   func() {},
-			envUnset: func() {},
-			state:    []client.Object{&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: "flux-system", Name: "cluster-user-auth"}}},
+			name:        "Cluster auth secret set",
+			envSet:      func() {},
+			envUnset:    func() {},
+			state:       []client.Object{&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: "flux-system", Name: "cluster-user-auth"}}},
 			oidcEnabled: false,
 			result: map[string]string{
 				"CLUSTER_USER_AUTH": "true",
@@ -43,10 +43,10 @@ func TestGetFeatureFlags(t *testing.T) {
 			},
 		},
 		{
-			name:     "Cluster auth secret not set",
-			envSet:   func() {},
-			envUnset: func() {},
-			state:    []client.Object{},
+			name:        "Cluster auth secret not set",
+			envSet:      func() {},
+			envUnset:    func() {},
+			state:       []client.Object{},
 			oidcEnabled: false,
 			result: map[string]string{
 				"CLUSTER_USER_AUTH": "false",
@@ -54,10 +54,10 @@ func TestGetFeatureFlags(t *testing.T) {
 			},
 		},
 		{
-			name:     "OIDC secret set",
-			envSet:   func() {},
-			envUnset: func() {},
-			state:    []client.Object{&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: "flux-system", Name: "oidc-auth"}}},
+			name:        "OIDC secret set",
+			envSet:      func() {},
+			envUnset:    func() {},
+			state:       []client.Object{&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: "flux-system", Name: "oidc-auth"}}},
 			oidcEnabled: true,
 			result: map[string]string{
 				"CLUSTER_USER_AUTH": "false",
@@ -65,10 +65,10 @@ func TestGetFeatureFlags(t *testing.T) {
 			},
 		},
 		{
-			name:     "OIDC secret not set",
-			envSet:   func() {},
-			envUnset: func() {},
-			state:    []client.Object{},
+			name:        "OIDC secret not set",
+			envSet:      func() {},
+			envUnset:    func() {},
+			state:       []client.Object{},
 			oidcEnabled: false,
 			result: map[string]string{
 				"CLUSTER_USER_AUTH": "false",

--- a/core/server/featureflags_test.go
+++ b/core/server/featureflags_test.go
@@ -81,7 +81,7 @@ func TestGetFeatureFlags(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := server.NewCoreConfig(logr.Discard(), &rest.Config{}, "test", &clustersmngrfakes.FakeClientsFactory{})
 
-			auth.SetOidcEnabled(tt.oidcEnabled)
+			auth.SetOIDCEnabled(tt.oidcEnabled)
 
 			k8s := fake.NewClientBuilder().WithScheme(kube.CreateScheme()).WithObjects(tt.state...).Build()
 			fakeClientGetter := kubefakes.NewFakeClientGetter(k8s)

--- a/pkg/server/auth/server.go
+++ b/pkg/server/auth/server.go
@@ -119,6 +119,11 @@ func NewAuthServer(ctx context.Context, cfg AuthConfig) (*AuthServer, error) {
 	return &AuthServer{cfg, provider}, nil
 }
 
+// SetOidcEnabled is intended for test use only
+func SetOidcEnabled(newVal bool) {
+	isOidcEnabled = newVal
+}
+
 func OidcEnabled() bool {
 	return isOidcEnabled
 }

--- a/pkg/server/auth/server.go
+++ b/pkg/server/auth/server.go
@@ -26,7 +26,7 @@ const (
 )
 
 // This is a horrible global setting but I think this is the easiest way to do this
-var isOidcEnabled bool = false
+var isOIDCEnabled bool = false
 
 // OIDCConfig is used to configure an AuthServer to interact with
 // an OIDC issuer.
@@ -112,20 +112,20 @@ func NewAuthServer(ctx context.Context, cfg AuthConfig) (*AuthServer, error) {
 		if err != nil {
 			return nil, fmt.Errorf("could not create provider: %w", err)
 		}
-		// Set isOidcEnabled now we have a valid provider
-		isOidcEnabled = true
+		// Set isOIDCEnabled now we have a valid provider
+		isOIDCEnabled = true
 	}
 
 	return &AuthServer{cfg, provider}, nil
 }
 
-// SetOidcEnabled is intended for test use only
-func SetOidcEnabled(newVal bool) {
-	isOidcEnabled = newVal
+// SetOIDCEnabled is intended for test use only
+func SetOIDCEnabled(newVal bool) {
+	isOIDCEnabled = newVal
 }
 
-func OidcEnabled() bool {
-	return isOidcEnabled
+func OIDCEnabled() bool {
+	return isOIDCEnabled
 }
 
 // SetRedirectURL is used to set the redirect URL. This is meant to be used
@@ -135,7 +135,7 @@ func (s *AuthServer) SetRedirectURL(url string) {
 }
 
 func (s *AuthServer) oidcEnabled() bool {
-	return OidcEnabled()
+	return OIDCEnabled()
 }
 
 func (s *AuthServer) verifier() *oidc.IDTokenVerifier {
@@ -169,7 +169,7 @@ func (s *AuthServer) oauth2Config(scopes []string) *oauth2.Config {
 
 func (s *AuthServer) OAuth2Flow() http.HandlerFunc {
 	return func(rw http.ResponseWriter, r *http.Request) {
-		if !OidcEnabled() {
+		if !OIDCEnabled() {
 			JSONError(s.Log, rw, "oidc provider not configured", http.StatusBadRequest)
 			return
 		}
@@ -358,7 +358,7 @@ func (s *AuthServer) UserInfo() http.HandlerFunc {
 			return
 		}
 
-		if !OidcEnabled() {
+		if !OIDCEnabled() {
 			ui := UserInfo{}
 			toJson(rw, ui, s.Log)
 

--- a/pkg/server/auth/server_test.go
+++ b/pkg/server/auth/server_test.go
@@ -632,6 +632,8 @@ func makeAuthServer(t *testing.T, client ctrlclient.Client, tsv auth.TokenSigner
 	t.Helper()
 	g := gomega.NewGomegaWithT(t)
 
+	auth.SetOIDCEnabled(false) // Reset this
+
 	m, err := mockoidc.Run()
 	g.Expect(err).NotTo(HaveOccurred())
 

--- a/website/docs/configuration/securing-access-to-the-dashboard.mdx
+++ b/website/docs/configuration/securing-access-to-the-dashboard.mdx
@@ -25,15 +25,15 @@ In order to login via your OIDC provider, you need to create a Kubernetes secret
 
 | Parameter         |  Description                                                                                                                      | Default   |
 | ------------------|  -------------------------------------------------------------------------------------------------------------------------------- | --------- |
-| `IssuerURL`       |  The URL of the issuer, typically the discovery URL without a path                                                                |           |
-| `ClientID`        |  The client ID that has been setup for Weave GitOps in the issuer                                                                 |           |
-| `ClientSecret`    |  The client secret that has been setup for Weave GitOps in the issuer                                                             |           |
-| `RedirectURL`     |  The redirect URL that has been setup for Weave GitOps in the issuer, typically the dashboard URL followed by `/oauth2/callback ` |           |
-| `TokenDuration`   |  The time duration that the ID Token will remain valid, after successful authentication                               | "1h0m0s"  |           |
+| `issuerURL`       |  The URL of the issuer, typically the discovery URL without a path                                                                |           |
+| `clientID`        |  The client ID that has been setup for Weave GitOps in the issuer                                                                 |           |
+| `clientSecret`    |  The client secret that has been setup for Weave GitOps in the issuer                                                             |           |
+| `redirectURL`     |  The redirect URL that has been setup for Weave GitOps in the issuer, typically the dashboard URL followed by `/oauth2/callback ` |           |
+| `tokenDuration`   |  The time duration that the ID Token will remain valid, after successful authentication                                           | "1h0m0s"  |
 
 Ensure that your OIDC provider has been setup with a client ID/secret and the redirect URL of the dashboard.
 
-Create a secret named `oidc-auth` in the `wego-system` namespace with these parameters set:
+Create a secret named `oidc-auth` in the `flux-system` namespace with these parameters set:
 
 ```sh
 kubectl create secret generic oidc-auth \

--- a/website/versioned_docs/version-0.8.0/configuration/securing-access-to-the-dashboard.mdx
+++ b/website/versioned_docs/version-0.8.0/configuration/securing-access-to-the-dashboard.mdx
@@ -32,15 +32,15 @@ In order to login via your OIDC provider, you need to create a Kubernetes secret
 
 | Parameter         |  Description                                                                                                                      | Default   |
 | ------------------|  -------------------------------------------------------------------------------------------------------------------------------- | --------- |
-| `IssuerURL`       |  The URL of the issuer, typically the discovery URL without a path                                                                |           |
-| `ClientID`        |  The client ID that has been setup for Weave GitOps in the issuer                                                                 |           |
-| `ClientSecret`    |  The client secret that has been setup for Weave GitOps in the issuer                                                             |           |
-| `RedirectURL`     |  The redirect URL that has been setup for Weave GitOps in the issuer, typically the dashboard URL followed by `/oauth2/callback ` |           |
-| `TokenDuration`   |  The time duration that the ID Token will remain valid, after successful authentication                               | "1h0m0s"  |           |
+| `issuerURL`       |  The URL of the issuer, typically the discovery URL without a path                                                                |           |
+| `clientID`        |  The client ID that has been setup for Weave GitOps in the issuer                                                                 |           |
+| `clientSecret`    |  The client secret that has been setup for Weave GitOps in the issuer                                                             |           |
+| `redirectURL`     |  The redirect URL that has been setup for Weave GitOps in the issuer, typically the dashboard URL followed by `/oauth2/callback ` |           |
+| `tokenDuration`   |  The time duration that the ID Token will remain valid, after successful authentication                                           | "1h0m0s"  |
 
 Ensure that your OIDC provider has been setup with a client ID/secret and the redirect URL of the dashboard.
 
-Create a secret named `oidc-auth` in the `wego-system` namespace with these parameters set:
+Create a secret named `oidc-auth` in the `flux-system` namespace with these parameters set:
 
 ```sh
 kubectl create secret generic oidc-auth \

--- a/website/versioned_docs/version-0.8.1/configuration/securing-access-to-the-dashboard.mdx
+++ b/website/versioned_docs/version-0.8.1/configuration/securing-access-to-the-dashboard.mdx
@@ -25,15 +25,15 @@ In order to login via your OIDC provider, you need to create a Kubernetes secret
 
 | Parameter         |  Description                                                                                                                      | Default   |
 | ------------------|  -------------------------------------------------------------------------------------------------------------------------------- | --------- |
-| `IssuerURL`       |  The URL of the issuer, typically the discovery URL without a path                                                                |           |
-| `ClientID`        |  The client ID that has been setup for Weave GitOps in the issuer                                                                 |           |
-| `ClientSecret`    |  The client secret that has been setup for Weave GitOps in the issuer                                                             |           |
-| `RedirectURL`     |  The redirect URL that has been setup for Weave GitOps in the issuer, typically the dashboard URL followed by `/oauth2/callback ` |           |
-| `TokenDuration`   |  The time duration that the ID Token will remain valid, after successful authentication                               | "1h0m0s"  |           |
+| `issuerURL`       |  The URL of the issuer, typically the discovery URL without a path                                                                |           |
+| `clientID`        |  The client ID that has been setup for Weave GitOps in the issuer                                                                 |           |
+| `clientSecret`    |  The client secret that has been setup for Weave GitOps in the issuer                                                             |           |
+| `redirectURL`     |  The redirect URL that has been setup for Weave GitOps in the issuer, typically the dashboard URL followed by `/oauth2/callback ` |           |
+| `tokenDuration`   |  The time duration that the ID Token will remain valid, after successful authentication                                           | "1h0m0s"  |
 
 Ensure that your OIDC provider has been setup with a client ID/secret and the redirect URL of the dashboard.
 
-Create a secret named `oidc-auth` in the `wego-system` namespace with these parameters set:
+Create a secret named `oidc-auth` in the `flux-system` namespace with these parameters set:
 
 ```sh
 kubectl create secret generic oidc-auth \

--- a/website/versioned_docs/version-0.9.0/configuration/securing-access-to-the-dashboard.mdx
+++ b/website/versioned_docs/version-0.9.0/configuration/securing-access-to-the-dashboard.mdx
@@ -25,15 +25,15 @@ In order to login via your OIDC provider, you need to create a Kubernetes secret
 
 | Parameter         |  Description                                                                                                                      | Default   |
 | ------------------|  -------------------------------------------------------------------------------------------------------------------------------- | --------- |
-| `IssuerURL`       |  The URL of the issuer, typically the discovery URL without a path                                                                |           |
-| `ClientID`        |  The client ID that has been setup for Weave GitOps in the issuer                                                                 |           |
-| `ClientSecret`    |  The client secret that has been setup for Weave GitOps in the issuer                                                             |           |
-| `RedirectURL`     |  The redirect URL that has been setup for Weave GitOps in the issuer, typically the dashboard URL followed by `/oauth2/callback ` |           |
-| `TokenDuration`   |  The time duration that the ID Token will remain valid, after successful authentication                               | "1h0m0s"  |           |
+| `issuerURL`       |  The URL of the issuer, typically the discovery URL without a path                                                                |           |
+| `clientID`        |  The client ID that has been setup for Weave GitOps in the issuer                                                                 |           |
+| `clientSecret`    |  The client secret that has been setup for Weave GitOps in the issuer                                                             |           |
+| `redirectURL`     |  The redirect URL that has been setup for Weave GitOps in the issuer, typically the dashboard URL followed by `/oauth2/callback ` |           |
+| `tokenDuration`   |  The time duration that the ID Token will remain valid, after successful authentication                                           | "1h0m0s"  |
 
 Ensure that your OIDC provider has been setup with a client ID/secret and the redirect URL of the dashboard.
 
-Create a secret named `oidc-auth` in the `wego-system` namespace with these parameters set:
+Create a secret named `oidc-auth` in the `flux-system` namespace with these parameters set:
 
 ```sh
 kubectl create secret generic oidc-auth \


### PR DESCRIPTION
**What changed?**

* Added `--oidc-secret-name` flag to allow alternate secrets to be provided to the server
* Enabled creation of the `oidc-auth` secret as part of the helm chart
* Improved logging around OIDC start up
* Fixed some typos in the docs

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**

Because I ran into problems relating to these issues several times whilst setting up Dex (particularly around the logging not providing feedback on why OIDC wasn't working). The additional flag was mostly a "while I'm here".

This should also mean that providing OIDC configuration via CLI actually works now (I believe it didn't previously because `featureflag.go` would fail to find a secret and then mark `OIDC_AUTH` as disabled).

<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**

Mostly through adding a new flag. The only debatable change was adding a global variable to the `pkg/server/auth/server.go` (`isOidcEnabled`) which replaces the `featureflag.go` secret lookup. I think this is a preferable method as the state of this flag is exposed by a function in the server.go file and should be the concern of it (rather than featureflag). Alternates involved threading a lot more state through the system as featureflag and the authserver are fairly disjoint. I think in theory the information could have been passed by context but that felt even messier.

<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**

I added some tests and ran it locally with dex in a variety of configurations (default `oidc-auth` secret, oidc passed by CLI and oidc from a different secret). All worked as expected.

The helm chart change was tested by inspection of the output of `helm template`

<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**

No

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**

Fixed some types which gave incorrectly capitalised oidc parameters in the table and listed the namespace to use as the legacy `wego-system`
