### PR TITLE
Set version flags when building release images, too

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -113,6 +113,10 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set build-time flags
+        run: |
+          echo "LDFLAGS=$(make echo-ldflags)" >> $GITHUB_ENV
+          echo "FLUX_VERSION=$(make echo-flux-version)" >> $GITHUB_ENV
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v3
@@ -123,6 +127,10 @@ jobs:
             type=semver,pattern={{version}},value=${{ needs.tag-release.outputs.version }}
           flavor: |
             latest=true
+          build-args: |
+            FLUX_VERSION=${{ env.FLUX_VERSION }}
+            LDFLAGS=${{ env.LDFLAGS }}
+            GIT_COMMIT=${{ github.sha }}
       - name: Build and push Docker image
         uses: docker/build-push-action@v2
         with:


### PR DESCRIPTION
When hitting `/v1/version` against a 0.9.0 image, it returns
`{"semver":"v0.0.0","commit":"","branch":"","buildTime":""}`. This is
incorrect.

This copy-pastes bits from the dev image build process that we use to
set these properly for the staging cluster.

The footer still prints the correct thing since the javascript does
have the right versions.

This fixes #2370