### PR TITLE
Add gitops get bcrypt-hash command to relevant docs

### DIFF
--- a/charts/gitops-server/Chart.yaml
+++ b/charts/gitops-server/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.2.1
+version: 2.2.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/gitops-server/values.yaml
+++ b/charts/gitops-server/values.yaml
@@ -79,8 +79,8 @@ adminUser:
   # k8s. Requires `adminUser.create` and `adminUser.createSecret`.
   username: gitops-test-user
   # -- (string) Set the password for local admin user. Requires `adminUser.create` and `adminUser.createSecret`
-  # This needs to have been hashed using a bcrypt
-  # algorithm. You can access one via our CLI with `gitops get bcrypt-hash`.
+  # This needs to have been hashed using bcrypt.
+  # You can access one via our CLI with `gitops get bcrypt-hash`.
   passwordHash:
 
 podAnnotations: {}

--- a/charts/gitops-server/values.yaml
+++ b/charts/gitops-server/values.yaml
@@ -79,8 +79,8 @@ adminUser:
   # k8s. Requires `adminUser.create` and `adminUser.createSecret`.
   username: gitops-test-user
   # -- (string) Set the password for local admin user. Requires `adminUser.create` and `adminUser.createSecret`
-  # This needs to have been hashed using the bcrypt
-  # algorithm. E.g. `go install github.com/bitnami/bcrypt-cli@v1.0.2 && bcrypt-cli <<< $PASSWORD`
+  # This needs to have been hashed using a bcrypt
+  # algorithm. You can access one via our CLI with `gitops get bcrypt-hash`.
   passwordHash:
 
 podAnnotations: {}

--- a/charts/gitops-server/values.yaml
+++ b/charts/gitops-server/values.yaml
@@ -80,7 +80,7 @@ adminUser:
   username: gitops-test-user
   # -- (string) Set the password for local admin user. Requires `adminUser.create` and `adminUser.createSecret`
   # This needs to have been hashed using bcrypt.
-  # You can access one via our CLI with `gitops get bcrypt-hash`.
+  # You can do this via our CLI with `gitops get bcrypt-hash`.
   passwordHash:
 
 podAnnotations: {}

--- a/website/docs/configuration/securing-access-to-the-dashboard.mdx
+++ b/website/docs/configuration/securing-access-to-the-dashboard.mdx
@@ -49,14 +49,14 @@ Once the HTTP server starts unauthenticated users will have to click the 'login 
 
 ## Login via a cluster user account
 
-Before you login via the cluster user account, you need to generate a bcrypt hash for your chosen password and store it as a secret in Kubernetes. There are several different ways to generate a bcrypt hash, this guide uses a Go Docker image to generate one:
+Before you login via the cluster user account, you need to generate a bcrypt hash for your chosen password and store it as a secret in Kubernetes. There are several different ways to generate a bcrypt hash, this guide uses `gitops get bcrypt-hash` from our CLI:
 
 Generate the password by running:
 
-```sh
+```
 PASSWORD="<your password>"
-docker run -it golang:1.17 bash -c "go install github.com/bitnami/bcrypt-cli@v1.0.2 2> /dev/null && echo -n '$PASSWORD' | bcrypt-cli"
-$2a$10$OS5NJmPNEb13UTOSKngMxOWlmS7mlxX77hv4yAiISvZ71Dc7IuN3q
+echo  $PASSWORD | gitops get bcrypt-hash
+$2a$10$OS5NJmPNEb13UgTOSKnMxOWlmS7mlxX77hv4yAiISvZ71Dc7IuN3q
 ```
 
 Now create a Kubernetes secret to store your chosen username and the password hash:

--- a/website/docs/configuration/securing-access-to-the-dashboard.mdx
+++ b/website/docs/configuration/securing-access-to-the-dashboard.mdx
@@ -53,7 +53,7 @@ Before you login via the cluster user account, you need to generate a bcrypt has
 
 Generate the password by running:
 
-```
+```sh
 PASSWORD="<your password>"
 echo  $PASSWORD | gitops get bcrypt-hash
 $2a$10$OS5NJmPNEb13UgTOSKnMxOWlmS7mlxX77hv4yAiISvZ71Dc7IuN3q

--- a/website/docs/getting-started.mdx
+++ b/website/docs/getting-started.mdx
@@ -94,7 +94,7 @@ echo  $PASSWORD | gitops get bcrypt-hash
 $2a$10$OS5NJmPNEb13UgTOSKnMxOWlmS7mlxX77hv4yAiISvZ71Dc7IuN3q
 ```
 
-Save this [bcrypt-hash](https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/Password_Storage_Cheat_Sheet.md) in a values file:
+3. Save this [bcrypt-hash](https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/Password_Storage_Cheat_Sheet.md) in a values file:
 ```yaml title="./weave-gitops-values.yaml"
 adminUser:
   create: true

--- a/website/docs/getting-started.mdx
+++ b/website/docs/getting-started.mdx
@@ -94,9 +94,8 @@ echo  $PASSWORD | gitops get bcrypt-hash
 $2a$10$OS5NJmPNEb13UgTOSKnMxOWlmS7mlxX77hv4yAiISvZ71Dc7IuN3q
 ```
 
-3. Save this bcrypt-hash in a values file:
-
-```
+Save this [bcrypt-hash](https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/Password_Storage_Cheat_Sheet.md) in a values file:
+```yaml title="./weave-gitops-values.yaml"
 adminUser:
   create: true
   username: admin

--- a/website/docs/getting-started.mdx
+++ b/website/docs/getting-started.mdx
@@ -13,8 +13,8 @@ If you haven't already, be sure to check out our [introduction](./intro.md) to W
 ## Before you begin
 
 We will provide a complete walkthrough of getting Flux installed and Weave GitOps configured. However, if you have:
--  an existing cluster bootstrapped Flux 🎉
--  followed our [installation](./installation.mdx) doc to configure access to the Weave GitOps dashboard then install Weave GitOps 👏
+- an existing cluster bootstrapped Flux 🎉
+- followed our [installation](./installation.mdx) doc to configure access to the Weave GitOps dashboard then install Weave GitOps 👏
 
 Then you can skip ahead to [Part 1](#part-1---weave-gitops-overview) 🏃
 but note ⚠️ you may need to alter commands where we are committing files to GitHub ⚠️.
@@ -77,7 +77,7 @@ The bootstrap command above does following:
 ### Configure access to the dashboard
 For this guide we will use the cluster user, for complete documentation including how to configure an OIDC provider see the documentation [here](./configuration/securing-access-to-the-dashboard.mdx).
 
-We will generate a bcrypt hash for your chosen password and store it as a secret in Kubernetes. There are several different ways to generate a bcrypt hash, this guide uses a Go Docker image to generate one.
+We will generate a bcrypt hash for your chosen password and store it as a secret in Kubernetes. There are several different ways to generate a bcrypt hash, this guide uses `gitops get bcrypt-hash` from our CLI.
 
 1. Clone your git repository where Flux has been bootstrapped (you could skip this step if you performed previous steps in this doc).
 
@@ -86,16 +86,17 @@ git clone https://github.com/$GITHUB_USER/fleet-infra
 cd fleet-infra
 ```
 
-2. Generate the password using a golang image:
+2. Generate the password:
 
 ```
 PASSWORD="<your password>"
-docker run -it --rm golang:1.17 bash -c "go install github.com/bitnami/bcrypt-cli@v1.0.2 2> /dev/null && echo -n '$PASSWORD' | bcrypt-cli"
+echo  $PASSWORD | gitops get bcrypt-hash
 $2a$10$OS5NJmPNEb13UgTOSKnMxOWlmS7mlxX77hv4yAiISvZ71Dc7IuN3q
 ```
 
-3. Save this [bcrypt-hash](https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/Password_Storage_Cheat_Sheet.md) in a values file:
-```yaml title="./weave-gitops-values.yaml"
+3. Save this bcrypt-hash in a values file:
+
+```
 adminUser:
   create: true
   username: admin

--- a/website/docs/installation.mdx
+++ b/website/docs/installation.mdx
@@ -356,7 +356,7 @@ In order to login to the WGE UI, you need to generate a bcrypt hash for your cho
 
 There are several different ways to generate a bcrypt hash, this guide uses `gitops get bcrypt-hash` from our CLI.
 
-```
+```bash
 PASSWORD="<your password>"
 echo  $PASSWORD | gitops get bcrypt-hash
 $2a$10$OS5NJmPNEb13UgTOSKnMxOWlmS7mlxX77hv4yAiISvZ71Dc7IuN3q
@@ -368,7 +368,7 @@ Use the hashed output to create a Kubernetes username/password secret.
 kubectl create secret generic cluster-user-auth \
   --namespace flux-system \
   --from-literal=username=wego-admin \
-  --from-literal=password='$2a$10$OS5NJmPNEb13UgTOSKnMxOWlmS7mlxX77hv4yAiISvZ71Dc7IuN3q'
+  --from-literal=password='$2a$.......'
 ```
 
 ### 7. Check that WGE is installed

--- a/website/docs/installation.mdx
+++ b/website/docs/installation.mdx
@@ -354,10 +354,12 @@ Flux will reconcile the helm-release and WGE will be deployed into the cluster. 
 
 In order to login to the WGE UI, you need to generate a bcrypt hash for your chosen password and store it as a secret in the Kubernetes cluster.
 
-Run the following Docker command and supply the password of your choice as an environment variable:
+There are several different ways to generate a bcrypt hash, this guide uses `gitops get bcrypt-hash` from our CLI.
 
-```bash
-docker run -e PASSWORD="<your password>" -it golang:1.17 bash -c 'go install github.com/bitnami/bcrypt-cli@v1.0.2 2> /dev/null && echo -n $PASSWORD | bcrypt-cli'
+```
+PASSWORD="<your password>"
+echo  $PASSWORD | gitops get bcrypt-hash
+$2a$10$OS5NJmPNEb13UgTOSKnMxOWlmS7mlxX77hv4yAiISvZ71Dc7IuN3q
 ```
 
 Use the hashed output to create a Kubernetes username/password secret.
@@ -366,7 +368,7 @@ Use the hashed output to create a Kubernetes username/password secret.
 kubectl create secret generic cluster-user-auth \
   --namespace flux-system \
   --from-literal=username=wego-admin \
-  --from-literal=password='$2a$.......'
+  --from-literal=password='$2a$10$OS5NJmPNEb13UgTOSKnMxOWlmS7mlxX77hv4yAiISvZ71Dc7IuN3q'
 ```
 
 ### 7. Check that WGE is installed


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes #2290 

Updates docs and helm chart with the new `gitops get bcrypt-hash` command
