### PR TITLE
Add SubRouterTab Styles

### DIFF
--- a/ui/components/SubRouterTabs.tsx
+++ b/ui/components/SubRouterTabs.tsx
@@ -123,7 +123,7 @@ export default styled(SubRouterTabs).attrs({ className: SubRouterTabs.name })`
   .MuiTabs-fixed {
     height: 32px;
   }
-  .PrivateTabIndicator-root-1 {
+  .MuiTabs-indicator {
     height: 3px;
   }
 `;

--- a/ui/components/SubRouterTabs.tsx
+++ b/ui/components/SubRouterTabs.tsx
@@ -124,6 +124,6 @@ export default styled(SubRouterTabs).attrs({ className: SubRouterTabs.name })`
     height: 32px;
   }
   .PrivateTabIndicator-root-1 {
-    height 3px;
+    height: 3px;
   }
 `;

--- a/ui/components/SubRouterTabs.tsx
+++ b/ui/components/SubRouterTabs.tsx
@@ -68,21 +68,30 @@ function SubRouterTabs({ className, children, rootPath, clearQuery }: Props) {
         indicatorColor="primary"
         value={routesToIndex(routes, window.location.pathname)}
       >
-        {_.map(routes, (route, i) => (
-          <Tab
-            component={ForwardedLink as typeof Link}
-            key={i}
-            to={formatURL(`${route.path}`, clearQuery ? "" : query)}
-            className={`${
-              window.location.pathname.includes(route.path) && "active-tab"
-            }`}
-            label={
-              <Text uppercase bold>
-                {route.name}
-              </Text>
-            }
-          />
-        ))}
+        {_.map(routes, (route, i) => {
+          const bold = window.location.pathname.includes(route.path);
+          return (
+            <Tab
+              component={ForwardedLink as typeof Link}
+              key={i}
+              to={formatURL(`${route.path}`, clearQuery ? "" : query)}
+              className={`${
+                window.location.pathname.includes(route.path) && "active-tab"
+              }`}
+              label={
+                <Text
+                  size="small"
+                  uppercase
+                  bold={bold}
+                  semiBold={!bold}
+                  color={bold ? "primary10" : "neutral30"}
+                >
+                  {route.name}
+                </Text>
+              }
+            />
+          );
+        })}
       </Tabs>
       <Spacer padding="xs" />
       <Switch>
@@ -96,5 +105,25 @@ function SubRouterTabs({ className, children, rootPath, clearQuery }: Props) {
 export default styled(SubRouterTabs).attrs({ className: SubRouterTabs.name })`
   .active-tab {
     background: ${(props) => props.theme.colors.primary}19;
+  }
+  .MuiTab-root {
+    line-height: 1;
+    letter-spacing: 1px;
+    height: 32px;
+    min-height: 32px;
+    width: 132px;
+    @media (min-width: 600px) {
+      min-width: 132px;
+    }
+  }
+  //trust me there's both tab and tabS
+  .MuiTabs-root {
+    min-height: 32px;
+  }
+  .MuiTabs-fixed {
+    height: 32px;
+  }
+  .PrivateTabIndicator-root-1 {
+    height 3px;
   }
 `;


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes #2412

<!-- Describe what has changed in this PR -->
Tab styling now more consistent with Buttons

<img width="1008" alt="image" src="https://user-images.githubusercontent.com/65822698/181092703-32c80a06-034c-4810-8de7-32821ecda3ef.png">

