### PR TITLE
Redirect to previous location on 401

### DIFF
--- a/ui/contexts/AuthContext.tsx
+++ b/ui/contexts/AuthContext.tsx
@@ -15,14 +15,6 @@ interface AuthCheckProps {
   Loader?: React.ElementType;
 }
 
-const makeRedirect = () => {
-  const search = location.search;
-  const query = qs.parse(search);
-  console.log(query);
-  if (!query.redirect) query.redirect = location.pathname + search;
-  return qs.stringify(query);
-};
-
 export const AuthCheck = ({ children, Loader }: AuthCheckProps) => {
   const { userInfo } = React.useContext(Auth);
   // Wait until userInfo is loaded before showing signin or app content
@@ -36,7 +28,10 @@ export const AuthCheck = ({ children, Loader }: AuthCheckProps) => {
   // User appears not be logged in, off to signin
   return (
     <Redirect
-      to={{ pathname: AuthRoutes.AUTH_PATH_SIGNIN, search: makeRedirect() }}
+      to={{
+        pathname: AuthRoutes.AUTH_PATH_SIGNIN,
+        search: qs.stringify({ redirect: location.pathname + location.search }),
+      }}
     />
   );
 };
@@ -86,7 +81,6 @@ export default function AuthContextProvider({ children }) {
   }, []);
 
   const getUserInfo = React.useCallback(() => {
-    console.log("user info running");
     setLoading(true);
     return request(AuthRoutes.USER_INFO)
       .then((response) => {
@@ -111,7 +105,7 @@ export default function AuthContextProvider({ children }) {
           setError(response);
           return;
         }
-        window.location.pathname = AuthRoutes.AUTH_PATH_SIGNIN;
+        window.location.replace(AuthRoutes.AUTH_PATH_SIGNIN);
       })
       .finally(() => setLoading(false));
   }, []);

--- a/ui/contexts/AuthContext.tsx
+++ b/ui/contexts/AuthContext.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Redirect, useHistory } from "react-router-dom";
+import { useHistory } from "react-router-dom";
 import { AppContext } from "./AppContext";
 
 export enum AuthRoutes {
@@ -16,19 +16,19 @@ interface AuthCheckProps {
 
 export const AuthCheck = ({ children, Loader }: AuthCheckProps) => {
   const { userInfo } = React.useContext(Auth);
-
+  const history = useHistory();
+  console.log("auth check running");
   // Wait until userInfo is loaded before showing signin or app content
   if (!userInfo) {
     return Loader ? <Loader /> : null;
   }
-
   // Signed in! Show app
   if (userInfo?.email) {
     return children;
   }
-
   // User appears not be logged in, off to signin
-  return <Redirect to={AuthRoutes.AUTH_PATH_SIGNIN} />;
+  history.push(AuthRoutes.AUTH_PATH_SIGNIN);
+  return children;
 };
 
 export type AuthContext = {
@@ -69,8 +69,7 @@ export default function AuthContextProvider({ children }) {
         }
         getUserInfo().then(() => {
           setError(null);
-          const prev = history.location.state;
-          if (prev) history.push(prev.pathname + prev.search);
+          if (history.length > 1) history.goBack();
           else history.push("/");
         });
       })
@@ -78,6 +77,7 @@ export default function AuthContextProvider({ children }) {
   }, []);
 
   const getUserInfo = React.useCallback(() => {
+    console.log("user info running");
     setLoading(true);
     return request(AuthRoutes.USER_INFO)
       .then((response) => {
@@ -102,7 +102,7 @@ export default function AuthContextProvider({ children }) {
           setError(response);
           return;
         }
-        window.location.pathname = AuthRoutes.AUTH_PATH_SIGNIN;
+        window.location.assign(AuthRoutes.AUTH_PATH_SIGNIN);
       })
       .finally(() => setLoading(false));
   }, []);

--- a/ui/contexts/AuthContext.tsx
+++ b/ui/contexts/AuthContext.tsx
@@ -69,7 +69,9 @@ export default function AuthContextProvider({ children }) {
         }
         getUserInfo().then(() => {
           setError(null);
-          history.push("/");
+          const prev = history.location.state;
+          if (prev) history.push(prev.pathname + prev.search);
+          else history.push("/");
         });
       })
       .finally(() => setLoading(false));

--- a/ui/contexts/CoreClientContext.tsx
+++ b/ui/contexts/CoreClientContext.tsx
@@ -1,5 +1,6 @@
+import qs from "query-string";
 import * as React from "react";
-import { Redirect, useLocation } from "react-router-dom";
+import { Redirect } from "react-router-dom";
 import { Core } from "../lib/api/core/core.pb";
 import { AuthRoutes } from "./AuthContext";
 
@@ -15,7 +16,7 @@ export type CoreClientContextType = {
 export const CoreClientContext =
   React.createContext<CoreClientContextType | null>(null);
 
-export function UnAuthorizedInterceptor(api: any, location: any) {
+export function UnAuthorizedInterceptor(api: any) {
   const wrapped = {} as any;
   //   Wrap each API method in a check that redirects to the signin page if a 401 is returned.
   for (const method of Object.getOwnPropertyNames(api)) {
@@ -28,8 +29,10 @@ export function UnAuthorizedInterceptor(api: any, location: any) {
           return (
             <Redirect
               to={{
-                path: AuthRoutes.AUTH_PATH_SIGNIN,
-                state: { from: location },
+                pathname: AuthRoutes.AUTH_PATH_SIGNIN,
+                search: qs.stringify({
+                  redirect: location.pathname + location.search,
+                }),
               }}
             />
           );
@@ -42,8 +45,7 @@ export function UnAuthorizedInterceptor(api: any, location: any) {
 }
 
 export default function CoreClientContextProvider({ api, children }: Props) {
-  const location = useLocation();
-  const wrapped = UnAuthorizedInterceptor(api, location) as typeof Core;
+  const wrapped = UnAuthorizedInterceptor(api) as typeof Core;
 
   return (
     <CoreClientContext.Provider value={{ api: wrapped }}>

--- a/ui/contexts/CoreClientContext.tsx
+++ b/ui/contexts/CoreClientContext.tsx
@@ -25,7 +25,7 @@ export function UnAuthorizedInterceptor(api: any) {
     wrapped[method] = (req, initReq) => {
       return api[method](req, initReq).catch((err) => {
         if (err.code === 401) {
-          return window.location.replace(
+          window.location.replace(
             AuthRoutes.AUTH_PATH_SIGNIN +
               qs.stringify({
                 redirect: location.pathname + location.search,

--- a/ui/contexts/CoreClientContext.tsx
+++ b/ui/contexts/CoreClientContext.tsx
@@ -27,6 +27,7 @@ export function UnAuthorizedInterceptor(api: any) {
         if (err.code === 401) {
           window.location.replace(
             AuthRoutes.AUTH_PATH_SIGNIN +
+              "?" +
               qs.stringify({
                 redirect: location.pathname + location.search,
               })

--- a/ui/contexts/CoreClientContext.tsx
+++ b/ui/contexts/CoreClientContext.tsx
@@ -1,6 +1,5 @@
 import qs from "query-string";
 import * as React from "react";
-import { Redirect } from "react-router-dom";
 import { Core } from "../lib/api/core/core.pb";
 import { AuthRoutes } from "./AuthContext";
 
@@ -26,15 +25,11 @@ export function UnAuthorizedInterceptor(api: any) {
     wrapped[method] = (req, initReq) => {
       return api[method](req, initReq).catch((err) => {
         if (err.code === 401) {
-          return (
-            <Redirect
-              to={{
-                pathname: AuthRoutes.AUTH_PATH_SIGNIN,
-                search: qs.stringify({
-                  redirect: location.pathname + location.search,
-                }),
-              }}
-            />
+          return window.location.replace(
+            AuthRoutes.AUTH_PATH_SIGNIN +
+              qs.stringify({
+                redirect: location.pathname + location.search,
+              })
           );
         }
         throw err;


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes #2361 

Saves the url under redirect in search params when the user doesn't pass the auth check. Navigates to that redirect url on sign in if it exists.

https://user-images.githubusercontent.com/65822698/177589208-80d41137-6243-4cc6-8814-b228ed8580eb.mov
