### PR TITLE
Unify oci link handling

### DIFF
--- a/ui/components/HelmRepositoryDetail.tsx
+++ b/ui/components/HelmRepositoryDetail.tsx
@@ -31,7 +31,7 @@ function HelmRepositoryDetail({
       info={(hr: HelmRepository = {}) => [
         ["Type", removeKind(FluxObjectKind.KindHelmRepository)],
         ["Repository Type", hr.repositoryType.toLowerCase()],
-        ["URL", tryLink(hr.url)],
+        ["URL", <Link>hr.url</Link>],
         [
           "Last Updated",
           hr.lastUpdatedAt ? <Timestamp time={hr.lastUpdatedAt} /> : "-",
@@ -42,18 +42,6 @@ function HelmRepositoryDetail({
       ]}
     />
   );
-}
-
-export function tryLink(url: string): React.ReactElement<any, any> | string {
-  if (url.startsWith("http")) {
-    return (
-      <Link newTab href={url}>
-        {url}
-      </Link>
-    );
-  } else {
-    return url;
-  }
 }
 
 export default styled(HelmRepositoryDetail).attrs({

--- a/ui/components/Link.tsx
+++ b/ui/components/Link.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { Link as RouterLink } from "react-router-dom";
 import styled from "styled-components";
+import { isAllowedLink } from "../lib/utils";
 import Text, { TextProps } from "./Text";
 
 type Props = {
@@ -24,6 +25,10 @@ function Link({
   textProps,
   ...props
 }: Props) {
+  if (href && !isAllowedLink(href)) {
+    return <Text {...textProps}>{children}</Text>;
+  }
+
   const txt = (
     <Text color="primary" {...textProps}>
       {children}

--- a/ui/components/SourcesTable.tsx
+++ b/ui/components/SourcesTable.tsx
@@ -5,7 +5,6 @@ import {
   FluxObjectKind,
   GitRepository,
   HelmRepository,
-  HelmRepositoryType,
 } from "../lib/api/core/types.pb";
 import { formatURL, objectTypeToRoute } from "../lib/nav";
 import { showInterval } from "../lib/time";
@@ -109,12 +108,8 @@ function SourcesTable({ className, sources }: Props) {
                 return "-";
               case FluxObjectKind.KindHelmRepository:
                 text = (s as HelmRepository).url;
-                if (
-                  (s as HelmRepository).repositoryType != HelmRepositoryType.OCI
-                ) {
-                  url = text;
-                  link = true;
-                }
+                url = text;
+                link = true;
                 break;
             }
             return link ? (

--- a/ui/components/__tests__/Link.test.tsx
+++ b/ui/components/__tests__/Link.test.tsx
@@ -1,0 +1,73 @@
+import React from "react";
+import { MemoryRouter } from "react-router-dom";
+import { render } from "@testing-library/react";
+import { withTheme } from "../../lib/test-utils";
+import Link from "../Link";
+
+describe("Link", () => {
+  it("doesn't create a link for oci links", () => {
+    const { container: link } = render(
+      withTheme(<Link href="oci://ghcr.io/some/chart">Text</Link>)
+    );
+    const a = link.querySelector("a");
+    expect(a).toBe(null);
+    expect(link.textContent).toBe("Text");
+  });
+  it("creates a link for http links", () => {
+    const { container: link } = render(
+      withTheme(<Link href="http://google.com">Text</Link>)
+    );
+    const a = link.querySelector("a");
+    expect(a).not.toBe(null);
+    expect(a.href).toBe("http://google.com/");
+    expect(a.textContent).toBe("Text");
+  });
+  it("creates a link for relative links", () => {
+    const { container: link } = render(
+      withTheme(<Link href="/some-page">Text</Link>)
+    );
+    const a = link.querySelector("a");
+    expect(a).not.toBe(null);
+    expect(a.href).toBe("http://localhost/some-page");
+    expect(a.textContent).toBe("Text");
+  });
+  it("creates a router link for to links", () => {
+    const { container: link } = render(
+      withTheme(
+        <MemoryRouter>
+          <Link to="/some-page">Text</Link>
+        </MemoryRouter>
+      )
+    );
+    const a = link.querySelector("a");
+    expect(a).not.toBe(null);
+    expect(a.href).toBe("http://localhost/some-page");
+    expect(a.textContent).toBe("Text");
+  });
+  it("makes to links relative when specifying an absolute link", () => {
+    const { container: link } = render(
+      withTheme(
+        <MemoryRouter>
+          <Link to="http://google.com">Text</Link>
+        </MemoryRouter>
+      )
+    );
+    const a = link.querySelector("a");
+    expect(a).not.toBe(null);
+    expect(a.href).toBe("http://localhost/http://google.com");
+    expect(link.textContent).toBe("Text");
+  });
+  it("makes to links relative when specifying an oic link", () => {
+    const { container: link } = render(
+      withTheme(
+        <MemoryRouter>
+          <Link to="oci://ghcr.io/some/chart">Text</Link>
+        </MemoryRouter>
+      )
+    );
+    const a = link.querySelector("a");
+    expect(a).not.toBe(null);
+    expect(a.href).toBe("http://localhost/oci://ghcr.io/some/chart");
+    expect(link.textContent).toBe("Text");
+  });
+});

--- a/ui/index.ts
+++ b/ui/index.ts
@@ -61,7 +61,7 @@ import {
 } from "./lib/storage";
 import { muiTheme, theme } from "./lib/theme";
 import { V2Routes } from "./lib/types";
-import { statusSortHelper } from "./lib/utils";
+import { statusSortHelper, isAllowedLink } from "./lib/utils";
 import OAuthCallback from "./pages/OAuthCallback";
 import SignIn from "./pages/SignIn";
 import { formatURL } from "./lib/nav";
@@ -104,6 +104,7 @@ export {
   IconType,
   InfoList,
   Interval,
+  isAllowedLink,
   KubeStatusIndicator,
   KustomizationDetail,
   Link,

--- a/ui/lib/__tests__/utils.test.ts
+++ b/ui/lib/__tests__/utils.test.ts
@@ -8,6 +8,7 @@ import {
   formatMetadataKey,
   gitlabOAuthRedirectURI,
   isHTTP,
+  isAllowedLink,
   makeImageString,
   mapScaleToZoomPercent,
   mapZoomPercentToScale,
@@ -80,6 +81,40 @@ describe("utils lib", () => {
       );
       expect(isHTTP("foo/file.html")).toEqual(false);
       expect(isHTTP("//.com")).toEqual(false);
+    });
+  });
+  describe("isAllowedLink", () => {
+    it("allows http", () => {
+      expect(isAllowedLink("http://www.google.com")).toEqual(true);
+      expect(isAllowedLink("http:// this is a random http sentence")).toEqual(
+        true
+      );
+    });
+    it("allows https", () => {
+      expect(isAllowedLink("https://www.google.com")).toEqual(true);
+      expect(isAllowedLink("https:// this is a random https sentence")).toEqual(
+        true
+      );
+    });
+    it("allows relative links", () => {
+      // Some of these are nonsensical, but if you _want_ them to be a
+      // relative link, it's not forbidden.
+      expect(isAllowedLink("/hello")).toEqual(true);
+      expect(isAllowedLink("test string")).toEqual(true);
+      expect(
+        isAllowedLink("github.com/weaveworks/weave-gitops-clusters")
+      ).toEqual(true);
+      expect(isAllowedLink("foo/file.html")).toEqual(true);
+      expect(isAllowedLink("//.com")).toEqual(true);
+    });
+    it("doesn't allow other links", () => {
+      expect(isAllowedLink("oci://server/")).toEqual(false);
+      expect(isAllowedLink("smtp://server/")).toEqual(false);
+      expect(isAllowedLink("smtp://http/")).toEqual(false);
+      expect(isAllowedLink("smtp://https/")).toEqual(false);
+      expect(
+        isAllowedLink("ssh://git@github.com/weaveworks/weave-gitops-clusters")
+      ).toEqual(false);
     });
   });
   describe("convertGitURLToGitProvider", () => {

--- a/ui/lib/utils.ts
+++ b/ui/lib/utils.ts
@@ -27,6 +27,9 @@ export function poller(cb, interval): any {
   return setInterval(cb, interval);
 }
 
+// isHTTP checks if something looks link-like enough that we think it
+// would be a good idea to auto-link. This is quite strict, and does
+// not allow e.g relative links. See also isAllowedLink
 export function isHTTP(uri: string): boolean {
   // Regex from Diego Perini's gist: https://gist.github.com/dperini/729294
   // It works better than other regular expressions for validating HTTP and HTTPS URLs.
@@ -34,6 +37,18 @@ export function isHTTP(uri: string): boolean {
     /^(?:(?:(?:https?):)?\/\/)(?:\S+(?::\S*)?@)?(?:(?!(?:10|127)(?:\.\d{1,3}){3})(?!(?:169\.254|192\.168)(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z0-9\u00a1-\uffff][a-z0-9\u00a1-\uffff_-]{0,62})?[a-z0-9\u00a1-\uffff]\.)+(?:[a-z\u00a1-\uffff]{2,}\.?))(?::\d{2,5})?(?:[/?#]\S*)?$/i
   );
 
+  return regex.test(uri);
+}
+
+// isAllowedLink checks if making a "link" clickable will do anybody
+// any good. This is quite permissive - it's to stop e.g. oci:// links
+// being clickable, because clicking them will make nobody happy. See
+// also isAllowedLink
+export function isAllowedLink(uri: string): boolean {
+  // Regex from https://github.com/cure53/DOMPurify/blob/cce00ac40d33c2aae6422eaa59e6a8aad5c73901/src/regexp.js
+  const regex = new RegExp(
+    /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|cid|xmpp):|[^a-z]|[a-z+.\-]+(?:[^a-z+.\-:]|$))/i // eslint-disable-line no-useless-escape
+  );
   return regex.test(uri);
 }
 


### PR DESCRIPTION
This stops `oci://` links from showing up anywhere in the UI.

This does not use `isHTTP`, because we actually use `<Link/>` for `mailto:`