### PR TITLE
add an `-n` option not to print a newline when generating hash

### DIFF
--- a/website/docs/getting-started.mdx
+++ b/website/docs/getting-started.mdx
@@ -97,7 +97,7 @@ We will generate a bcrypt hash for your chosen password and store it as a secret
 
    ```
    PASSWORD="<your password>"
-   echo  $PASSWORD | gitops get bcrypt-hash
+   echo -n $PASSWORD | gitops get bcrypt-hash
    $2a$10$OS5NJmPNEb13UgTOSKnMxOWlmS7mlxX77hv4yAiISvZ71Dc7IuN3q
    ```
 


### PR DESCRIPTION
I followed this document, but I didn't sign-in because of invalid hash.
finally i found the problem. that's why i open a pr. 😸 

<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
- X

<!-- Describe what has changed in this PR -->
**What changed?**
- just added an '-n' option in this document.

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**
- because this guide gives us a way to make an invalid hash.

<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**
- X

<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**
typed this command and finally i logged in!

<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**
- X

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
- Yes it just changed this documentation
