### PR TITLE
Move Cluster column forward on Sources page

### DIFF
--- a/ui/components/SourcesTable.tsx
+++ b/ui/components/SourcesTable.tsx
@@ -69,6 +69,10 @@ function SourcesTable({ className, sources }: Props) {
         { label: "Type", value: "type" },
         { label: "Namespace", value: "namespace" },
         {
+          label: "Cluster",
+          value: (s: Source) => s.clusterName,
+        },
+        {
           label: "Status",
           value: (s: Source) => (
             <KubeStatusIndicator
@@ -84,10 +88,6 @@ function SourcesTable({ className, sources }: Props) {
           label: "Message",
           value: (s) => computeMessage(s.conditions),
           maxWidth: 600,
-        },
-        {
-          label: "Cluster",
-          value: (s: Source) => s.clusterName,
         },
         {
           label: "URL",


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes #2428 

<!-- Describe what has changed in this PR -->
Placement of the cluster column now matches `AutomationsTable`
<img width="1405" alt="image" src="https://user-images.githubusercontent.com/65822698/180510141-380f80f9-c155-4d14-86e3-60dc1b0f44d1.png">
