### PR TITLE
build multi-platform container image upon release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -135,10 +135,15 @@ jobs:
             FLUX_VERSION=${{ env.FLUX_VERSION }}
             LDFLAGS=${{ env.LDFLAGS }}
             GIT_COMMIT=${{ github.sha }}
+      - name: setup qemu
+        uses: docker/setup-qemu-action@v2
+      - name: setup docker buildx
+        uses: docker/setup-buildx-action@v2
       - name: Build and push Docker image
         uses: docker/build-push-action@v2
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
The GitHub Actions "release" workflow now produces a multi-platform container image of Weave GitOps for AMD64 and ARM64.

closes #2055