### PR TITLE
change docs to refer to the OCI registry for chart storage

### DIFF
--- a/website/docs/getting-started.mdx
+++ b/website/docs/getting-started.mdx
@@ -122,7 +122,7 @@ cd fleet-infra
 ```
 flux create source helm ww-gitops \
   --interval=60m \
-  --url=https://helm.gitops.weave.works \
+  --url=oci://ghcr.io/weaveworks/charts \
   --export > ./clusters/my-cluster/weave-gitops-source.yaml
 ```
 
@@ -136,7 +136,8 @@ metadata:
   namespace: flux-system
 spec:
   interval: 1h0m0s
-  url: https://helm.gitops.weave.works
+  type: oci
+  url: oci://ghcr.io/weaveworks/charts
 ```
 
 3. Commit and push the `weave-gitops-source.yaml` to the `fleet-infra` repository

--- a/website/docs/getting-started.mdx
+++ b/website/docs/getting-started.mdx
@@ -13,7 +13,7 @@ If you haven't already, be sure to check out our [introduction](./intro.md) to W
 ## Before you begin
 
 We will provide a complete walkthrough of getting Flux installed and Weave GitOps configured. However, if you have:
-- an existing cluster bootstrapped Flux 🎉
+- an existing cluster bootstrapped Flux version >= 0.31.0 🎉
 - followed our [installation](./installation.mdx) doc to configure access to the Weave GitOps dashboard then install Weave GitOps 👏
 
 Then you can skip ahead to [Part 1](#part-1---weave-gitops-overview) 🏃
@@ -34,14 +34,20 @@ brew install fluxcd/tap/flux
 
 For For other installation methods, see the relevant [Flux documentation](https://fluxcd.io/docs/installation/#install-the-flux-cli).
 
-2. Export your credentials
+1. Make sure that the CLI version is at least 0.31.0
+
+```
+flux -v
+```
+
+1. Export your credentials
 
 ```
 export GITHUB_TOKEN=<your-token>
 export GITHUB_USER=<your-username>
 ```
 
-3. Check your Kubernetes cluster
+1. Check your Kubernetes cluster
 
 ```
 flux check --pre
@@ -54,7 +60,7 @@ The output is similar to:
 ✔ prerequisites checks passed
 ```
 
-4. Install Flux onto your cluster with the `flux bootstrap` command
+1. Install Flux onto your cluster with the `flux bootstrap` command
 
 ```
 flux bootstrap github \

--- a/website/docs/installation.mdx
+++ b/website/docs/installation.mdx
@@ -32,6 +32,9 @@ This version of Weave GitOps is tested against the following Flux releases:
 * 0.31
 
 ### Install the Helm Chart
+
+⚠️ Note that the following instructions require Flux version 0.31.0 or later to make use of the OCI registry for Helm chart storage. If your Flux version is older, please upgrade prior to following the instructions below. ⚠️.
+
 Weave GitOps is provided through a Helm Chart and installed as a Flux resource through a `HelmRepository` and `HelmRelease`. To install on your cluster, adjust the following so that `username` is the username you want and `passwordHash` is a bcrypt hash of your password, and commit the file to the location bootstrapped with Flux so that it is synchronized to your Cluster.
 
 ```

--- a/website/docs/installation.mdx
+++ b/website/docs/installation.mdx
@@ -62,7 +62,8 @@ metadata:
   namespace: flux-system
 spec:
   interval: 60m0s
-  url: https://helm.gitops.weave.works
+  type: oci
+  url: oci://ghcr.io/weaveworks/charts
 ```
 
 There are many other values you can configure - for more information, see [our value file reference](./references/helm-reference.md).


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->

<!-- Describe what has changed in this PR -->
**What changed?**

Revised all public-facing documentation to refer to the ghcr.io OCI registry for chart storage.


<!-- Tell your future self why have you made these changes -->
**Why was this change made?**

OCI is more efficient in terms of resource usage by Flux (no index to
be cached etc.) and in terms of maintenance as no index has to be
created and published.

The existing HTTPS Helm repository may also have led to issues with
caching as hinted to by the discussion in
https://github.com/fluxcd/flux2/discussions/2939.

Preview: https://staging.docs.gitops.weave.works/docs/next/installation