### PR TITLE
Fix local development

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -40,9 +40,7 @@ if advanced_go_dev_mode:
             './bin',
         ],
         dockerfile="dev.dockerfile",
-        entrypoint="/app/build/gitops-server --log-level=debug --insecure --dev-mode --dev-user {dev_user}".format(
-            dev_user=os.getenv("DEV_USER", "wego-admin")
-        ),
+        entrypoint="/app/build/gitops-server --log-level=debug --insecure --dev-mode",
         live_update=[
             sync('./bin', '/app/build'),
         ],

--- a/cmd/gitops-server/cmd/cmd.go
+++ b/cmd/gitops-server/cmd/cmd.go
@@ -24,7 +24,6 @@ import (
 	httpmiddleware "github.com/slok/go-http-metrics/middleware"
 	httpmiddlewarestd "github.com/slok/go-http-metrics/middleware/std"
 	"github.com/spf13/cobra"
-	"github.com/weaveworks/weave-gitops/api/v1alpha1"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/cmderrors"
 	"github.com/weaveworks/weave-gitops/core/clustersmngr"
 	"github.com/weaveworks/weave-gitops/core/clustersmngr/fetcher"
@@ -69,7 +68,6 @@ type Options struct {
 	OIDCSecret string
 	// Dev mode
 	DevMode bool
-	DevUser string
 	// Metrics
 	EnableMetrics  bool
 	MetricsAddress string
@@ -105,8 +103,7 @@ func NewCommand() *cobra.Command {
 	cmd.Flags().StringVar(&options.OIDC.RedirectURL, "oidc-redirect-url", "", "The OAuth2 redirect URL")
 	cmd.Flags().DurationVar(&options.OIDC.TokenDuration, "oidc-token-duration", time.Hour, "The duration of the ID token. It should be set in the format: number + time unit (s,m,h) e.g., 20m")
 	// Dev mode
-	cmd.Flags().BoolVar(&options.DevMode, "dev-mode", false, "Enables development mode")
-	cmd.Flags().StringVar(&options.DevUser, "dev-user", v1alpha1.DefaultClaimsSubject, "Sets development User")
+	cmd.Flags().BoolVar(&options.DevMode, "dev-mode", false, "Enables development mode - this disables verifying cookie signatures, do not use")
 	// Metrics
 	cmd.Flags().BoolVar(&options.EnableMetrics, "enable-metrics", false, "Starts the metrics listener")
 	cmd.Flags().StringVar(&options.MetricsAddress, "metrics-address", ":2112", "If the metrics listener is enabled, bind to this address")
@@ -169,7 +166,7 @@ func runCmd(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("could not create kube http client: %w", err)
 	}
 
-	authServer, err := auth.InitAuthServer(cmd.Context(), log, rawClient, options.OIDC, options.OIDCSecret, options.DevUser, options.DevMode, options.AuthMethods)
+	authServer, err := auth.InitAuthServer(cmd.Context(), log, rawClient, options.OIDC, options.OIDCSecret, options.DevMode, options.AuthMethods)
 
 	if err != nil {
 		return fmt.Errorf("could not initialise authentication server: %w", err)

--- a/pkg/server/auth/init.go
+++ b/pkg/server/auth/init.go
@@ -17,7 +17,7 @@ import (
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func InitAuthServer(ctx context.Context, log logr.Logger, rawKubernetesClient ctrlclient.Client, oidcConfig OIDCConfig, oidcSecret, devUser string, devMode bool, authMethodStrings []string) (*AuthServer, error) {
+func InitAuthServer(ctx context.Context, log logr.Logger, rawKubernetesClient ctrlclient.Client, oidcConfig OIDCConfig, oidcSecret string, devMode bool, authMethodStrings []string) (*AuthServer, error) {
 	log.V(logger.LogLevelDebug).Info("Registering authentication methods", "methods", authMethodStrings)
 
 	authMethods, err := ParseAuthMethodArray(authMethodStrings)
@@ -65,7 +65,7 @@ func InitAuthServer(ctx context.Context, log logr.Logger, rawKubernetesClient ct
 
 	if devMode {
 		log.V(logger.LogLevelWarn).Info("Dev-mode is enabled. This should be used for local work only.")
-		tsv.SetDevMode(devUser)
+		tsv.SetDevMode(devMode)
 	}
 
 	authCfg, err := NewAuthServerConfig(log, oidcConfig, rawKubernetesClient, tsv, authMethods)

--- a/pkg/server/auth/init_test.go
+++ b/pkg/server/auth/init_test.go
@@ -126,7 +126,7 @@ func TestInitAuthServer(t *testing.T) {
 
 			fakeKubernetesClient := partialKubernetesClient.Build()
 
-			srv, err := auth.InitAuthServer(context.Background(), logr.Discard(), fakeKubernetesClient, tt.cliOIDCConfig, tt.oidcSecretName, "", false, tt.authMethods)
+			srv, err := auth.InitAuthServer(context.Background(), logr.Discard(), fakeKubernetesClient, tt.cliOIDCConfig, tt.oidcSecretName, false, tt.authMethods)
 
 			if tt.expectErr {
 				g.Expect(err).To(gomega.HaveOccurred())


### PR DESCRIPTION
When I removed backwards compatibility in 75fbce6d, I also removed the
thing that made dev-mode work, since we were always overriding the
username with wego-admin in tilt.

This removes the dev-user altogether - it just replaces the username,
but we can just log in with a different username instead if we want -
and reimplements dev-mode to mean "use cookie, disable verification"