### PR TITLE
(almost) Support running gitops without flux-system namespace

### DIFF
--- a/api/v1alpha1/application_types.go
+++ b/api/v1alpha1/application_types.go
@@ -1,6 +1,5 @@
 package v1alpha1
 
 const (
-	DefaultNamespace     = "flux-system"
 	DefaultClaimsSubject = "wego-admin"
 )

--- a/api/v1alpha1/application_types.go
+++ b/api/v1alpha1/application_types.go
@@ -1,5 +1,0 @@
-package v1alpha1
-
-const (
-	DefaultClaimsSubject = "wego-admin"
-)

--- a/charts/gitops-server/Chart.yaml
+++ b/charts/gitops-server/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.2.5
+version: 3.0.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/gitops-server/templates/admin-user-creds.yaml
+++ b/charts/gitops-server/templates/admin-user-creds.yaml
@@ -5,6 +5,19 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: cluster-user-auth
+  namespace: {{ .Release.Namespace }}
+type: Opaque
+data:
+  {{- with .Values.adminUser }}
+  username: {{ .username | b64enc | quote }}
+  password: {{ .passwordHash | required "passwordHash must be set!" | b64enc | quote }}
+  {{- end }}
+{{- if ne .Release.Namespace "flux-system" }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cluster-user-auth
   namespace: flux-system
 type: Opaque
 data:
@@ -12,5 +25,6 @@ data:
   username: {{ .username | b64enc | quote }}
   password: {{ .passwordHash | required "passwordHash must be set!" | b64enc | quote }}
   {{- end }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/gitops-server/templates/admin-user-roles.yaml
+++ b/charts/gitops-server/templates/admin-user-roles.yaml
@@ -4,6 +4,50 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: wego-admin-role
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps", "secrets", "pods", "services", "namespaces", "persistentvolumes", "persistentvolumeclaims"]
+    verbs: [ "get", "list" ]
+  - apiGroups: ["apps"]
+    resources: [ "deployments", "replicasets", "statefulsets"]
+    verbs: [ "get", "list" ]
+  - apiGroups: ["batch"]
+    resources: [ "jobs", "cronjobs"]
+    verbs: [ "get", "list" ]
+  - apiGroups: ["autoscaling"]
+    resources: ["horizontalpodautoscalers"]
+    verbs: [ "get", "list" ]
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["roles", "clusterroles", "rolebindings", "clusterrolebindings"]
+    verbs: [ "get", "list" ]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses"]
+    verbs: [ "get", "list" ]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "watch", "list"]
+  - apiGroups: ["source.toolkit.fluxcd.io"]
+    resources: [ "buckets", "helmcharts", "gitrepositories", "helmrepositories" ]
+    verbs: [ "get", "list", "patch" ]
+  - apiGroups: ["kustomize.toolkit.fluxcd.io"]
+    resources: [ "kustomizations" ]
+    verbs: [ "get", "list", "patch" ]
+  - apiGroups: ["helm.toolkit.fluxcd.io"]
+    resources: [ "helmreleases" ]
+    verbs: [ "get", "list", "patch" ]
+  - apiGroups: ["infra.contrib.fluxcd.io"]
+    resources: ["terraforms"]
+    verbs: [ "get", "list", "patch" ]
+{{- if gt (len $.Values.rbac.additionalRules) 0 -}}
+{{- toYaml $.Values.rbac.additionalRules | nindent 2 -}}
+{{- end }}
+{{- if ne .Release.Namespace "flux-system" }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: wego-admin-role
   namespace: flux-system
 rules:
   - apiGroups: [""]
@@ -41,6 +85,7 @@ rules:
     verbs: [ "get", "list", "patch" ]
 {{- if gt (len $.Values.rbac.additionalRules) 0 -}}
 {{- toYaml $.Values.rbac.additionalRules | nindent 2 -}}
+{{- end -}}
 {{- end -}}
 {{- if .Values.adminUser.createClusterRole }}
 ---

--- a/charts/gitops-server/templates/admin-user.yaml
+++ b/charts/gitops-server/templates/admin-user.yaml
@@ -4,6 +4,21 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ .Values.adminUser.username }}-user-read-resources
+  namespace: {{ .Release.Namespace }}
+subjects:
+  - kind: User
+    name: wego-admin
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: wego-admin-role
+  apiGroup: rbac.authorization.k8s.io
+{{- if ne .Release.Namespace "flux-system" }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: wego-test-user-read-resources
   namespace: flux-system
 subjects:
   - kind: User
@@ -13,6 +28,7 @@ roleRef:
   kind: Role
   name: wego-admin-role
   apiGroup: rbac.authorization.k8s.io
+{{- end -}}
 {{- if .Values.adminUser.createClusterRole }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/cmd/gitops/beta/run/cmd.go
+++ b/cmd/gitops/beta/run/cmd.go
@@ -23,7 +23,6 @@ import (
 	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
 	"github.com/spf13/cobra"
-	wego "github.com/weaveworks/weave-gitops/api/v1alpha1"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/cmderrors"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/config"
 	clilogger "github.com/weaveworks/weave-gitops/cmd/gitops/logger"
@@ -265,7 +264,7 @@ func betaRunCommandRunE(opts *config.Options) func(*cobra.Command, []string) err
 
 		log.Actionf("Checking if GitOps Dashboard is already installed ...")
 
-		dashboardInstalled := run.IsDashboardInstalled(log, ctx, kubeClient, wego.DefaultNamespace)
+		dashboardInstalled := run.IsDashboardInstalled(log, ctx, kubeClient, flags.Namespace)
 
 		if dashboardInstalled {
 			log.Successf("GitOps Dashboard is found")
@@ -277,7 +276,7 @@ func betaRunCommandRunE(opts *config.Options) func(*cobra.Command, []string) err
 			}
 			_, err = prompt.Run()
 			if err == nil {
-				err = run.InstallDashboard(log, ctx, kubeClient, kubeConfigArgs, wego.DefaultNamespace)
+				err = run.InstallDashboard(log, ctx, kubeClient, kubeConfigArgs, flags.Namespace)
 				if err != nil {
 					return fmt.Errorf("gitops dashboard installation failed: %w", err)
 				} else {
@@ -448,7 +447,7 @@ func betaRunCommandRunE(opts *config.Options) func(*cobra.Command, []string) err
 
 		ticker.Stop()
 
-		if err := run.CleanupBucketSourceAndKS(log, kubeClient, "flux-system"); err != nil {
+		if err := run.CleanupBucketSourceAndKS(log, kubeClient, flags.Namespace); err != nil {
 			return err
 		}
 

--- a/cmd/gitops/root/cmd.go
+++ b/cmd/gitops/root/cmd.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	wego "github.com/weaveworks/weave-gitops/api/v1alpha1"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/add"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/beta"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/check"
@@ -24,6 +23,8 @@ import (
 	"github.com/weaveworks/weave-gitops/pkg/utils"
 	"k8s.io/client-go/rest"
 )
+
+const defaultNamespace = "flux-system"
 
 var options = &config.Options{}
 
@@ -90,7 +91,7 @@ func RootCmd(client *adapters.HTTPClient) *cobra.Command {
 		},
 	}
 
-	rootCmd.PersistentFlags().String("namespace", wego.DefaultNamespace, "The namespace scope for this operation")
+	rootCmd.PersistentFlags().String("namespace", defaultNamespace, "The namespace scope for this operation")
 	rootCmd.PersistentFlags().StringVarP(&options.Endpoint, "endpoint", "e", os.Getenv("WEAVE_GITOPS_ENTERPRISE_API_URL"), "The Weave GitOps Enterprise HTTP API endpoint can be set with `WEAVE_GITOPS_ENTERPRISE_API_URL` environment variable")
 	rootCmd.PersistentFlags().StringVarP(&options.Username, "username", "u", "", "The Weave GitOps Enterprise username for authentication can be set with `WEAVE_GITOPS_USERNAME` environment variable")
 	rootCmd.PersistentFlags().StringVarP(&options.Password, "password", "p", "", "The Weave GitOps Enterprise password for authentication can be set with `WEAVE_GITOPS_PASSWORD` environment variable")

--- a/cmd/gitops/upgrade/cmd.go
+++ b/cmd/gitops/upgrade/cmd.go
@@ -6,7 +6,6 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	wego "github.com/weaveworks/weave-gitops/api/v1alpha1"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/logger"
 	"github.com/weaveworks/weave-gitops/cmd/internal"
 	"github.com/weaveworks/weave-gitops/pkg/flux"
@@ -18,13 +17,12 @@ import (
 
 var upgradeCmdFlags upgrade.UpgradeValues
 
-var example = fmt.Sprintf(`  # Upgrade Weave GitOps in the %s namespace
+var example = `  # Upgrade Weave GitOps
   gitops upgrade --version 0.0.17 --config-repo https://github.com/my-org/my-management-cluster.git
 
   # Upgrade Weave GitOps and set the natsURL
   gitops upgrade --version 0.0.17 --set "agentTemplate.natsURL=my-cluster.acme.org:4222" \
-    --config-repo https://github.com/my-org/my-management-cluster.git`,
-	wego.DefaultNamespace)
+    --config-repo https://github.com/my-org/my-management-cluster.git`
 
 var Cmd = &cobra.Command{
 	Use:           "upgrade",

--- a/pkg/flux/flux_test.go
+++ b/pkg/flux/flux_test.go
@@ -7,7 +7,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	wego "github.com/weaveworks/weave-gitops/api/v1alpha1"
 	"github.com/weaveworks/weave-gitops/pkg/flux"
 	"github.com/weaveworks/weave-gitops/pkg/gitproviders"
 	"github.com/weaveworks/weave-gitops/pkg/runner/runnerfakes"
@@ -31,7 +30,7 @@ var _ = Describe("CreateSecretGit", func() {
 
 		repoUrl, err := gitproviders.NewRepoURL("ssh://git@github.com/foo/bar.git")
 		Expect(err).ShouldNot(HaveOccurred())
-		out, err := fluxClient.CreateSecretGit("my-secret", repoUrl, wego.DefaultNamespace)
+		out, err := fluxClient.CreateSecretGit("my-secret", repoUrl, "flux-system")
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(out).To(Equal([]byte("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCh...")))
 
@@ -40,7 +39,7 @@ var _ = Describe("CreateSecretGit", func() {
 		cmd, args := runner.RunArgsForCall(0)
 		Expect(cmd).To(Equal(fluxPath()))
 
-		Expect(strings.Join(args, " ")).To(Equal(fmt.Sprintf("create secret git my-secret --url ssh://git@github.com/foo/bar.git --namespace %s --export", wego.DefaultNamespace)))
+		Expect(strings.Join(args, " ")).To(Equal(fmt.Sprintf("create secret git my-secret --url ssh://git@github.com/foo/bar.git --namespace %s --export", "flux-system")))
 	})
 })
 

--- a/pkg/run/get_kube_client_test.go
+++ b/pkg/run/get_kube_client_test.go
@@ -3,7 +3,6 @@ package run_test
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	wego "github.com/weaveworks/weave-gitops/api/v1alpha1"
 	"github.com/weaveworks/weave-gitops/pkg/logger/loggerfakes"
 	"github.com/weaveworks/weave-gitops/pkg/run"
 )
@@ -18,7 +17,7 @@ var _ = Describe("GetKubeClient", func() {
 	It("returns kube client", func() {
 		kubeConfigArgs := run.GetKubeConfigArgs()
 
-		namespace := wego.DefaultNamespace
+		namespace := "test-namespace"
 
 		kubeConfigArgs.Namespace = &namespace
 

--- a/pkg/run/install_dashboard.go
+++ b/pkg/run/install_dashboard.go
@@ -8,7 +8,6 @@ import (
 
 	helmv2 "github.com/fluxcd/helm-controller/api/v2beta1"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1beta2"
-	wego "github.com/weaveworks/weave-gitops/api/v1alpha1"
 	"github.com/weaveworks/weave-gitops/pkg/logger"
 	"github.com/weaveworks/weave-gitops/pkg/server"
 	"github.com/weaveworks/weave-gitops/pkg/utils"
@@ -26,12 +25,11 @@ import (
 )
 
 const (
-	helmRepositoryName      = "ww-gitops"
-	helmReleaseName         = "ww-gitops"
-	helmChartName           = "weave-gitops"
-	helmChartNamespacedName = wego.DefaultNamespace + "-ww-gitops"
-	podName                 = "ww-gitops-weave-gitops"
-	helmRepositoryUrl       = "https://helm.gitops.weave.works"
+	helmRepositoryName = "ww-gitops"
+	helmReleaseName    = "ww-gitops"
+	helmChartName      = "weave-gitops"
+	podName            = "ww-gitops-weave-gitops"
+	helmRepositoryUrl  = "https://helm.gitops.weave.works"
 )
 
 // InstallDashboard installs the GitOps Dashboard.
@@ -89,7 +87,7 @@ func IsDashboardInstalled(log logger.Logger, ctx context.Context, kubeClient cli
 	helmChart := sourcev1.HelmChart{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
-			Name:      helmChartNamespacedName,
+			Name:      namespace + "-" + helmReleaseName,
 		},
 	}
 	if err := kubeClient.Get(ctx, client.ObjectKeyFromObject(&helmChart), &helmChart); err != nil {
@@ -145,7 +143,7 @@ func ReconcileDashboard(kubeClient client.Client, namespace string, timeout time
 	// reconcile dashboard
 	namespacedName := types.NamespacedName{
 		Namespace: namespace,
-		Name:      helmChartNamespacedName,
+		Name:      namespace + "-" + helmReleaseName,
 	}
 	gvk := schema.GroupVersionKind{
 		Group:   "source.toolkit.fluxcd.io",
@@ -170,7 +168,7 @@ func ReconcileDashboard(kubeClient client.Client, namespace string, timeout time
 		dashboard := &sourcev1.HelmChart{}
 		if err := kubeClient.Get(context.Background(), types.NamespacedName{
 			Namespace: namespace,
-			Name:      helmChartNamespacedName,
+			Name:      namespace + "-" + helmReleaseName,
 		}, dashboard); err != nil {
 			return false, err
 		}

--- a/pkg/server/auth/auth_test.go
+++ b/pkg/server/auth/auth_test.go
@@ -23,6 +23,8 @@ import (
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
+const testNamespace = "flux-system"
+
 func TestWithAPIAuthReturns401ForUnauthenticatedRequests(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
@@ -48,7 +50,7 @@ func TestWithAPIAuthReturns401ForUnauthenticatedRequests(t *testing.T) {
 
 	authMethods := map[auth.AuthMethod]bool{auth.OIDC: true}
 
-	authCfg, err := auth.NewAuthServerConfig(logr.Discard(), oidcCfg, fakeKubernetesClient, tokenSignerVerifier, authMethods)
+	authCfg, err := auth.NewAuthServerConfig(logr.Discard(), oidcCfg, fakeKubernetesClient, tokenSignerVerifier, testNamespace, authMethods)
 	g.Expect(err).NotTo(HaveOccurred())
 
 	srv, err := auth.NewAuthServer(context.Background(), authCfg)
@@ -121,7 +123,7 @@ func TestWithAPIAuthOnlyUsesValidMethods(t *testing.T) {
 
 	authMethods := map[auth.AuthMethod]bool{} // This is not a valid AuthMethod
 
-	authCfg, err := auth.NewAuthServerConfig(logr.Discard(), oidcCfg, fakeKubernetesClient, tokenSignerVerifier, authMethods)
+	authCfg, err := auth.NewAuthServerConfig(logr.Discard(), oidcCfg, fakeKubernetesClient, tokenSignerVerifier, testNamespace, authMethods)
 	g.Expect(err).NotTo(HaveOccurred())
 
 	srv, err := auth.NewAuthServer(context.Background(), authCfg)
@@ -184,7 +186,7 @@ func TestOauth2FlowRedirectsToOIDCIssuerForUnauthenticatedRequests(t *testing.T)
 
 	authMethods := map[auth.AuthMethod]bool{auth.OIDC: true}
 
-	authCfg, err := auth.NewAuthServerConfig(logr.Discard(), oidcCfg, fakeKubernetesClient, tokenSignerVerifier, authMethods)
+	authCfg, err := auth.NewAuthServerConfig(logr.Discard(), oidcCfg, fakeKubernetesClient, tokenSignerVerifier, testNamespace, authMethods)
 	g.Expect(err).NotTo(HaveOccurred())
 
 	srv, err := auth.NewAuthServer(context.Background(), authCfg)
@@ -246,7 +248,7 @@ func TestRateLimit(t *testing.T) {
 
 	authMethods := map[auth.AuthMethod]bool{auth.UserAccount: true}
 
-	authCfg, err := auth.NewAuthServerConfig(logr.Discard(), oidcCfg, fakeKubernetesClient, tokenSignerVerifier, authMethods)
+	authCfg, err := auth.NewAuthServerConfig(logr.Discard(), oidcCfg, fakeKubernetesClient, tokenSignerVerifier, testNamespace, authMethods)
 	g.Expect(err).NotTo(HaveOccurred())
 
 	srv, err := auth.NewAuthServer(context.Background(), authCfg)

--- a/pkg/server/auth/init.go
+++ b/pkg/server/auth/init.go
@@ -3,15 +3,10 @@ package auth
 import (
 	"context"
 	"fmt"
-	"net/http"
-	"net/url"
-	"time"
 
-	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/go-logr/logr"
 	"github.com/weaveworks/weave-gitops/api/v1alpha1"
 	"github.com/weaveworks/weave-gitops/core/logger"
-	"github.com/weaveworks/weave-gitops/pkg/featureflags"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -79,82 +74,4 @@ func InitAuthServer(ctx context.Context, log logr.Logger, rawKubernetesClient ct
 	}
 
 	return authServer, err
-}
-
-func NewOIDCConfigFromSecret(secret corev1.Secret) OIDCConfig {
-	cfg := OIDCConfig{
-		IssuerURL:    string(secret.Data["issuerURL"]),
-		ClientID:     string(secret.Data["clientID"]),
-		ClientSecret: string(secret.Data["clientSecret"]),
-		RedirectURL:  string(secret.Data["redirectURL"]),
-	}
-
-	tokenDuration, err := time.ParseDuration(string(secret.Data["tokenDuration"]))
-	if err != nil {
-		tokenDuration = defaultCookieDuration
-	}
-
-	cfg.TokenDuration = tokenDuration
-
-	return cfg
-}
-
-func NewAuthServerConfig(log logr.Logger, oidcCfg OIDCConfig, kubernetesClient ctrlclient.Client, tsv TokenSignerVerifier, authMethods map[AuthMethod]bool) (AuthConfig, error) {
-	if authMethods[OIDC] {
-		if _, err := url.Parse(oidcCfg.IssuerURL); err != nil {
-			return AuthConfig{}, fmt.Errorf("invalid issuer URL: %w", err)
-		}
-
-		if _, err := url.Parse(oidcCfg.RedirectURL); err != nil {
-			return AuthConfig{}, fmt.Errorf("invalid redirect URL: %w", err)
-		}
-	}
-
-	return AuthConfig{
-		Log:                 log.WithName("auth-server"),
-		client:              http.DefaultClient,
-		kubernetesClient:    kubernetesClient,
-		tokenSignerVerifier: tsv,
-		config:              oidcCfg,
-		authMethods:         authMethods,
-	}, nil
-}
-
-// NewAuthServer creates a new AuthServer object.
-func NewAuthServer(ctx context.Context, cfg AuthConfig) (*AuthServer, error) {
-	if cfg.authMethods[UserAccount] {
-		var secret corev1.Secret
-		err := cfg.kubernetesClient.Get(ctx, client.ObjectKey{
-			Namespace: v1alpha1.DefaultNamespace,
-			Name:      ClusterUserAuthSecretName,
-		}, &secret)
-
-		if err != nil {
-			return nil, fmt.Errorf("Could not get secret for cluster user, %w", err)
-		} else {
-			featureflags.Set(FeatureFlagClusterUser, FeatureFlagSet)
-		}
-	} else {
-		featureflags.Set(FeatureFlagClusterUser, "false")
-	}
-
-	var provider *oidc.Provider
-
-	if cfg.config.IssuerURL == "" {
-		featureflags.Set(FeatureFlagOIDCAuth, "false")
-	} else if cfg.authMethods[OIDC] {
-		var err error
-
-		provider, err = oidc.NewProvider(ctx, cfg.config.IssuerURL)
-		if err != nil {
-			return nil, fmt.Errorf("could not create provider: %w", err)
-		}
-		featureflags.Set(FeatureFlagOIDCAuth, FeatureFlagSet)
-	}
-
-	if featureflags.Get(FeatureFlagOIDCAuth) != FeatureFlagSet && featureflags.Get(FeatureFlagClusterUser) != FeatureFlagSet {
-		return nil, fmt.Errorf("Neither OIDC auth or local auth enabled, can't start")
-	}
-
-	return &AuthServer{cfg, provider}, nil
 }

--- a/pkg/server/auth/init_test.go
+++ b/pkg/server/auth/init_test.go
@@ -126,7 +126,7 @@ func TestInitAuthServer(t *testing.T) {
 
 			fakeKubernetesClient := partialKubernetesClient.Build()
 
-			srv, err := auth.InitAuthServer(context.Background(), logr.Discard(), fakeKubernetesClient, tt.cliOIDCConfig, tt.oidcSecretName, false, tt.authMethods)
+			srv, err := auth.InitAuthServer(context.Background(), logr.Discard(), fakeKubernetesClient, tt.cliOIDCConfig, tt.oidcSecretName, false, "test-namespace", tt.authMethods)
 
 			if tt.expectErr {
 				g.Expect(err).To(gomega.HaveOccurred())
@@ -147,7 +147,7 @@ func makeOIDCSecret(oidcConfig *mockoidc.Config, secretName string) *corev1.Secr
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      secretName,
-			Namespace: "flux-system",
+			Namespace: "test-namespace",
 		},
 		Data: map[string][]byte{
 			"issuerURL":    []byte(oidcConfig.Issuer),
@@ -164,7 +164,7 @@ func makeClusterUserSecret(password, secretName string) *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      secretName,
-			Namespace: "flux-system",
+			Namespace: "test-namespace",
 		},
 		Data: map[string][]byte{
 			"password": hashed,

--- a/pkg/server/auth/server.go
+++ b/pkg/server/auth/server.go
@@ -1,10 +1,12 @@
 package auth
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/coreos/go-oidc/v3/oidc"
@@ -14,6 +16,7 @@ import (
 	"golang.org/x/crypto/bcrypt"
 	"golang.org/x/oauth2"
 	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -67,6 +70,84 @@ type LoginRequest struct {
 type UserInfo struct {
 	Email  string   `json:"email"`
 	Groups []string `json:"groups"`
+}
+
+func NewOIDCConfigFromSecret(secret corev1.Secret) OIDCConfig {
+	cfg := OIDCConfig{
+		IssuerURL:    string(secret.Data["issuerURL"]),
+		ClientID:     string(secret.Data["clientID"]),
+		ClientSecret: string(secret.Data["clientSecret"]),
+		RedirectURL:  string(secret.Data["redirectURL"]),
+	}
+
+	tokenDuration, err := time.ParseDuration(string(secret.Data["tokenDuration"]))
+	if err != nil {
+		tokenDuration = time.Hour
+	}
+
+	cfg.TokenDuration = tokenDuration
+
+	return cfg
+}
+
+func NewAuthServerConfig(log logr.Logger, oidcCfg OIDCConfig, kubernetesClient ctrlclient.Client, tsv TokenSignerVerifier, authMethods map[AuthMethod]bool) (AuthConfig, error) {
+	if authMethods[OIDC] {
+		if _, err := url.Parse(oidcCfg.IssuerURL); err != nil {
+			return AuthConfig{}, fmt.Errorf("invalid issuer URL: %w", err)
+		}
+
+		if _, err := url.Parse(oidcCfg.RedirectURL); err != nil {
+			return AuthConfig{}, fmt.Errorf("invalid redirect URL: %w", err)
+		}
+	}
+
+	return AuthConfig{
+		Log:                 log.WithName("auth-server"),
+		client:              http.DefaultClient,
+		kubernetesClient:    kubernetesClient,
+		tokenSignerVerifier: tsv,
+		config:              oidcCfg,
+		authMethods:         authMethods,
+	}, nil
+}
+
+// NewAuthServer creates a new AuthServer object.
+func NewAuthServer(ctx context.Context, cfg AuthConfig) (*AuthServer, error) {
+	if cfg.authMethods[UserAccount] {
+		var secret corev1.Secret
+		err := cfg.kubernetesClient.Get(ctx, client.ObjectKey{
+			Namespace: v1alpha1.DefaultNamespace,
+			Name:      ClusterUserAuthSecretName,
+		}, &secret)
+
+		if err != nil {
+			return nil, fmt.Errorf("Could not get secret for cluster user, %w", err)
+		} else {
+			featureflags.Set(FeatureFlagClusterUser, FeatureFlagSet)
+		}
+	} else {
+		featureflags.Set(FeatureFlagClusterUser, "false")
+	}
+
+	var provider *oidc.Provider
+
+	if cfg.config.IssuerURL == "" {
+		featureflags.Set(FeatureFlagOIDCAuth, "false")
+	} else if cfg.authMethods[OIDC] {
+		var err error
+
+		provider, err = oidc.NewProvider(ctx, cfg.config.IssuerURL)
+		if err != nil {
+			return nil, fmt.Errorf("could not create provider: %w", err)
+		}
+		featureflags.Set(FeatureFlagOIDCAuth, FeatureFlagSet)
+	}
+
+	if featureflags.Get(FeatureFlagOIDCAuth) != FeatureFlagSet && featureflags.Get(FeatureFlagClusterUser) != FeatureFlagSet {
+		return nil, fmt.Errorf("Neither OIDC auth or local auth enabled, can't start")
+	}
+
+	return &AuthServer{cfg, provider}, nil
 }
 
 // SetRedirectURL is used to set the redirect URL. This is meant to be used

--- a/pkg/server/auth/server_test.go
+++ b/pkg/server/auth/server_test.go
@@ -722,7 +722,7 @@ func makeAuthServer(t *testing.T, client ctrlclient.Client, tsv auth.TokenSigner
 		authMethodsMap[mthd] = true
 	}
 
-	authCfg, err := auth.NewAuthServerConfig(logr.Discard(), oidcCfg, client, tsv, authMethodsMap)
+	authCfg, err := auth.NewAuthServerConfig(logr.Discard(), oidcCfg, client, tsv, testNamespace, authMethodsMap)
 	g.Expect(err).NotTo(HaveOccurred())
 
 	s, err := auth.NewAuthServer(context.Background(), authCfg)
@@ -739,7 +739,7 @@ func TestAuthMethods(t *testing.T) {
 
 	authMethods := map[auth.AuthMethod]bool{}
 
-	authCfg, err := auth.NewAuthServerConfig(logr.Discard(), auth.OIDCConfig{}, ctrlclientfake.NewClientBuilder().Build(), nil, authMethods)
+	authCfg, err := auth.NewAuthServerConfig(logr.Discard(), auth.OIDCConfig{}, ctrlclientfake.NewClientBuilder().Build(), nil, testNamespace, authMethods)
 	g.Expect(err).NotTo(HaveOccurred())
 
 	_, err = auth.NewAuthServer(context.Background(), authCfg)
@@ -762,7 +762,7 @@ func TestAuthMethods(t *testing.T) {
 
 	authMethods = map[auth.AuthMethod]bool{auth.UserAccount: true}
 
-	authCfg, err = auth.NewAuthServerConfig(logr.Discard(), auth.OIDCConfig{}, fakeKubernetesClient, nil, authMethods)
+	authCfg, err = auth.NewAuthServerConfig(logr.Discard(), auth.OIDCConfig{}, fakeKubernetesClient, nil, testNamespace, authMethods)
 	g.Expect(err).NotTo(HaveOccurred())
 	_, err = auth.NewAuthServer(context.Background(), authCfg)
 	g.Expect(err).NotTo(HaveOccurred())
@@ -785,7 +785,7 @@ func TestAuthMethods(t *testing.T) {
 	}
 	authMethods = map[auth.AuthMethod]bool{auth.OIDC: true}
 
-	authCfg, err = auth.NewAuthServerConfig(logr.Discard(), oidcCfg, ctrlclientfake.NewClientBuilder().Build(), nil, authMethods)
+	authCfg, err = auth.NewAuthServerConfig(logr.Discard(), oidcCfg, ctrlclientfake.NewClientBuilder().Build(), nil, testNamespace, authMethods)
 	g.Expect(err).NotTo(HaveOccurred())
 	_, err = auth.NewAuthServer(context.Background(), authCfg)
 	g.Expect(err).NotTo(HaveOccurred())

--- a/pkg/upgrade/upgrade_test.go
+++ b/pkg/upgrade/upgrade_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/fluxcd/go-git-providers/gitprovider"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1beta2"
 	"github.com/stretchr/testify/assert"
-	wego "github.com/weaveworks/weave-gitops/api/v1alpha1"
 	"github.com/weaveworks/weave-gitops/pkg/git/gitfakes"
 	"github.com/weaveworks/weave-gitops/pkg/gitproviders"
 	"github.com/weaveworks/weave-gitops/pkg/gitproviders/gitprovidersfakes"
@@ -20,6 +19,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
+
+const testNamespace = "some-namespace"
 
 func TestUpgradeDryRun(t *testing.T) {
 	gitClient := &gitfakes.FakeGit{}
@@ -38,7 +39,7 @@ func TestUpgradeDryRun(t *testing.T) {
 		HeadBranch:    "upgrade-to-wge",
 		BaseBranch:    "main",
 		CommitMessage: "Upgrade to wge",
-		Namespace:     wego.DefaultNamespace,
+		Namespace:     testNamespace,
 		DryRun:        true,
 	}, kubeClient, gitClient, gitProvider, logger, &output)
 
@@ -78,7 +79,7 @@ func TestUpgrade(t *testing.T) {
 		HeadBranch:    "upgrade-to-wge",
 		BaseBranch:    "main",
 		CommitMessage: "Upgrade to wge",
-		Namespace:     wego.DefaultNamespace,
+		Namespace:     testNamespace,
 	}, kubeClient, gitClient, gitProvider, logger, &output)
 
 	assert.NoError(t, err)
@@ -111,7 +112,7 @@ func TestGetGitAuthFromDeployKey(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			kubeClient := makeClient(t, tt.clusterState...)
-			err := getBasicAuth(context.Background(), kubeClient, wego.DefaultNamespace)
+			err := getBasicAuth(context.Background(), kubeClient, testNamespace)
 			assert.Equal(t, tt.expectedErr, err)
 		})
 	}
@@ -183,7 +184,7 @@ func createSecret(opts ...func(*corev1.Secret)) *corev1.Secret {
 	s := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "weave-gitops-enterprise-credentials",
-			Namespace: wego.DefaultNamespace,
+			Namespace: testNamespace,
 		},
 		Type: "Opaque",
 		Data: map[string][]byte{
@@ -204,7 +205,7 @@ func createGitRepository(name string) *sourcev1.GitRepository {
 	return &sourcev1.GitRepository{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: wego.DefaultNamespace,
+			Namespace: testNamespace,
 		},
 	}
 }

--- a/ui/lib/types.ts
+++ b/ui/lib/types.ts
@@ -35,7 +35,6 @@ export enum V2Routes {
   NotImplemented = "/not_implemented",
 }
 
-export const WeGONamespace = "flux-system";
 export const DefaultCluster = "Default";
 export const NoNamespace = "";
 


### PR DESCRIPTION
Before this, we expected there to be a namespace `flux-system`. While
    we supported running in any namespace, and supported finding flux
    itself in any namespace, you couldn't log in unless there was a
    pre-existing flux-system namespace.
    
This duplicates the helm chart so it installs both permissions and
    secrets in both `flux-system` and wherever you install gitops.
    
The code is then adapted to look for secrets in the current namespace,
    and all constants containing `flux-system` has finally been vanquished.
    
Because the helm chart still uses `flux-system` with this change in
    place, you still actually need a `flux-system` namespace, so this
    doesn't actually fix the problem. However, as soon as we've made a
    release with this in place, we can remove the hard-coded `flux-system`
    copies of all of these resources, and we'll be done.
    
Thus this does most of #2415.

