### PR TITLE
Add flags to gitops run

### DIFF
--- a/cmd/gitops/beta/run/cmd.go
+++ b/cmd/gitops/beta/run/cmd.go
@@ -15,6 +15,7 @@ import (
 	"github.com/weaveworks/weave-gitops/cmd/internal"
 	"github.com/weaveworks/weave-gitops/pkg/kube"
 	"github.com/weaveworks/weave-gitops/pkg/run"
+	"github.com/weaveworks/weave-gitops/pkg/version"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
@@ -55,7 +56,7 @@ gitops beta run ./deploy/overlays/dev [flags]`,
 
 	cmdFlags := cmd.Flags()
 
-	cmdFlags.StringVar(&flags.FluxVersion, "flux-version", "v0.31.3", "The version of Flux to install")
+	cmdFlags.StringVar(&flags.FluxVersion, "flux-version", version.FluxVersion, "The version of Flux to install")
 	cmdFlags.StringVar(&flags.AllowK8sContext, "allow-k8s-context", "", "The name of the kubeconfig context to allow explicitly")
 	cmdFlags.StringSliceVar(&flags.Components, "components", []string{"source-controller", "kustomize-controller", "helm-controller", "notification-controller"}, "The Flux components to install, as a comma-separated list: --components=component1,component2,component3")
 	cmdFlags.StringSliceVar(&flags.ComponentsExtra, "components-extra", []string{}, "Additional Flux components to install, as a comma-separated list: --components=component1,component2,component3")

--- a/cmd/gitops/beta/run/cmd.go
+++ b/cmd/gitops/beta/run/cmd.go
@@ -125,10 +125,10 @@ func betaRunCommandRunE(opts *config.Options) func(*cobra.Command, []string) err
 			return cmderrors.ErrNoCluster
 		}
 
-		kubeConfigOptions := run.GetKubeConfigOptions()
-		kubeClientOptions := run.GetKubeClientOptions()
+		kubeConfigArgs := run.GetKubeConfigArgs()
+		kubeClientOpts := run.GetKubeClientOptions()
 
-		kubeClient, err := run.GetKubeClient(log, clusterName, kubeConfigOptions, kubeClientOptions)
+		kubeClient, err := run.GetKubeClient(log, clusterName, kubeConfigArgs, kubeClientOpts)
 		if err != nil {
 			return cmderrors.ErrGetKubeClient
 		}
@@ -157,7 +157,7 @@ func betaRunCommandRunE(opts *config.Options) func(*cobra.Command, []string) err
 				Timeout:         flags.Timeout,
 			}
 
-			if err := run.InstallFlux(log, ctx, kubeClient, installOpts, kubeConfigOptions); err != nil {
+			if err := run.InstallFlux(log, ctx, kubeClient, installOpts, kubeConfigArgs); err != nil {
 				return fmt.Errorf("flux installation failed: %w", err)
 			} else {
 				log.Successf("Flux has been installed")

--- a/cmd/gitops/beta/run/cmd.go
+++ b/cmd/gitops/beta/run/cmd.go
@@ -28,8 +28,7 @@ type runCommandFlags struct {
 	Namespace  string
 	KubeConfig string
 	// Flags, created by genericclioptions.
-	ClusterName string
-	Context     string
+	Context string
 }
 
 var flags runCommandFlags
@@ -56,18 +55,13 @@ gitops beta run ./deploy/overlays/dev [flags]`,
 
 	cmdFlags := cmd.Flags()
 
-	cmdFlags.StringVar(&flags.FluxVersion, "flux-version", "v0.31.3", "")
-	cmdFlags.StringVar(&flags.AllowK8sContext, "allow-k8s-context", "", "")
-	cmdFlags.StringSliceVar(&flags.Components, "components", []string{"source-controller", "kustomize-controller", "helm-controller", "notification-controller"}, "")
-	cmdFlags.StringSliceVar(&flags.ComponentsExtra, "components-extra", []string{}, "")
-	cmdFlags.DurationVar(&flags.Timeout, "timeout", 5*time.Second, "")
+	cmdFlags.StringVar(&flags.FluxVersion, "flux-version", "v0.31.3", "The version of Flux to install")
+	cmdFlags.StringVar(&flags.AllowK8sContext, "allow-k8s-context", "", "The name of the kubeconfig context to allow explicitly")
+	cmdFlags.StringSliceVar(&flags.Components, "components", []string{"source-controller", "kustomize-controller", "helm-controller", "notification-controller"}, "The Flux components to install, as a comma-separated list: --components=component1,component2,component3")
+	cmdFlags.StringSliceVar(&flags.ComponentsExtra, "components-extra", []string{}, "Additional Flux components to install, as a comma-separated list: --components=component1,component2,component3")
+	cmdFlags.DurationVar(&flags.Timeout, "timeout", 5*time.Second, "The timeout for Flux installation")
 
 	kubeConfigArgs = run.GetKubeConfigArgs()
-	// Since some subcommands use the `-s` flag as a short version for `--silent`, we manually configure the server flag
-	// without the `-s` short version. While we're no longer on par with kubectl's flags, we maintain backwards compatibility
-	// on the CLI interface.
-	apiServer := ""
-	kubeConfigArgs.APIServer = &apiServer
 
 	kubeConfigArgs.AddFlags(cmd.Flags())
 
@@ -127,10 +121,6 @@ func betaRunCommandRunE(opts *config.Options) func(*cobra.Command, []string) err
 		}
 
 		if flags.Context, err = cmd.Flags().GetString("context"); err != nil {
-			return err
-		}
-
-		if flags.ClusterName, err = cmd.Flags().GetString("cluster"); err != nil {
 			return err
 		}
 

--- a/cmd/gitops/beta/run/cmd.go
+++ b/cmd/gitops/beta/run/cmd.go
@@ -27,8 +27,7 @@ type runCommandFlags struct {
 	Context         string
 	Cluster         string
 	// global flags
-	Namespace             string
-	InsecureSkipTlsVerify bool
+	Namespace string
 }
 
 var flags runCommandFlags
@@ -108,10 +107,6 @@ func betaRunCommandRunE(opts *config.Options) func(*cobra.Command, []string) err
 		var err error
 
 		if flags.Namespace, err = cmd.Flags().GetString("namespace"); err != nil {
-			return err
-		}
-
-		if flags.InsecureSkipTlsVerify, err = cmd.Flags().GetBool("insecure-skip-tls-verify"); err != nil {
 			return err
 		}
 

--- a/cmd/gitops/beta/run/cmd.go
+++ b/cmd/gitops/beta/run/cmd.go
@@ -19,7 +19,7 @@ import (
 
 type runCommandFlags struct {
 	FluxVersion     string
-	AllowK8sCluster string
+	AllowK8sContext string
 	Components      []string
 	ComponentsExtra []string
 	Timeout         time.Duration
@@ -52,7 +52,7 @@ gitops beta run ./deploy/overlays/dev [flags]`,
 	}
 
 	cmd.Flags().StringVar(&flags.FluxVersion, "flux-version", "", "")
-	cmd.Flags().StringVar(&flags.AllowK8sCluster, "allow-k8s-cluster", "", "")
+	cmd.Flags().StringVar(&flags.AllowK8sContext, "allow-k8s-context", "", "")
 	cmd.Flags().StringSliceVar(&flags.Components, "components", flags.Components, "")
 	cmd.Flags().StringSliceVar(&flags.ComponentsExtra, "components-extra", flags.ComponentsExtra, "")
 	cmd.Flags().DurationVar(&flags.Timeout, "timeout", flags.Timeout, "")
@@ -133,7 +133,10 @@ func betaRunCommandRunE(opts *config.Options) func(*cobra.Command, []string) err
 			return cmderrors.ErrGetKubeClient
 		}
 
-		if !isLocalCluster(kubeClient) {
+		contextName := kubeClient.ClusterName
+		if flags.AllowK8sContext == contextName {
+			log.Infow("Explicitly allow GitOps Run on %s context", contextName)
+		} else if !isLocalCluster(kubeClient) {
 			return errors.New("allowed to run against a local cluster only")
 		}
 

--- a/cmd/gitops/cmderrors/errors.go
+++ b/cmd/gitops/cmderrors/errors.go
@@ -3,11 +3,12 @@ package cmderrors
 import "errors"
 
 var (
-	ErrNoWGEEndpoint     = errors.New("the Weave GitOps Enterprise HTTP API endpoint flag (--endpoint) has not been set")
-	ErrNoURL             = errors.New("the URL flag (--url) has not been set")
-	ErrNoTLSCertOrKey    = errors.New("flags --tls-cert-file and --tls-private-key-file cannot be empty")
-	ErrNoFilePath        = errors.New("the filepath has not been set")
-	ErrMultipleFilePaths = errors.New("only one filepath is allowed")
-	ErrNoCluster         = errors.New("no cluster in the kube config")
-	ErrGetKubeClient     = errors.New("error getting Kube HTTP client")
+	ErrNoWGEEndpoint          = errors.New("the Weave GitOps Enterprise HTTP API endpoint flag (--endpoint) has not been set")
+	ErrNoURL                  = errors.New("the URL flag (--url) has not been set")
+	ErrNoTLSCertOrKey         = errors.New("flags --tls-cert-file and --tls-private-key-file cannot be empty")
+	ErrNoFilePath             = errors.New("the filepath has not been set")
+	ErrMultipleFilePaths      = errors.New("only one filepath is allowed")
+	ErrNoContextForKubeConfig = errors.New("no context provided for the kubeconfig")
+	ErrNoCluster              = errors.New("no cluster in the kube config")
+	ErrGetKubeClient          = errors.New("error getting Kube HTTP client")
 )

--- a/pkg/run/forwarder/forwarder.go
+++ b/pkg/run/forwarder/forwarder.go
@@ -3,7 +3,6 @@ package forwarder
 import (
 	"context"
 	"fmt"
-	"github.com/weaveworks/weave-gitops/pkg/kube"
 	"net/http"
 	"net/url"
 	"os"
@@ -22,12 +21,7 @@ import (
 var once sync.Once
 
 //WithForwarders forward ports per the options. Cancel the context will stop the forwarder.
-func WithForwarders(ctx context.Context, options []*Option) (*Result, error) {
-	config, _, err := kube.RestConfig()
-	if err != nil {
-		return nil, err
-	}
-
+func WithForwarders(ctx context.Context, config *rest.Config, options []*Option) (*Result, error) {
 	return forwarders(ctx, options, config)
 }
 

--- a/pkg/run/install_dev_bucket.go
+++ b/pkg/run/install_dev_bucket.go
@@ -16,6 +16,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -24,7 +25,7 @@ const (
 	port      = 9000
 )
 
-func InstallBucketServer(log logger.Logger, kubeClient *kube.KubeHTTP) error {
+func InstallBucketServer(log logger.Logger, kubeClient *kube.KubeHTTP, config *rest.Config) error {
 	var (
 		err                error
 		devBucketAppLabels = map[string]string{
@@ -184,7 +185,7 @@ func InstallBucketServer(log logger.Logger, kubeClient *kube.KubeHTTP) error {
 
 	defer cancel()
 
-	ret, err := forwarder.WithForwarders(ctx, options)
+	ret, err := forwarder.WithForwarders(ctx, config, options)
 	if err != nil {
 		return err
 	}

--- a/pkg/run/install_flux.go
+++ b/pkg/run/install_flux.go
@@ -14,7 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func InstallFlux(log logger.Logger, ctx context.Context, kubeClient *kube.KubeHTTP, installOptions install.Options, kubeConfigOptions genericclioptions.RESTClientGetter) error {
+func InstallFlux(log logger.Logger, ctx context.Context, kubeClient *kube.KubeHTTP, installOptions install.Options, kubeConfigArgs genericclioptions.RESTClientGetter) error {
 	log.Actionf("Installing Flux ...")
 
 	manifests, err := install.Generate(installOptions, "")
@@ -25,7 +25,7 @@ func InstallFlux(log logger.Logger, ctx context.Context, kubeClient *kube.KubeHT
 
 	content := []byte(manifests.Content)
 
-	applyOutput, err := apply(log, ctx, kubeClient, kubeConfigOptions, content)
+	applyOutput, err := apply(log, ctx, kubeClient, kubeConfigArgs, content)
 	if err != nil {
 		log.Failuref("Flux install failed")
 		return err

--- a/pkg/run/install_flux.go
+++ b/pkg/run/install_flux.go
@@ -14,19 +14,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func InstallFlux(log logger.Logger, ctx context.Context, kubeClient *kube.KubeHTTP, kubeConfigOptions genericclioptions.RESTClientGetter) error {
+func InstallFlux(log logger.Logger, ctx context.Context, kubeClient *kube.KubeHTTP, installOptions install.Options, kubeConfigOptions genericclioptions.RESTClientGetter) error {
 	log.Actionf("Installing Flux ...")
 
-	opts := install.Options{
-		BaseURL:      install.MakeDefaultOptions().BaseURL,
-		Version:      "v0.31.2",
-		Namespace:    "flux-system",
-		Components:   []string{"source-controller", "kustomize-controller", "helm-controller", "notification-controller"},
-		ManifestFile: "flux-system.yaml",
-		Timeout:      5 * time.Second,
-	}
-
-	manifests, err := install.Generate(opts, "")
+	manifests, err := install.Generate(installOptions, "")
 	if err != nil {
 		log.Failuref("Couldn't generate manifests")
 		return err

--- a/pkg/run/run.go
+++ b/pkg/run/run.go
@@ -70,6 +70,7 @@ func GetKubeConfigArgs() *genericclioptions.ConfigFlags {
 	kubeConfigArgs.Timeout = nil
 	kubeConfigArgs.KubeConfig = nil
 	kubeConfigArgs.CacheDir = nil
+	kubeConfigArgs.ClusterName = nil
 	kubeConfigArgs.AuthInfoName = nil
 	kubeConfigArgs.Namespace = nil
 	kubeConfigArgs.APIServer = nil

--- a/pkg/run/run.go
+++ b/pkg/run/run.go
@@ -62,42 +62,42 @@ func GetFluxVersion(log logger.Logger, ctx context.Context, kubeClient *kube.Kub
 	return fluxVersion, nil
 }
 
-func GetKubeConfigOptions() genericclioptions.RESTClientGetter {
-	kubeConfigOptions := genericclioptions.NewConfigFlags(false)
+func GetKubeConfigArgs() genericclioptions.RESTClientGetter {
+	kubeConfigArgs := genericclioptions.NewConfigFlags(false)
 
 	fromEnv := os.Getenv("FLUX_SYSTEM_NAMESPACE")
 	if fromEnv != "" {
-		kubeConfigOptions.Namespace = &fromEnv
+		kubeConfigArgs.Namespace = &fromEnv
 	}
 
-	kubeConfigOptions.APIServer = nil // prevent AddFlags from configuring --server flag
-	kubeConfigOptions.Timeout = nil   // prevent AddFlags from configuring --request-timeout flag, we have --timeout instead
+	kubeConfigArgs.APIServer = nil // prevent AddFlags from configuring --server flag
+	kubeConfigArgs.Timeout = nil   // prevent AddFlags from configuring --request-timeout flag, we have --timeout instead
 
 	// Since some subcommands use the `-s` flag as a short version for `--silent`, we manually configure the server flag
 	// without the `-s` short version. While we're no longer on par with kubectl's flags, we maintain backwards compatibility
 	// on the CLI interface.
 	apiServer := ""
-	kubeConfigOptions.APIServer = &apiServer
+	kubeConfigArgs.APIServer = &apiServer
 
-	return kubeConfigOptions
+	return kubeConfigArgs
 }
 
 func GetKubeClientOptions() *runclient.Options {
-	kubeClientOptions := new(runclient.Options)
+	kubeClientOpts := new(runclient.Options)
 
-	return kubeClientOptions
+	return kubeClientOpts
 }
 
-func GetKubeClient(log logger.Logger, clusterName string, kubeConfigOptions genericclioptions.RESTClientGetter, kubeClientOptions *runclient.Options) (*kube.KubeHTTP, error) {
-	cfg, err := kubeConfigOptions.ToRESTConfig()
+func GetKubeClient(log logger.Logger, clusterName string, kubeConfigArgs genericclioptions.RESTClientGetter, kubeClientOpts *runclient.Options) (*kube.KubeHTTP, error) {
+	cfg, err := kubeConfigArgs.ToRESTConfig()
 	if err != nil {
 		log.Failuref("Error getting a restconfig: %v", err.Error())
 		return nil, err
 	}
 
 	// avoid throttling request when some Flux CRDs are not registered
-	cfg.QPS = kubeClientOptions.QPS
-	cfg.Burst = kubeClientOptions.Burst
+	cfg.QPS = kubeClientOpts.QPS
+	cfg.Burst = kubeClientOpts.Burst
 
 	kubeClient, err := kube.NewKubeHTTPClientWithConfig(cfg, clusterName)
 	if err != nil {
@@ -108,8 +108,8 @@ func GetKubeClient(log logger.Logger, clusterName string, kubeConfigOptions gene
 	return kubeClient, nil
 }
 
-func newManager(log logger.Logger, ctx context.Context, kubeClient ctrlclient.Client, kubeConfigOptions genericclioptions.RESTClientGetter) (*ssa.ResourceManager, error) {
-	restMapper, err := kubeConfigOptions.ToRESTMapper()
+func newManager(log logger.Logger, ctx context.Context, kubeClient ctrlclient.Client, kubeConfigArgs genericclioptions.RESTClientGetter) (*ssa.ResourceManager, error) {
+	restMapper, err := kubeConfigArgs.ToRESTMapper()
 	if err != nil {
 		log.Failuref("Error getting a restmapper")
 		return nil, err
@@ -123,8 +123,8 @@ func newManager(log logger.Logger, ctx context.Context, kubeClient ctrlclient.Cl
 	}), nil
 }
 
-func applySet(log logger.Logger, ctx context.Context, kubeClient ctrlclient.Client, kubeConfigOptions genericclioptions.RESTClientGetter, objects []*unstructured.Unstructured) (*ssa.ChangeSet, error) {
-	man, err := newManager(log, ctx, kubeClient, kubeConfigOptions)
+func applySet(log logger.Logger, ctx context.Context, kubeClient ctrlclient.Client, kubeConfigArgs genericclioptions.RESTClientGetter, objects []*unstructured.Unstructured) (*ssa.ChangeSet, error) {
+	man, err := newManager(log, ctx, kubeClient, kubeConfigArgs)
 	if err != nil {
 		log.Failuref("Error applying set")
 		return nil, err
@@ -143,7 +143,7 @@ func waitForSet(log logger.Logger, ctx context.Context, kubeClient ctrlclient.Cl
 	return man.WaitForSet(changeSet.ToObjMetadataSet(), ssa.WaitOptions{Interval: 2 * time.Second, Timeout: time.Minute})
 }
 
-func apply(log logger.Logger, ctx context.Context, kubeClient ctrlclient.Client, kubeConfigOptions genericclioptions.RESTClientGetter, manifestsContent []byte) (string, error) {
+func apply(log logger.Logger, ctx context.Context, kubeClient ctrlclient.Client, kubeConfigArgs genericclioptions.RESTClientGetter, manifestsContent []byte) (string, error) {
 	objs, err := ssa.ReadObjects(bytes.NewReader(manifestsContent))
 	if err != nil {
 		log.Failuref("Error reading Kubernetes objects from the manifests")
@@ -176,7 +176,7 @@ func apply(log logger.Logger, ctx context.Context, kubeClient ctrlclient.Client,
 	}
 
 	if len(stageOne) > 0 {
-		cs, err := applySet(log, ctx, kubeClient, kubeConfigOptions, stageOne)
+		cs, err := applySet(log, ctx, kubeClient, kubeConfigArgs, stageOne)
 		if err != nil {
 			log.Failuref("Error applying stage one objects")
 			return "", err
@@ -185,13 +185,13 @@ func apply(log logger.Logger, ctx context.Context, kubeClient ctrlclient.Client,
 		changeSet.Append(cs.Entries)
 	}
 
-	if err := waitForSet(log, ctx, kubeClient, kubeConfigOptions, changeSet); err != nil {
+	if err := waitForSet(log, ctx, kubeClient, kubeConfigArgs, changeSet); err != nil {
 		log.Failuref("Error waiting for set")
 		return "", err
 	}
 
 	if len(stageTwo) > 0 {
-		cs, err := applySet(log, ctx, kubeClient, kubeConfigOptions, stageTwo)
+		cs, err := applySet(log, ctx, kubeClient, kubeConfigArgs, stageTwo)
 		if err != nil {
 			log.Failuref("Error applying stage two objects")
 			return "", err

--- a/pkg/run/run.go
+++ b/pkg/run/run.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/rest"
 	"sigs.k8s.io/cli-utils/pkg/kstatus/polling"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -90,13 +91,7 @@ func GetKubeClientOptions() *runclient.Options {
 	return kubeClientOpts
 }
 
-func GetKubeClient(log logger.Logger, contextName string, kubeConfigArgs genericclioptions.RESTClientGetter, kubeClientOpts *runclient.Options) (*kube.KubeHTTP, error) {
-	cfg, err := kubeConfigArgs.ToRESTConfig()
-	if err != nil {
-		log.Failuref("Error getting a restconfig: %v", err.Error())
-		return nil, err
-	}
-
+func GetKubeClient(log logger.Logger, contextName string, cfg *rest.Config, kubeClientOpts *runclient.Options) (*kube.KubeHTTP, error) {
 	// avoid throttling request when some Flux CRDs are not registered
 	cfg.QPS = kubeClientOpts.QPS
 	cfg.Burst = kubeClientOpts.Burst

--- a/pkg/run/run.go
+++ b/pkg/run/run.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"os"
 	"time"
 
 	runclient "github.com/fluxcd/pkg/runtime/client"
@@ -62,22 +61,24 @@ func GetFluxVersion(log logger.Logger, ctx context.Context, kubeClient *kube.Kub
 	return fluxVersion, nil
 }
 
-func GetKubeConfigArgs() genericclioptions.RESTClientGetter {
+func GetKubeConfigArgs() *genericclioptions.ConfigFlags {
 	kubeConfigArgs := genericclioptions.NewConfigFlags(false)
 
-	fromEnv := os.Getenv("FLUX_SYSTEM_NAMESPACE")
-	if fromEnv != "" {
-		kubeConfigArgs.Namespace = &fromEnv
-	}
-
-	kubeConfigArgs.APIServer = nil // prevent AddFlags from configuring --server flag
-	kubeConfigArgs.Timeout = nil   // prevent AddFlags from configuring --request-timeout flag, we have --timeout instead
-
-	// Since some subcommands use the `-s` flag as a short version for `--silent`, we manually configure the server flag
-	// without the `-s` short version. While we're no longer on par with kubectl's flags, we maintain backwards compatibility
-	// on the CLI interface.
-	apiServer := ""
-	kubeConfigArgs.APIServer = &apiServer
+	// Prevent AddFlags from configuring unnecessary flags.
+	kubeConfigArgs.Insecure = nil
+	kubeConfigArgs.Timeout = nil
+	kubeConfigArgs.CacheDir = nil
+	kubeConfigArgs.AuthInfoName = nil
+	kubeConfigArgs.Namespace = nil
+	kubeConfigArgs.APIServer = nil
+	kubeConfigArgs.TLSServerName = nil
+	kubeConfigArgs.CertFile = nil
+	kubeConfigArgs.KeyFile = nil
+	kubeConfigArgs.CAFile = nil
+	kubeConfigArgs.BearerToken = nil
+	kubeConfigArgs.Impersonate = nil
+	kubeConfigArgs.ImpersonateUID = nil
+	kubeConfigArgs.ImpersonateGroup = nil
 
 	return kubeConfigArgs
 }

--- a/pkg/run/run.go
+++ b/pkg/run/run.go
@@ -67,6 +67,7 @@ func GetKubeConfigArgs() *genericclioptions.ConfigFlags {
 	// Prevent AddFlags from configuring unnecessary flags.
 	kubeConfigArgs.Insecure = nil
 	kubeConfigArgs.Timeout = nil
+	kubeConfigArgs.KubeConfig = nil
 	kubeConfigArgs.CacheDir = nil
 	kubeConfigArgs.AuthInfoName = nil
 	kubeConfigArgs.Namespace = nil
@@ -89,7 +90,7 @@ func GetKubeClientOptions() *runclient.Options {
 	return kubeClientOpts
 }
 
-func GetKubeClient(log logger.Logger, clusterName string, kubeConfigArgs genericclioptions.RESTClientGetter, kubeClientOpts *runclient.Options) (*kube.KubeHTTP, error) {
+func GetKubeClient(log logger.Logger, contextName string, kubeConfigArgs genericclioptions.RESTClientGetter, kubeClientOpts *runclient.Options) (*kube.KubeHTTP, error) {
 	cfg, err := kubeConfigArgs.ToRESTConfig()
 	if err != nil {
 		log.Failuref("Error getting a restconfig: %v", err.Error())
@@ -100,7 +101,7 @@ func GetKubeClient(log logger.Logger, clusterName string, kubeConfigArgs generic
 	cfg.QPS = kubeClientOpts.QPS
 	cfg.Burst = kubeClientOpts.Burst
 
-	kubeClient, err := kube.NewKubeHTTPClientWithConfig(cfg, clusterName)
+	kubeClient, err := kube.NewKubeHTTPClientWithConfig(cfg, contextName)
 	if err != nil {
 		log.Failuref("Kubernetes client initialization failed: %v", err.Error())
 		return nil, err

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -4,5 +4,5 @@ var (
 	// The constants below are to be set by flags passed to `go build`.
 	// Examples: -X version.FluxVersion=xxxxx
 
-	FluxVersion = "undefined"
+	FluxVersion = "latest"
 )


### PR DESCRIPTION
Closes #2426 

- Added the following command-specific flags to the `run` command: `--flux-version`, `--allow-k8s-context`, `--components`, `--components-extra`, `--timeout`.
- Added using two global flags, `--namespace` and `--kubeconfig` by the `run` command.
- Hooked up the `--context` flag, auto-generated by `genericclioptions`, when creating `kubeConfigArgs`.
- Reworked creation of kube config args and kube client.
- Added passing the kube config to the `InstallBucketServer` and down the line.
- Renamed `kubeConfigOptions` to `kubeConfigArgs` back, for consistency with their purpose and  the Flux code.

Notes:
- If a `--kubeconfig` flag is provided a `--context` flag is required too, because in this case we are not able to call `RestConfig()` initially to get the current context name in this case. Added an error message if the `--context` flag is not provided together with the `--kubeconfig` flag.
- Have not added the `--cluster` and `--allow-k8s-cluster` flags yet. We need to decide first how to use them.
- I think the default values displayed in the command help for the `--components` and `--components-extra` flags (empty, fortunately) of type strings slice are somewhat misleading:

```
--components strings         The Flux components to install, as a comma-separated list: --components=component1,component2,component3 (default [source-controller,kustomize-controller,helm-controller,notification-controller])
--components-extra strings   Additional Flux components to install, as a comma-separated list: --components=component1,component2,component3
```

It looks like the default value should be passed with square brackets while it should be just a comma-delimited list. Thus, I added and example in the usage string. If the user passes in

`components=[component1,component2,component3]`
instead of
`components=component1,component2,component3`

the components will be auto-split like `[component1`, `component2`, and `component3]`.

I hope it's a well-known argument format and it will be easy to understand how to format the flag values.

Issues:
- When using the flag `--allow-k8s-context` with a context name with underscores (for example, `--allow-k8s-context=gke_denim-testing_us-central1-c_olga-testing-1`) without also providing `--context=gke_denim-testing_us-central1-c_olga-testing-1` there is an issue with the context name changed when sanitized.

When this remote cluster is selected, we get context name from the `kube.RestConfig()` call. And it calls the following function under the hood to sanitize the context name:

```
func sanitizeClusterName(s string) string {
	// remove leading email address or username prefix from context
	if strings.Contains(s, "@") {
		return s[strings.LastIndex(s, "@")+1:]
	}

	s = strings.ReplaceAll(s, "_", "-")

	return s
}
```

So, after all underscores get replaces with dashes, the context name received from the rest config becomes `gke-denim-testing-us-central1-c-olga-testing-1` and the following check does not pass:

```
contextName = kubeClient.ClusterName
if flags.AllowK8sContext == contextName {
	log.Actionf("Explicitly allow GitOps Run on %s context", contextName)
} else if !isLocalCluster(kubeClient) {
	return errors.New("allowed to run against a local cluster only")
}
```

Temp log values:

```
flags.AllowK8sContext:
gke_denim-testing_us-central1-c_olga-testing-1

contextName:
gke-denim-testing-us-central1-c-olga-testing-1

kubeClient.ClusterName:
gke-denim-testing-us-central1-c-olga-testing-1
```