### PR TITLE
Removes tags from image links

### DIFF
--- a/ui/lib/__tests__/utils.test.ts
+++ b/ui/lib/__tests__/utils.test.ts
@@ -263,5 +263,10 @@ describe("utils lib", () => {
         "https://gcr.io/cloud-builders/gcloud"
       );
     });
+    it("should remove tags", () => {
+      expect(
+        convertImage("ghcr.io/weaveworks/charts/weave-gitops:10.4.5.2335224")
+      ).toEqual("https://ghcr.io/weaveworks/charts/weave-gitops");
+    });
   });
 });

--- a/ui/lib/__tests__/utils.test.ts
+++ b/ui/lib/__tests__/utils.test.ts
@@ -268,5 +268,12 @@ describe("utils lib", () => {
         convertImage("ghcr.io/weaveworks/charts/weave-gitops:10.4.5.2335224")
       ).toEqual("https://ghcr.io/weaveworks/charts/weave-gitops");
     });
+    it("should not link to unsupported images", () => {
+      expect(
+        convertImage(
+          "fakeimage.itisfake.donotdoit.io/fake/fake/fake.com.net.org"
+        )
+      ).toEqual(false);
+    });
   });
 });

--- a/ui/lib/utils.ts
+++ b/ui/lib/utils.ts
@@ -130,33 +130,25 @@ export const convertImage = (image: string) => {
   //Github GHCR or Google GCR
   if (prefix === "ghcr.io" || prefix === "gcr.io") return "https://" + noTag;
   //Quay.io
-  else if (prefix === "quay.io") {
+  if (prefix === "quay.io") {
     url = "https://quay.io/repository/";
     return makeUrl(url, split);
   }
   //complex docker prefix case
-  else if (prefix === "docker.io") {
+  if (prefix === "docker.io") {
     url = "https://hub.docker.com/r/";
     //library alias
     if (split[0] === "library") return url + "_/" + split[1];
     //global
-    else if (!split[1]) return url + "_/" + split[0];
+    if (!split[1]) return url + "_/" + split[0];
     //namespaced
-    else {
-      return makeUrl(url, split);
-    }
+    return makeUrl(url, split);
   }
   //docker without prefix
-  else if (prefix === "library")
-    return "https://hub.docker.com/r/_/" + split[0];
+  if (prefix === "library") return "https://hub.docker.com/r/_/" + split[0];
   //this one's at risk if we have to add others - global docker images can just be one word apparently
-  else if (
-    !prefix.includes("public.ecr.aws") &&
-    !prefix.includes("amazonaws.com")
-  ) {
-    if (!split[0]) return "https://hub.docker.com/r/_/" + noTag;
-    else {
-      return "https://hub.docker.com/r/" + noTag;
-    }
-  } else return "";
+  if (!split[0]) {
+    return "https://hub.docker.com/r/_/" + noTag;
+  }
+  return "https://hub.docker.com/r/" + noTag;
 };

--- a/ui/lib/utils.ts
+++ b/ui/lib/utils.ts
@@ -113,26 +113,17 @@ export const convertImage = (image: string) => {
   const tag = split[split.length - 1];
   if (tag.includes(":"))
     split[split.length - 1] = tag.slice(0, tag.indexOf(":"));
-  const noTag = split.join("/");
 
   const prefix = split.shift();
+  const noTag = split.join("/");
   let url = "";
 
-  const makeUrl = (url: string, parts: string[]) => {
-    let newUrl = url;
-    parts.forEach((part, index) => {
-      if (index === split.length - 1) newUrl += part;
-      else newUrl += `${part}/`;
-    });
-    return newUrl;
-  };
-
   //Github GHCR or Google GCR
-  if (prefix === "ghcr.io" || prefix === "gcr.io") return "https://" + noTag;
+  if (prefix === "ghcr.io" || prefix === "gcr.io")
+    return `https://${prefix}/${noTag}`;
   //Quay.io
   if (prefix === "quay.io") {
-    url = "https://quay.io/repository/";
-    return makeUrl(url, split);
+    return `https://quay.io/repository/${noTag}`;
   }
   //complex docker prefix case
   if (prefix === "docker.io") {
@@ -142,13 +133,16 @@ export const convertImage = (image: string) => {
     //global
     if (!split[1]) return url + "_/" + split[0];
     //namespaced
-    return makeUrl(url, split);
+    return url + noTag;
   }
   //docker without prefix
   if (prefix === "library") return "https://hub.docker.com/r/_/" + split[0];
   //this one's at risk if we have to add others - global docker images can just be one word apparently
   if (!split[0]) {
-    return "https://hub.docker.com/r/_/" + noTag;
+    return "https://hub.docker.com/r/_/" + prefix;
   }
-  return "https://hub.docker.com/r/" + noTag;
+  //any other url
+  if (prefix.includes(".")) return false;
+  //one slash docker images w/o docker.io
+  return `https://hub.docker.com/r/${prefix}/${noTag}`;
 };

--- a/ui/lib/utils.ts
+++ b/ui/lib/utils.ts
@@ -108,6 +108,13 @@ export function formatMetadataKey(key: string): string {
 
 export const convertImage = (image: string) => {
   const split = image.split("/");
+
+  //remove tags
+  const tag = split[split.length - 1];
+  if (tag.includes(":"))
+    split[split.length - 1] = tag.slice(0, tag.indexOf(":"));
+  const noTag = split.join("/");
+
   const prefix = split.shift();
   let url = "";
 
@@ -121,7 +128,7 @@ export const convertImage = (image: string) => {
   };
 
   //Github GHCR or Google GCR
-  if (prefix === "ghcr.io" || prefix === "gcr.io") return "https://" + image;
+  if (prefix === "ghcr.io" || prefix === "gcr.io") return "https://" + noTag;
   //Quay.io
   else if (prefix === "quay.io") {
     url = "https://quay.io/repository/";
@@ -147,9 +154,9 @@ export const convertImage = (image: string) => {
     !prefix.includes("public.ecr.aws") &&
     !prefix.includes("amazonaws.com")
   ) {
-    if (!split[0]) return "https://hub.docker.com/r/_/" + image;
+    if (!split[0]) return "https://hub.docker.com/r/_/" + noTag;
     else {
-      return "https://hub.docker.com/r/" + image;
+      return "https://hub.docker.com/r/" + noTag;
     }
   } else return "";
 };


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes #2386

<!-- Describe what has changed in this PR -->
Adds a check on the last piece of the image string to remove anything after and including the `:` character plus a test - the tag will still show in the table but it will not be a part of the link
