### PR TITLE
Use getObject for all sources details

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "build": "parcel build --target default",
     "build:lib": "parcel build --target lib",
-    "typedefs": "npx -p typescript tsc ui/**/*.ts ui/**/*.tsx --resolveJsonModule --skipLibCheck --esModuleInterop --jsx react-jsx --declaration --allowJs --emitDeclarationOnly --outDir dist",
+    "typedefs": "tsc --declaration --emitDeclarationOnly --outDir dist -p .",
     "start": "parcel serve --port 4567 ui/index.html",
     "lint": "eslint ui --max-warnings 0 && npm run typecheck",
     "prettify:check": "prettier --check ui",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,5 +4,10 @@
         "jsx": "react",
         "resolveJsonModule": true,
         "skipLibCheck": true,
+        "target": "ES5",
+        "module": "CommonJS",
     },
+    "include": [
+        "ui/**/*"
+    ]
 }

--- a/ui/components/AutomationDetail.tsx
+++ b/ui/components/AutomationDetail.tsx
@@ -106,7 +106,7 @@ function AutomationDetail({ automation, className, info }: Props) {
         <RouterTab name="Details" path={`${path}/details`}>
           <>
             <InfoList items={info} />
-            <Metadata metadata={object?.metadata()} />
+            <Metadata metadata={object?.metadata} />
             <ReconciledObjectsTable
               automationKind={automation?.kind}
               automationName={automation?.name}
@@ -143,7 +143,7 @@ function AutomationDetail({ automation, className, info }: Props) {
         {object ? (
           <RouterTab name="yaml" path={`${path}/yaml`}>
             <YamlView
-              yaml={object.yaml()}
+              yaml={object.yaml}
               object={{
                 kind: automation?.kind,
                 name: automation?.name,

--- a/ui/components/BucketDetail.tsx
+++ b/ui/components/BucketDetail.tsx
@@ -3,7 +3,8 @@ import styled from "styled-components";
 import Interval from "../components/Interval";
 import SourceDetail from "../components/SourceDetail";
 import Timestamp from "../components/Timestamp";
-import { Bucket, FluxObjectKind } from "../lib/api/core/types.pb";
+import { FluxObjectKind } from "../lib/api/core/types.pb";
+import { Bucket } from "../lib/objects";
 import { removeKind } from "../lib/utils";
 
 type Props = {
@@ -21,8 +22,7 @@ function BucketDetail({ name, namespace, className, clusterName }: Props) {
       namespace={namespace}
       clusterName={clusterName}
       type={FluxObjectKind.KindBucket}
-      // Guard against an undefined bucket with a default empty object
-      info={(b: Bucket = {}) => [
+      info={(b: Bucket = new Bucket({})) => [
         ["Type", removeKind(FluxObjectKind.KindBucket)],
         ["Endpoint", b.endpoint],
         ["Bucket Name", b.name],

--- a/ui/components/GitRepositoryDetail.tsx
+++ b/ui/components/GitRepositoryDetail.tsx
@@ -3,8 +3,9 @@ import styled from "styled-components";
 import Link from "../components/Link";
 import SourceDetail from "../components/SourceDetail";
 import Timestamp from "../components/Timestamp";
-import { FluxObjectKind, GitRepository } from "../lib/api/core/types.pb";
+import { FluxObjectKind } from "../lib/api/core/types.pb";
 import { convertGitURLToGitProvider, removeKind } from "../lib/utils";
+import { GitRepository } from "../lib/objects";
 
 type Props = {
   className?: string;

--- a/ui/components/HelmChartDetail.tsx
+++ b/ui/components/HelmChartDetail.tsx
@@ -4,7 +4,8 @@ import Interval from "../components/Interval";
 import SourceDetail from "../components/SourceDetail";
 import Timestamp from "../components/Timestamp";
 import { removeKind } from "../lib/utils";
-import { FluxObjectKind, HelmChart } from "../lib/api/core/types.pb";
+import { FluxObjectKind } from "../lib/api/core/types.pb";
+import { HelmChart } from "../lib/objects";
 
 type Props = {
   className?: string;
@@ -21,7 +22,7 @@ function HelmChartDetail({ name, namespace, className, clusterName }: Props) {
       type={FluxObjectKind.KindHelmChart}
       className={className}
       clusterName={clusterName}
-      info={(ch: HelmChart) => [
+      info={(ch: HelmChart = new HelmChart({})) => [
         ["Type", removeKind(FluxObjectKind.KindHelmChart)],
         ["Chart", ch?.chart],
         ["Ref", ch?.sourceRef?.name],

--- a/ui/components/HelmRepositoryDetail.tsx
+++ b/ui/components/HelmRepositoryDetail.tsx
@@ -1,7 +1,8 @@
 import * as React from "react";
 import styled from "styled-components";
 import { removeKind } from "../lib/utils";
-import { FluxObjectKind, HelmRepository } from "../lib/api/core/types.pb";
+import { FluxObjectKind } from "../lib/api/core/types.pb";
+import { HelmRepository } from "../lib/objects";
 import Interval from "./Interval";
 import Link from "./Link";
 import SourceDetail from "./SourceDetail";
@@ -27,8 +28,7 @@ function HelmRepositoryDetail({
       namespace={namespace}
       clusterName={clusterName}
       type={FluxObjectKind.KindHelmRepository}
-      // Guard against an undefined repo with a default empty object
-      info={(hr: HelmRepository = {}) => [
+      info={(hr: HelmRepository = new HelmRepository({})) => [
         ["Type", removeKind(FluxObjectKind.KindHelmRepository)],
         ["Repository Type", hr.repositoryType.toLowerCase()],
         ["URL", <Link>hr.url</Link>],

--- a/ui/components/SourceDetail.tsx
+++ b/ui/components/SourceDetail.tsx
@@ -6,9 +6,8 @@ import { AppContext } from "../contexts/AppContext";
 import { useListAutomations, useSyncFluxObject } from "../hooks/automations";
 import { useToggleSuspend } from "../hooks/flux";
 import { useGetObject } from "../hooks/objects";
-import { useListSources } from "../hooks/sources";
 import { FluxObjectKind } from "../lib/api/core/types.pb";
-import { fluxObjectKindToKind } from "../lib/objects";
+import { FluxObject, fluxObjectKindToKind } from "../lib/objects";
 import Alert from "./Alert";
 import AutomationsTable from "./AutomationsTable";
 import Button from "./Button";
@@ -24,35 +23,33 @@ import SyncButton from "./SyncButton";
 import Text from "./Text";
 import YamlView from "./YamlView";
 
-type Props = {
+type Props<T> = {
   className?: string;
   type: FluxObjectKind;
   name: string;
   namespace: string;
   clusterName: string;
   children?: JSX.Element;
-  info: <T>(s: T) => InfoField[];
+  info: (s: T) => InfoField[];
 };
 
-function SourceDetail({
+function SourceDetail<T extends FluxObject>({
   className,
   name,
   namespace,
   clusterName,
   info,
   type,
-}: Props) {
+}: Props<T>) {
   const { notifySuccess } = React.useContext(AppContext);
-  const { data: sources, isLoading, error } = useListSources();
   const { data: automations, isLoading: automationsLoading } =
     useListAutomations();
   const { path } = useRouteMatch();
-  const { data: object } = useGetObject(
-    name,
-    namespace,
-    fluxObjectKindToKind(type),
-    clusterName
-  );
+  const {
+    data: source,
+    isLoading,
+    error,
+  } = useGetObject<T>(name, namespace, fluxObjectKindToKind(type), clusterName);
   const [isSuspended, setIsSuspended] = React.useState(false);
 
   const suspend = useToggleSuspend(
@@ -75,18 +72,6 @@ function SourceDetail({
 
   if (isLoading || automationsLoading) {
     return <LoadingPage />;
-  }
-
-  const source = _.find(sources, { name, namespace, kind: type, clusterName });
-
-  if (!source) {
-    return (
-      <Alert
-        severity="error"
-        title="Not found"
-        message={`Could not find source '${name}'`}
-      />
-    );
   }
 
   if (isSuspended != source.suspended) {
@@ -164,7 +149,7 @@ function SourceDetail({
         <RouterTab name="Details" path={`${path}/details`}>
           <>
             <InfoList items={items} />
-            <Metadata metadata={object?.metadata()} />
+            <Metadata metadata={source?.metadata} />
             <AutomationsTable automations={relevantAutomations} hideSource />
           </>
         </RouterTab>
@@ -178,20 +163,16 @@ function SourceDetail({
             }}
           />
         </RouterTab>
-        {object ? (
-          <RouterTab name="yaml" path={`${path}/yaml`}>
-            <YamlView
-              yaml={object.yaml()}
-              object={{
-                kind: source?.kind,
-                name: source?.name,
-                namespace: source?.namespace,
-              }}
-            />
-          </RouterTab>
-        ) : (
-          <></>
-        )}
+        <RouterTab name="yaml" path={`${path}/yaml`}>
+          <YamlView
+            yaml={source.yaml}
+            object={{
+              kind: source?.kind,
+              name: source?.name,
+              namespace: source?.namespace,
+            }}
+          />
+        </RouterTab>
       </SubRouterTabs>
     </Flex>
   );

--- a/ui/hooks/objects.ts
+++ b/ui/hooks/objects.ts
@@ -3,15 +3,34 @@ import { useQuery } from "react-query";
 import { CoreClientContext } from "../contexts/CoreClientContext";
 import { GetObjectResponse } from "../lib/api/core/core.pb";
 import { Object as ResponseObject } from "../lib/api/core/types.pb";
-import { FluxObject, Kind } from "../lib/objects";
+import {
+  Bucket,
+  FluxObject,
+  HelmChart,
+  GitRepository,
+  HelmRepository,
+  Kind,
+} from "../lib/objects";
 import { RequestError } from "../lib/types";
 
-function convertResponse(response: ResponseObject): FluxObject {
-  const fluxObject = new FluxObject(response);
-  return fluxObject;
+function convertResponse(kind: Kind, response: ResponseObject) {
+  if (kind == Kind.HelmRepository) {
+    return new HelmRepository(response);
+  }
+  if (kind == Kind.HelmChart) {
+    return new HelmChart(response);
+  }
+  if (kind == Kind.Bucket) {
+    return new Bucket(response);
+  }
+  if (kind == Kind.GitRepository) {
+    return new GitRepository(response);
+  }
+
+  return new FluxObject(response);
 }
 
-export function useGetObject(
+export function useGetObject<T extends FluxObject>(
   name: string,
   namespace: string,
   kind: Kind,
@@ -19,12 +38,15 @@ export function useGetObject(
 ) {
   const { api } = useContext(CoreClientContext);
 
-  return useQuery<FluxObject, RequestError>(
+  return useQuery<T, RequestError>(
     ["object", clusterName, kind, namespace, name],
     () =>
       api
         .GetObject({ name, namespace, kind, clusterName })
-        .then((result: GetObjectResponse) => convertResponse(result.object)),
+        .then(
+          (result: GetObjectResponse) =>
+            convertResponse(kind, result.object) as T
+        ),
     { retry: false, refetchInterval: 5000 }
   );
 }

--- a/ui/lib/__tests__/objects.test.ts
+++ b/ui/lib/__tests__/objects.test.ts
@@ -1,4 +1,11 @@
-import { FluxObject } from "../objects";
+import {
+  Bucket,
+  GitRepository,
+  FluxObject,
+  HelmRepository,
+  HelmChart,
+} from "../objects";
+import { FluxObjectKind } from "../api/core/types.pb";
 
 describe("objects lib", () => {
   it("extracts annotations", () => {
@@ -9,7 +16,7 @@ describe("objects lib", () => {
       payload,
     });
 
-    const metadata = obj.metadata();
+    const metadata = obj.metadata;
     expect(metadata).toEqual([["test", "value"]]);
   });
 
@@ -21,7 +28,7 @@ describe("objects lib", () => {
       payload,
     });
 
-    const metadata = obj.metadata();
+    const metadata = obj.metadata;
     expect(metadata).toEqual([
       ["impolite-value", "<script>alert()</script>\n"],
     ]);
@@ -35,9 +42,245 @@ describe("objects lib", () => {
       payload,
     });
 
-    const yaml = obj.yaml();
+    const yaml = obj.yaml;
     expect(yaml).toEqual(
       "apiVersion: helm.toolkit.fluxcd.io/v2beta1\nkind: HelmRelease\n"
     );
+  });
+
+  describe("supports basic helmrepository object", () => {
+    const response = {
+      object: {
+        payload:
+          '{"apiVersion":"source.toolkit.fluxcd.io/v1beta2","kind":"HelmRepository","metadata":{"annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\\"apiVersion\\":\\"source.toolkit.fluxcd.io/v1beta2\\",\\"kind\\":\\"HelmRepository\\",\\"metadata\\":{\\"annotations\\":{},\\"name\\":\\"the name\\",\\"namespace\\":\\"some namespace\\"},\\"spec\\":{\\"interval\\":\\"1h2m3s\\",\\"url\\":\\"https://helm.gitops.weave.works\\"}}\\n"},"creationTimestamp":"2022-07-14T17:57:56Z","finalizers":["finalizers.fluxcd.io"],"generation":1,"managedFields":[{"apiVersion":"source.toolkit.fluxcd.io/v1beta2","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{".":{},"f:kubectl.kubernetes.io/last-applied-configuration":{}}},"f:spec":{".":{},"f:interval":{},"f:timeout":{},"f:url":{}}},"manager":"kubectl-client-side-apply","operation":"Update","time":"2022-07-14T17:57:56Z"},{"apiVersion":"source.toolkit.fluxcd.io/v1beta2","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:finalizers":{".":{},"v:\\"finalizers.fluxcd.io\\"":{}}},"f:status":{"f:artifact":{".":{},"f:checksum":{},"f:lastUpdateTime":{},"f:path":{},"f:revision":{},"f:size":{},"f:url":{}},"f:conditions":{},"f:observedGeneration":{},"f:url":{}}},"manager":"source-controller","operation":"Update","time":"2022-07-14T17:58:12Z"}],"name":"the name","namespace":"some namespace","resourceVersion":"35391","uid":"f2804b1f-9fec-45e6-acb1-4ea135859290"},"spec":{"interval":"1h2m3s","timeout":"60s","url":"https://helm.gitops.weave.works"},"status":{"artifact":{"checksum":"194ca040b33f7a2d54b77c1bc5c8265eece32c9e065d8a9ea3fb816797e9b5b5","lastUpdateTime":"2022-07-14T18:03:32Z","path":"helmrepository/metadata/helmrepository/index-194ca040b33f7a2d54b77c1bc5c8265eece32c9e065d8a9ea3fb816797e9b5b5.yaml","revision":"194ca040b33f7a2d54b77c1bc5c8265eece32c9e065d8a9ea3fb816797e9b5b5","size":6524,"url":"http://source-controller.flux-system.svc.cluster.local./helmrepository/metadata/helmrepository/index-194ca040b33f7a2d54b77c1bc5c8265eece32c9e065d8a9ea3fb816797e9b5b5.yaml"},"conditions":[{"lastTransitionTime":"2022-07-14T17:58:12Z","message":"stored artifact for revision \'194ca040b33f7a2d54b77c1bc5c8265eece32c9e065d8a9ea3fb816797e9b5b5\'","observedGeneration":1,"reason":"Succeeded","status":"True","type":"Ready"},{"lastTransitionTime":"2022-07-14T17:57:57Z","message":"stored artifact for revision \'194ca040b33f7a2d54b77c1bc5c8265eece32c9e065d8a9ea3fb816797e9b5b5\'","observedGeneration":1,"reason":"Succeeded","status":"True","type":"ArtifactInStorage"}],"observedGeneration":1,"url":"http://source-controller.flux-system.svc.cluster.local./helmrepository/metadata/helmrepository/index.yaml"}}\n',
+        clusterName: "Default",
+      },
+    };
+
+    const obj = new HelmRepository(response.object);
+
+    it("extracts name", () => {
+      expect(obj.name).toEqual("the name");
+    });
+
+    it("extracts namespace", () => {
+      expect(obj.namespace).toEqual("some namespace");
+    });
+
+    it("extracts suspended", () => {
+      expect(obj.suspended).toEqual(false);
+    });
+
+    it("extracts kind", () => {
+      expect(obj.kind).toEqual(FluxObjectKind.KindHelmRepository);
+    });
+
+    it("extracts interval", () => {
+      expect(obj.interval).toEqual({ hours: "1", minutes: "2", seconds: "3" });
+    });
+
+    it("extracts last updated", () => {
+      expect(obj.lastUpdatedAt).toEqual("2022-07-14T18:03:32Z");
+    });
+
+    it("extracts repository type", () => {
+      expect(obj.repositoryType).toEqual("Default");
+    });
+
+    it("extracts url", () => {
+      expect(obj.url).toEqual("https://helm.gitops.weave.works");
+    });
+  });
+
+  describe("supports basic helmchart object", () => {
+    const response = {
+      object: {
+        payload:
+          '{"apiVersion":"source.toolkit.fluxcd.io/v1beta2","kind":"HelmChart","metadata":{"creationTimestamp":"2022-07-14T17:57:56Z","finalizers":["finalizers.fluxcd.io"],"generation":1,"managedFields":[{"apiVersion":"source.toolkit.fluxcd.io/v1beta2","fieldsType":"FieldsV1","fieldsV1":{"f:spec":{".":{},"f:chart":{},"f:interval":{},"f:reconcileStrategy":{},"f:sourceRef":{".":{},"f:kind":{},"f:name":{}},"f:version":{}}},"manager":"helm-controller","operation":"Update","time":"2022-07-14T17:57:56Z"},{"apiVersion":"source.toolkit.fluxcd.io/v1beta2","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:finalizers":{".":{},"v:\\"finalizers.fluxcd.io\\"":{}}},"f:status":{"f:artifact":{".":{},"f:checksum":{},"f:lastUpdateTime":{},"f:path":{},"f:revision":{},"f:size":{},"f:url":{}},"f:conditions":{},"f:observedChartName":{},"f:observedGeneration":{},"f:observedSourceArtifactRevision":{},"f:url":{}}},"manager":"source-controller","operation":"Update","time":"2022-07-14T18:03:33Z"}],"name":"metadata-helmrelease","namespace":"metadata","resourceVersion":"35401","uid":"3e3bd715-ac42-4b95-80f8-0364a4091cdc"},"spec":{"chart":"weave-gitops","interval":"1h0m0s","reconcileStrategy":"ChartVersion","sourceRef":{"kind":"HelmRepository","name":"helmrepository"},"version":"*"},"status":{"artifact":{"checksum":"2b32ac51161e98a1eeba69566832c83f7f601d82e7f7f60d6fe87c1372bd2390","lastUpdateTime":"2022-07-14T18:03:33Z","path":"helmchart/metadata/metadata-helmrelease/weave-gitops-2.2.0.tgz","revision":"2.2.0","size":8051,"url":"http://source-controller.flux-system.svc.cluster.local./helmchart/metadata/metadata-helmrelease/weave-gitops-2.2.0.tgz"},"conditions":[{"lastTransitionTime":"2022-07-14T18:03:33Z","message":"pulled \'weave-gitops\' chart with version \'2.2.0\'","observedGeneration":1,"reason":"ChartPullSucceeded","status":"True","type":"Ready"},{"lastTransitionTime":"2022-07-14T18:03:33Z","message":"pulled \'weave-gitops\' chart with version \'2.2.0\'","observedGeneration":1,"reason":"ChartPullSucceeded","status":"True","type":"ArtifactInStorage"}],"observedChartName":"weave-gitops","observedGeneration":1,"observedSourceArtifactRevision":"194ca040b33f7a2d54b77c1bc5c8265eece32c9e065d8a9ea3fb816797e9b5b5","url":"http://source-controller.flux-system.svc.cluster.local./helmchart/metadata/metadata-helmrelease/latest.tar.gz"}}\n',
+        clusterName: "Default",
+      },
+    };
+    const obj = new HelmChart(response.object);
+
+    it("extracts name", () => {
+      expect(obj.name).toEqual("metadata-helmrelease");
+    });
+
+    it("extracts namespace", () => {
+      expect(obj.namespace).toEqual("metadata");
+    });
+
+    it("extracts suspended", () => {
+      expect(obj.suspended).toEqual(false);
+    });
+
+    it("extracts kind", () => {
+      expect(obj.kind).toEqual(FluxObjectKind.KindHelmChart);
+    });
+
+    it("extracts interval", () => {
+      expect(obj.interval).toEqual({ hours: "1", minutes: "0", seconds: "0" });
+    });
+
+    it("extracts last updated", () => {
+      expect(obj.lastUpdatedAt).toEqual("2022-07-14T18:03:33Z");
+    });
+
+    it("extracts source ref", () => {
+      // Note: listHelmChart returns incorrect sourceRef name and
+      // doesn't ensure namespace key, so this is incompatible with it.
+      expect(obj.sourceRef).toEqual({
+        kind: "KindHelmRepository",
+        name: "helmrepository",
+        namespace: "metadata",
+      });
+    });
+
+    it("extracts chart", () => {
+      expect(obj.chart).toEqual("weave-gitops");
+    });
+  });
+
+  describe("supports basic gitrepository object", () => {
+    const response = {
+      object: {
+        payload:
+          '{"apiVersion":"source.toolkit.fluxcd.io/v1beta2","kind":"GitRepository","metadata":{"annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\\"apiVersion\\":\\"source.toolkit.fluxcd.io/v1beta2\\",\\"kind\\":\\"GitRepository\\",\\"metadata\\":{\\"annotations\\":{\\"metadata.weave.works/description\\":\\"This is my Weave GitOps application\\",\\"metadata.weave.works/metrics-dashboard\\":\\"https://www.google.com/\\",\\"metadata.weave.works/multi-line\\":\\"I can put my metadata\\\\nAcross multiple lines\\\\n\\"},\\"name\\":\\"gitrepository\\",\\"namespace\\":\\"metadata\\"},\\"spec\\":{\\"interval\\":\\"1h1s\\",\\"ref\\":{\\"branch\\":\\"main\\"},\\"url\\":\\"https://github.com/ozamosi/flux-cases.git\\"}}\\n","metadata.weave.works/description":"This is my Weave GitOps application","metadata.weave.works/metrics-dashboard":"https://www.google.com/","metadata.weave.works/multi-line":"I can put my metadata\\nAcross multiple lines\\n"},"creationTimestamp":"2022-07-14T17:57:56Z","finalizers":["finalizers.fluxcd.io"],"generation":1,"managedFields":[{"apiVersion":"source.toolkit.fluxcd.io/v1beta2","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{".":{},"f:kubectl.kubernetes.io/last-applied-configuration":{},"f:metadata.weave.works/description":{},"f:metadata.weave.works/metrics-dashboard":{},"f:metadata.weave.works/multi-line":{}}},"f:spec":{".":{},"f:gitImplementation":{},"f:interval":{},"f:ref":{".":{},"f:branch":{}},"f:timeout":{},"f:url":{}}},"manager":"kubectl-client-side-apply","operation":"Update","time":"2022-07-14T17:57:56Z"},{"apiVersion":"source.toolkit.fluxcd.io/v1beta2","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:finalizers":{".":{},"v:\\"finalizers.fluxcd.io\\"":{}}},"f:status":{"f:artifact":{".":{},"f:checksum":{},"f:lastUpdateTime":{},"f:path":{},"f:revision":{},"f:size":{},"f:url":{}},"f:conditions":{},"f:contentConfigChecksum":{},"f:observedGeneration":{},"f:url":{}}},"manager":"source-controller","operation":"Update","time":"2022-07-14T17:58:12Z"}],"name":"gitrepository","namespace":"metadata","resourceVersion":"35392","uid":"da3dbe82-d564-4aea-a84e-c443f7596c87"},"spec":{"gitImplementation":"go-git","interval":"1h1s","ref":{"branch":"main"},"timeout":"60s","url":"https://github.com/ozamosi/flux-cases.git"},"status":{"artifact":{"checksum":"3a4311e0e3112f882c9b476cf4835f07d9b78ec97b6b53cbd63ce99d790ff07c","lastUpdateTime":"2022-07-14T18:03:33Z","path":"gitrepository/metadata/gitrepository/1ab71eff7d482a6c5e4ee20b8032a1b4f3bbd23d.tar.gz","revision":"main/1ab71eff7d482a6c5e4ee20b8032a1b4f3bbd23d","size":1111,"url":"http://source-controller.flux-system.svc.cluster.local./gitrepository/metadata/gitrepository/1ab71eff7d482a6c5e4ee20b8032a1b4f3bbd23d.tar.gz"},"conditions":[{"lastTransitionTime":"2022-07-14T17:58:12Z","message":"stored artifact for revision \'main/1ab71eff7d482a6c5e4ee20b8032a1b4f3bbd23d\'","observedGeneration":1,"reason":"Succeeded","status":"True","type":"Ready"},{"lastTransitionTime":"2022-07-14T17:57:57Z","message":"stored artifact for revision \'main/1ab71eff7d482a6c5e4ee20b8032a1b4f3bbd23d\'","observedGeneration":1,"reason":"Succeeded","status":"True","type":"ArtifactInStorage"}],"contentConfigChecksum":"sha256:fcbcf165908dd18a9e49f7ff27810176db8e9f63b4352213741664245224f8aa","observedGeneration":1,"url":"http://source-controller.flux-system.svc.cluster.local./gitrepository/metadata/gitrepository/latest.tar.gz"}}\n',
+        clusterName: "Default",
+      },
+    };
+
+    const obj = new GitRepository(response.object);
+
+    it("extracts name", () => {
+      expect(obj.name).toEqual("gitrepository");
+    });
+
+    it("extracts namespace", () => {
+      expect(obj.namespace).toEqual("metadata");
+    });
+
+    it("extracts suspended", () => {
+      expect(obj.suspended).toEqual(false);
+    });
+
+    it("extracts kind", () => {
+      expect(obj.kind).toEqual(FluxObjectKind.KindGitRepository);
+    });
+
+    it("extracts interval", () => {
+      expect(obj.interval).toEqual({ hours: "1", minutes: "0", seconds: "1" });
+    });
+
+    it("extracts last updated", () => {
+      expect(obj.lastUpdatedAt).toEqual("2022-07-14T18:03:33Z");
+    });
+
+    it("extracts url", () => {
+      expect(obj.url).toEqual("https://github.com/ozamosi/flux-cases.git");
+    });
+
+    it("extracts reference", () => {
+      expect(obj.reference).toEqual({ branch: "main" });
+    });
+  });
+
+  describe("supports basic bucket object", () => {
+    const response = {
+      object: {
+        payload:
+          '{"apiVersion":"source.toolkit.fluxcd.io/v1beta2","kind":"Bucket","metadata":{"annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\\"apiVersion\\":\\"source.toolkit.fluxcd.io/v1beta2\\",\\"kind\\":\\"Bucket\\",\\"metadata\\":{\\"annotations\\":{},\\"name\\":\\"minio-bucket\\",\\"namespace\\":\\"bucket\\"},\\"spec\\":{\\"bucketName\\":\\"example\\",\\"endpoint\\":\\"minio.minio.svc.cluster.local:9000\\",\\"insecure\\":true,\\"interval\\":\\"5m0s\\",\\"secretRef\\":{\\"name\\":\\"minio-bucket-secret\\"}}}\\n","reconcile.fluxcd.io/requestedAt":"2022-07-15T11:46:15.484144053Z"},"creationTimestamp":"2022-07-15T11:45:45Z","finalizers":["finalizers.fluxcd.io"],"generation":2,"managedFields":[{"apiVersion":"source.toolkit.fluxcd.io/v1beta2","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{".":{},"f:kubectl.kubernetes.io/last-applied-configuration":{}}},"f:spec":{".":{},"f:bucketName":{},"f:endpoint":{},"f:insecure":{},"f:interval":{},"f:provider":{},"f:secretRef":{".":{},"f:name":{}},"f:timeout":{}}},"manager":"kubectl-client-side-apply","operation":"Update","time":"2022-07-15T11:45:45Z"},{"apiVersion":"source.toolkit.fluxcd.io/v1beta2","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:finalizers":{".":{},"v:\\"finalizers.fluxcd.io\\"":{}}},"f:status":{"f:artifact":{".":{},"f:checksum":{},"f:lastUpdateTime":{},"f:path":{},"f:revision":{},"f:size":{},"f:url":{}},"f:conditions":{},"f:lastHandledReconcileAt":{},"f:observedGeneration":{},"f:url":{}}},"manager":"source-controller","operation":"Update","time":"2022-07-15T11:46:15Z"},{"apiVersion":"source.toolkit.fluxcd.io/v1beta2","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{"f:reconcile.fluxcd.io/requestedAt":{}}},"f:spec":{"f:suspend":{}}},"manager":"gitops-server","operation":"Update","time":"2022-07-15T11:53:33Z"}],"name":"minio-bucket","namespace":"bucket","resourceVersion":"253347","uid":"917cb4b8-4c2a-40bd-8421-95675219e6cc"},"spec":{"bucketName":"example","endpoint":"minio.minio.svc.cluster.local:9000","insecure":true,"interval":"5m0s","provider":"generic","secretRef":{"name":"minio-bucket-secret"},"suspend":true,"timeout":"60s"},"status":{"artifact":{"checksum":"72aa638abb455ca5f9ef4825b949fd2de4d4be0a74895bf7ed2338622cd12686","lastUpdateTime":"2022-07-15T11:46:15Z","path":"bucket/bucket/minio-bucket/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.tar.gz","revision":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855","size":74,"url":"http://source-controller.flux-system.svc.cluster.local./bucket/bucket/minio-bucket/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.tar.gz"},"conditions":[{"lastTransitionTime":"2022-07-15T11:46:15Z","message":"stored artifact for revision \'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\'","observedGeneration":1,"reason":"Succeeded","status":"True","type":"Ready"},{"lastTransitionTime":"2022-07-15T11:46:15Z","message":"stored artifact for revision \'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\'","observedGeneration":1,"reason":"Succeeded","status":"True","type":"ArtifactInStorage"}],"lastHandledReconcileAt":"2022-07-15T11:46:15.484144053Z","observedGeneration":1,"url":"http://source-controller.flux-system.svc.cluster.local./bucket/bucket/minio-bucket/latest.tar.gz"}}\n',
+        clusterName: "Default",
+      },
+    };
+
+    const obj = new Bucket(response.object);
+
+    it("extracts name", () => {
+      expect(obj.name).toEqual("minio-bucket");
+    });
+
+    it("extracts namespace", () => {
+      expect(obj.namespace).toEqual("bucket");
+    });
+
+    it("extracts suspended", () => {
+      expect(obj.suspended).toEqual(true);
+    });
+
+    it("extracts conditions", () => {
+      expect(obj.conditions).toEqual([
+        {
+          type: "Ready",
+          status: "True",
+          reason: "Succeeded",
+          message:
+            "stored artifact for revision 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'",
+          timestamp: "2022-07-15T11:46:15Z",
+        },
+        {
+          type: "ArtifactInStorage",
+          status: "True",
+          reason: "Succeeded",
+          message:
+            "stored artifact for revision 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'",
+          timestamp: "2022-07-15T11:46:15Z",
+        },
+      ]);
+    });
+
+    it("extracts kind", () => {
+      expect(obj.kind).toEqual(FluxObjectKind.KindBucket);
+    });
+
+    it("extracts interval", () => {
+      expect(obj.interval).toEqual({ hours: "0", minutes: "5", seconds: "0" });
+    });
+
+    it("extracts last updated", () => {
+      expect(obj.lastUpdatedAt).toEqual("2022-07-15T11:46:15Z");
+    });
+
+    it("extracts endpoint", () => {
+      expect(obj.endpoint).toEqual("minio.minio.svc.cluster.local:9000");
+    });
+  });
+
+  describe("doesn't crash on empty object", () => {
+    const obj = new FluxObject({ payload: "" });
+
+    it("extracts name", () => {
+      expect(obj.name).toEqual("");
+    });
+
+    it("extracts namespace", () => {
+      expect(obj.namespace).toEqual("");
+    });
+
+    it("extracts suspended", () => {
+      expect(obj.suspended).toEqual(false);
+    });
+
+    it("extracts conditions", () => {
+      expect(obj.conditions).toEqual([]);
+    });
+
+    it("extracts kind", () => {
+      expect(obj.kind).toEqual(undefined);
+    });
+
+    it("extracts interval", () => {
+      expect(obj.interval).toEqual({ hours: "0", minutes: "0", seconds: "0" });
+    });
+
+    it("extracts last updated", () => {
+      expect(obj.lastUpdatedAt).toEqual("");
+    });
+
+    const completelyEmpty = new FluxObject({});
+
+    it("extracts name", () => {
+      expect(completelyEmpty.name).toEqual("");
+    });
   });
 });

--- a/ui/lib/objects.ts
+++ b/ui/lib/objects.ts
@@ -1,5 +1,13 @@
 import { stringify } from "yaml";
-import { FluxObjectKind, Object as ResponseObject } from "./api/core/types.pb";
+import { addKind } from "./utils";
+import {
+  GitRepositoryRef,
+  Condition,
+  FluxObjectKind,
+  FluxObjectRef,
+  Object as ResponseObject,
+  Interval,
+} from "./api/core/types.pb";
 
 export enum Kind {
   GitRepository = "GitRepository",
@@ -16,20 +24,34 @@ export function fluxObjectKindToKind(fok: FluxObjectKind): Kind {
 
 export class FluxObject {
   obj: any;
+  clusterName: string;
 
   constructor(response: ResponseObject) {
-    this.obj = JSON.parse(response.payload);
+    try {
+      this.obj = JSON.parse(response.payload);
+    } catch {
+      this.obj = {};
+    }
+    this.clusterName = response.clusterName;
   }
 
-  yaml() {
+  get yaml(): string {
     return stringify(this.obj);
+  }
+
+  get name(): string {
+    return this.obj.metadata?.name || "";
+  }
+
+  get namespace(): string {
+    return this.obj.metadata?.namespace || "";
   }
 
   // Return list of key-value pairs for the metadata annotations that follow
   // our spec
-  metadata(): [string, string][] {
+  get metadata(): [string, string][] {
     const prefix = "metadata.weave.works/";
-    const annotations = this.obj.metadata.annotations || {};
+    const annotations = this.obj.metadata?.annotations || {};
     return Object.keys(annotations).flatMap((key) => {
       if (!key.startsWith(prefix)) {
         return [];
@@ -37,5 +59,92 @@ export class FluxObject {
         return [[key.slice(prefix.length), annotations[key] as string]];
       }
     });
+  }
+
+  get suspended(): boolean {
+    return Boolean(this.obj.spec?.suspend); // if this is missing, it's not suspended
+  }
+
+  get kind(): FluxObjectKind | undefined {
+    if (this.obj.kind) {
+      return FluxObjectKind[addKind(this.obj.kind)];
+    }
+  }
+
+  get conditions(): Condition[] {
+    return (
+      this.obj.status?.conditions?.map((condition) => {
+        return {
+          type: condition.type,
+          status: condition.status,
+          reason: condition.reason,
+          message: condition.message,
+          timestamp: condition.lastTransitionTime,
+        };
+      }) || []
+    );
+  }
+
+  get interval(): Interval {
+    const match =
+      /((?<hours>[0-9]+)h)?((?<minutes>[0-9]+)m)?((?<seconds>[0-9]+)s)?/.exec(
+        this.obj.spec?.interval
+      );
+    const interval = match.groups;
+    return {
+      hours: interval.hours || "0",
+      minutes: interval.minutes || "0",
+      seconds: interval.seconds || "0",
+    };
+  }
+
+  get lastUpdatedAt(): string {
+    return this.obj.status?.artifact?.lastUpdateTime || "";
+  }
+}
+
+export class HelmRepository extends FluxObject {
+  get repositoryType(): string {
+    return this.obj.spec?.type == "oci" ? "OCI" : "Default";
+  }
+
+  get url(): string {
+    return this.obj.spec?.url || "";
+  }
+}
+
+export class HelmChart extends FluxObject {
+  get sourceRef(): FluxObjectRef {
+    if (!this.obj.spec?.sourceRef) {
+      return {};
+    }
+    const sourceRef = {
+      ...this.obj.spec.sourceRef,
+      kind: FluxObjectKind[addKind(this.obj.spec.sourceRef.kind)],
+    };
+    if (!sourceRef.namespace) {
+      sourceRef.namespace = this.namespace;
+    }
+    return sourceRef;
+  }
+
+  get chart(): string {
+    return this.obj.spec?.chart || "";
+  }
+}
+
+export class Bucket extends FluxObject {
+  get endpoint(): string {
+    return this.obj.spec?.endpoint || "";
+  }
+}
+
+export class GitRepository extends FluxObject {
+  get url(): string {
+    return this.obj.spec?.url || "";
+  }
+
+  get reference(): GitRepositoryRef {
+    return this.obj.spec?.ref || {};
   }
 }


### PR DESCRIPTION
The `getObject` endpoint already contains everything we need to display any details page - at least for source kinds (there's a complication related to helmreleases and secrets, but that's a problem we can solve when we get to it). So we can just unpack that response, and fill in all the data.

This commit simply ports some of the `core/server/types` code to the frontend. It uses getters in order to allow the display code to behave as if it's still operating on a plain object similar to the GRPC one, but all the fields are lazy-loaded so we're only paying for the fields that we use.

I've left the server-side code alone, and I've left every page other than the source details pages alone - this ports a significant chunk of the types code, but it's definitely not all of it. However, my goal is to apply this approach to all pages.

The reason I started with the sources pages is that they had no `get` endpoints, so the code had to fetch every source and then filter in the frontend. We already had to load the `getObject` endpoint, so as a result of this little architectural experiment the UI should end up a little bit snappier.