### PR TITLE
Upgrade `gofakes3` to the latest version.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/helm/helm v2.17.0+incompatible
 	github.com/jarcoal/httpmock v1.0.8
-	github.com/johannesboyne/gofakes3 v0.0.0-00010101000000-000000000000
+	github.com/johannesboyne/gofakes3 v0.0.0-20220627085814-c3ac35da23b2
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.4.1
 	github.com/minio/minio-go/v7 v7.0.31
 	github.com/oauth2-proxy/mockoidc v0.0.0-20220308204021-b9169deeb282


### PR DESCRIPTION
I hope it will fix the invalid dependency issue reported in [0.9.1.rc1](https://github.com/weaveworks/weave-gitops/releases/tag/v0.9.1-rc.1)
```
weave-gitops-enterprise git:(985-view-flagger-generated-objects) ✗ go run cmd/clusters-service/main.go
cmd/clusters-service/app/server.go:25:2: github.com/weaveworks/weave-gitops@v0.9.1-rc.1 requires
	github.com/johannesboyne/gofakes3@v0.0.0-00010101000000-000000000000: invalid version: unknown revision 000000000000
```
[diff link](https://github.com/weaveworks/weave-gitops/compare/v0.9.0...v0.9.1-rc.1#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R31) provided

Ran the tests locally, does not break anything. Let's see what the PR  checks show.

Closing it as a non-issue base on clarification from @chanwit that the patched version should be used instead.