### PR TITLE
clustersmngr: Make it possible to inject another clusterpool

### DIFF
--- a/cmd/gitops-server/cmd/cmd.go
+++ b/cmd/gitops-server/cmd/cmd.go
@@ -211,7 +211,7 @@ func runCmd(cmd *cobra.Command, args []string) error {
 
 	fetcher := fetcher.NewSingleClusterFetcher(rest)
 
-	clusterClientsFactory := clustersmngr.NewClientFactory(fetcher, nsaccess.NewChecker(nsaccess.DefautltWegoAppRules), log, kube.CreateScheme())
+	clusterClientsFactory := clustersmngr.NewClientFactory(fetcher, nsaccess.NewChecker(nsaccess.DefautltWegoAppRules), log, kube.CreateScheme(), clustersmngr.NewClustersClientsPool)
 	clusterClientsFactory.Start(ctx)
 
 	coreConfig := core.NewCoreConfig(log, rest, clusterName, clusterClientsFactory)

--- a/core/clustersmngr/factory_test.go
+++ b/core/clustersmngr/factory_test.go
@@ -28,7 +28,7 @@ func TestGetImpersonatedClient(t *testing.T) {
 
 	clustersFetcher := fetcher.NewSingleClusterFetcher(k8sEnv.Rest)
 
-	clientsFactory := clustersmngr.NewClientFactory(clustersFetcher, nsChecker, logger, kube.CreateScheme())
+	clientsFactory := clustersmngr.NewClientFactory(clustersFetcher, nsChecker, logger, kube.CreateScheme(), clustersmngr.NewClustersClientsPool)
 	err := clientsFactory.UpdateClusters(ctx)
 	g.Expect(err).To(BeNil())
 
@@ -65,7 +65,7 @@ func TestGetImpersonatedDiscoveryClient(t *testing.T) {
 
 	clustersFetcher := fetcher.NewSingleClusterFetcher(k8sEnv.Rest)
 
-	clientsFactory := clustersmngr.NewClientFactory(clustersFetcher, nsChecker, logger, kube.CreateScheme())
+	clientsFactory := clustersmngr.NewClientFactory(clustersFetcher, nsChecker, logger, kube.CreateScheme(), clustersmngr.NewClustersClientsPool)
 	err := clientsFactory.UpdateClusters(ctx)
 	g.Expect(err).To(BeNil())
 
@@ -85,7 +85,7 @@ func TestUpdateNamespaces(t *testing.T) {
 	ctx := context.Background()
 	nsChecker := &nsaccessfakes.FakeChecker{}
 	clustersFetcher := new(clustersmngrfakes.FakeClusterFetcher)
-	clientsFactory := clustersmngr.NewClientFactory(clustersFetcher, nsChecker, logger, kube.CreateScheme())
+	clientsFactory := clustersmngr.NewClientFactory(clustersFetcher, nsChecker, logger, kube.CreateScheme(), clustersmngr.NewClustersClientsPool)
 
 	clusterName1 := "foo"
 	clusterName2 := "bar"
@@ -126,7 +126,7 @@ func TestUpdateUsers(t *testing.T) {
 	ctx := context.Background()
 	nsChecker := &nsaccessfakes.FakeChecker{}
 	clustersFetcher := new(clustersmngrfakes.FakeClusterFetcher)
-	clientsFactory := clustersmngr.NewClientFactory(clustersFetcher, nsChecker, logger, kube.CreateScheme())
+	clientsFactory := clustersmngr.NewClientFactory(clustersFetcher, nsChecker, logger, kube.CreateScheme(), clustersmngr.NewClustersClientsPool)
 
 	clusterName1 := "foo"
 	clusterName2 := "bar"

--- a/core/server/suite_test.go
+++ b/core/server/suite_test.go
@@ -19,7 +19,9 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/test/bufconn"
 	v1 "k8s.io/api/core/v1"
+	apiruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var k8sEnv *testutils.K8sTestEnv
@@ -54,7 +56,7 @@ func makeGRPCServer(cfg *rest.Config, t *testing.T) (pb.CoreClient, server.CoreS
 	fetcher := &clustersmngrfakes.FakeClusterFetcher{}
 	fetcher.FetchReturns([]clustersmngr.Cluster{restConfigToCluster(k8sEnv.Rest)}, nil)
 
-	clientsFactory := clustersmngr.NewClientFactory(fetcher, &nsChecker, log, kube.CreateScheme())
+	clientsFactory := clustersmngr.NewClientFactory(fetcher, &nsChecker, log, kube.CreateScheme(), clustersmngr.NewClustersClientsPool)
 
 	coreCfg := server.NewCoreConfig(log, cfg, "foobar", clientsFactory)
 	coreCfg.NSAccess = &nsChecker
@@ -68,7 +70,7 @@ func makeGRPCServer(cfg *rest.Config, t *testing.T) (pb.CoreClient, server.CoreS
 
 	principal := &auth.UserPrincipal{}
 	s := grpc.NewServer(
-		withClientsPoolInterceptor(clientsFactory, cfg, principal),
+		withClientsPoolInterceptor(clientsFactory, principal),
 	)
 
 	pb.RegisterCoreServer(s, core)
@@ -101,7 +103,7 @@ func makeGRPCServer(cfg *rest.Config, t *testing.T) (pb.CoreClient, server.CoreS
 	return pb.NewCoreClient(conn), coreCfg
 }
 
-func withClientsPoolInterceptor(clientsFactory clustersmngr.ClientsFactory, config *rest.Config, user *auth.UserPrincipal) grpc.ServerOption {
+func withClientsPoolInterceptor(clientsFactory clustersmngr.ClientsFactory, user *auth.UserPrincipal) grpc.ServerOption {
 	return grpc.UnaryInterceptor(func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 		if err := clientsFactory.UpdateClusters(ctx); err != nil {
 			return nil, err
@@ -125,4 +127,70 @@ func restConfigToCluster(cfg *rest.Config) clustersmngr.Cluster {
 		BearerToken: cfg.BearerToken,
 		TLSConfig:   cfg.TLSClientConfig,
 	}
+}
+
+func makeServerConfig(fakeClient client.Client, t *testing.T) server.CoreServerConfig {
+	log := logr.Discard()
+	nsChecker = nsaccessfakes.FakeChecker{}
+	nsChecker.FilterAccessibleNamespacesStub = func(ctx context.Context, c *rest.Config, n []v1.Namespace) ([]v1.Namespace, error) {
+		// Pretend the user has access to everything
+		return n, nil
+	}
+
+	fetcher := &clustersmngrfakes.FakeClusterFetcher{}
+	fetcher.FetchReturns([]clustersmngr.Cluster{}, nil)
+
+	clientsFactory := clustersmngr.NewClientFactory(fetcher, &nsChecker, log, kube.CreateScheme(), func(scheme *apiruntime.Scheme) clustersmngr.ClientsPool {
+		f := &clustersmngrfakes.FakeClientsPool{}
+		f.ClientStub = func(clusterName string) (client.Client, error) { return fakeClient, nil }
+		return f
+	})
+
+	coreCfg := server.NewCoreConfig(log, &rest.Config{}, "foobar", clientsFactory)
+	coreCfg.NSAccess = &nsChecker
+
+	return coreCfg
+}
+
+func makeServer(cfg server.CoreServerConfig, t *testing.T) pb.CoreClient {
+	core, err := server.NewCoreServer(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lis := bufconn.Listen(1024 * 1024)
+
+	principal := &auth.UserPrincipal{}
+	s := grpc.NewServer(
+		withClientsPoolInterceptor(cfg.ClientsFactory, principal),
+	)
+
+	pb.RegisterCoreServer(s, core)
+
+	dialer := func(context.Context, string) (net.Conn, error) {
+		return lis.Dial()
+	}
+
+	go func(tt *testing.T) {
+		if err := s.Serve(lis); err != nil {
+			tt.Error(err)
+		}
+	}(t)
+
+	conn, err := grpc.DialContext(
+		context.Background(),
+		"bufnet",
+		grpc.WithContextDialer(dialer),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		s.GracefulStop()
+		conn.Close()
+	})
+
+	return pb.NewCoreClient(conn)
 }


### PR DESCRIPTION
What I want to achieve is to be able to inject a fake k8s client for
tests that bypasses the provided restconfig, since I want to be able
to run tests without having an API server running.

This is not just about the time it takes to start an API server
(although that is nice) - this means we get to set arbitrary object
state, and then test how that state is represented.

Right now, this just adds complexity for the purpose of tests -
although, not a lot of complexity. I think this level of separation
from the core clustersmngr might be a useful level of abstraction for
other code too, but I'm not going to try that out right now.