### PR TITLE
Introduce BE featureflags, make the auth system use them

### DIFF
--- a/core/server/featureflags.go
+++ b/core/server/featureflags.go
@@ -2,44 +2,13 @@ package server
 
 import (
 	"context"
-	"fmt"
-	"strconv"
 
-	"github.com/weaveworks/weave-gitops/api/v1alpha1"
 	pb "github.com/weaveworks/weave-gitops/pkg/api/core"
-	serverauth "github.com/weaveworks/weave-gitops/pkg/server/auth"
-	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	"github.com/weaveworks/weave-gitops/pkg/featureflags"
 )
 
 func (cs *coreServer) GetFeatureFlags(ctx context.Context, msg *pb.GetFeatureFlagsRequest) (*pb.GetFeatureFlagsResponse, error) {
-	flags := make(map[string]string)
-
-	cl, err := cs.k8s.Client(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("cannot get Kubernetes client from context: %w", err)
-	}
-
-	var secret corev1.Secret
-	err = cl.Get(ctx, client.ObjectKey{
-		Namespace: v1alpha1.DefaultNamespace,
-		Name:      serverauth.ClusterUserAuthSecretName,
-	}, &secret)
-
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			flags["CLUSTER_USER_AUTH"] = "false"
-		} else {
-			cs.logger.Error(err, "could not get secret for cluster user")
-		}
-	} else {
-		flags["CLUSTER_USER_AUTH"] = "true"
-	}
-
-	flags["OIDC_AUTH"] = strconv.FormatBool(serverauth.OIDCEnabled())
-
 	return &pb.GetFeatureFlagsResponse{
-		Flags: flags,
+		Flags: featureflags.GetFlags(),
 	}, nil
 }

--- a/core/server/featureflags_test.go
+++ b/core/server/featureflags_test.go
@@ -2,7 +2,6 @@ package server_test
 
 import (
 	"context"
-	"github.com/weaveworks/weave-gitops/pkg/server/auth"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -11,89 +10,24 @@ import (
 	"github.com/weaveworks/weave-gitops/core/clustersmngr/clustersmngrfakes"
 	"github.com/weaveworks/weave-gitops/core/server"
 	pb "github.com/weaveworks/weave-gitops/pkg/api/core"
-	"github.com/weaveworks/weave-gitops/pkg/kube"
+	"github.com/weaveworks/weave-gitops/pkg/featureflags"
 	"github.com/weaveworks/weave-gitops/pkg/kube/kubefakes"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestGetFeatureFlags(t *testing.T) {
 	RegisterFailHandler(Fail)
 
-	tests := []struct {
-		name        string
-		envSet      func()
-		envUnset    func()
-		state       []client.Object
-		oidcEnabled bool
-		result      map[string]string
-	}{
-		{
-			name:        "Cluster auth secret set",
-			envSet:      func() {},
-			envUnset:    func() {},
-			state:       []client.Object{&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: "flux-system", Name: "cluster-user-auth"}}},
-			oidcEnabled: false,
-			result: map[string]string{
-				"CLUSTER_USER_AUTH": "true",
-				"OIDC_AUTH":         "false",
-			},
-		},
-		{
-			name:        "Cluster auth secret not set",
-			envSet:      func() {},
-			envUnset:    func() {},
-			state:       []client.Object{},
-			oidcEnabled: false,
-			result: map[string]string{
-				"CLUSTER_USER_AUTH": "false",
-				"OIDC_AUTH":         "false",
-			},
-		},
-		{
-			name:        "OIDC secret set",
-			envSet:      func() {},
-			envUnset:    func() {},
-			state:       []client.Object{&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: "flux-system", Name: "oidc-auth"}}},
-			oidcEnabled: true,
-			result: map[string]string{
-				"CLUSTER_USER_AUTH": "false",
-				"OIDC_AUTH":         "true",
-			},
-		},
-		{
-			name:        "OIDC secret not set",
-			envSet:      func() {},
-			envUnset:    func() {},
-			state:       []client.Object{},
-			oidcEnabled: false,
-			result: map[string]string{
-				"CLUSTER_USER_AUTH": "false",
-				"OIDC_AUTH":         "false",
-			},
-		},
-	}
+	featureflags.Set("this is a flag", "you won't find it anywhere else")
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			cfg := server.NewCoreConfig(logr.Discard(), &rest.Config{}, "test", &clustersmngrfakes.FakeClientsFactory{})
+	cfg := server.NewCoreConfig(logr.Discard(), &rest.Config{}, "test", &clustersmngrfakes.FakeClientsFactory{})
+	k8s := fake.NewClientBuilder().Build()
+	fakeClientGetter := kubefakes.NewFakeClientGetter(k8s)
+	coreSrv, err := server.NewCoreServer(cfg, server.WithClientGetter(fakeClientGetter))
+	Expect(err).NotTo(HaveOccurred())
 
-			auth.SetOIDCEnabled(tt.oidcEnabled)
-
-			k8s := fake.NewClientBuilder().WithScheme(kube.CreateScheme()).WithObjects(tt.state...).Build()
-			fakeClientGetter := kubefakes.NewFakeClientGetter(k8s)
-			coreSrv, err := server.NewCoreServer(cfg, server.WithClientGetter(fakeClientGetter))
-			Expect(err).NotTo(HaveOccurred())
-
-			tt.envSet()
-			defer tt.envUnset()
-
-			resp, err := coreSrv.GetFeatureFlags(context.Background(), &pb.GetFeatureFlagsRequest{})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(tt.result).To(Equal(resp.Flags))
-		})
-	}
+	resp, err := coreSrv.GetFeatureFlags(context.Background(), &pb.GetFeatureFlagsRequest{})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(resp.Flags).To(HaveKeyWithValue("this is a flag", "you won't find it anywhere else"))
 }

--- a/pkg/featureflags/featureflags.go
+++ b/pkg/featureflags/featureflags.go
@@ -1,0 +1,42 @@
+// The featureflags module exists to control optional functionality
+//
+// The main purpose is to hide functionality that is still in
+// development, that isn't yet fully featured enough to be GA, or that
+// isn't relevant to all users.
+//
+// The format is key-value, both strings, for rare situations where
+// new values need to be introduced to the same flag.  You should
+// usually treat the value as a boolean - create one flag per
+// alternative, don't create complicated sets of values. E.g. set
+// FOO_BAR_ENABLED and FOO_BAR_IN_MAIN_MENU as separate flags, not
+// FOO_BAR="enabled" or "FOO_BAR="in_main_menu", as the latter format
+// is more likely to be confused. At the same time, you should check
+// for exact value when checking the flag, to avoid misinterpreting it
+// in the future.
+//
+// All flags that are set here on the backend will also be set in the
+// featureflags endpoint on the frontend.
+package featureflags
+
+var flags map[string]string = make(map[string]string)
+
+// Set sets one specific featureflag
+// Existing flags will be overwritten.
+func Set(key, value string) {
+	flags[key] = value
+}
+
+// Get returns the value of a flag, or "" if the flag wasn't set
+// You should use the same behaviour for "flag not set" as you would
+// for "flag set to unknown value", so always check for the exact
+// value.
+func Get(key string) string {
+	return flags[key]
+}
+
+// GetFlags returns all featureflags
+// This is only intended to be used by the API to return the flags to
+// the frontend - for all other uses, use `Get`
+func GetFlags() map[string]string {
+	return flags
+}

--- a/pkg/featureflags/featureflags_test.go
+++ b/pkg/featureflags/featureflags_test.go
@@ -1,0 +1,55 @@
+package featureflags
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("featureflags", func() {
+	BeforeEach(func() {
+		// Clear flags
+		flags = make(map[string]string)
+	})
+
+	It("updates when Set is called", func() {
+		Expect(flags).To(BeEmpty())
+
+		Set("FLAG", "is set")
+		Expect(flags).To(HaveKeyWithValue("FLAG", "is set"))
+
+		Set("OTHER_FLAG", "is also set")
+		Expect(flags).To(HaveKeyWithValue("OTHER_FLAG", "is also set"))
+
+		Set("FLAG", "other value")
+		Expect(flags).To(HaveKeyWithValue("FLAG", "other value"))
+	})
+
+	It("returns flags when Get is called", func() {
+		Expect(Get("FLAG")).To(Equal(""))
+
+		Set("FLAG", "is set")
+		Expect(Get("FLAG")).To(Equal("is set"))
+	})
+
+	It("returns all flags when GetFlags is called", func() {
+		Expect(GetFlags()).To(BeEmpty())
+
+		Set("FLAG", "is set")
+		Expect(GetFlags()).To(HaveKeyWithValue("FLAG", "is set"))
+		Expect(GetFlags()).To(HaveLen(1))
+
+		Set("FLAG", "other value")
+		Expect(GetFlags()).To(HaveKeyWithValue("FLAG", "other value"))
+		Expect(GetFlags()).To(HaveLen(1))
+
+		Set("OTHER_FLAG", "some value")
+		Expect(GetFlags()).To(HaveKeyWithValue("FLAG", "other value"))
+		Expect(GetFlags()).To(HaveKeyWithValue("OTHER_FLAG", "some value"))
+		Expect(GetFlags()).To(HaveLen(2))
+
+		Get("Key that doesn't exist")
+		Expect(GetFlags()).To(HaveKeyWithValue("FLAG", "other value"))
+		Expect(GetFlags()).To(HaveKeyWithValue("OTHER_FLAG", "some value"))
+		Expect(GetFlags()).To(HaveLen(2))
+	})
+})


### PR DESCRIPTION
There is a bit of godoc in the new featureflags module - basically,
it's a static, global map. It is initialised automatically from server
startup by setting an env var starting with
`WEAVE_GITOPS_FEATURE_whatever`, and you can also call the `Set()`
function directly. The frontend featureflag endpoint now literally
just copies this map, so the backend and frontend are in sync.

To test it out, dump the following in `tools/helm-values-dev.yaml`:
```
envVars:
  - name: WEAVE_GITOPS_FEATURE_FOO
    value: it worked
```
Then visit the sign in page, and you'll see the frontend request
feature flags, which (after the backend pod restarted) now includes
this flag.

This changes the auth system to use the same flags - which has a
behaviour change: the pod will now refuse to start if there's no login
methods configured. This "preserves" the behaviour that you can create
a secret after installing the pod and have that be picked up, but it
does mean the pod is red until you've created it.

This fixes #2392.