### PR TITLE
Graph view hides resources with default zoom

### DIFF
--- a/ui/components/DirectedGraph.tsx
+++ b/ui/components/DirectedGraph.tsx
@@ -245,7 +245,7 @@ class D3Graph {
   graph;
   opts;
 
-  constructor(element, opts: D3GraphOptions) {
+  constructor(element: any, opts: D3GraphOptions) {
     const dagreD3LibRef = dagreD3;
 
     this.graph = new dagreD3LibRef.graphlib.Graph();

--- a/ui/components/DirectedGraph.tsx
+++ b/ui/components/DirectedGraph.tsx
@@ -7,6 +7,7 @@ import styled from "styled-components";
 import { muiTheme } from "../lib/theme";
 import Flex from "./Flex";
 import Spacer from "./Spacer";
+import Text from "./Text";
 
 type Props<N> = {
   className?: string;
@@ -30,6 +31,21 @@ const PercentFlex = styled(Flex)`
   padding: 10px;
   background: rgba(0, 179, 236, 0.1);
   border-radius: 2px;
+`;
+
+const GraphFlex = styled(Flex)`
+  position: relative;
+`;
+
+const LoadingText = styled(Text)`
+  position: absolute;
+`;
+
+const Svg = styled.svg`
+  &.loading {
+    opacity: 0;
+    pointer-events: none;
+  }
 `;
 
 function DirectedGraph<T>({
@@ -74,14 +90,31 @@ function DirectedGraph<T>({
     graphRef.current.render();
   }, [nodes, edges]);
 
-  const viewBoxOffsetX = -zoomPercent * 1.25;
+  const d3Graph = graphRef?.current?.graph;
+  const graphNodes = d3Graph ? d3Graph.nodes() : null;
+  const rootNode = graphNodes
+    ? d3Graph.node(graphNodes[graphNodes.length - 1])
+    : null;
+  const nodeOffsetX = rootNode
+    ? ((rootNode.x - rootNode.width) * (zoomPercent + 20)) / 1000
+    : 0;
+
+  const viewBoxOffsetX = -zoomPercent * 1.25 + nodeOffsetX;
+
+  const isLoadingGraph = !rootNode;
+
+  const loadingText =
+    "Fetching all reconciled objects, building directional relationship, determining central node...";
 
   return (
-    <Flex wide tall className={className}>
-      <svg
+    <GraphFlex wide tall className={className}>
+      {isLoadingGraph && <LoadingText>{loadingText}</LoadingText>}
+
+      <Svg
         viewBox={`${viewBoxOffsetX} 0 100 100`}
         preserveAspectRatio="xMidYMid meet"
         ref={svgRef}
+        className={isLoadingGraph ? "loading" : ""}
       />
 
       <Flex tall>
@@ -96,7 +129,7 @@ function DirectedGraph<T>({
           <PercentFlex>{zoomPercent}%</PercentFlex>
         </SliderFlex>
       </Flex>
-    </Flex>
+    </GraphFlex>
   );
 }
 

--- a/ui/components/DirectedGraph.tsx
+++ b/ui/components/DirectedGraph.tsx
@@ -37,7 +37,9 @@ const PercentFlex = styled(Flex)`
 `;
 
 const GraphFlex = styled(Flex)`
-  position: relative;
+  &.loading {
+    position: relative;
+  }
 `;
 
 const LoadingText = styled(Text)`
@@ -155,15 +157,17 @@ function DirectedGraph<T>({
 
   const isLoadingGraph = nodeOffsetX === 0;
 
+  const loadingClassName = isLoadingGraph ? "loading" : "";
+
   return (
-    <GraphFlex wide tall className={className}>
+    <GraphFlex wide tall className={`${className} ${loadingClassName}`}>
       {isLoadingGraph && <LoadingText>{loadingText}</LoadingText>}
 
       <Svg
         viewBox="0 0 100 100"
         preserveAspectRatio="xMidYMid meet"
         ref={svgRef}
-        className={isLoadingGraph ? "loading" : ""}
+        className={loadingClassName}
       />
 
       <Flex tall>

--- a/ui/components/Footer.tsx
+++ b/ui/components/Footer.tsx
@@ -68,10 +68,10 @@ function Footer({ className }: Props) {
       <RightFoot>
         {!isLoading &&
           versions.map((version, index) => (
-            <>
+            <React.Fragment key={`version ${index}`}>
               <Spacer padding="xxs" />
-              <Version key={`key ${index}`} {...version} />
-            </>
+              <Version {...version} />
+            </React.Fragment>
           ))}
         <Spacer padding="xxs" />
         <Text noWrap>© 2022 Weaveworks</Text>

--- a/ui/components/ReconciliationGraph.tsx
+++ b/ui/components/ReconciliationGraph.tsx
@@ -10,7 +10,7 @@ import {
 } from "../lib/api/core/types.pb";
 import images from "../lib/images";
 import { removeKind } from "../lib/utils";
-import DirectedGraph from "./DirectedGraph";
+import DirectedGraph, { defaultScale } from "./DirectedGraph";
 import Flex from "./Flex";
 import { computeReady } from "./KubeStatusIndicator";
 import { ReconciledVisualizationProps } from "./ReconciledObjectsTable";
@@ -170,7 +170,7 @@ function ReconciliationGraph({
     <RequestStateHandler loading={isLoading} error={error}>
       <div className={className} style={{ height: "100%", width: "100%" }}>
         <DirectedGraph
-          scale={20}
+          scale={defaultScale}
           nodes={nodes}
           edges={edges}
           labelShape="rect"

--- a/ui/lib/__tests__/utils.test.ts
+++ b/ui/lib/__tests__/utils.test.ts
@@ -16,7 +16,7 @@ import {
   statusSortHelper,
 } from "../utils";
 
-const floatDiff = 0.0000000000000000001;
+const floatPrecision = 19;
 
 describe("utils lib", () => {
   describe("gitlabOAuthRedirectURI", () => {
@@ -284,15 +284,15 @@ describe("utils lib", () => {
   });
   describe("calculateZoomRatio", () => {
     it("calculates zoom ratio", () => {
-      expect(
-        Math.abs(calculateZoomRatio(0) - 0.013333333333333334)
-      ).toBeLessThanOrEqual(floatDiff);
-      expect(
-        Math.abs(calculateZoomRatio(20) - 0.02666666666666667)
-      ).toBeLessThanOrEqual(floatDiff);
-      expect(Math.abs(calculateZoomRatio(100) - 0.08)).toBeLessThanOrEqual(
-        floatDiff
+      expect(calculateZoomRatio(0)).toBeCloseTo(
+        0.013333333333333334,
+        floatPrecision
       );
+      expect(calculateZoomRatio(20)).toBeCloseTo(
+        0.02666666666666667,
+        floatPrecision
+      );
+      expect(calculateZoomRatio(100)).toBeCloseTo(0.08, floatPrecision);
     });
   });
   describe("calculateNodeOffsetX", () => {
@@ -306,47 +306,32 @@ describe("utils lib", () => {
     };
     it("calculates x-offset for the node", () => {
       expect(
-        Math.abs(
-          calculateNodeOffsetX(rootNode, 0, 0.013333333333333334) -
-            -40.400000000000006
-        )
-      ).toBeLessThanOrEqual(floatDiff);
+        calculateNodeOffsetX(rootNode, 0, 0.013333333333333334)
+      ).toBeCloseTo(-40.400000000000006, floatPrecision);
       expect(
-        Math.abs(
-          calculateNodeOffsetX(rootNode, 20, 0.02666666666666667) -
-            -55.80000000000001
-        )
-      ).toBeLessThanOrEqual(floatDiff);
+        calculateNodeOffsetX(rootNode, 20, 0.02666666666666667)
+      ).toBeCloseTo(-55.80000000000001, floatPrecision);
       expect(
-        Math.abs(
-          calculateNodeOffsetX(rootNode, 50, 0.04666666666666667) - -78.9
-        )
-      ).toBeLessThanOrEqual(floatDiff);
-      expect(
-        Math.abs(calculateNodeOffsetX(rootNode, 100, 0.08) - -117.4)
-      ).toBeLessThanOrEqual(floatDiff);
+        calculateNodeOffsetX(rootNode, 50, 0.04666666666666667)
+      ).toBeCloseTo(-78.9, floatPrecision);
+      expect(calculateNodeOffsetX(rootNode, 100, 0.08)).toBeCloseTo(
+        -117.4,
+        floatPrecision
+      );
     });
   });
   describe("mapScaleToZoomPercent", () => {
     it("maps zoom percent to scale", () => {
       expect(mapScaleToZoomPercent(0)).toEqual(0);
-      expect(Math.abs(mapScaleToZoomPercent(20) - 10)).toBeLessThanOrEqual(
-        floatDiff
-      );
-      expect(Math.abs(mapScaleToZoomPercent(100) - 50)).toBeLessThanOrEqual(
-        floatDiff
-      );
+      expect(mapScaleToZoomPercent(20)).toBeCloseTo(10, floatPrecision);
+      expect(mapScaleToZoomPercent(100)).toBeCloseTo(50, floatPrecision);
     });
   });
   describe("mapZoomPercentToScale", () => {
     it("maps scale to zoom percent", () => {
       expect(mapZoomPercentToScale(0)).toEqual(0);
-      expect(Math.abs(mapZoomPercentToScale(20) - 40)).toBeLessThanOrEqual(
-        floatDiff
-      );
-      expect(Math.abs(mapZoomPercentToScale(100) - 200)).toBeLessThanOrEqual(
-        floatDiff
-      );
+      expect(mapZoomPercentToScale(20)).toBeCloseTo(40, floatPrecision);
+      expect(mapZoomPercentToScale(100)).toBeCloseTo(200, floatPrecision);
     });
   });
 });

--- a/ui/lib/__tests__/utils.test.ts
+++ b/ui/lib/__tests__/utils.test.ts
@@ -1,16 +1,22 @@
 import { jest } from "@jest/globals";
 import {
   addKind,
+  calculateZoomRatio,
+  calculateNodeOffsetX,
   convertGitURLToGitProvider,
   convertImage,
   formatMetadataKey,
   gitlabOAuthRedirectURI,
   isHTTP,
   makeImageString,
+  mapScaleToZoomPercent,
+  mapZoomPercentToScale,
   pageTitleWithAppName,
   removeKind,
   statusSortHelper,
 } from "../utils";
+
+const floatDiff = 0.0000000000000000001;
 
 describe("utils lib", () => {
   describe("gitlabOAuthRedirectURI", () => {
@@ -274,6 +280,73 @@ describe("utils lib", () => {
           "fakeimage.itisfake.donotdoit.io/fake/fake/fake.com.net.org"
         )
       ).toEqual(false);
+    });
+  });
+  describe("calculateZoomRatio", () => {
+    it("calculates zoom ratio", () => {
+      expect(
+        Math.abs(calculateZoomRatio(0) - 0.013333333333333334)
+      ).toBeLessThanOrEqual(floatDiff);
+      expect(
+        Math.abs(calculateZoomRatio(20) - 0.02666666666666667)
+      ).toBeLessThanOrEqual(floatDiff);
+      expect(Math.abs(calculateZoomRatio(100) - 0.08)).toBeLessThanOrEqual(
+        floatDiff
+      );
+    });
+  });
+  describe("calculateNodeOffsetX", () => {
+    it("returns 0 if the node is undefined", () => {
+      expect(calculateNodeOffsetX(undefined, 20, 0.04)).toEqual(0);
+    });
+
+    const rootNode = {
+      width: 670,
+      x: 3700,
+    };
+    it("calculates x-offset for the node", () => {
+      expect(
+        Math.abs(
+          calculateNodeOffsetX(rootNode, 0, 0.013333333333333334) -
+            -40.400000000000006
+        )
+      ).toBeLessThanOrEqual(floatDiff);
+      expect(
+        Math.abs(
+          calculateNodeOffsetX(rootNode, 20, 0.02666666666666667) -
+            -55.80000000000001
+        )
+      ).toBeLessThanOrEqual(floatDiff);
+      expect(
+        Math.abs(
+          calculateNodeOffsetX(rootNode, 50, 0.04666666666666667) - -78.9
+        )
+      ).toBeLessThanOrEqual(floatDiff);
+      expect(
+        Math.abs(calculateNodeOffsetX(rootNode, 100, 0.08) - -117.4)
+      ).toBeLessThanOrEqual(floatDiff);
+    });
+  });
+  describe("mapScaleToZoomPercent", () => {
+    it("maps zoom percent to scale", () => {
+      expect(mapScaleToZoomPercent(0)).toEqual(0);
+      expect(Math.abs(mapScaleToZoomPercent(20) - 10)).toBeLessThanOrEqual(
+        floatDiff
+      );
+      expect(Math.abs(mapScaleToZoomPercent(100) - 50)).toBeLessThanOrEqual(
+        floatDiff
+      );
+    });
+  });
+  describe("mapZoomPercentToScale", () => {
+    it("maps scale to zoom percent", () => {
+      expect(mapZoomPercentToScale(0)).toEqual(0);
+      expect(Math.abs(mapZoomPercentToScale(20) - 40)).toBeLessThanOrEqual(
+        floatDiff
+      );
+      expect(Math.abs(mapZoomPercentToScale(100) - 200)).toBeLessThanOrEqual(
+        floatDiff
+      );
     });
   });
 });

--- a/ui/lib/utils.ts
+++ b/ui/lib/utils.ts
@@ -146,3 +146,27 @@ export const convertImage = (image: string) => {
   //one slash docker images w/o docker.io
   return `https://hub.docker.com/r/${prefix}/${noTag}`;
 };
+
+export function calculateZoomRatio(zoomPercent: number): number {
+  return (zoomPercent + 20) / 1500;
+}
+
+export function calculateNodeOffsetX(
+  rootNode: any,
+  zoomPercent: number,
+  zoomRatio: number
+): number {
+  if (!rootNode) {
+    return 0;
+  }
+
+  return zoomPercent * 1.25 + (rootNode.width - rootNode.x) * zoomRatio;
+}
+
+export function mapScaleToZoomPercent(scale: number): number {
+  return scale * 0.5;
+}
+
+export function mapZoomPercentToScale(zoomPercent: number): number {
+  return Math.round(zoomPercent * 2);
+}


### PR DESCRIPTION
Closes #2312 

- Fixed the initial zoom level and position of the graph.
- Improved graph positioning performance thanks to using d3 `translate` instead of the SVG `viewBox` attribute.
- Reduced graph zoom level (added custom mapping from slider scale to graph zoom percent).
- Added graph utility functions (for converting and mapping zoom-related values) to utils and added tests for them.
- Fixed version keys in the footer (because it produced a warning when running tests, I had wrapped the version elements with React fragments but had forgotten to move the keys to fragments).
- Reworked D3Graph props and types and zoom options.
- Improved graph positioning in general. Hopefully, other graph-related issues will be easier to handle in the future after this rework and refactoring.
- Added a loading text message to display while the graph is rendering the nodes (until it is possible to the size and position of the root node).
- The issue #1225 will be handled later in a separate PR  because the current branch already introduces many changes.