### PR TITLE
Write unit tests for GitOps Run: Flux and GitOps Dashboard installation Part 1

### DIFF
--- a/cmd/gitops/beta/run/cmd.go
+++ b/cmd/gitops/beta/run/cmd.go
@@ -39,7 +39,7 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
-type runCommandFlags struct {
+type RunCommandFlags struct {
 	FluxVersion     string
 	AllowK8sContext string
 	Components      []string
@@ -55,7 +55,7 @@ type runCommandFlags struct {
 	Context string
 }
 
-var flags runCommandFlags
+var flags RunCommandFlags
 
 var kubeConfigArgs *genericclioptions.ConfigFlags
 

--- a/pkg/run/get_kube_client_test.go
+++ b/pkg/run/get_kube_client_test.go
@@ -1,0 +1,38 @@
+package run_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	wego "github.com/weaveworks/weave-gitops/api/v1alpha1"
+	"github.com/weaveworks/weave-gitops/pkg/logger/loggerfakes"
+	"github.com/weaveworks/weave-gitops/pkg/run"
+)
+
+var _ = Describe("GetKubeClient", func() {
+	var fakeLogger *loggerfakes.FakeLogger
+
+	BeforeEach(func() {
+		fakeLogger = &loggerfakes.FakeLogger{}
+	})
+
+	It("returns kube client", func() {
+		kubeConfigArgs := run.GetKubeConfigArgs()
+
+		namespace := wego.DefaultNamespace
+
+		kubeConfigArgs.Namespace = &namespace
+
+		_, err := kubeConfigArgs.ToRESTConfig()
+		Expect(err).NotTo(HaveOccurred())
+
+		kubeClientOpts := run.GetKubeClientOptions()
+
+		contextName := "some-context"
+
+		kubeClient, err := run.GetKubeClient(fakeLogger, contextName, k8sEnv.Rest, kubeClientOpts)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(kubeClient).ToNot(BeNil())
+		Expect(kubeClient.ClusterName).To(Equal(contextName))
+	})
+})

--- a/pkg/run/install_flux_test.go
+++ b/pkg/run/install_flux_test.go
@@ -1,0 +1,51 @@
+package run_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/weaveworks/weave-gitops/core/server"
+	coretypes "github.com/weaveworks/weave-gitops/core/server/types"
+	"github.com/weaveworks/weave-gitops/pkg/flux"
+	"github.com/weaveworks/weave-gitops/pkg/logger/loggerfakes"
+	"github.com/weaveworks/weave-gitops/pkg/run"
+	v1 "k8s.io/api/core/v1"
+)
+
+const (
+	testVersion = "some-version"
+)
+
+var _ = Describe("GetFluxVersion", func() {
+	var fakeLogger *loggerfakes.FakeLogger
+
+	BeforeEach(func() {
+		fakeLogger = &loggerfakes.FakeLogger{}
+	})
+
+	It("gets flux version", func() {
+		kubeClientOpts := run.GetKubeClientOptions()
+
+		contextName := "some-context"
+
+		kubeClient, err := run.GetKubeClient(fakeLogger, contextName, k8sEnv.Rest, kubeClientOpts)
+		Expect(err).NotTo(HaveOccurred())
+
+		ctx := context.Background()
+
+		fluxNs := &v1.Namespace{}
+		fluxNs.Name = "flux-ns-test"
+		fluxNs.Labels = map[string]string{
+			coretypes.PartOfLabel: server.FluxNamespacePartOf,
+			flux.VersionLabelKey:  testVersion,
+		}
+
+		Expect(kubeClient.Create(ctx, fluxNs)).To(Succeed())
+
+		fluxVersion, err := run.GetFluxVersion(fakeLogger, ctx, kubeClient)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(fluxVersion).To(Equal(testVersion))
+	})
+})

--- a/pkg/run/run_suite_test.go
+++ b/pkg/run/run_suite_test.go
@@ -5,9 +5,30 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/weaveworks/weave-gitops/pkg/testutils"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	k8sClient client.Client
+	k8sEnv    *testutils.K8sTestEnv
 )
 
 func TestRun(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Run Suite")
 }
+
+var cleanupK8s func()
+
+var _ = BeforeSuite(func() {
+	var err error
+	k8sEnv, err = testutils.StartK8sTestEnvironment([]string{
+		"../../manifests/crds",
+		"../../tools/testcrds",
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	cleanupK8s = k8sEnv.Stop
+	k8sClient = k8sEnv.Client
+})

--- a/pkg/run/utils_test.go
+++ b/pkg/run/utils_test.go
@@ -1,0 +1,172 @@
+package run_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/weaveworks/weave-gitops/pkg/kube"
+	"github.com/weaveworks/weave-gitops/pkg/run"
+	corev1 "k8s.io/api/core/v1"
+)
+
+type isLocalClusterTest struct {
+	clusterName string
+	expected    bool
+}
+
+func runIsLocalClusterTest(client *kube.KubeHTTP, test isLocalClusterTest) {
+	actual := run.IsLocalCluster(client)
+
+	Expect(actual).To(Equal(test.expected))
+}
+
+var _ = Describe("IsLocalCluster", func() {
+	var fakeKube *kube.KubeHTTP
+
+	BeforeEach(func() {
+		fakeKube = &kube.KubeHTTP{}
+	})
+
+	It("returns true for kind prefix", func() {
+		test := isLocalClusterTest{
+			clusterName: "kind-wego-dev",
+			expected:    true,
+		}
+
+		fakeKube.ClusterName = test.clusterName
+
+		runIsLocalClusterTest(fakeKube, test)
+	})
+
+	It("returns true for k3d prefix", func() {
+		test := isLocalClusterTest{
+			clusterName: "k3d-wego-dev",
+			expected:    true,
+		}
+
+		fakeKube.ClusterName = test.clusterName
+
+		runIsLocalClusterTest(fakeKube, test)
+	})
+
+	It("returns true if cluster name is minikube", func() {
+		test := isLocalClusterTest{
+			clusterName: "minikube",
+			expected:    true,
+		}
+
+		fakeKube.ClusterName = test.clusterName
+
+		runIsLocalClusterTest(fakeKube, test)
+	})
+
+	It("returns true if cluster name is docker-for-desktop", func() {
+		test := isLocalClusterTest{
+			clusterName: "docker-for-desktop",
+			expected:    true,
+		}
+
+		fakeKube.ClusterName = test.clusterName
+
+		runIsLocalClusterTest(fakeKube, test)
+	})
+
+	It("returns true if cluster name is docker-desktop", func() {
+		test := isLocalClusterTest{
+			clusterName: "docker-desktop",
+			expected:    true,
+		}
+
+		fakeKube.ClusterName = test.clusterName
+
+		runIsLocalClusterTest(fakeKube, test)
+	})
+
+	It("returns false for a gke cluster", func() {
+		test := isLocalClusterTest{
+			clusterName: "gke_testing_cluster-1",
+			expected:    false,
+		}
+
+		fakeKube.ClusterName = test.clusterName
+
+		runIsLocalClusterTest(fakeKube, test)
+	})
+
+	It("returns false for an empty string", func() {
+		test := isLocalClusterTest{
+			clusterName: "",
+			expected:    false,
+		}
+
+		fakeKube.ClusterName = test.clusterName
+
+		runIsLocalClusterTest(fakeKube, test)
+	})
+})
+
+type isPodStatusConditionPresentAndEqualTest struct {
+	conditions      []corev1.PodCondition
+	conditionType   corev1.PodConditionType
+	conditionStatus corev1.ConditionStatus
+	expected        bool
+}
+
+func runIsPodStatusConditionPresentAndEqualTest(test isPodStatusConditionPresentAndEqualTest) {
+	actual := run.IsPodStatusConditionPresentAndEqual(test.conditions, test.conditionType, test.conditionStatus)
+
+	Expect(actual).To(Equal(test.expected))
+}
+
+var _ = Describe("IsPodStatusConditionPresentAndEqual", func() {
+	It("returns true if condition statuses are the same and condition is true", func() {
+		test := isPodStatusConditionPresentAndEqualTest{
+			conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+			},
+			conditionType:   corev1.PodReady,
+			conditionStatus: corev1.ConditionTrue,
+			expected:        true,
+		}
+
+		runIsPodStatusConditionPresentAndEqualTest(test)
+	})
+
+	It("returns true if condition statuses are the same and condition is false", func() {
+		test := isPodStatusConditionPresentAndEqualTest{
+			conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionFalse},
+			},
+			conditionType:   corev1.PodReady,
+			conditionStatus: corev1.ConditionFalse,
+			expected:        true,
+		}
+		runIsPodStatusConditionPresentAndEqualTest(test)
+	})
+
+	It("returns false if condition statuses are different", func() {
+		test := isPodStatusConditionPresentAndEqualTest{
+			conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionUnknown},
+			},
+			conditionType:   corev1.PodReady,
+			conditionStatus: corev1.ConditionTrue,
+			expected:        false,
+		}
+
+		runIsPodStatusConditionPresentAndEqualTest(test)
+	})
+
+	It("returns false if condition types are different and condition statuses are the same", func() {
+		test := isPodStatusConditionPresentAndEqualTest{
+			conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+			},
+			conditionType:   corev1.PodInitialized,
+			conditionStatus: corev1.ConditionTrue,
+			expected:        false,
+		}
+
+		runIsPodStatusConditionPresentAndEqualTest(test)
+	})
+})


### PR DESCRIPTION
Partial PR for 2512 (Write unit tests for GitOps Run: Flux and GitOps Dashboard installation).

- Added unit tests for simpler functions. Will cover `InstallFlux` and `InstallDashboard` in the second PR.

Notes:
- Had to pass test config `k8sEnv.Rest` to `GetKubeClient` in the test instead of the actual config created with `kubeConfigArgs.ToRESTConfig()` (which is used when running the `gitops run` command) because I was getting an "error initializing kube client". So, for the actual config I am only checking that no error occurs when calling `kubeConfigArgs.ToRESTConfig()`.
