### PR TITLE
release: Set tag on the correct commit

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,9 @@ jobs:
       version: ${{ steps.release-version.outputs.version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Find release version
         id: release-version
         run: |
@@ -35,7 +37,9 @@ jobs:
     needs: tag-release
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Unshallow
         run: |
           git fetch --prune --unshallow


### PR DESCRIPTION
`actions/checkout` checks out a temporary merge commit of the PR, not
the commit in the PR.

This means our release tags ended up on identical but different
merges, compared to what then ended up in main. For example, v0.9.0 is
set on 5283dd5, not 6d0669e (as I expected) or 8aecaae (which is the
merge that's actually reachable from main).