### PR TITLE
Enable the metrics port on the deployment if metrics are enabled

### DIFF
--- a/charts/gitops-server/Chart.yaml
+++ b/charts/gitops-server/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.2.0
+version: 2.2.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/gitops-server/templates/deployment.yaml
+++ b/charts/gitops-server/templates/deployment.yaml
@@ -55,6 +55,11 @@ spec:
             - name: http
               containerPort: 9001
               protocol: TCP
+          {{- if .Values.metrics.enabled }}
+            - name: http-metrics
+              containerPort: {{ .Values.metrics.service.port }}
+              protocol: TCP
+          {{- end }}
           livenessProbe:
             httpGet:
               path: /


### PR DESCRIPTION
I added the port of to the service, I made the pod start listening to the port, but I didn't put it in the deployment itself.