### PR TITLE
Fix pod not found error.

### DIFF
--- a/cmd/gitops/beta/run/cmd.go
+++ b/cmd/gitops/beta/run/cmd.go
@@ -234,7 +234,7 @@ func betaRunCommandRunE(opts *config.Options) func(*cobra.Command, []string) err
 			components = append(components, flags.ComponentsExtra...)
 
 			if err := ValidateComponents(components); err != nil {
-				return fmt.Errorf("Can't install flux: %w", err)
+				return fmt.Errorf("can't install flux: %w", err)
 			}
 
 			installOpts := install.MakeDefaultOptions()


### PR DESCRIPTION
It looks like it was broken again with the following error  during the first run (if installing the dashboard right after installing Flux) or during the second run (if installing Flux during the first run and the dashboard during the second run):

```
macbook-pro:podinfo olga$ /Volumes/Macintosh_HD_Data/_job_ww/_src/weave-gitops-3/bin/gitops beta run ./deploy/overlays/dev --timeout=3m --port-forward namespace=dev,resource=svc/backend,port=9898:9898
► Checking for a cluster in the kube config ...
► Checking if Flux is already installed ...
► Getting Flux version ...
⚠️ Flux is not found: error getting Flux labels
► Installing Flux ...
CustomResourceDefinition/alerts.notification.toolkit.fluxcd.io created
CustomResourceDefinition/buckets.source.toolkit.fluxcd.io created
CustomResourceDefinition/gitrepositories.source.toolkit.fluxcd.io created
CustomResourceDefinition/helmcharts.source.toolkit.fluxcd.io created
CustomResourceDefinition/helmreleases.helm.toolkit.fluxcd.io created
CustomResourceDefinition/helmrepositories.source.toolkit.fluxcd.io created
CustomResourceDefinition/kustomizations.kustomize.toolkit.fluxcd.io created
CustomResourceDefinition/providers.notification.toolkit.fluxcd.io created
CustomResourceDefinition/receivers.notification.toolkit.fluxcd.io created
Namespace/flux-system created
ServiceAccount/flux-system/helm-controller created
ServiceAccount/flux-system/kustomize-controller created
ServiceAccount/flux-system/notification-controller created
ServiceAccount/flux-system/source-controller created
ClusterRole/crd-controller-flux-system created
ClusterRoleBinding/cluster-reconciler-flux-system created
ClusterRoleBinding/crd-controller-flux-system created
Service/flux-system/notification-controller created
Service/flux-system/source-controller created
Service/flux-system/webhook-receiver created
Deployment/flux-system/helm-controller created
Deployment/flux-system/kustomize-controller created
Deployment/flux-system/notification-controller created
Deployment/flux-system/source-controller created
NetworkPolicy/flux-system/allow-egress created
NetworkPolicy/flux-system/allow-scraping created
NetworkPolicy/flux-system/allow-webhooks created
✔ Flux has been installed
► Waiting for flux-system/source-controller to be ready ...
✔ flux-system/source-controller is now ready ...
► Waiting for flux-system/kustomize-controller to be ready ...
✔ flux-system/kustomize-controller is now ready ...
► Waiting for flux-system/helm-controller to be ready ...
✔ flux-system/helm-controller is now ready ...
► Waiting for flux-system/notification-controller to be ready ...
✔ flux-system/notification-controller is now ready ...
► Checking if GitOps Dashboard is already installed ...
Would you like to install the GitOps Dashboard: y
► Installing the GitOps Dashboard ...
Please enter your password to generate the secret: 
✔ Secret has been generated:
$2a$10$e0UvHWgR.pFl/0JJZLMNYeGIg8PIvkC/cju6wRVGxsVbSyO6jrohe
► Installing the GitOps Dashboard ...
✔ Generated GitOps Dashboard manifests
✔ GitOps Dashboard has been installed
HelmRelease/flux-system/ww-gitops created
HelmRepository/flux-system/ww-gitops created
✔ GitOps Dashboard has been installed
► Request reconciliation of dashboard (timeout 3m0s) ...
✗ Error requesting reconciliation of dashboard: helmcharts.source.toolkit.fluxcd.io "flux-system-ww-gitops" not found
► Checking namespace dev-bucket ...
✔ Created namespace dev-bucket
► Checking service dev-bucket/dev-bucket ...
✔ Created service dev-bucket/dev-bucket
► Checking deployment dev-bucket/dev-bucket ...
✔ Created deployment dev-bucket/dev-bucket
► Waiting for deployment dev-bucket to be ready ...
► Port forwarding to pod dev-bucket/dev-bucket-f649c7d6c-hgdkb ...
Forwarding from 127.0.0.1:9000 -> 9000
Forwarding from [::1]:9000 -> 9000
✔ Port forwarding for dev-bucket is ready.
✗ Error getting pod from specMap: no running pods found for deployment
Error: dashboard pod not found
```

For some reason, when I move waiting for Flux components to be ready out of that condition (similar to how it as before), it starts working without an error. Weird behaviour.