### PR TITLE
Port forwarding error immediately after installing the GitOps Dashboard not on the same run when installing Flux

### DIFF
--- a/pkg/run/install_dev_bucket_server.go
+++ b/pkg/run/install_dev_bucket_server.go
@@ -182,7 +182,7 @@ func InstallDevBucketServer(log logger.Logger, kubeClient *kube.KubeHTTP, config
 		ContainerPort: "9000",
 	}
 	// get pod from specMap
-	pod, err := GetPodFromSpecMap(specMap, kubeClient)
+	pod, err := GetPodFromSpecMap(specMap, kubeClient, corev1.PodRunning)
 	if err != nil {
 		log.Failuref("Error getting pod from specMap: %v", err)
 	}


### PR DESCRIPTION
Closes #2489 

It looks like the bug was caused by a big "typo": when moving the "wait for dashboard ready"code to a separate file, I copied only the wait for reconciliation code, twice. 🤦 

So, I've added code to wait for the dashboard reconciliation and pod running properly. It is working as expected now.

Questions:

1) Is it OK to use the pod and wait for its status == running to wait for dashboard ready?

I also have some old code which seems to work for our purpose, but it uses a HelmRelease:

```
// wait for dashboard to be ready
if err := wait.Poll(interval, timeout, func() (bool, error) {
	dashboard := &helmv2.HelmRelease{}
	if err := kubeClient.Get(context.Background(), types.NamespacedName{
		Namespace: namespace,
		Name:      helmReleaseName,
	}, dashboard); err != nil {
		return false, err
	}

	return apimeta.IsStatusConditionPresentAndEqual(dashboard.Status.Conditions, meta.ReadyCondition, metav1.ConditionTrue), nil
}); err != nil {
	return err
}
```

But I think it's better to use the pod instead of the HelmRelease, correct?

2) Is it OK to add getting the pod the way I did with `GetPodFromSpecMap`? Because I don't actually need the whole specmap.

3) Also added getting any type of pods, including non-running pods with `GetPodFromSpecMap`. 

@chanwit, @ozamosi are you OK with that or do you know of a better way? Would it be better to wait for the deployment object ready instead? If yes, how can I get it?

4) I tried just directly getting the pod with kubeClient by name, but its name looks like that `ww-gitops-weave-gitops-96b7c495f-vsp8c` and names without this suffix do not work.

So, if you know how to get the pod directly with kubeClient based on the name without the suffix, I would not need to use `GetPodFromSpecMap`.