### PR TITLE
Help command for gitops beta run

### DIFF
--- a/cmd/gitops/beta/cmd.go
+++ b/cmd/gitops/beta/cmd.go
@@ -1,0 +1,19 @@
+package beta
+
+import (
+	"github.com/go-resty/resty/v2"
+	"github.com/spf13/cobra"
+	"github.com/weaveworks/weave-gitops/cmd/gitops/beta/run"
+	"github.com/weaveworks/weave-gitops/cmd/internal/config"
+)
+
+func GetCommand(opts *config.Options, client *resty.Client) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "beta",
+		Short: "This component contains unstable or still-in-development functionality",
+	}
+
+	cmd.AddCommand(run.RunCommand(opts, client))
+
+	return cmd
+}

--- a/cmd/gitops/beta/run/cmd.go
+++ b/cmd/gitops/beta/run/cmd.go
@@ -1,0 +1,50 @@
+package run
+
+import (
+	"github.com/go-resty/resty/v2"
+	"github.com/spf13/cobra"
+	"github.com/weaveworks/weave-gitops/cmd/gitops/cmderrors"
+	"github.com/weaveworks/weave-gitops/cmd/internal/config"
+)
+
+type runCommandFlags struct{}
+
+// TODO: Add flags when adding the actual run command.
+var flags runCommandFlags //nolint
+
+func RunCommand(opts *config.Options, client *resty.Client) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "run",
+		Short: "Set up an interactive sync between your cluster and your local file system",
+		Long:  "This will set up a sync between the cluster in your kubeconfig and the path that you specify on your local filesystem.  If you do not have Flux installed on the cluster then this will add it to the cluster automatically.  This is a requirement so we can sync the files successfully from your local system onto the cluster.  Flux will take care of producing the objects for you.",
+		Example: `
+# Run the sync on the current working directory
+gitops beta run . [flags]
+
+# Run the sync against the dev overlay path
+gitops beta run ./deploy/overlays/dev [flags]`,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		PreRunE:       betaRunCommandPreRunE(&opts.Endpoint),
+		RunE:          betaRunCommandRunE(opts, client),
+		Args:          cobra.MinimumNArgs(1),
+	}
+
+	return cmd
+}
+
+func betaRunCommandPreRunE(endpoint *string) func(*cobra.Command, []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		if *endpoint == "" {
+			return cmderrors.ErrNoWGEEndpoint
+		}
+
+		return nil
+	}
+}
+
+func betaRunCommandRunE(opts *config.Options, client *resty.Client) func(*cobra.Command, []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		return nil
+	}
+}

--- a/cmd/gitops/beta/run/cmd.go
+++ b/cmd/gitops/beta/run/cmd.go
@@ -27,7 +27,6 @@ gitops beta run ./deploy/overlays/dev [flags]`,
 		SilenceErrors: true,
 		PreRunE:       betaRunCommandPreRunE(&opts.Endpoint),
 		RunE:          betaRunCommandRunE(opts, client),
-		Args:          cobra.MinimumNArgs(1),
 	}
 
 	return cmd
@@ -35,8 +34,14 @@ gitops beta run ./deploy/overlays/dev [flags]`,
 
 func betaRunCommandPreRunE(endpoint *string) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
-		if *endpoint == "" {
-			return cmderrors.ErrNoWGEEndpoint
+		numArgs := len(args)
+
+		if numArgs == 0 {
+			return cmderrors.ErrNoFilePath
+		}
+
+		if numArgs > 1 {
+			return cmderrors.ErrMultipleFilePaths
 		}
 
 		return nil

--- a/cmd/gitops/cmderrors/errors.go
+++ b/cmd/gitops/cmderrors/errors.go
@@ -3,7 +3,9 @@ package cmderrors
 import "errors"
 
 var (
-	ErrNoWGEEndpoint  = errors.New("the Weave GitOps Enterprise HTTP API endpoint flag (--endpoint) has not been set")
-	ErrNoURL          = errors.New("the URL flag (--url) has not been set")
-	ErrNoTLSCertOrKey = errors.New("flags --tls-cert-file and --tls-private-key-file cannot be empty")
+	ErrNoWGEEndpoint     = errors.New("the Weave GitOps Enterprise HTTP API endpoint flag (--endpoint) has not been set")
+	ErrNoURL             = errors.New("the URL flag (--url) has not been set")
+	ErrNoTLSCertOrKey    = errors.New("flags --tls-cert-file and --tls-private-key-file cannot be empty")
+	ErrNoFilePath        = errors.New("the filepath has not been set")
+	ErrMultipleFilePaths = errors.New("only one filepath is allowed")
 )

--- a/cmd/gitops/root/cmd.go
+++ b/cmd/gitops/root/cmd.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/viper"
 	wego "github.com/weaveworks/weave-gitops/api/v1alpha1"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/add"
+	"github.com/weaveworks/weave-gitops/cmd/gitops/beta"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/check"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/delete"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/docs"
@@ -112,6 +113,7 @@ func RootCmd(client *resty.Client) *cobra.Command {
 	rootCmd.AddCommand(upgrade.Cmd)
 	rootCmd.AddCommand(docs.Cmd)
 	rootCmd.AddCommand(check.Cmd)
+	rootCmd.AddCommand(beta.GetCommand(options, client))
 
 	return rootCmd
 }


### PR DESCRIPTION
Closes #2356

- Added templates for the `beta` command with `run` subcommand.
- Added a short description for the `beta` command.
- Added a short and a long description for the `run` command.
- Added a positional argument requirement (this argument will be used for `filepath`) to the `run` command.

**Possible improvements/questions:**

1. There are `[flags]` mentioned in the `run` command help in #2356 , but I don't see specific flags in #2355 Probably it will be clarified what flags the `run` command can support when the actual command is added.

That's why, I've added an empty placeholder structure for flags (with suppressing the linter warning and a todo).

If the `run` command is supposed to be run with global flags only, I can remove the placeholder.

2. I've added checking for the enterprise endpoint set up in the `run` command, similar to the `add cluster` command. Is this check needed?

3. If the sync/run is a priority feature, should "how to get help for the`run` command" info be added to the command usage examples of the `gitops` command, similar to the `add cluster` command? Current description:

```
Example: `
  # Get help for gitops add cluster command
  gitops add cluster -h
  gitops help add cluster

  # Get the version of gitops along with commit, branch, and flux version
  gitops version

  To learn more, you can find our documentation at https://docs.gitops.weave.works/
`,
```
4. For now, at least one positional argument is required for the `beta run` command and the `cobra.MinimumNArgs(1)` validator displays a default error message: `Error: requires at least 1 arg(s), only received 0`.

If we should require exactly one argument I can switch to the range argument validator. I could also add a custom error message, like `the filepath has not been set` instead of just complaining about the missing argument. What is preferred for validating that positional arguments are provided?

5. I haven't split the long description for the run command to strings (because it's a single line in the ticket description), but it might be easier to read if split to lines shorter than 80 characters. This is what it looks like right now:

<img width="954" alt="Screenshot 2022-07-04 at 20 35 40" src="https://user-images.githubusercontent.com/8824708/177204651-6e3578b4-831b-41cf-92f9-e6884b82952a.png">

Should I keep it like that? Or if it should be split, then how exactly?


