### PR TITLE
cli: Move CLI logger out of internal

### DIFF
--- a/cmd/gitops/add/profiles/cmd.go
+++ b/cmd/gitops/add/profiles/cmd.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/cmderrors"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/config"
+	"github.com/weaveworks/weave-gitops/cmd/gitops/logger"
 	"github.com/weaveworks/weave-gitops/cmd/internal"
 	"github.com/weaveworks/weave-gitops/pkg/adapters"
 	"github.com/weaveworks/weave-gitops/pkg/flux"
@@ -65,9 +66,9 @@ func addProfileCmdPreRunE(endpoint *string) func(*cobra.Command, []string) error
 
 func addProfileCmdRunE(opts *config.Options, client *adapters.HTTPClient) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
-		log := internal.NewCLILogger(os.Stdout)
+		log := logger.NewCLILogger(os.Stdout)
 		fluxClient := flux.New(&runner.CLIRunner{})
-		factory := services.NewFactory(fluxClient, internal.Logr())
+		factory := services.NewFactory(fluxClient, logger.Logr())
 		providerClient := internal.NewGitProviderClient(os.Stdout, os.LookupEnv, log)
 
 		err := client.ConfigureClientWithOptions(opts, os.Stdout)

--- a/cmd/gitops/beta/run/cmd.go
+++ b/cmd/gitops/beta/run/cmd.go
@@ -7,11 +7,12 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"strings"
 	"sync/atomic"
 	"syscall"
 	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/fluxcd/flux2/pkg/manifestgen/install"
 	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1beta2"
@@ -24,7 +25,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/cmderrors"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/config"
-	"github.com/weaveworks/weave-gitops/cmd/internal"
+	clilogger "github.com/weaveworks/weave-gitops/cmd/gitops/logger"
 	"github.com/weaveworks/weave-gitops/pkg/kube"
 	"github.com/weaveworks/weave-gitops/pkg/logger"
 	"github.com/weaveworks/weave-gitops/pkg/run"
@@ -70,7 +71,7 @@ gitops beta run . [flags]
 # Run the sync against the dev overlay path
 gitops beta run ./deploy/overlays/dev
 
-# Run the sync on the dev directory and forward the port. 
+# Run the sync on the dev directory and forward the port.
 # Listen on port 8080 on localhost, forwarding to 5000 in a pod of the service app.
 gitops beta run ./dev --port-forward port=8080:5000,resource=svc/app
 
@@ -176,7 +177,7 @@ func betaRunCommandRunE(opts *config.Options) func(*cobra.Command, []string) err
 			return err
 		}
 
-		log := internal.NewCLILogger(os.Stdout)
+		log := clilogger.NewCLILogger(os.Stdout)
 
 		if flags.KubeConfig != "" {
 			kubeConfigArgs.KubeConfig = &flags.KubeConfig

--- a/cmd/gitops/get/profiles/cmd.go
+++ b/cmd/gitops/get/profiles/cmd.go
@@ -7,7 +7,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/cmderrors"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/config"
-	"github.com/weaveworks/weave-gitops/cmd/internal"
+	"github.com/weaveworks/weave-gitops/cmd/gitops/logger"
 	"github.com/weaveworks/weave-gitops/pkg/adapters"
 	"github.com/weaveworks/weave-gitops/pkg/services/profiles"
 	"k8s.io/cli-runtime/pkg/printers"
@@ -53,6 +53,6 @@ func getProfilesCmdRunE(opts *config.Options, client *adapters.HTTPClient) func(
 
 		defer w.Flush()
 
-		return profiles.NewService(internal.NewCLILogger(os.Stdout)).Get(context.Background(), client, w)
+		return profiles.NewService(logger.NewCLILogger(os.Stdout)).Get(context.Background(), client, w)
 	}
 }

--- a/cmd/gitops/logger/logger.go
+++ b/cmd/gitops/logger/logger.go
@@ -1,4 +1,4 @@
-package internal
+package logger
 
 import (
 	"fmt"

--- a/cmd/gitops/logger/logger_test.go
+++ b/cmd/gitops/logger/logger_test.go
@@ -1,4 +1,4 @@
-package internal
+package logger
 
 import (
 	"bytes"

--- a/cmd/gitops/update/profiles/profiles.go
+++ b/cmd/gitops/update/profiles/profiles.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/cmderrors"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/config"
+	"github.com/weaveworks/weave-gitops/cmd/gitops/logger"
 	"github.com/weaveworks/weave-gitops/cmd/internal"
 	"github.com/weaveworks/weave-gitops/pkg/adapters"
 	"github.com/weaveworks/weave-gitops/pkg/flux"
@@ -64,9 +65,9 @@ func updateProfileCmdPreRunE(endpoint *string) func(*cobra.Command, []string) er
 
 func updateProfileCmdRunE(opts *config.Options, client *adapters.HTTPClient) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
-		log := internal.NewCLILogger(os.Stdout)
+		log := logger.NewCLILogger(os.Stdout)
 		fluxClient := flux.New(&runner.CLIRunner{})
-		factory := services.NewFactory(fluxClient, internal.Logr())
+		factory := services.NewFactory(fluxClient, logger.Logr())
 		providerClient := internal.NewGitProviderClient(os.Stdout, os.LookupEnv, log)
 
 		err := client.ConfigureClientWithOptions(opts, os.Stdout)

--- a/cmd/gitops/upgrade/cmd.go
+++ b/cmd/gitops/upgrade/cmd.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 	wego "github.com/weaveworks/weave-gitops/api/v1alpha1"
+	"github.com/weaveworks/weave-gitops/cmd/gitops/logger"
 	"github.com/weaveworks/weave-gitops/cmd/internal"
 	"github.com/weaveworks/weave-gitops/pkg/flux"
 	"github.com/weaveworks/weave-gitops/pkg/kube"
@@ -64,9 +65,9 @@ func upgradeCmdRunE() func(*cobra.Command, []string) error {
 		// FIXME: maybe a better way to do this?
 		upgradeCmdFlags.Namespace = namespace
 
-		log := internal.NewCLILogger(os.Stdout)
+		log := logger.NewCLILogger(os.Stdout)
 		fluxClient := flux.New(&runner.CLIRunner{})
-		factory := services.NewFactory(fluxClient, internal.Logr())
+		factory := services.NewFactory(fluxClient, logger.Logr())
 
 		providerClient := internal.NewGitProviderClient(os.Stdout, os.LookupEnv, log)
 

--- a/cmd/gitops/version/cmd.go
+++ b/cmd/gitops/version/cmd.go
@@ -5,7 +5,7 @@ import (
 	"os"
 
 	"github.com/weaveworks/go-checkpoint"
-	"github.com/weaveworks/weave-gitops/cmd/internal"
+	"github.com/weaveworks/weave-gitops/cmd/gitops/logger"
 
 	"github.com/spf13/cobra"
 )
@@ -34,7 +34,7 @@ func runCmd(cmd *cobra.Command, args []string) {
 
 // CheckVersion looks to see if there is a newer version of the software available
 func CheckVersion(p *checkpoint.CheckParams) {
-	log := internal.NewCLILogger(os.Stdout)
+	log := logger.NewCLILogger(os.Stdout)
 	checkResponse, err := checkpoint.Check(p)
 
 	if err == nil && checkResponse.Outdated {


### PR DESCRIPTION
This will allow commands to be moved around without getting blocked by
the logger being inside the internal module, which is a prerequisite
for #1992.