### PR TITLE
Use access token for UserInfo endpoint access

### DIFF
--- a/pkg/server/auth/auth.go
+++ b/pkg/server/auth/auth.go
@@ -18,6 +18,10 @@ const (
 	// IDTokenCookieName is the name of the cookie that holds the ID Token once
 	// the user has authenticated successfully with the OIDC Provider.
 	IDTokenCookieName = "id_token"
+	// AccessTokenCookieName is the name of the cookie that holds the access token once
+	// the user has authenticated successfully with the OIDC Provider. It's used for further
+	// resource requests from the provider.
+	AccessTokenCookieName = "access_token"
 	// AuthorizationTokenHeaderName is the name of the header that holds the bearer token
 	// used for token passthrough authentication.
 	AuthorizationTokenHeaderName = "Authorization"

--- a/pkg/server/auth/server_test.go
+++ b/pkg/server/auth/server_test.go
@@ -638,17 +638,21 @@ func TestLogoutSuccess(t *testing.T) {
 	resp := w.Result()
 	g.Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
-	var cookie *http.Cookie
+	cookies := make(map[string]*http.Cookie)
 
 	for _, c := range resp.Cookies() {
-		if c.Name == auth.IDTokenCookieName {
-			cookie = c
-			break
+		if c.Name == auth.IDTokenCookieName || c.Name == auth.AccessTokenCookieName {
+			cookies[c.Name] = c
 		}
 	}
 
-	g.Expect(cookie).ToNot(BeNil())
-	g.Expect(cookie.Value).To(Equal(""))
+	g.Expect(cookies).To(HaveKey(auth.IDTokenCookieName))
+	g.Expect(cookies).To(HaveKey(auth.AccessTokenCookieName))
+
+	for _, c := range cookies {
+		g.Expect(c).ToNot(BeNil())
+		g.Expect(c.Value).To(Equal(""))
+	}
 }
 
 func TestLogoutWithWrongMethod(t *testing.T) {


### PR DESCRIPTION
Some OIDC providers (such as Keycloak) check the token type to match
"Bearer" which is not true for the ID token which holds the token type
"ID". Therefore, the ID token cannot (and supposedly should not) be
used to authorize requests to resource servers.

With this change the auth server stores the access token alongside the
ID token in the browser's cookies so that it can be used by the
weave-gitops server later on, e.g. to make requests against the
UserInfo endpoint of the OIDC provider.

A caveat of this change is that the mock OIDC server used in tests
doesn't check the token type so without further changes to the
upstream library we cannot really test usage of the access token
properly.

closes #2125
