### PR TITLE
Install & wait for extra components when specified

### DIFF
--- a/cmd/gitops/beta/run/cmd.go
+++ b/cmd/gitops/beta/run/cmd.go
@@ -242,6 +242,17 @@ func betaRunCommandRunE(opts *config.Options) func(*cobra.Command, []string) err
 			} else {
 				log.Successf("Flux has been installed")
 			}
+
+			for _, controllerName := range []string{"source-controller", "kustomize-controller", "helm-controller", "notification-controller"} {
+				log.Actionf("Waiting for %s/%s to be ready ...", flags.Namespace, controllerName)
+
+				if err := run.WaitForDeploymentToBeReady(log, kubeClient, controllerName, flags.Namespace); err != nil {
+					return err
+				}
+
+				log.Successf("%s/%s is now ready ...", flags.Namespace, controllerName)
+			}
+
 		} else {
 			log.Successf("Flux version %s is found", fluxVersion)
 		}
@@ -269,16 +280,6 @@ func betaRunCommandRunE(opts *config.Options) func(*cobra.Command, []string) err
 					log.Successf("GitOps Dashboard has been installed")
 				}
 			}
-		}
-
-		for _, controllerName := range []string{"source-controller", "kustomize-controller", "helm-controller", "notification-controller"} {
-			log.Actionf("Waiting for %s/%s to be ready ...", flags.Namespace, controllerName)
-
-			if err := run.WaitForDeploymentToBeReady(log, kubeClient, controllerName, flags.Namespace); err != nil {
-				return err
-			}
-
-			log.Successf("%s/%s is now ready ...", flags.Namespace, controllerName)
 		}
 
 		if dashboardInstalled {

--- a/go.mod
+++ b/go.mod
@@ -252,7 +252,7 @@ require (
 	k8s.io/klog/v2 v2.60.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20220401212409-b28bf2818661 // indirect
 	k8s.io/kubectl v0.24.1 // indirect
-	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9 // indirect
+	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9
 	oras.land/oras-go v1.1.1 // indirect
 	sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 // indirect
 	sigs.k8s.io/kustomize/kyaml v0.13.7 // indirect


### PR DESCRIPTION
This moves the waiting for components so it only happens when we install flux, rewires the installation of extra components so it works, and then proceeds to wait for the components the user specified.

This fixes #2423