### PR TITLE
fix: stop auth passthrough from ignoring token in favour of SA

### DIFF
--- a/charts/gitops-server/Chart.yaml
+++ b/charts/gitops-server/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.2.2
+version: 2.2.3
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/gitops-server/templates/token_review_crb.yaml
+++ b/charts/gitops-server/templates/token_review_crb.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.rbac.create -}}
+{{- if semverCompare "<1.17-0" (include "common.capabilities.kubeVersion" .) -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+{{- else }}
+apiVersion: rbac.authorization.k8s.io/v1
+{{- end }}
+kind: ClusterRoleBinding
+metadata:
+  name:  {{ include "chart.fullname" . }}-token-review
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+  {{- with .Values.rbac.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "chart.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: system:auth-delegator
+  apiGroup: rbac.authorization.k8s.io
+{{- end -}}

--- a/core/clustersmngr/clustersmngr.go
+++ b/core/clustersmngr/clustersmngr.go
@@ -76,12 +76,18 @@ func ClientConfigWithUser(user *auth.UserPrincipal) ClusterClientConfig {
 	return func(cluster Cluster) *rest.Config {
 		config := &rest.Config{
 			Host:            cluster.Server,
-			BearerToken:     cluster.BearerToken,
 			TLSClientConfig: cluster.TLSConfig,
-			Impersonate: rest.ImpersonationConfig{
+		}
+
+		if user.Token != "" {
+			config.BearerToken = user.Token
+			config.BearerTokenFile = ""
+		} else {
+			config.BearerToken = cluster.BearerToken
+			config.Impersonate = rest.ImpersonationConfig{
 				UserName: user.ID,
 				Groups:   user.Groups,
-			},
+			}
 		}
 
 		enabled, err := flowcontrol.IsEnabled(context.Background(), config)

--- a/core/clustersmngr/clustersmngr.go
+++ b/core/clustersmngr/clustersmngr.go
@@ -81,7 +81,6 @@ func ClientConfigWithUser(user *auth.UserPrincipal) ClusterClientConfig {
 
 		if user.Token != "" {
 			config.BearerToken = user.Token
-			config.BearerTokenFile = ""
 		} else {
 			config.BearerToken = cluster.BearerToken
 			config.Impersonate = rest.ImpersonationConfig{

--- a/pkg/kube/config_getter.go
+++ b/pkg/kube/config_getter.go
@@ -38,6 +38,7 @@ func (r *ImpersonatingConfigGetter) Config(ctx context.Context) *rest.Config {
 	if p := auth.Principal(ctx); p != nil {
 		if p.Token != "" {
 			shallowCopy.BearerToken = p.Token
+			shallowCopy.BearerTokenFile = ""
 		} else {
 			shallowCopy.Impersonate = rest.ImpersonationConfig{
 				UserName: p.ID,

--- a/pkg/kube/kubehttp.go
+++ b/pkg/kube/kubehttp.go
@@ -14,6 +14,7 @@ import (
 	sourcev1 "github.com/fluxcd/source-controller/api/v1beta2"
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
+	authv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	extensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -29,6 +30,7 @@ func CreateScheme() *apiruntime.Scheme {
 	_ = extensionsv1.AddToScheme(scheme)
 	_ = appsv1.AddToScheme(scheme)
 	_ = rbacv1.AddToScheme(scheme)
+	_ = authv1.AddToScheme(scheme)
 
 	return scheme
 }

--- a/pkg/server/auth/auth.go
+++ b/pkg/server/auth/auth.go
@@ -92,7 +92,7 @@ func WithPrincipal(ctx context.Context, p *UserPrincipal) context.Context {
 // Unauthorized requests will be denied with a 401 status code.
 func WithAPIAuth(next http.Handler, srv *AuthServer, publicRoutes []string) http.Handler {
 	adminAuth := NewJWTAdminCookiePrincipalGetter(srv.Log, srv.tokenSignerVerifier, IDTokenCookieName)
-	tokenAuth := NewBearerTokenPassthroughPrincipalGetter(srv.Log, nil, AuthorizationTokenHeaderName)
+	tokenAuth := NewBearerTokenPassthroughPrincipalGetter(srv.Log, nil, AuthorizationTokenHeaderName, srv.kubernetesClient)
 	multi := MultiAuthPrincipal{adminAuth, tokenAuth}
 
 	if srv.oidcEnabled() {

--- a/pkg/server/auth/passthrough.go
+++ b/pkg/server/auth/passthrough.go
@@ -43,8 +43,6 @@ func (pg *BearerTokenPassthroughPrincipalGetter) Principal(r *http.Request) (*Us
 
 	token = extractToken(token)
 
-	authv1.AddToScheme(pg.kubernetesClient.Scheme())
-
 	tr := authv1.TokenReview{
 		Spec: authv1.TokenReviewSpec{
 			Token: token,


### PR DESCRIPTION
Fix a bug where the `BearerToken` is being ignored because the `BearerTokenFile` is being used to authenticate the client as the InCluster service account.

Additionally, we now validate the token when it is received by utilising the `TokenReview` API. This requires additional permissions on the service account:

```
apiGroup: rbac.authorization.k8s.io
kind: ClusterRole
name: system:auth-delegator
```