### PR TITLE
Fixed bug in computeReady function

### DIFF
--- a/ui/components/KubeStatusIndicator.tsx
+++ b/ui/components/KubeStatusIndicator.tsx
@@ -14,19 +14,21 @@ type Props = {
 };
 export enum ReadyType {
   Ready = "Ready",
-  NotReady = "NotReady",
+  NotReady = "Not Ready",
   Reconciling = "Reconciling",
 }
 
 export function computeReady(conditions: Condition[]): string {
-  if (
+  const readyCondition =
     _.find(conditions, (c) => c.type === "Ready") ||
-    _.find(conditions, (c) => c.type === "Available")
-  ) {
-    return _.find(conditions, (c) => c.status === "Unknown") &&
-      _.find(conditions, (c) => c.reason === "Progressing")
-      ? ReadyType.Reconciling
-      : ReadyType.Ready;
+    _.find(conditions, (c) => c.type === "Available");
+  if (readyCondition) {
+    if (readyCondition.status === "True") return ReadyType.Ready;
+    if (
+      readyCondition.status === "Unknown" &&
+      readyCondition.reason === "Progressing"
+    )
+      return ReadyType.Reconciling;
   }
   return undefined;
 }

--- a/ui/components/__tests__/KubeStatusIndicator.test.tsx
+++ b/ui/components/__tests__/KubeStatusIndicator.test.tsx
@@ -64,9 +64,9 @@ describe("KubeStatusIndicator", () => {
         timestamp: "2022-03-03 17:00:38 +0000 UTC",
       },
     ];
-    render(withTheme(<KubeStatusIndicator conditions={conditions} />));
+    render(withTheme(<KubeStatusIndicator conditions={conditions} short />));
 
-    const msg = screen.getByText(conditions[0].message);
+    const msg = screen.getByText("Not Ready");
     expect(msg).toBeTruthy();
   });
   it("1593 - handles unhealthy", () => {
@@ -88,9 +88,9 @@ describe("KubeStatusIndicator", () => {
       },
     ];
 
-    render(withTheme(<KubeStatusIndicator conditions={conditions} />));
+    render(withTheme(<KubeStatusIndicator conditions={conditions} short />));
 
-    const msg = screen.getByText(conditions[0].message);
+    const msg = screen.getByText("Not Ready");
     expect(msg).toBeTruthy();
   });
   it("handles suspended", () => {
@@ -139,7 +139,9 @@ describe("KubeStatusIndicator", () => {
         },
       ];
       const tree = renderer
-        .create(withTheme(<KubeStatusIndicator conditions={conditions} />))
+        .create(
+          withTheme(<KubeStatusIndicator conditions={conditions} short />)
+        )
         .toJSON();
       expect(tree).toMatchSnapshot();
     });

--- a/ui/components/__tests__/__snapshots__/KubeStatusIndicator.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/KubeStatusIndicator.test.tsx.snap
@@ -81,7 +81,7 @@ exports[`KubeStatusIndicator snapshots renders error 1`] = `
       className="c5 c6"
       size="medium"
     >
-      There was a problem
+      Not Ready
     </span>
   </div>
 </div>


### PR DESCRIPTION
`computeReady` in `KubeStatusIndicator` was not using the status field of the `Condition` object - tests didn't catch this because without the `short` prop the component renders the message no matter what, even though the wrong icon could be displayed. Added the short prop in a couple tests and am correctly testing "Not Ready" instead of the full message.

