### PR TITLE
refactor: move AddToScheme to scheme builder and handle errors

### DIFF
--- a/cmd/gitops-server/cmd/cmd.go
+++ b/cmd/gitops-server/cmd/cmd.go
@@ -149,8 +149,13 @@ func runCmd(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("could not create client config: %w", err)
 	}
 
+	scheme, err := kube.CreateScheme()
+	if err != nil {
+		return fmt.Errorf("could not create scheme: %w", err)
+	}
+
 	rawClient, err := client.New(rest, client.Options{
-		Scheme: kube.CreateScheme(),
+		Scheme: scheme,
 	})
 	if err != nil {
 		return fmt.Errorf("could not create kube http client: %w", err)
@@ -211,7 +216,7 @@ func runCmd(cmd *cobra.Command, args []string) error {
 
 	fetcher := fetcher.NewSingleClusterFetcher(rest)
 
-	clusterClientsFactory := clustersmngr.NewClientFactory(fetcher, nsaccess.NewChecker(nsaccess.DefautltWegoAppRules), log, kube.CreateScheme(), clustersmngr.NewClustersClientsPool)
+	clusterClientsFactory := clustersmngr.NewClientFactory(fetcher, nsaccess.NewChecker(nsaccess.DefautltWegoAppRules), log, scheme, clustersmngr.NewClustersClientsPool)
 	clusterClientsFactory.Start(ctx)
 
 	coreConfig := core.NewCoreConfig(log, rest, clusterName, clusterClientsFactory)

--- a/core/clustersmngr/client_test.go
+++ b/core/clustersmngr/client_test.go
@@ -33,7 +33,7 @@ func TestClientGet(t *testing.T) {
 
 	appName := "myapp" + rand.String(5)
 
-	clientsPool := clustersmngr.NewClustersClientsPool(kube.CreateScheme())
+	clientsPool := createClusterClientsPool(g)
 
 	err := clientsPool.Add(
 		clustersmngr.ClientConfigWithUser(&auth.UserPrincipal{}),
@@ -80,7 +80,7 @@ func TestClientClusteredList(t *testing.T) {
 	clusterName := "mycluster"
 	appName := "myapp" + rand.String(5)
 
-	clientsPool := clustersmngr.NewClustersClientsPool(kube.CreateScheme())
+	clientsPool := createClusterClientsPool(g)
 
 	err := clientsPool.Add(
 		clustersmngr.ClientConfigWithUser(&auth.UserPrincipal{}),
@@ -185,7 +185,8 @@ func TestClientClusteredListPagination(t *testing.T) {
 		createKust(appName, ns2.Name)
 	}
 
-	clientsPool := clustersmngr.NewClustersClientsPool(kube.CreateScheme())
+	clientsPool := createClusterClientsPool(g)
+
 	err := clientsPool.Add(
 		clustersmngr.ClientConfigWithUser(&auth.UserPrincipal{}),
 		clustersmngr.Cluster{
@@ -237,7 +238,7 @@ func TestClientClusteredListClusterScoped(t *testing.T) {
 	clusterName := "mycluster"
 	appName := "myapp" + rand.String(5)
 
-	clientsPool := clustersmngr.NewClustersClientsPool(kube.CreateScheme())
+	clientsPool := createClusterClientsPool(g)
 
 	err := clientsPool.Add(
 		clustersmngr.ClientConfigWithUser(&auth.UserPrincipal{}),
@@ -289,7 +290,7 @@ func TestClientCLusteredListErrors(t *testing.T) {
 
 	clusterName := "mycluster"
 
-	clientsPool := clustersmngr.NewClustersClientsPool(kube.CreateScheme())
+	clientsPool := createClusterClientsPool(g)
 
 	err := clientsPool.Add(
 		clustersmngr.ClientConfigWithUser(&auth.UserPrincipal{}),
@@ -330,7 +331,7 @@ func TestClientList(t *testing.T) {
 	clusterName := "mycluster"
 	appName := "myapp" + rand.String(5)
 
-	clientsPool := clustersmngr.NewClustersClientsPool(kube.CreateScheme())
+	clientsPool := createClusterClientsPool(g)
 
 	err := clientsPool.Add(
 		clustersmngr.ClientConfigWithUser(&auth.UserPrincipal{}),
@@ -377,7 +378,7 @@ func TestClientCreate(t *testing.T) {
 	clusterName := "mycluster"
 	appName := "myapp" + rand.String(5)
 
-	clientsPool := clustersmngr.NewClustersClientsPool(kube.CreateScheme())
+	clientsPool := createClusterClientsPool(g)
 
 	err := clientsPool.Add(
 		clustersmngr.ClientConfigWithUser(&auth.UserPrincipal{}),
@@ -422,7 +423,7 @@ func TestClientDelete(t *testing.T) {
 	clusterName := "mycluster"
 	appName := "myapp" + rand.String(5)
 
-	clientsPool := clustersmngr.NewClustersClientsPool(kube.CreateScheme())
+	clientsPool := createClusterClientsPool(g)
 
 	err := clientsPool.Add(
 		clustersmngr.ClientConfigWithUser(&auth.UserPrincipal{}),
@@ -465,7 +466,7 @@ func TestClientUpdate(t *testing.T) {
 	clusterName := "mycluster"
 	appName := "myapp" + rand.String(5)
 
-	clientsPool := clustersmngr.NewClustersClientsPool(kube.CreateScheme())
+	clientsPool := createClusterClientsPool(g)
 
 	err := clientsPool.Add(
 		clustersmngr.ClientConfigWithUser(&auth.UserPrincipal{}),
@@ -513,7 +514,7 @@ func TestClientPatch(t *testing.T) {
 	clusterName := "mycluster"
 	appName := "myapp" + rand.String(5)
 
-	clientsPool := clustersmngr.NewClustersClientsPool(kube.CreateScheme())
+	clientsPool := createClusterClientsPool(g)
 
 	err := clientsPool.Add(
 		clustersmngr.ClientConfigWithUser(&auth.UserPrincipal{}),
@@ -567,4 +568,13 @@ func createNamespace(g *GomegaWithT) *corev1.Namespace {
 	g.Expect(k8sEnv.Client.Create(context.Background(), ns)).To(Succeed())
 
 	return ns
+}
+
+func createClusterClientsPool(g *GomegaWithT) clustersmngr.ClientsPool {
+	scheme, err := kube.CreateScheme()
+	g.Expect(err).To(BeNil())
+
+	clientsPool := clustersmngr.NewClustersClientsPool(scheme)
+
+	return clientsPool
 }

--- a/core/clustersmngr/factory_test.go
+++ b/core/clustersmngr/factory_test.go
@@ -28,8 +28,11 @@ func TestGetImpersonatedClient(t *testing.T) {
 
 	clustersFetcher := fetcher.NewSingleClusterFetcher(k8sEnv.Rest)
 
-	clientsFactory := clustersmngr.NewClientFactory(clustersFetcher, nsChecker, logger, kube.CreateScheme(), clustersmngr.NewClustersClientsPool)
-	err := clientsFactory.UpdateClusters(ctx)
+	scheme, err := kube.CreateScheme()
+	g.Expect(err).To(BeNil())
+
+	clientsFactory := clustersmngr.NewClientFactory(clustersFetcher, nsChecker, logger, scheme, clustersmngr.NewClustersClientsPool)
+	err = clientsFactory.UpdateClusters(ctx)
 	g.Expect(err).To(BeNil())
 
 	err = clientsFactory.UpdateNamespaces(ctx)
@@ -65,8 +68,11 @@ func TestGetImpersonatedDiscoveryClient(t *testing.T) {
 
 	clustersFetcher := fetcher.NewSingleClusterFetcher(k8sEnv.Rest)
 
-	clientsFactory := clustersmngr.NewClientFactory(clustersFetcher, nsChecker, logger, kube.CreateScheme(), clustersmngr.NewClustersClientsPool)
-	err := clientsFactory.UpdateClusters(ctx)
+	scheme, err := kube.CreateScheme()
+	g.Expect(err).To(BeNil())
+
+	clientsFactory := clustersmngr.NewClientFactory(clustersFetcher, nsChecker, logger, scheme, clustersmngr.NewClustersClientsPool)
+	err = clientsFactory.UpdateClusters(ctx)
 	g.Expect(err).To(BeNil())
 
 	err = clientsFactory.UpdateNamespaces(ctx)
@@ -85,7 +91,11 @@ func TestUpdateNamespaces(t *testing.T) {
 	ctx := context.Background()
 	nsChecker := &nsaccessfakes.FakeChecker{}
 	clustersFetcher := new(clustersmngrfakes.FakeClusterFetcher)
-	clientsFactory := clustersmngr.NewClientFactory(clustersFetcher, nsChecker, logger, kube.CreateScheme(), clustersmngr.NewClustersClientsPool)
+
+	scheme, err := kube.CreateScheme()
+	g.Expect(err).To(BeNil())
+
+	clientsFactory := clustersmngr.NewClientFactory(clustersFetcher, nsChecker, logger, scheme, clustersmngr.NewClustersClientsPool)
 
 	clusterName1 := "foo"
 	clusterName2 := "bar"
@@ -126,7 +136,11 @@ func TestUpdateUsers(t *testing.T) {
 	ctx := context.Background()
 	nsChecker := &nsaccessfakes.FakeChecker{}
 	clustersFetcher := new(clustersmngrfakes.FakeClusterFetcher)
-	clientsFactory := clustersmngr.NewClientFactory(clustersFetcher, nsChecker, logger, kube.CreateScheme(), clustersmngr.NewClustersClientsPool)
+
+	scheme, err := kube.CreateScheme()
+	g.Expect(err).To(BeNil())
+
+	clientsFactory := clustersmngr.NewClientFactory(clustersFetcher, nsChecker, logger, scheme, clustersmngr.NewClustersClientsPool)
 
 	clusterName1 := "foo"
 	clusterName2 := "bar"

--- a/core/nsaccess/nsaccess_test.go
+++ b/core/nsaccess/nsaccess_test.go
@@ -36,8 +36,11 @@ func TestFilterAccessibleNamespaces(t *testing.T) {
 		}
 	}()
 
+	scheme, err := kube.CreateScheme()
+	g.Expect(err).To(BeNil())
+
 	adminClient, err := client.New(testCfg, client.Options{
-		Scheme: kube.CreateScheme(),
+		Scheme: scheme,
 	})
 	g.Expect(err).NotTo(HaveOccurred())
 
@@ -290,8 +293,13 @@ func createRole(t *testing.T, cl client.Client, key types.NamespacedName, rules 
 func newRestConfigWithRole(t *testing.T, testCfg *rest.Config, roleName types.NamespacedName, rules []rbacv1.PolicyRule) *rest.Config {
 	t.Helper()
 
+	scheme, err := kube.CreateScheme()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	adminClient, err := client.New(testCfg, client.Options{
-		Scheme: kube.CreateScheme(),
+		Scheme: scheme,
 	})
 
 	if err != nil {

--- a/core/server/events_test.go
+++ b/core/server/events_test.go
@@ -22,8 +22,11 @@ func TestListEvents(t *testing.T) {
 
 	c, _ := makeGRPCServer(k8sEnv.Rest, t)
 
+	scheme, err := kube.CreateScheme()
+	g.Expect(err).To(BeNil())
+
 	k, err := client.New(k8sEnv.Rest, client.Options{
-		Scheme: kube.CreateScheme(),
+		Scheme: scheme,
 	})
 	g.Expect(err).NotTo(HaveOccurred())
 

--- a/core/server/fluxruntime_test.go
+++ b/core/server/fluxruntime_test.go
@@ -26,8 +26,11 @@ func TestGetReconciledObjects(t *testing.T) {
 
 	c, _ := makeGRPCServer(k8sEnv.Rest, t)
 
+	scheme, err := kube.CreateScheme()
+	g.Expect(err).To(BeNil())
+
 	k, err := client.New(k8sEnv.Rest, client.Options{
-		Scheme: kube.CreateScheme(),
+		Scheme: scheme,
 	})
 	g.Expect(err).NotTo(HaveOccurred())
 
@@ -141,7 +144,10 @@ func TestGetChildObjects(t *testing.T) {
 		Name:       deployment.Name,
 	}})
 
-	client := fake.NewClientBuilder().WithScheme(kube.CreateScheme()).WithRuntimeObjects(&ns, deployment, rs).Build()
+	scheme, err := kube.CreateScheme()
+	g.Expect(err).To(BeNil())
+
+	client := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(&ns, deployment, rs).Build()
 	cfg := makeServerConfig(client, t)
 	c := makeServer(cfg, t)
 

--- a/core/server/helm_release_test.go
+++ b/core/server/helm_release_test.go
@@ -27,8 +27,11 @@ func TestListHelmReleases(t *testing.T) {
 
 	c, _ := makeGRPCServer(k8sEnv.Rest, t)
 
+	scheme, err := kube.CreateScheme()
+	g.Expect(err).To(BeNil())
+
 	k, err := client.New(k8sEnv.Rest, client.Options{
-		Scheme: kube.CreateScheme(),
+		Scheme: scheme,
 	})
 	g.Expect(err).NotTo(HaveOccurred())
 
@@ -49,8 +52,11 @@ func TestListHelmReleases_inMultipleNamespaces(t *testing.T) {
 
 	c, _ := makeGRPCServer(k8sEnv.Rest, t)
 
+	scheme, err := kube.CreateScheme()
+	g.Expect(err).To(BeNil())
+
 	k, err := client.New(k8sEnv.Rest, client.Options{
-		Scheme: kube.CreateScheme(),
+		Scheme: scheme,
 	})
 	g.Expect(err).NotTo(HaveOccurred())
 
@@ -84,8 +90,11 @@ func TestGetHelmRelease(t *testing.T) {
 
 	c, _ := makeGRPCServer(k8sEnv.Rest, t)
 
+	scheme, err := kube.CreateScheme()
+	g.Expect(err).To(BeNil())
+
 	k, err := client.New(k8sEnv.Rest, client.Options{
-		Scheme: kube.CreateScheme(),
+		Scheme: scheme,
 	})
 	g.Expect(err).NotTo(HaveOccurred())
 
@@ -135,8 +144,11 @@ func TestGetHelmRelease_withInventory(t *testing.T) {
 
 	c, _ := makeGRPCServer(k8sEnv.Rest, t)
 
+	scheme, err := kube.CreateScheme()
+	g.Expect(err).To(BeNil())
+
 	k, err := client.New(k8sEnv.Rest, client.Options{
-		Scheme: kube.CreateScheme(),
+		Scheme: scheme,
 	})
 	g.Expect(err).NotTo(HaveOccurred())
 
@@ -219,8 +231,11 @@ func TestGetHelmRelease_withInventoryCompressed(t *testing.T) {
 
 	c, _ := makeGRPCServer(k8sEnv.Rest, t)
 
+	scheme, err := kube.CreateScheme()
+	g.Expect(err).To(BeNil())
+
 	k, err := client.New(k8sEnv.Rest, client.Options{
-		Scheme: kube.CreateScheme(),
+		Scheme: scheme,
 	})
 	g.Expect(err).NotTo(HaveOccurred())
 

--- a/core/server/kustomization_test.go
+++ b/core/server/kustomization_test.go
@@ -28,8 +28,11 @@ func TestListKustomizations(t *testing.T) {
 
 	c, _ := makeGRPCServer(k8sEnv.Rest, t)
 
+	scheme, err := kube.CreateScheme()
+	g.Expect(err).To(BeNil())
+
 	k, err := client.New(k8sEnv.Rest, client.Options{
-		Scheme: kube.CreateScheme(),
+		Scheme: scheme,
 	})
 	g.Expect(err).NotTo(HaveOccurred())
 
@@ -51,8 +54,11 @@ func TestListKustomizations_inMultipleNamespaces(t *testing.T) {
 
 	c, _ := makeGRPCServer(k8sEnv.Rest, t)
 
+	scheme, err := kube.CreateScheme()
+	g.Expect(err).To(BeNil())
+
 	k, err := client.New(k8sEnv.Rest, client.Options{
-		Scheme: kube.CreateScheme(),
+		Scheme: scheme,
 	})
 	g.Expect(err).NotTo(HaveOccurred())
 
@@ -86,8 +92,11 @@ func TestListKustomizationPagination(t *testing.T) {
 	ctx := context.Background()
 	c, _ := makeGRPCServer(k8sEnv.Rest, t)
 
+	scheme, err := kube.CreateScheme()
+	g.Expect(err).To(BeNil())
+
 	k, err := client.New(k8sEnv.Rest, client.Options{
-		Scheme: kube.CreateScheme(),
+		Scheme: scheme,
 	})
 	g.Expect(err).NotTo(HaveOccurred())
 
@@ -139,8 +148,11 @@ func TestGetKustomization(t *testing.T) {
 
 	c, _ := makeGRPCServer(k8sEnv.Rest, t)
 
+	scheme, err := kube.CreateScheme()
+	g.Expect(err).To(BeNil())
+
 	k, err := client.New(k8sEnv.Rest, client.Options{
-		Scheme: kube.CreateScheme(),
+		Scheme: scheme,
 	})
 	g.Expect(err).NotTo(HaveOccurred())
 

--- a/core/server/objects_test.go
+++ b/core/server/objects_test.go
@@ -23,8 +23,11 @@ func TestGetObject(t *testing.T) {
 
 	c, _ := makeGRPCServer(k8sEnv.Rest, t)
 
+	scheme, err := kube.CreateScheme()
+	g.Expect(err).To(BeNil())
+
 	k, err := client.New(k8sEnv.Rest, client.Options{
-		Scheme: kube.CreateScheme(),
+		Scheme: scheme,
 	})
 	g.Expect(err).NotTo(HaveOccurred())
 
@@ -88,12 +91,15 @@ func TestGetObjectOtherKinds(t *testing.T) {
 	appName := "myapp"
 	dep := newDeployment(appName, ns.Name)
 
-	client := fake.NewClientBuilder().WithScheme(kube.CreateScheme()).WithRuntimeObjects(&ns, dep).Build()
+	scheme, err := kube.CreateScheme()
+	g.Expect(err).To(BeNil())
+
+	client := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(&ns, dep).Build()
 	cfg := makeServerConfig(client, t)
 
 	c := makeServer(cfg, t)
 
-	_, err := c.GetObject(ctx, &pb.GetObjectRequest{
+	_, err = c.GetObject(ctx, &pb.GetObjectRequest{
 		Name:        appName,
 		Namespace:   ns.Name,
 		Kind:        "deployment",

--- a/core/server/sources_test.go
+++ b/core/server/sources_test.go
@@ -19,8 +19,11 @@ func TestListGitRepositories(t *testing.T) {
 
 	c, _ := makeGRPCServer(k8sEnv.Rest, t)
 
+	scheme, err := kube.CreateScheme()
+	g.Expect(err).To(BeNil())
+
 	k, err := client.New(k8sEnv.Rest, client.Options{
-		Scheme: kube.CreateScheme(),
+		Scheme: scheme,
 	})
 	g.Expect(err).NotTo(HaveOccurred())
 
@@ -41,8 +44,11 @@ func TestListHelmRepositories(t *testing.T) {
 
 	c, _ := makeGRPCServer(k8sEnv.Rest, t)
 
+	scheme, err := kube.CreateScheme()
+	g.Expect(err).To(BeNil())
+
 	k, err := client.New(k8sEnv.Rest, client.Options{
-		Scheme: kube.CreateScheme(),
+		Scheme: scheme,
 	})
 	g.Expect(err).NotTo(HaveOccurred())
 
@@ -68,8 +74,11 @@ func TestListGitRepositories_inMultipleNamespaces(t *testing.T) {
 
 	c, _ := makeGRPCServer(k8sEnv.Rest, t)
 
+	scheme, err := kube.CreateScheme()
+	g.Expect(err).To(BeNil())
+
 	k, err := client.New(k8sEnv.Rest, client.Options{
-		Scheme: kube.CreateScheme(),
+		Scheme: scheme,
 	})
 	g.Expect(err).NotTo(HaveOccurred())
 
@@ -102,8 +111,11 @@ func TestListHelmRepositories_inMultipleNamespaces(t *testing.T) {
 
 	c, _ := makeGRPCServer(k8sEnv.Rest, t)
 
+	scheme, err := kube.CreateScheme()
+	g.Expect(err).To(BeNil())
+
 	k, err := client.New(k8sEnv.Rest, client.Options{
-		Scheme: kube.CreateScheme(),
+		Scheme: scheme,
 	})
 	g.Expect(err).NotTo(HaveOccurred())
 
@@ -142,8 +154,11 @@ func TestListHelmCharts(t *testing.T) {
 
 	c, _ := makeGRPCServer(k8sEnv.Rest, t)
 
+	scheme, err := kube.CreateScheme()
+	g.Expect(err).To(BeNil())
+
 	k, err := client.New(k8sEnv.Rest, client.Options{
-		Scheme: kube.CreateScheme(),
+		Scheme: scheme,
 	})
 	g.Expect(err).NotTo(HaveOccurred())
 
@@ -175,8 +190,11 @@ func TestListHelmCharts_inMultipleNamespaces(t *testing.T) {
 
 	c, _ := makeGRPCServer(k8sEnv.Rest, t)
 
+	scheme, err := kube.CreateScheme()
+	g.Expect(err).To(BeNil())
+
 	k, err := client.New(k8sEnv.Rest, client.Options{
-		Scheme: kube.CreateScheme(),
+		Scheme: scheme,
 	})
 	g.Expect(err).NotTo(HaveOccurred())
 
@@ -209,8 +227,11 @@ func TestListBuckets(t *testing.T) {
 
 	c, _ := makeGRPCServer(k8sEnv.Rest, t)
 
+	scheme, err := kube.CreateScheme()
+	g.Expect(err).To(BeNil())
+
 	k, err := client.New(k8sEnv.Rest, client.Options{
-		Scheme: kube.CreateScheme(),
+		Scheme: scheme,
 	})
 	g.Expect(err).NotTo(HaveOccurred())
 
@@ -242,8 +263,11 @@ func TestListBuckets_inMultipleNamespaces(t *testing.T) {
 
 	c, _ := makeGRPCServer(k8sEnv.Rest, t)
 
+	scheme, err := kube.CreateScheme()
+	g.Expect(err).To(BeNil())
+
 	k, err := client.New(k8sEnv.Rest, client.Options{
-		Scheme: kube.CreateScheme(),
+		Scheme: scheme,
 	})
 	g.Expect(err).NotTo(HaveOccurred())
 

--- a/core/server/suite_test.go
+++ b/core/server/suite_test.go
@@ -56,7 +56,12 @@ func makeGRPCServer(cfg *rest.Config, t *testing.T) (pb.CoreClient, server.CoreS
 	fetcher := &clustersmngrfakes.FakeClusterFetcher{}
 	fetcher.FetchReturns([]clustersmngr.Cluster{restConfigToCluster(k8sEnv.Rest)}, nil)
 
-	clientsFactory := clustersmngr.NewClientFactory(fetcher, &nsChecker, log, kube.CreateScheme(), clustersmngr.NewClustersClientsPool)
+	scheme, err := kube.CreateScheme()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	clientsFactory := clustersmngr.NewClientFactory(fetcher, &nsChecker, log, scheme, clustersmngr.NewClustersClientsPool)
 
 	coreCfg := server.NewCoreConfig(log, cfg, "foobar", clientsFactory)
 	coreCfg.NSAccess = &nsChecker
@@ -140,7 +145,12 @@ func makeServerConfig(fakeClient client.Client, t *testing.T) server.CoreServerC
 	fetcher := &clustersmngrfakes.FakeClusterFetcher{}
 	fetcher.FetchReturns([]clustersmngr.Cluster{}, nil)
 
-	clientsFactory := clustersmngr.NewClientFactory(fetcher, &nsChecker, log, kube.CreateScheme(), func(scheme *apiruntime.Scheme) clustersmngr.ClientsPool {
+	scheme, err := kube.CreateScheme()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	clientsFactory := clustersmngr.NewClientFactory(fetcher, &nsChecker, log, scheme, func(scheme *apiruntime.Scheme) clustersmngr.ClientsPool {
 		f := &clustersmngrfakes.FakeClientsPool{}
 		f.ClientStub = func(clusterName string) (client.Client, error) { return fakeClient, nil }
 		return f

--- a/core/server/suspend_test.go
+++ b/core/server/suspend_test.go
@@ -19,8 +19,11 @@ func TestSuspend_Suspend(t *testing.T) {
 
 	ctx := context.Background()
 
+	scheme, err := kube.CreateScheme()
+	g.Expect(err).To(BeNil())
+
 	k, err := client.New(k8sEnv.Rest, client.Options{
-		Scheme: kube.CreateScheme(),
+		Scheme: scheme,
 	})
 	g.Expect(err).NotTo(HaveOccurred())
 

--- a/core/server/sync_test.go
+++ b/core/server/sync_test.go
@@ -28,8 +28,11 @@ func TestSync(t *testing.T) {
 
 	c, _ := makeGRPCServer(k8sEnv.Rest, t)
 
+	scheme, err := kube.CreateScheme()
+	g.Expect(err).To(BeNil())
+
 	k, err := client.New(k8sEnv.Rest, client.Options{
-		Scheme: kube.CreateScheme(),
+		Scheme: scheme,
 	})
 	g.Expect(err).NotTo(HaveOccurred())
 

--- a/core/server/version_test.go
+++ b/core/server/version_test.go
@@ -21,8 +21,12 @@ const (
 func TestGetVersion(t *testing.T) {
 	g := NewGomegaWithT(t)
 	c, _ := makeGRPCServer(k8sEnv.Rest, t)
-	_, err := client.New(k8sEnv.Rest, client.Options{
-		Scheme: kube.CreateScheme(),
+
+	scheme, err := kube.CreateScheme()
+	g.Expect(err).To(BeNil())
+
+	_, err = client.New(k8sEnv.Rest, client.Options{
+		Scheme: scheme,
 	})
 
 	g.Expect(err).NotTo(HaveOccurred())
@@ -30,7 +34,7 @@ func TestGetVersion(t *testing.T) {
 	ctx := context.Background()
 
 	_, err = client.New(k8sEnv.Rest, client.Options{
-		Scheme: kube.CreateScheme(),
+		Scheme: scheme,
 	})
 	g.Expect(err).NotTo(HaveOccurred())
 

--- a/pkg/kube/kubehttp.go
+++ b/pkg/kube/kubehttp.go
@@ -20,17 +20,24 @@ import (
 	apiruntime "k8s.io/apimachinery/pkg/runtime"
 )
 
-func CreateScheme() *apiruntime.Scheme {
+func CreateScheme() (*apiruntime.Scheme, error) {
 	scheme := apiruntime.NewScheme()
-	_ = sourcev1.AddToScheme(scheme)
-	_ = kustomizev2.AddToScheme(scheme)
-	_ = helmv2.AddToScheme(scheme)
-	_ = corev1.AddToScheme(scheme)
-	_ = extensionsv1.AddToScheme(scheme)
-	_ = appsv1.AddToScheme(scheme)
-	_ = rbacv1.AddToScheme(scheme)
+	builder := apiruntime.SchemeBuilder{
+		sourcev1.AddToScheme,
+		kustomizev2.AddToScheme,
+		helmv2.AddToScheme,
+		corev1.AddToScheme,
+		extensionsv1.AddToScheme,
+		appsv1.AddToScheme,
+		rbacv1.AddToScheme,
+	}
 
-	return scheme
+	err := builder.AddToScheme(scheme)
+	if err != nil {
+		return nil, fmt.Errorf("could not add to scheme: %w", err)
+	}
+
+	return scheme, nil
 }
 
 const WeGOCRDName = "apps.wego.weave.works"
@@ -54,10 +61,16 @@ var InClusterConfig func() (*rest.Config, error) = func() (*rest.Config, error) 
 var ErrNamespaceNotFound = errors.New("namespace not found")
 
 func NewKubeHTTPClientWithConfig(config *rest.Config, contextName string, additionalSchemes ...func(*apiruntime.Scheme) error) (*KubeHTTP, error) {
-	scheme := CreateScheme()
+	scheme, err := CreateScheme()
+	if err != nil {
+		return nil, fmt.Errorf("could not create scheme: %w", err)
+	}
 
 	for _, add := range additionalSchemes {
-		_ = add(scheme)
+		err = add(scheme)
+		if err != nil {
+			return nil, fmt.Errorf("could not add to scheme: %w", err)
+		}
 	}
 
 	rawClient, err := client.New(config, client.Options{

--- a/pkg/kube/kubehttp.go
+++ b/pkg/kube/kubehttp.go
@@ -31,7 +31,7 @@ func CreateScheme() (*apiruntime.Scheme, error) {
 		extensionsv1.AddToScheme,
 		appsv1.AddToScheme,
 		rbacv1.AddToScheme,
-    authv1.AddToScheme,
+		authv1.AddToScheme,
 	}
 
 	err := builder.AddToScheme(scheme)

--- a/pkg/server/server_suite_test.go
+++ b/pkg/server/server_suite_test.go
@@ -56,9 +56,10 @@ func bufDialer(context.Context, string) (net.Conn, error) {
 }
 
 var _ = BeforeSuite(func() {
-	scheme = kube.CreateScheme()
-
 	var err error
+	scheme, err = kube.CreateScheme()
+	Expect(err).To(BeNil())
+
 	env, err = testutils.StartK8sTestEnvironment([]string{
 		"../../manifests/crds",
 		"../../tools/testcrds",

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -300,7 +300,11 @@ var _ = Describe("ApplicationsServer", func() {
 				var log logr.Logger
 
 				log, sink = testutils.MakeFakeLogr()
-				k8s := fake.NewClientBuilder().WithScheme(kube.CreateScheme()).Build()
+
+				scheme, err := kube.CreateScheme()
+				Expect(err).To(BeNil())
+
+				k8s := fake.NewClientBuilder().WithScheme(scheme).Build()
 
 				fakeFactory := &servicesfakes.FakeFactory{}
 
@@ -314,7 +318,7 @@ var _ = Describe("ApplicationsServer", func() {
 				appsSrv := server.NewApplicationsServer(&cfg, server.WithClientGetter(fakeClientGetter))
 				mux = runtime.NewServeMux(middleware.WithGrpcErrorLogging(log))
 				httpHandler := middleware.WithLogging(log, mux)
-				err := pb.RegisterApplicationsHandlerServer(context.Background(), mux, appsSrv)
+				err = pb.RegisterApplicationsHandlerServer(context.Background(), mux, appsSrv)
 				Expect(err).NotTo(HaveOccurred())
 
 				ts = httptest.NewServer(httpHandler)

--- a/pkg/services/auth/auth_suite_test.go
+++ b/pkg/services/auth/auth_suite_test.go
@@ -18,5 +18,7 @@ func TestGitProviderAuth(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	k8sClient = fake.NewClientBuilder().WithScheme(kube.CreateScheme()).Build()
+	scheme, err := kube.CreateScheme()
+	Expect(err).To(BeNil())
+	k8sClient = fake.NewClientBuilder().WithScheme(scheme).Build()
 })

--- a/pkg/testutils/testutils.go
+++ b/pkg/testutils/testutils.go
@@ -74,7 +74,10 @@ func StartK8sTestEnvironment(crdPaths []string) (*K8sTestEnv, error) {
 		return nil, fmt.Errorf("could not start testEnv: %w", err)
 	}
 
-	scheme := kube.CreateScheme()
+	scheme, err := kube.CreateScheme()
+	if err != nil {
+		return nil, fmt.Errorf("could not create scheme", err)
+	}
 
 	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
 		ClientDisableCacheFor: []client.Object{

--- a/pkg/testutils/testutils.go
+++ b/pkg/testutils/testutils.go
@@ -76,7 +76,7 @@ func StartK8sTestEnvironment(crdPaths []string) (*K8sTestEnv, error) {
 
 	scheme, err := kube.CreateScheme()
 	if err != nil {
-		return nil, fmt.Errorf("could not create scheme", err)
+		return nil, fmt.Errorf("could not create scheme: %w", err)
 	}
 
 	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{


### PR DESCRIPTION
`AddToScheme` method errors was not handled previously. Move to a SchemeBuilder and handle errors. 

Amend usages of `kube.CreateScheme()` to handle error return.