### PR TITLE
Update watchNamespaces() with a watcher

### DIFF
--- a/charts/gitops-server/templates/role.yaml
+++ b/charts/gitops-server/templates/role.yaml
@@ -30,5 +30,5 @@ rules:
   # The service account needs to read namespaces to know where it can query
   - apiGroups: [ "" ]
     resources: [ "namespaces" ]
-    verbs: [ "get", "list" ]
+    verbs: [ "get", "list", "watch" ]
 {{- end -}}

--- a/core/clustersmngr/factory_test.go
+++ b/core/clustersmngr/factory_test.go
@@ -17,12 +17,15 @@ import (
 )
 
 func TestGetImpersonatedClient(t *testing.T) {
+	createdNS := make(map[string]struct{})
 	g := NewGomegaWithT(t)
 	logger := logr.Discard()
 	ctx := context.Background()
 
 	ns1 := createNamespace(g)
+	createdNS[ns1.Name] = struct{}{}
 	ns2 := createNamespace(g)
+	createdNS[ns2.Name] = struct{}{}
 
 	nsChecker := &nsaccessfakes.FakeChecker{}
 	nsChecker.FilterAccessibleNamespacesReturns([]v1.Namespace{*ns2}, nil)
@@ -48,7 +51,7 @@ func TestGetImpersonatedClient(t *testing.T) {
 		_, _, nss := nsChecker.FilterAccessibleNamespacesArgsForCall(0)
 		nsFound := 0
 		for _, n := range nss {
-			if n.Name == ns1.Name || n.Name == ns2.Name {
+			if _, ok := createdNS[n.Name]; ok {
 				nsFound++
 			}
 		}

--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,7 @@ require (
 	github.com/weaveworks/go-checkpoint v0.0.0-20170503165305-ebbb8b0518ab
 	go.uber.org/zap v1.23.0
 	golang.org/x/crypto v0.0.0-20220826181053-bd7e27e6170d
+	golang.org/x/exp v0.0.0-20220827204233-334a2380cb91
 	golang.org/x/oauth2 v0.0.0-20220722155238-128564f6959c
 	google.golang.org/genproto v0.0.0-20220715211116-798f69b842b9
 	google.golang.org/grpc v1.48.0

--- a/go.sum
+++ b/go.sum
@@ -1344,6 +1344,8 @@ golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
 golang.org/x/exp v0.0.0-20200331195152-e8c3332aa8e5/go.mod h1:4M0jN8W1tt0AVLNr8HDosyJCDCDuyL9N9+3m7wDWgKw=
+golang.org/x/exp v0.0.0-20220827204233-334a2380cb91 h1:tnebWN09GYg9OLPss1KXj8txwZc6X6uMr6VFdcGNbHw=
+golang.org/x/exp v0.0.0-20220827204233-334a2380cb91/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=


### PR DESCRIPTION
Signed-off-by: Soule BA <bah.soule@gmail.com>

<!-- Describe what has changed in this PR -->
**What changed?**

Instead of polling at fix interval, we use a watcher to update namespaces.


<!-- Tell your future self why have you made these changes -->
**Why was this change made?**

We expect to detect new namespace earlier with this change and to reduce the pressure on the kube-api server.
<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**

<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**

Tested manually and with the existing test suites. The namespaces and workload are seen earlier as expected.
<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**


<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
