### PR TITLE
Nav fixed vertically, but scrolls horizontally

### DIFF
--- a/ui/components/Layout.tsx
+++ b/ui/components/Layout.tsx
@@ -69,12 +69,12 @@ const navWidth = "200px";
 const topBarHeight = "60px";
 
 const NavContainer = styled.div`
-  position: fixed;
   width: ${navWidth};
-  //topBarHeight + correct margins of 36px
-  height: calc(100% - 84px);
+  min-width: ${navWidth};
+  height: calc(100% - 24px);
   margin-top: ${(props) => props.theme.spacing.small};
-  margin-bottom: ${(props) => props.theme.spacing.small};
+  //topBarHeight + small margin
+  transform: translateY(72);
 `;
 
 const NavContent = styled.div`
@@ -129,7 +129,6 @@ const ContentContainer = styled.div`
   padding-bottom: ${(props) => props.theme.spacing.small};
   padding-right: ${(props) => props.theme.spacing.medium};
   padding-left: ${(props) => props.theme.spacing.medium};
-  margin-left: ${navWidth};
   overflow: hidden;
   overflow-y: scroll;
   box-sizing: border-box;
@@ -144,7 +143,8 @@ const TopToolBar = styled(Flex)`
   position: fixed;
   background-color: ${(props) => props.theme.colors.primary};
   height: ${topBarHeight};
-  min-width: 900px;
+  min-width: 650px;
+  width: 100%;
   ${UserSettings} {
     justify-self: flex-end;
     margin-left: auto;
@@ -185,6 +185,7 @@ function Layout({ className, children }: Props) {
             </Tabs>
           </NavContent>
         </NavContainer>
+
         <ContentContainer>{children}</ContentContainer>
       </Main>
     </AppContainer>

--- a/ui/components/Layout.tsx
+++ b/ui/components/Layout.tsx
@@ -185,7 +185,6 @@ function Layout({ className, children }: Props) {
             </Tabs>
           </NavContent>
         </NavContainer>
-
         <ContentContainer>{children}</ContentContainer>
       </Main>
     </AppContainer>


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes #2383 

<!-- Describe what has changed in this PR -->
Here's the new behavior - a cool trick with `transform: translate` allows for a half-fixed styling of the nav so the page overflows horizontally as expected. Also decreased top tool bar min width so that the user settings icon is visible more often

https://user-images.githubusercontent.com/65822698/176738109-7da2e54f-bd6c-46d6-89ed-a73df917631f.mov

