### PR TITLE
2489 gitops run port forwarding error follow up

### DIFF
--- a/cmd/gitops/beta/run/cmd.go
+++ b/cmd/gitops/beta/run/cmd.go
@@ -30,7 +30,6 @@ import (
 	"github.com/weaveworks/weave-gitops/pkg/logger"
 	"github.com/weaveworks/weave-gitops/pkg/run"
 	"github.com/weaveworks/weave-gitops/pkg/version"
-	corev1 "k8s.io/api/core/v1"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -395,7 +394,7 @@ func betaRunCommandRunE(opts *config.Options) func(*cobra.Command, []string) err
 							}
 
 							// get pod from specMap
-							pod, err := run.GetPodFromSpecMap(specMap, kubeClient, corev1.PodRunning)
+							pod, err := run.GetPodFromSpecMap(specMap, kubeClient)
 							if err != nil {
 								log.Failuref("Error getting pod from specMap: %v", err)
 							}

--- a/cmd/gitops/beta/run/cmd.go
+++ b/cmd/gitops/beta/run/cmd.go
@@ -23,6 +23,7 @@ import (
 	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
 	"github.com/spf13/cobra"
+	wego "github.com/weaveworks/weave-gitops/api/v1alpha1"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/cmderrors"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/config"
 	clilogger "github.com/weaveworks/weave-gitops/cmd/gitops/logger"
@@ -247,7 +248,7 @@ func betaRunCommandRunE(opts *config.Options) func(*cobra.Command, []string) err
 
 		log.Actionf("Checking if GitOps Dashboard is already installed ...")
 
-		dashboardInstalled := run.IsDashboardInstalled(log, ctx, kubeClient)
+		dashboardInstalled := run.IsDashboardInstalled(log, ctx, kubeClient, wego.DefaultNamespace)
 
 		if dashboardInstalled {
 			log.Successf("GitOps Dashboard is found")
@@ -259,7 +260,7 @@ func betaRunCommandRunE(opts *config.Options) func(*cobra.Command, []string) err
 			}
 			_, err = prompt.Run()
 			if err == nil {
-				err = run.InstallDashboard(log, ctx, kubeClient, kubeConfigArgs)
+				err = run.InstallDashboard(log, ctx, kubeClient, kubeConfigArgs, wego.DefaultNamespace)
 				if err != nil {
 					return fmt.Errorf("gitops dashboard installation failed: %w", err)
 				} else {
@@ -281,7 +282,7 @@ func betaRunCommandRunE(opts *config.Options) func(*cobra.Command, []string) err
 		}
 
 		if dashboardInstalled {
-			log.Actionf("Request reconciliation of dashboard ...")
+			log.Actionf("Request reconciliation of dashboard (timeout %v) ...", flags.Timeout)
 
 			if err := run.ReconcileDashboard(kubeClient, flags.Namespace, flags.Timeout, flags.DashboardPort); err != nil {
 				log.Failuref("Error requesting reconciliation of dashboard: %v", err.Error())

--- a/pkg/run/errors.go
+++ b/pkg/run/errors.go
@@ -1,0 +1,11 @@
+package run
+
+import "errors"
+
+var (
+	ErrNoPodsForService           = errors.New("no pods found for service")
+	ErrNoPodsForDeployment        = errors.New("no pods found for deployment")
+	ErrNoRunningPodsForService    = errors.New("no running pods found for service")
+	ErrNoRunningPodsForDeployment = errors.New("no running pods found for deployment")
+	ErrDashboardPodNotFound       = errors.New("dashboard pod not found")
+)

--- a/pkg/run/forward_port.go
+++ b/pkg/run/forward_port.go
@@ -148,7 +148,7 @@ func GetPodFromSpecMap(specMap *PortForwardSpec, kubeClient client.Client) (*cor
 		}
 
 		if len(podList.Items) == 0 {
-			return nil, errors.New("no pods found for service")
+			return nil, ErrNoPodsForService
 		}
 
 		for _, pod := range podList.Items {
@@ -157,7 +157,7 @@ func GetPodFromSpecMap(specMap *PortForwardSpec, kubeClient client.Client) (*cor
 			}
 		}
 
-		return nil, errors.New("no running pods found for service")
+		return nil, ErrNoRunningPodsForService
 	case "deployment":
 		deployment := &appsv1.Deployment{}
 		if err := kubeClient.Get(context.Background(), namespacedName, deployment); err != nil {
@@ -176,7 +176,7 @@ func GetPodFromSpecMap(specMap *PortForwardSpec, kubeClient client.Client) (*cor
 		}
 
 		if len(podList.Items) == 0 {
-			return nil, errors.New("no pods found for deployment")
+			return nil, ErrNoPodsForDeployment
 		}
 
 		for _, pod := range podList.Items {
@@ -185,7 +185,7 @@ func GetPodFromSpecMap(specMap *PortForwardSpec, kubeClient client.Client) (*cor
 			}
 		}
 
-		return nil, errors.New("no running pods found for deployment")
+		return nil, ErrNoRunningPodsForDeployment
 	}
 
 	return nil, errors.New("unsupported spec kind")

--- a/pkg/run/install_dashboard.go
+++ b/pkg/run/install_dashboard.go
@@ -35,7 +35,7 @@ const (
 )
 
 // InstallDashboard installs the GitOps Dashboard.
-func InstallDashboard(log logger.Logger, ctx context.Context, kubeClient client.Client, kubeConfigArgs *genericclioptions.ConfigFlags) error {
+func InstallDashboard(log logger.Logger, ctx context.Context, kubeClient client.Client, kubeConfigArgs *genericclioptions.ConfigFlags, namespace string) error {
 	log.Actionf("Installing the GitOps Dashboard ...")
 
 	password, err := utils.ReadPasswordFromStdin(log, "Please enter your password to generate the secret: ")
@@ -55,8 +55,8 @@ func InstallDashboard(log logger.Logger, ctx context.Context, kubeClient client.
 
 	log.Actionf("Installing the GitOps Dashboard ...")
 
-	helmRepository := makeHelmRepository()
-	helmRelease, err := makeHelmRelease(log, string(secret))
+	helmRepository := makeHelmRepository(namespace)
+	helmRelease, err := makeHelmRelease(log, string(secret), namespace)
 
 	if err != nil {
 		log.Failuref("Creating HelmRelease failed")
@@ -85,10 +85,10 @@ func InstallDashboard(log logger.Logger, ctx context.Context, kubeClient client.
 }
 
 // IsDashboardInstalled checks if the GitOps Dashboard is installed.
-func IsDashboardInstalled(log logger.Logger, ctx context.Context, kubeClient client.Client) bool {
+func IsDashboardInstalled(log logger.Logger, ctx context.Context, kubeClient client.Client, namespace string) bool {
 	helmChart := sourcev1.HelmChart{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: wego.DefaultNamespace,
+			Namespace: namespace,
 			Name:      helmChartNamespacedName,
 		},
 	}
@@ -104,7 +104,7 @@ func EnablePortForwardingForDashboard(log logger.Logger, kubeClient client.Clien
 	specMap := &PortForwardSpec{
 		Namespace:     namespace,
 		Name:          podName,
-		Kind:          "service",
+		Kind:          "deployment",
 		HostPort:      dashboardPort,
 		ContainerPort: server.DefaultPort,
 	}
@@ -135,23 +135,26 @@ func EnablePortForwardingForDashboard(log logger.Logger, kubeClient client.Clien
 		return cancelPortFwd, nil
 	}
 
-	return nil, fmt.Errorf("dashboard pod not found")
+	return nil, ErrDashboardPodNotFound
 }
 
 // ReconcileDashboard reconciles the dashboard.
 func ReconcileDashboard(kubeClient client.Client, namespace string, timeout time.Duration, dashboardPort string) error {
 	const interval = 3 * time.Second / 2
 
+	namespacedName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      helmChartNamespacedName,
+	}
+	gvk := schema.GroupVersionKind{
+		Group:   "source.toolkit.fluxcd.io",
+		Version: "v1beta2",
+		Kind:    "HelmChart",
+	}
+
 	// reconcile dashboard
 	sourceRequestedAt, err := RequestReconciliation(context.Background(), kubeClient,
-		types.NamespacedName{
-			Namespace: namespace,
-			Name:      helmChartNamespacedName,
-		}, schema.GroupVersionKind{
-			Group:   "source.toolkit.fluxcd.io",
-			Version: "v1beta2",
-			Kind:    "HelmChart",
-		})
+		namespacedName, gvk)
 	if err != nil {
 		return err
 	}
@@ -171,19 +174,20 @@ func ReconcileDashboard(kubeClient client.Client, namespace string, timeout time
 		return err
 	}
 
+	// wait for dashboard pod to be running
+	specMap := &PortForwardSpec{
+		Namespace:     namespace,
+		Name:          podName,
+		Kind:          "deployment",
+		HostPort:      dashboardPort,
+		ContainerPort: server.DefaultPort,
+	}
+
 	// wait for dashboard to be ready
 	if err := wait.Poll(interval, timeout, func() (bool, error) {
-		specMap := &PortForwardSpec{
-			Namespace:     wego.DefaultNamespace,
-			Name:          podName,
-			Kind:          "service",
-			HostPort:      dashboardPort,
-			ContainerPort: server.DefaultPort,
-		}
-
-		dashboard, err := GetPodFromSpecMap(specMap, kubeClient)
-		if err != nil {
-			return false, err
+		dashboard, _ := GetPodFromSpecMap(specMap, kubeClient)
+		if dashboard == nil {
+			return false, nil
 		}
 
 		return IsPodStatusConditionPresentAndEqual(dashboard.Status.Conditions, corev1.PodReady, corev1.ConditionTrue), nil
@@ -218,7 +222,7 @@ func generateManifests(log logger.Logger, secret string, helmRepository *sourcev
 }
 
 // makeHelmRepository creates a HelmRepository object for installing the GitOps Dashboard.
-func makeHelmRepository() *sourcev1.HelmRepository {
+func makeHelmRepository(namespace string) *sourcev1.HelmRepository {
 	helmRepository := &sourcev1.HelmRepository{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       sourcev1.HelmRepositoryKind,
@@ -226,7 +230,7 @@ func makeHelmRepository() *sourcev1.HelmRepository {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      helmRepositoryName,
-			Namespace: wego.DefaultNamespace,
+			Namespace: namespace,
 		},
 		Spec: sourcev1.HelmRepositorySpec{
 			URL: helmRepositoryUrl,
@@ -240,7 +244,7 @@ func makeHelmRepository() *sourcev1.HelmRepository {
 }
 
 // makeHelmRelease creates a HelmRelease object for installing the GitOps Dashboard.
-func makeHelmRelease(log logger.Logger, secret string) (*helmv2.HelmRelease, error) {
+func makeHelmRelease(log logger.Logger, secret string, namespace string) (*helmv2.HelmRelease, error) {
 	helmRelease := &helmv2.HelmRelease{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       helmv2.HelmReleaseKind,
@@ -248,7 +252,7 @@ func makeHelmRelease(log logger.Logger, secret string) (*helmv2.HelmRelease, err
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      helmReleaseName,
-			Namespace: wego.DefaultNamespace,
+			Namespace: namespace,
 		},
 		Spec: helmv2.HelmReleaseSpec{
 			Interval: metav1.Duration{

--- a/pkg/run/install_dashboard.go
+++ b/pkg/run/install_dashboard.go
@@ -109,7 +109,7 @@ func EnablePortForwardingForDashboard(log logger.Logger, kubeClient client.Clien
 		ContainerPort: server.DefaultPort,
 	}
 	// get pod from specMap
-	pod, err := GetPodFromSpecMap(specMap, kubeClient, corev1.PodRunning)
+	pod, err := GetPodFromSpecMap(specMap, kubeClient)
 	if err != nil {
 		log.Failuref("Error getting pod from specMap: %v", err)
 	}
@@ -181,7 +181,7 @@ func ReconcileDashboard(kubeClient client.Client, namespace string, timeout time
 			ContainerPort: server.DefaultPort,
 		}
 
-		dashboard, err := GetPodFromSpecMap(specMap, kubeClient, "")
+		dashboard, err := GetPodFromSpecMap(specMap, kubeClient)
 		if err != nil {
 			return false, err
 		}

--- a/pkg/run/install_dashboard.go
+++ b/pkg/run/install_dashboard.go
@@ -186,7 +186,7 @@ func ReconcileDashboard(kubeClient client.Client, namespace string, timeout time
 			return false, err
 		}
 
-		return dashboard.Status.Phase == corev1.PodRunning, nil
+		return IsPodStatusConditionPresentAndEqual(dashboard.Status.Conditions, corev1.PodReady, corev1.ConditionTrue), nil
 	}); err != nil {
 		return err
 	}

--- a/pkg/run/install_dev_bucket_server.go
+++ b/pkg/run/install_dev_bucket_server.go
@@ -181,7 +181,7 @@ func InstallDevBucketServer(log logger.Logger, kubeClient client.Client, config 
 		ContainerPort: "9000",
 	}
 	// get pod from specMap
-	pod, err := GetPodFromSpecMap(specMap, kubeClient, corev1.PodRunning)
+	pod, err := GetPodFromSpecMap(specMap, kubeClient)
 	if err != nil {
 		log.Failuref("Error getting pod from specMap: %v", err)
 	}

--- a/pkg/run/utils.go
+++ b/pkg/run/utils.go
@@ -4,20 +4,22 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
 	"github.com/fluxcd/pkg/apis/meta"
 	"github.com/fsnotify/fsnotify"
 	"github.com/minio/minio-go/v7"
 	"github.com/weaveworks/weave-gitops/pkg/kube"
 	"github.com/weaveworks/weave-gitops/pkg/logger"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
-	"os"
-	"path/filepath"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"strings"
-	"time"
 )
 
 // FindGitRepoDir finds git repo root directory
@@ -215,4 +217,15 @@ func IsLocalCluster(kubeClient *kube.KubeHTTP) bool {
 	} else {
 		return false
 	}
+}
+
+// IsPodStatusConditionPresentAndEqual returns true when conditionType is present and equal to status.
+func IsPodStatusConditionPresentAndEqual(conditions []corev1.PodCondition, conditionType corev1.PodConditionType, status corev1.ConditionStatus) bool {
+	for _, condition := range conditions {
+		if condition.Type == conditionType {
+			return condition.Status == status
+		}
+	}
+
+	return false
 }


### PR DESCRIPTION
Closes #2489 , finally. I tested it and am unable to reproduce the error anymore.

- Removed passing pod status phase to `GetPodFromSpecMap` (added in the previous PR). Now the code is simpler.
- Rolled back error messages to previous versions (without pod phase). Replaced "service" in deployment-related error messages in `GetPodFromSpecMap` with "deployment".
- Added properly waiting for getting the dashboard pod and making sure its pod Ready condition is true.
- Added constants for getting pod errors which are re-used in code or similar errors which could be re-used (also to make checking for specific errors easier). Other `run` pkg errors can be added later.
- Since I was on this, added passing namespace to some dashboard-related functions instead of using `wego.DefaultNamespace`.
- Added a utility function to test pod conditions `IsPodStatusConditionPresentAndEqual`.

Notes:
- The updated fix does not use these constants for checking the returned error, so they are only used once in the `GetPodFromSpecMap` function. So, I can remove them if needed. Just thought that maybe we could start adding some constants for run command error messages already.
- There is a static checks error because of reported vulnerability in the `"@docusaurus` packages:
https://github.com/weaveworks/weave-gitops/runs/7600157647?check_suite_focus=true
I could update them from version `^2.0.0-beta.20` to `^2.0.0-rc.1` (it might fix it, but I have not checked the `node-fetch` version the new version requires) but it is a core package (site generator).

So, it might be better if someone who works on the website checked that this update does not break anything.