### PR TITLE
docs: Use new algolia to re-enable search

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -81,8 +81,8 @@ module.exports = {
       copyright: `Copyright © ${new Date().getFullYear()} Weaveworks`,
     },
     algolia: {
-      appId: "BH4D9OD16A",
-      apiKey: "ae068e3fa083e30f6fe7311168e93568",
+      appId: "Z1KEXCDHZE",
+      apiKey: "c90c5ade2802df8213d6ac50cf3632f4",
       indexName: "weave",
       // Needed to handle the different versions of docs
       contextualSearch: true,


### PR DESCRIPTION
We didn't follow this [migration](https://docusaurus.io/blog/2021/11/21/algolia-docsearch-migration) when it happened, so our search has been completely broken for a bit.

This seems to fix it.