### PR TITLE
Write unit tests for GitOps Run: Flux and GitOps Dashboard installation Part 2

### DIFF
--- a/pkg/run/apply_manifests.go
+++ b/pkg/run/apply_manifests.go
@@ -10,11 +10,18 @@ import (
 	"github.com/weaveworks/weave-gitops/pkg/logger"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"sigs.k8s.io/cli-utils/pkg/kstatus/polling"
+	"sigs.k8s.io/cli-utils/pkg/object"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+type ResourceManagerForApply interface {
+	ApplyAll(ctx context.Context, objects []*unstructured.Unstructured, opts ssa.ApplyOptions) (*ssa.ChangeSet, error)
+	WaitForSet(set object.ObjMetadataSet, opts ssa.WaitOptions) error
+}
+
 // apply is the equivalent of 'kubectl apply --server-side -f'.
-func apply(log logger.Logger, ctx context.Context, kubeClient ctrlclient.Client, kubeConfigArgs genericclioptions.RESTClientGetter, manifestsContent []byte) (string, error) {
+func Apply(log logger.Logger, ctx context.Context, manager ResourceManagerForApply, manifestsContent []byte) (string, error) {
 	objs, err := ssa.ReadObjects(bytes.NewReader(manifestsContent))
 	if err != nil {
 		log.Failuref("Error reading Kubernetes objects from the manifests")
@@ -47,7 +54,7 @@ func apply(log logger.Logger, ctx context.Context, kubeClient ctrlclient.Client,
 	}
 
 	if len(stageOne) > 0 {
-		cs, err := applySet(log, ctx, kubeClient, kubeConfigArgs, stageOne)
+		cs, err := applySet(log, ctx, manager, stageOne)
 		if err != nil {
 			log.Failuref("Error applying stage one objects")
 			return "", err
@@ -55,14 +62,14 @@ func apply(log logger.Logger, ctx context.Context, kubeClient ctrlclient.Client,
 
 		changeSet.Append(cs.Entries)
 
-		if err := waitForSet(log, ctx, kubeClient, kubeConfigArgs, changeSet); err != nil {
+		if err := waitForSet(log, ctx, manager, changeSet); err != nil {
 			log.Failuref("Error waiting for set")
 			return "", err
 		}
 	}
 
 	if len(stageTwo) > 0 {
-		cs, err := applySet(log, ctx, kubeClient, kubeConfigArgs, stageTwo)
+		cs, err := applySet(log, ctx, manager, stageTwo)
 		if err != nil {
 			log.Failuref("Error applying stage two objects")
 			return "", err
@@ -74,22 +81,25 @@ func apply(log logger.Logger, ctx context.Context, kubeClient ctrlclient.Client,
 	return changeSet.String(), nil
 }
 
-func applySet(log logger.Logger, ctx context.Context, kubeClient ctrlclient.Client, kubeConfigArgs genericclioptions.RESTClientGetter, objects []*unstructured.Unstructured) (*ssa.ChangeSet, error) {
-	man, err := newManager(log, ctx, kubeClient, kubeConfigArgs)
+func applySet(log logger.Logger, ctx context.Context, manager ResourceManagerForApply, objects []*unstructured.Unstructured) (*ssa.ChangeSet, error) {
+	return manager.ApplyAll(ctx, objects, ssa.DefaultApplyOptions())
+}
+
+func waitForSet(log logger.Logger, ctx context.Context, manager ResourceManagerForApply, changeSet *ssa.ChangeSet) error {
+	return manager.WaitForSet(changeSet.ToObjMetadataSet(), ssa.WaitOptions{Interval: 2 * time.Second, Timeout: time.Minute})
+}
+
+func NewManager(log logger.Logger, ctx context.Context, kubeClient ctrlclient.Client, kubeConfigArgs genericclioptions.RESTClientGetter) (*ssa.ResourceManager, error) {
+	restMapper, err := kubeConfigArgs.ToRESTMapper()
 	if err != nil {
-		log.Failuref("Error applying set")
+		log.Failuref("Error getting a restmapper")
 		return nil, err
 	}
 
-	return man.ApplyAll(ctx, objects, ssa.DefaultApplyOptions())
-}
+	kubePoller := polling.NewStatusPoller(kubeClient, restMapper, polling.Options{})
 
-func waitForSet(log logger.Logger, ctx context.Context, kubeClient ctrlclient.Client, rcg genericclioptions.RESTClientGetter, changeSet *ssa.ChangeSet) error {
-	man, err := newManager(log, ctx, kubeClient, rcg)
-	if err != nil {
-		log.Failuref("Error waiting for set")
-		return err
-	}
-
-	return man.WaitForSet(changeSet.ToObjMetadataSet(), ssa.WaitOptions{Interval: 2 * time.Second, Timeout: time.Minute})
+	return ssa.NewResourceManager(kubeClient, kubePoller, ssa.Owner{
+		Field: "flux",
+		Group: "fluxcd.io",
+	}), nil
 }

--- a/pkg/run/apply_manifests_test.go
+++ b/pkg/run/apply_manifests_test.go
@@ -1,4 +1,4 @@
-package run_test
+package run
 
 import (
 	"context"
@@ -9,14 +9,13 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/weaveworks/weave-gitops/pkg/logger/loggerfakes"
-	"github.com/weaveworks/weave-gitops/pkg/run"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/cli-utils/pkg/object"
 )
 
 // mock ssa.ResourceManager
 type mockResourceManagerForApply struct {
-	run.ResourceManagerForApply
+	ResourceManagerForApply
 	state stateApply
 }
 
@@ -51,7 +50,7 @@ func (man *mockResourceManagerForApply) WaitForSet(set object.ObjMetadataSet, op
 	}
 }
 
-var _ = Describe("Apply", func() {
+var _ = Describe("apply", func() {
 	var fakeLogger *loggerfakes.FakeLogger
 	var fakeContext context.Context
 	var fakeInstallOptions install.Options
@@ -70,14 +69,14 @@ var _ = Describe("Apply", func() {
 	It("should apply manifests successfully", func() {
 		man := &mockResourceManagerForApply{}
 
-		_, err := run.Apply(fakeLogger, fakeContext, man, fakeManifestsContent)
+		_, err := apply(fakeLogger, fakeContext, man, fakeManifestsContent)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should return an apply all error if the resource manager returns an apply all error", func() {
 		man := &mockResourceManagerForApply{state: stateApplyAllReturnErr}
 
-		_, err := run.Apply(fakeLogger, fakeContext, man, fakeManifestsContent)
+		_, err := apply(fakeLogger, fakeContext, man, fakeManifestsContent)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(Equal(applyAllErrorMsg))
 	})
@@ -85,7 +84,7 @@ var _ = Describe("Apply", func() {
 	It("should return a wait for set error if the resource manager returns a wait for set error", func() {
 		man := &mockResourceManagerForApply{state: stateWaitForSetReturnErr}
 
-		_, err := run.Apply(fakeLogger, fakeContext, man, fakeManifestsContent)
+		_, err := apply(fakeLogger, fakeContext, man, fakeManifestsContent)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(Equal(waitForSetErrorMsg))
 	})

--- a/pkg/run/apply_manifests_test.go
+++ b/pkg/run/apply_manifests_test.go
@@ -1,0 +1,92 @@
+package run_test
+
+import (
+	"context"
+	"errors"
+
+	"github.com/fluxcd/flux2/pkg/manifestgen/install"
+	"github.com/fluxcd/pkg/ssa"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/weaveworks/weave-gitops/pkg/logger/loggerfakes"
+	"github.com/weaveworks/weave-gitops/pkg/run"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/cli-utils/pkg/object"
+)
+
+// mock ssa.ResourceManager
+type mockResourceManagerForApply struct {
+	run.ResourceManagerForApply
+	state stateApply
+}
+
+type stateApply string
+
+const (
+	stateApplyAllReturnErr   stateApply = "apply-all-return-err"
+	stateWaitForSetReturnErr stateApply = "wait-for-set-return-err"
+	applyAllErrorMsg                    = "apply all error"
+	waitForSetErrorMsg                  = "wait for set error"
+)
+
+func (man *mockResourceManagerForApply) ApplyAll(ctx context.Context, objects []*unstructured.Unstructured, opts ssa.ApplyOptions) (*ssa.ChangeSet, error) {
+	switch man.state {
+	case stateApplyAllReturnErr:
+		return nil, errors.New(applyAllErrorMsg)
+
+	default:
+		changeSet := ssa.NewChangeSet()
+
+		return changeSet, nil
+	}
+}
+
+func (man *mockResourceManagerForApply) WaitForSet(set object.ObjMetadataSet, opts ssa.WaitOptions) error {
+	switch man.state {
+	case stateWaitForSetReturnErr:
+		return errors.New(waitForSetErrorMsg)
+
+	default:
+		return nil
+	}
+}
+
+var _ = Describe("Apply", func() {
+	var fakeLogger *loggerfakes.FakeLogger
+	var fakeContext context.Context
+	var fakeInstallOptions install.Options
+	var fakeManifestsContent []byte
+
+	BeforeEach(func() {
+		fakeLogger = &loggerfakes.FakeLogger{}
+		fakeContext = context.Background()
+		fakeInstallOptions = install.MakeDefaultOptions()
+
+		fakeManifests, err := install.Generate(fakeInstallOptions, "")
+		Expect(err).NotTo(HaveOccurred())
+		fakeManifestsContent = []byte(fakeManifests.Content)
+	})
+
+	It("should apply manifests successfully", func() {
+		man := &mockResourceManagerForApply{}
+
+		_, err := run.Apply(fakeLogger, fakeContext, man, fakeManifestsContent)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should return an apply all error if the resource manager returns an apply all error", func() {
+		man := &mockResourceManagerForApply{state: stateApplyAllReturnErr}
+
+		_, err := run.Apply(fakeLogger, fakeContext, man, fakeManifestsContent)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(Equal(applyAllErrorMsg))
+	})
+
+	It("should return a wait for set error if the resource manager returns a wait for set error", func() {
+		man := &mockResourceManagerForApply{state: stateWaitForSetReturnErr}
+
+		_, err := run.Apply(fakeLogger, fakeContext, man, fakeManifestsContent)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(Equal(waitForSetErrorMsg))
+	})
+})

--- a/pkg/run/forward_port_test.go
+++ b/pkg/run/forward_port_test.go
@@ -3,6 +3,7 @@ package run_test
 import (
 	"context"
 	"errors"
+
 	"github.com/weaveworks/weave-gitops/pkg/run"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"

--- a/pkg/run/forward_port_test.go
+++ b/pkg/run/forward_port_test.go
@@ -1,10 +1,9 @@
-package run_test
+package run
 
 import (
 	"context"
 	"errors"
 
-	"github.com/weaveworks/weave-gitops/pkg/run"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -126,7 +125,7 @@ func (c *mockClientForGetPodFromSpecMap) Get(_ context.Context, key client.Objec
 
 var _ = Describe("GetPodFromSpecMap", func() {
 	It("should return an error if the pod spec is not correct", func() {
-		_, err := run.GetPodFromSpecMap(&run.PortForwardSpec{
+		_, err := GetPodFromSpecMap(&PortForwardSpec{
 			Kind: "something",
 		}, &mockClientForGetPodFromSpecMap{})
 
@@ -135,7 +134,7 @@ var _ = Describe("GetPodFromSpecMap", func() {
 	})
 
 	It("should return an error if the client returns an error", func() {
-		_, err := run.GetPodFromSpecMap(&run.PortForwardSpec{
+		_, err := GetPodFromSpecMap(&PortForwardSpec{
 			Namespace: "ns",
 			Name:      "name",
 			Kind:      "pod",
@@ -146,7 +145,7 @@ var _ = Describe("GetPodFromSpecMap", func() {
 	})
 
 	It("returns a pod according to the pod spec", func() {
-		pod, err := run.GetPodFromSpecMap(&run.PortForwardSpec{
+		pod, err := GetPodFromSpecMap(&PortForwardSpec{
 			Namespace: "ns",
 			Name:      "name",
 			Kind:      "pod",
@@ -160,7 +159,7 @@ var _ = Describe("GetPodFromSpecMap", func() {
 	// Service tests
 
 	It("should return an error if the client returns an error", func() {
-		_, err := run.GetPodFromSpecMap(&run.PortForwardSpec{
+		_, err := GetPodFromSpecMap(&PortForwardSpec{
 			Namespace: "ns",
 			Name:      "name",
 			Kind:      "service",
@@ -171,7 +170,7 @@ var _ = Describe("GetPodFromSpecMap", func() {
 	})
 
 	It("should return an error if the client returns an error", func() {
-		_, err := run.GetPodFromSpecMap(&run.PortForwardSpec{
+		_, err := GetPodFromSpecMap(&PortForwardSpec{
 			Namespace: "ns",
 			Name:      "name",
 			Kind:      "service",
@@ -182,7 +181,7 @@ var _ = Describe("GetPodFromSpecMap", func() {
 	})
 
 	It("returns a pod according to the service spec", func() {
-		pod, err := run.GetPodFromSpecMap(&run.PortForwardSpec{
+		pod, err := GetPodFromSpecMap(&PortForwardSpec{
 			Namespace: "ns",
 			Name:      "name",
 			Kind:      "service",
@@ -194,7 +193,7 @@ var _ = Describe("GetPodFromSpecMap", func() {
 	})
 
 	It("returns a pod according to the service spec", func() {
-		pod, err := run.GetPodFromSpecMap(&run.PortForwardSpec{
+		pod, err := GetPodFromSpecMap(&PortForwardSpec{
 			Namespace: "ns",
 			Name:      "name",
 			Kind:      "service",
@@ -206,7 +205,7 @@ var _ = Describe("GetPodFromSpecMap", func() {
 	})
 
 	It("returns a pod according to the service spec", func() {
-		pod, err := run.GetPodFromSpecMap(&run.PortForwardSpec{
+		pod, err := GetPodFromSpecMap(&PortForwardSpec{
 			Namespace: "ns",
 			Name:      "name",
 			Kind:      "service",
@@ -220,7 +219,7 @@ var _ = Describe("GetPodFromSpecMap", func() {
 	// Deployment tests
 
 	It("should return an error if the client returns an error", func() {
-		_, err := run.GetPodFromSpecMap(&run.PortForwardSpec{
+		_, err := GetPodFromSpecMap(&PortForwardSpec{
 			Namespace: "ns",
 			Name:      "name",
 			Kind:      "deployment",
@@ -231,7 +230,7 @@ var _ = Describe("GetPodFromSpecMap", func() {
 	})
 
 	It("should return an error if the client returns an error", func() {
-		_, err := run.GetPodFromSpecMap(&run.PortForwardSpec{
+		_, err := GetPodFromSpecMap(&PortForwardSpec{
 			Namespace: "ns",
 			Name:      "name",
 			Kind:      "deployment",
@@ -242,7 +241,7 @@ var _ = Describe("GetPodFromSpecMap", func() {
 	})
 
 	It("returns a pod according to the deployment spec", func() {
-		pod, err := run.GetPodFromSpecMap(&run.PortForwardSpec{
+		pod, err := GetPodFromSpecMap(&PortForwardSpec{
 			Namespace: "ns",
 			Name:      "name",
 			Kind:      "deployment",
@@ -254,7 +253,7 @@ var _ = Describe("GetPodFromSpecMap", func() {
 	})
 
 	It("returns a pod according to the deployment spec", func() {
-		pod, err := run.GetPodFromSpecMap(&run.PortForwardSpec{
+		pod, err := GetPodFromSpecMap(&PortForwardSpec{
 			Namespace: "ns",
 			Name:      "name",
 			Kind:      "deployment",
@@ -266,7 +265,7 @@ var _ = Describe("GetPodFromSpecMap", func() {
 	})
 
 	It("returns a pod according to the deployment spec", func() {
-		pod, err := run.GetPodFromSpecMap(&run.PortForwardSpec{
+		pod, err := GetPodFromSpecMap(&PortForwardSpec{
 			Namespace: "ns",
 			Name:      "name",
 			Kind:      "deployment",

--- a/pkg/run/get_kube_client.go
+++ b/pkg/run/get_kube_client.go
@@ -1,16 +1,11 @@
 package run
 
 import (
-	"context"
-
 	runclient "github.com/fluxcd/pkg/runtime/client"
-	"github.com/fluxcd/pkg/ssa"
 	"github.com/weaveworks/weave-gitops/pkg/kube"
 	"github.com/weaveworks/weave-gitops/pkg/logger"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/rest"
-	"sigs.k8s.io/cli-utils/pkg/kstatus/polling"
-	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func GetKubeConfigArgs() *genericclioptions.ConfigFlags {
@@ -55,19 +50,4 @@ func GetKubeClient(log logger.Logger, contextName string, cfg *rest.Config, kube
 	}
 
 	return kubeClient, nil
-}
-
-func newManager(log logger.Logger, ctx context.Context, kubeClient ctrlclient.Client, kubeConfigArgs genericclioptions.RESTClientGetter) (*ssa.ResourceManager, error) {
-	restMapper, err := kubeConfigArgs.ToRESTMapper()
-	if err != nil {
-		log.Failuref("Error getting a restmapper")
-		return nil, err
-	}
-
-	kubePoller := polling.NewStatusPoller(kubeClient, restMapper, polling.Options{})
-
-	return ssa.NewResourceManager(kubeClient, kubePoller, ssa.Owner{
-		Field: "flux",
-		Group: "fluxcd.io",
-	}), nil
 }

--- a/pkg/run/get_kube_client_test.go
+++ b/pkg/run/get_kube_client_test.go
@@ -1,10 +1,9 @@
-package run_test
+package run
 
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/weaveworks/weave-gitops/pkg/logger/loggerfakes"
-	"github.com/weaveworks/weave-gitops/pkg/run"
 )
 
 var _ = Describe("GetKubeClient", func() {
@@ -15,7 +14,7 @@ var _ = Describe("GetKubeClient", func() {
 	})
 
 	It("returns kube client", func() {
-		kubeConfigArgs := run.GetKubeConfigArgs()
+		kubeConfigArgs := GetKubeConfigArgs()
 
 		namespace := "test-namespace"
 
@@ -24,11 +23,11 @@ var _ = Describe("GetKubeClient", func() {
 		_, err := kubeConfigArgs.ToRESTConfig()
 		Expect(err).NotTo(HaveOccurred())
 
-		kubeClientOpts := run.GetKubeClientOptions()
+		kubeClientOpts := GetKubeClientOptions()
 
 		contextName := "test-context"
 
-		kubeClient, err := run.GetKubeClient(fakeLogger, contextName, k8sEnv.Rest, kubeClientOpts)
+		kubeClient, err := GetKubeClient(fakeLogger, contextName, k8sEnv.Rest, kubeClientOpts)
 
 		Expect(err).NotTo(HaveOccurred())
 		Expect(kubeClient).ToNot(BeNil())

--- a/pkg/run/get_kube_client_test.go
+++ b/pkg/run/get_kube_client_test.go
@@ -26,7 +26,7 @@ var _ = Describe("GetKubeClient", func() {
 
 		kubeClientOpts := run.GetKubeClientOptions()
 
-		contextName := "some-context"
+		contextName := "test-context"
 
 		kubeClient, err := run.GetKubeClient(fakeLogger, contextName, k8sEnv.Rest, kubeClientOpts)
 

--- a/pkg/run/install_bucket_source_and_ks_test.go
+++ b/pkg/run/install_bucket_source_and_ks_test.go
@@ -1,4 +1,4 @@
-package run_test
+package run
 
 import (
 	"context"
@@ -7,7 +7,6 @@ import (
 	. "github.com/onsi/gomega"
 
 	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1beta2"
-	"github.com/weaveworks/weave-gitops/pkg/run"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -121,7 +120,7 @@ var _ = Describe("FindConditionMessages", func() {
 				},
 			},
 		}
-		messages, err := run.FindConditionMessages(client, ks)
+		messages, err := FindConditionMessages(client, ks)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(messages).To(Equal([]string{
 			"Deployment default/deployment: This is message",

--- a/pkg/run/install_dashboard.go
+++ b/pkg/run/install_dashboard.go
@@ -56,15 +56,15 @@ func GenerateSecret(log logger.Logger) (string, error) {
 func InstallDashboard(log logger.Logger, ctx context.Context, manager ResourceManagerForApply, namespace string, secret string) error {
 	log.Actionf("Installing the GitOps Dashboard ...")
 
-	helmRepository := makeHelmRepository(namespace)
-	helmRelease, err := makeHelmRelease(log, secret, namespace)
+	helmRepository := MakeHelmRepository(namespace)
+	helmRelease, err := MakeHelmRelease(log, secret, namespace)
 
 	if err != nil {
 		log.Failuref("Creating HelmRelease failed")
 		return err
 	}
 
-	manifests, err := generateManifests(log, string(secret), helmRepository, helmRelease)
+	manifests, err := GenerateManifestsForDashboard(log, string(secret), helmRepository, helmRelease)
 	if err != nil {
 		log.Failuref("Generating GitOps Dashboard manifests failed")
 		return err
@@ -205,8 +205,8 @@ func ReconcileDashboard(kubeClient client.Client, namespace string, timeout time
 	return nil
 }
 
-// generateManifests generates dashboard manifests from objects.
-func generateManifests(log logger.Logger, secret string, helmRepository *sourcev1.HelmRepository, helmRelease *helmv2.HelmRelease) ([]byte, error) {
+// GenerateManifestsForDashboard generates dashboard manifests from objects.
+func GenerateManifestsForDashboard(log logger.Logger, secret string, helmRepository *sourcev1.HelmRepository, helmRelease *helmv2.HelmRelease) ([]byte, error) {
 	helmRepositoryData, err := yaml.Marshal(helmRepository)
 	if err != nil {
 		log.Failuref("Error generating HelmRepository manifest from object")
@@ -228,8 +228,8 @@ func generateManifests(log logger.Logger, secret string, helmRepository *sourcev
 	return content, nil
 }
 
-// makeHelmRepository creates a HelmRepository object for installing the GitOps Dashboard.
-func makeHelmRepository(namespace string) *sourcev1.HelmRepository {
+// MakeHelmRepository creates a HelmRepository object for installing the GitOps Dashboard.
+func MakeHelmRepository(namespace string) *sourcev1.HelmRepository {
 	helmRepository := &sourcev1.HelmRepository{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       sourcev1.HelmRepositoryKind,
@@ -250,8 +250,8 @@ func makeHelmRepository(namespace string) *sourcev1.HelmRepository {
 	return helmRepository
 }
 
-// makeHelmRelease creates a HelmRelease object for installing the GitOps Dashboard.
-func makeHelmRelease(log logger.Logger, secret string, namespace string) (*helmv2.HelmRelease, error) {
+// MakeHelmRelease creates a HelmRelease object for installing the GitOps Dashboard.
+func MakeHelmRelease(log logger.Logger, secret string, namespace string) (*helmv2.HelmRelease, error) {
 	helmRelease := &helmv2.HelmRelease{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       helmv2.HelmReleaseKind,
@@ -279,7 +279,7 @@ func makeHelmRelease(log logger.Logger, secret string, namespace string) (*helmv
 		},
 	}
 
-	valuesData, err := makeValues(secret)
+	valuesData, err := MakeValues(secret)
 	if err != nil {
 		log.Failuref("Error generating values from secret")
 		return nil, err
@@ -290,8 +290,8 @@ func makeHelmRelease(log logger.Logger, secret string, namespace string) (*helmv
 	return helmRelease, nil
 }
 
-// makeValues creates a values object for installing the GitOps Dashboard.
-func makeValues(secret string) ([]byte, error) {
+// MakeValues creates a values object for installing the GitOps Dashboard.
+func MakeValues(secret string) ([]byte, error) {
 	valuesMap := map[string]interface{}{
 		"adminUser": map[string]interface{}{
 			"create":       true,

--- a/pkg/run/install_dashboard.go
+++ b/pkg/run/install_dashboard.go
@@ -46,10 +46,7 @@ func GenerateSecret(log logger.Logger) (string, error) {
 
 	log.Successf("Secret has been generated:")
 
-	secretStr := string(secret)
-	fmt.Println(secretStr)
-
-	return secretStr, nil
+	return string(secret), nil
 }
 
 // InstallDashboard installs the GitOps Dashboard.

--- a/pkg/run/install_dashboard.go
+++ b/pkg/run/install_dashboard.go
@@ -87,17 +87,23 @@ func InstallDashboard(log logger.Logger, ctx context.Context, manager ResourceMa
 
 // IsDashboardInstalled checks if the GitOps Dashboard is installed.
 func IsDashboardInstalled(log logger.Logger, ctx context.Context, kubeClient client.Client, namespace string) bool {
+	return GetDashboardHelmChart(log, ctx, kubeClient, namespace) != nil
+}
+
+// GetDashboardHelmChart checks if the GitOps Dashboard is installed.
+func GetDashboardHelmChart(log logger.Logger, ctx context.Context, kubeClient client.Client, namespace string) *sourcev1.HelmChart {
 	helmChart := sourcev1.HelmChart{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      namespace + "-" + helmReleaseName,
 		},
 	}
+
 	if err := kubeClient.Get(ctx, client.ObjectKeyFromObject(&helmChart), &helmChart); err != nil {
-		return false
+		return nil
 	}
 
-	return true
+	return &helmChart
 }
 
 // EnablePortForwardingForDashboard enables port forwarding for the GitOps Dashboard.

--- a/pkg/run/install_dashboard.go
+++ b/pkg/run/install_dashboard.go
@@ -53,15 +53,15 @@ func GenerateSecret(log logger.Logger) (string, error) {
 func InstallDashboard(log logger.Logger, ctx context.Context, manager ResourceManagerForApply, namespace string, secret string) error {
 	log.Actionf("Installing the GitOps Dashboard ...")
 
-	helmRepository := MakeHelmRepository(namespace)
-	helmRelease, err := MakeHelmRelease(log, secret, namespace)
+	helmRepository := makeHelmRepository(namespace)
+	helmRelease, err := makeHelmRelease(log, secret, namespace)
 
 	if err != nil {
 		log.Failuref("Creating HelmRelease failed")
 		return err
 	}
 
-	manifests, err := GenerateManifestsForDashboard(log, string(secret), helmRepository, helmRelease)
+	manifests, err := generateManifestsForDashboard(log, string(secret), helmRepository, helmRelease)
 	if err != nil {
 		log.Failuref("Generating GitOps Dashboard manifests failed")
 		return err
@@ -69,7 +69,7 @@ func InstallDashboard(log logger.Logger, ctx context.Context, manager ResourceMa
 
 	log.Successf("Generated GitOps Dashboard manifests")
 
-	applyOutput, err := Apply(log, ctx, manager, manifests)
+	applyOutput, err := apply(log, ctx, manager, manifests)
 	if err != nil {
 		log.Failuref("GitOps Dashboard install failed")
 		return err
@@ -84,11 +84,11 @@ func InstallDashboard(log logger.Logger, ctx context.Context, manager ResourceMa
 
 // IsDashboardInstalled checks if the GitOps Dashboard is installed.
 func IsDashboardInstalled(log logger.Logger, ctx context.Context, kubeClient client.Client, namespace string) bool {
-	return GetDashboardHelmChart(log, ctx, kubeClient, namespace) != nil
+	return getDashboardHelmChart(log, ctx, kubeClient, namespace) != nil
 }
 
 // GetDashboardHelmChart checks if the GitOps Dashboard is installed.
-func GetDashboardHelmChart(log logger.Logger, ctx context.Context, kubeClient client.Client, namespace string) *sourcev1.HelmChart {
+func getDashboardHelmChart(log logger.Logger, ctx context.Context, kubeClient client.Client, namespace string) *sourcev1.HelmChart {
 	helmChart := sourcev1.HelmChart{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
@@ -200,7 +200,7 @@ func ReconcileDashboard(kubeClient client.Client, namespace string, timeout time
 			return false, nil
 		}
 
-		return IsPodStatusConditionPresentAndEqual(dashboard.Status.Conditions, corev1.PodReady, corev1.ConditionTrue), nil
+		return isPodStatusConditionPresentAndEqual(dashboard.Status.Conditions, corev1.PodReady, corev1.ConditionTrue), nil
 	}); err != nil {
 		return err
 	}
@@ -208,8 +208,8 @@ func ReconcileDashboard(kubeClient client.Client, namespace string, timeout time
 	return nil
 }
 
-// GenerateManifestsForDashboard generates dashboard manifests from objects.
-func GenerateManifestsForDashboard(log logger.Logger, secret string, helmRepository *sourcev1.HelmRepository, helmRelease *helmv2.HelmRelease) ([]byte, error) {
+// generateManifestsForDashboard generates dashboard manifests from objects.
+func generateManifestsForDashboard(log logger.Logger, secret string, helmRepository *sourcev1.HelmRepository, helmRelease *helmv2.HelmRelease) ([]byte, error) {
 	helmRepositoryData, err := yaml.Marshal(helmRepository)
 	if err != nil {
 		log.Failuref("Error generating HelmRepository manifest from object")
@@ -231,8 +231,8 @@ func GenerateManifestsForDashboard(log logger.Logger, secret string, helmReposit
 	return content, nil
 }
 
-// MakeHelmRepository creates a HelmRepository object for installing the GitOps Dashboard.
-func MakeHelmRepository(namespace string) *sourcev1.HelmRepository {
+// makeHelmRepository creates a HelmRepository object for installing the GitOps Dashboard.
+func makeHelmRepository(namespace string) *sourcev1.HelmRepository {
 	helmRepository := &sourcev1.HelmRepository{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       sourcev1.HelmRepositoryKind,
@@ -253,8 +253,8 @@ func MakeHelmRepository(namespace string) *sourcev1.HelmRepository {
 	return helmRepository
 }
 
-// MakeHelmRelease creates a HelmRelease object for installing the GitOps Dashboard.
-func MakeHelmRelease(log logger.Logger, secret string, namespace string) (*helmv2.HelmRelease, error) {
+// makeHelmRelease creates a HelmRelease object for installing the GitOps Dashboard.
+func makeHelmRelease(log logger.Logger, secret string, namespace string) (*helmv2.HelmRelease, error) {
 	helmRelease := &helmv2.HelmRelease{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       helmv2.HelmReleaseKind,
@@ -282,7 +282,7 @@ func MakeHelmRelease(log logger.Logger, secret string, namespace string) (*helmv
 		},
 	}
 
-	valuesData, err := MakeValues(secret)
+	valuesData, err := makeValues(secret)
 	if err != nil {
 		log.Failuref("Error generating values from secret")
 		return nil, err
@@ -293,8 +293,8 @@ func MakeHelmRelease(log logger.Logger, secret string, namespace string) (*helmv
 	return helmRelease, nil
 }
 
-// MakeValues creates a values object for installing the GitOps Dashboard.
-func MakeValues(secret string) ([]byte, error) {
+// makeValues creates a values object for installing the GitOps Dashboard.
+func makeValues(secret string) ([]byte, error) {
 	valuesMap := map[string]interface{}{
 		"adminUser": map[string]interface{}{
 			"create":       true,

--- a/pkg/run/install_dashboard_test.go
+++ b/pkg/run/install_dashboard_test.go
@@ -2,16 +2,23 @@ package run_test
 
 import (
 	"context"
+	"encoding/json"
+	"time"
 
+	helmv2 "github.com/fluxcd/helm-controller/api/v2beta1"
+	sourcev1 "github.com/fluxcd/source-controller/api/v1beta2"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/weaveworks/weave-gitops/pkg/logger/loggerfakes"
 	"github.com/weaveworks/weave-gitops/pkg/run"
+	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
 )
 
 const (
-	secret    = "some-secret"
-	namespace = "some-namespace"
+	secret    = "test-secret"
+	namespace = "test-namespace"
 )
 
 var _ = Describe("InstallDashboard", func() {
@@ -36,5 +43,193 @@ var _ = Describe("InstallDashboard", func() {
 		err := run.InstallDashboard(fakeLogger, fakeContext, man, namespace, secret)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(Equal(applyAllErrorMsg))
+	})
+})
+
+var _ = Describe("GenerateManifestsForDashboard", func() {
+	var fakeLogger *loggerfakes.FakeLogger
+
+	BeforeEach(func() {
+		fakeLogger = &loggerfakes.FakeLogger{}
+	})
+
+	It("generates manifests successfully", func() {
+		valuesMap := map[string]interface{}{
+			"adminUser": map[string]interface{}{
+				"create":       true,
+				"passwordHash": "test-secret",
+				"username":     "admin",
+			},
+		}
+
+		helmRepository := &sourcev1.HelmRepository{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       sourcev1.HelmRepositoryKind,
+				APIVersion: sourcev1.GroupVersion.Identifier(),
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "ww-gitops",
+				Namespace: "test-namespace",
+			},
+			Spec: sourcev1.HelmRepositorySpec{
+				URL: "https://helm.gitops.weave.works",
+				Interval: metav1.Duration{
+					Duration: time.Minute,
+				},
+			},
+		}
+
+		values, err := json.Marshal(valuesMap)
+		Expect(err).NotTo(HaveOccurred())
+
+		helmRelease := &helmv2.HelmRelease{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       helmv2.HelmReleaseKind,
+				APIVersion: helmv2.GroupVersion.Identifier(),
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "ww-gitops",
+				Namespace: "test-namespace",
+			},
+			Spec: helmv2.HelmReleaseSpec{
+				Interval: metav1.Duration{
+					Duration: time.Minute,
+				},
+				Chart: helmv2.HelmChartTemplate{
+					Spec: helmv2.HelmChartTemplateSpec{
+						Chart:   "weave-gitops",
+						Version: "2.0.6",
+						SourceRef: helmv2.CrossNamespaceObjectReference{
+							Kind: "HelmRepository",
+							Name: "ww-gitops",
+						},
+						ReconcileStrategy: "ChartVersion",
+					},
+				},
+				Values: &v1.JSON{Raw: values},
+			},
+		}
+
+		expectedHelmRepository, err := yaml.Marshal(helmRepository)
+		Expect(err).NotTo(HaveOccurred())
+
+		expectedHelmRelease, err := yaml.Marshal(helmRelease)
+		Expect(err).NotTo(HaveOccurred())
+
+		divider := []byte("---\n")
+
+		expected := append(divider, expectedHelmRepository...)
+		expected = append(expected, divider...)
+		expected = append(expected, expectedHelmRelease...)
+
+		actual, err := run.GenerateManifestsForDashboard(fakeLogger, secret, helmRepository, helmRelease)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(actual).To(Equal(expected))
+	})
+})
+
+var _ = Describe("MakeHelmRelease", func() {
+	var fakeLogger *loggerfakes.FakeLogger
+
+	BeforeEach(func() {
+		fakeLogger = &loggerfakes.FakeLogger{}
+	})
+
+	It("creates helmrelease successfully", func() {
+		valuesMap := map[string]interface{}{
+			"adminUser": map[string]interface{}{
+				"create":       true,
+				"passwordHash": "test-secret",
+				"username":     "admin",
+			},
+		}
+
+		values, err := json.Marshal(valuesMap)
+		Expect(err).NotTo(HaveOccurred())
+
+		helmRelease := &helmv2.HelmRelease{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       helmv2.HelmReleaseKind,
+				APIVersion: helmv2.GroupVersion.Identifier(),
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "ww-gitops",
+				Namespace: "test-namespace",
+			},
+			Spec: helmv2.HelmReleaseSpec{
+				Interval: metav1.Duration{
+					Duration: time.Minute,
+				},
+				Chart: helmv2.HelmChartTemplate{
+					Spec: helmv2.HelmChartTemplateSpec{
+						Chart:   "weave-gitops",
+						Version: "2.0.6",
+						SourceRef: helmv2.CrossNamespaceObjectReference{
+							Kind: "HelmRepository",
+							Name: "ww-gitops",
+						},
+						ReconcileStrategy: "ChartVersion",
+					},
+				},
+				Values: &v1.JSON{Raw: values},
+			},
+		}
+
+		expected, err := json.Marshal(helmRelease)
+		Expect(err).NotTo(HaveOccurred())
+
+		actualHelmRelease, err := run.MakeHelmRelease(fakeLogger, secret, namespace)
+		Expect(err).NotTo(HaveOccurred())
+
+		actual, err := json.Marshal(actualHelmRelease)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(actual).To(Equal(expected))
+	})
+})
+
+var _ = Describe("MakeHelmRepository", func() {
+	It("creates helmrepository successfully", func() {
+		helmRepository := &sourcev1.HelmRepository{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       sourcev1.HelmRepositoryKind,
+				APIVersion: sourcev1.GroupVersion.Identifier(),
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "ww-gitops",
+				Namespace: "test-namespace",
+			},
+			Spec: sourcev1.HelmRepositorySpec{
+				URL: "https://helm.gitops.weave.works",
+				Interval: metav1.Duration{
+					Duration: time.Minute,
+				},
+			},
+		}
+
+		expected, err := json.Marshal(helmRepository)
+		Expect(err).NotTo(HaveOccurred())
+
+		actual, err := json.Marshal(run.MakeHelmRepository(namespace))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(actual).To(Equal(expected))
+	})
+})
+
+var _ = Describe("MakeValues", func() {
+	It("creates values successfully", func() {
+		valuesMap := map[string]interface{}{
+			"adminUser": map[string]interface{}{
+				"create":       true,
+				"passwordHash": "test-secret",
+				"username":     "admin",
+			},
+		}
+
+		expected, err := json.Marshal(valuesMap)
+		Expect(err).NotTo(HaveOccurred())
+
+		actual, err := run.MakeValues(secret)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(actual).To(Equal(expected))
 	})
 })

--- a/pkg/run/install_dashboard_test.go
+++ b/pkg/run/install_dashboard_test.go
@@ -1,4 +1,4 @@
-package run_test
+package run
 
 import (
 	"context"
@@ -11,7 +11,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/weaveworks/weave-gitops/pkg/logger/loggerfakes"
-	"github.com/weaveworks/weave-gitops/pkg/run"
 	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -47,14 +46,14 @@ var _ = Describe("InstallDashboard", func() {
 	It("should install dashboard successfully", func() {
 		man := &mockResourceManagerForApply{}
 
-		err := run.InstallDashboard(fakeLogger, fakeContext, man, namespace, secret)
+		err := InstallDashboard(fakeLogger, fakeContext, man, namespace, secret)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should return an apply all error if the resource manager returns an apply all error", func() {
 		man := &mockResourceManagerForApply{state: stateApplyAllReturnErr}
 
-		err := run.InstallDashboard(fakeLogger, fakeContext, man, namespace, secret)
+		err := InstallDashboard(fakeLogger, fakeContext, man, namespace, secret)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(Equal(applyAllErrorMsg))
 	})
@@ -81,7 +80,7 @@ func (man *mockClientForGetDashboardHelmChart) Get(_ context.Context, key client
 	return nil
 }
 
-var _ = Describe("GetDashboardHelmChart", func() {
+var _ = Describe("getDashboardHelmChart", func() {
 	var fakeLogger *loggerfakes.FakeLogger
 	var fakeContext context.Context
 
@@ -91,19 +90,19 @@ var _ = Describe("GetDashboardHelmChart", func() {
 	})
 
 	It("returns the dashboard helmchart if there is no error when getting the helmchart", func() {
-		helmChart := run.GetDashboardHelmChart(fakeLogger, fakeContext, &mockClientForGetDashboardHelmChart{}, namespace)
+		helmChart := getDashboardHelmChart(fakeLogger, fakeContext, &mockClientForGetDashboardHelmChart{}, namespace)
 		Expect(helmChart).ToNot(BeNil())
 		Expect(helmChart.Namespace).To(Equal("test-namespace"))
 		Expect(helmChart.Name).To(Equal("test-namespace-ww-gitops"))
 	})
 
 	It("returns nil if there is an error when getting the helmchart", func() {
-		helmChart := run.GetDashboardHelmChart(fakeLogger, fakeContext, &mockClientForGetDashboardHelmChart{state: stateGetDashboardHelmChartGetReturnErr}, namespace)
+		helmChart := getDashboardHelmChart(fakeLogger, fakeContext, &mockClientForGetDashboardHelmChart{state: stateGetDashboardHelmChartGetReturnErr}, namespace)
 		Expect(helmChart).To(BeNil())
 	})
 })
 
-var _ = Describe("GenerateManifestsForDashboard", func() {
+var _ = Describe("generateManifestsForDashboard", func() {
 	var fakeLogger *loggerfakes.FakeLogger
 
 	BeforeEach(func() {
@@ -179,13 +178,13 @@ var _ = Describe("GenerateManifestsForDashboard", func() {
 		expected = append(expected, divider...)
 		expected = append(expected, expectedHelmRelease...)
 
-		actual, err := run.GenerateManifestsForDashboard(fakeLogger, secret, helmRepository, helmRelease)
+		actual, err := generateManifestsForDashboard(fakeLogger, secret, helmRepository, helmRelease)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(actual).To(Equal(expected))
 	})
 })
 
-var _ = Describe("MakeHelmRelease", func() {
+var _ = Describe("makeHelmRelease", func() {
 	var fakeLogger *loggerfakes.FakeLogger
 
 	BeforeEach(func() {
@@ -235,7 +234,7 @@ var _ = Describe("MakeHelmRelease", func() {
 		expected, err := json.Marshal(helmRelease)
 		Expect(err).NotTo(HaveOccurred())
 
-		actualHelmRelease, err := run.MakeHelmRelease(fakeLogger, secret, namespace)
+		actualHelmRelease, err := makeHelmRelease(fakeLogger, secret, namespace)
 		Expect(err).NotTo(HaveOccurred())
 
 		actual, err := json.Marshal(actualHelmRelease)
@@ -244,7 +243,7 @@ var _ = Describe("MakeHelmRelease", func() {
 	})
 })
 
-var _ = Describe("MakeHelmRepository", func() {
+var _ = Describe("makeHelmRepository", func() {
 	It("creates helmrepository successfully", func() {
 		helmRepository := &sourcev1.HelmRepository{
 			TypeMeta: metav1.TypeMeta{
@@ -266,13 +265,13 @@ var _ = Describe("MakeHelmRepository", func() {
 		expected, err := json.Marshal(helmRepository)
 		Expect(err).NotTo(HaveOccurred())
 
-		actual, err := json.Marshal(run.MakeHelmRepository(namespace))
+		actual, err := json.Marshal(makeHelmRepository(namespace))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(actual).To(Equal(expected))
 	})
 })
 
-var _ = Describe("MakeValues", func() {
+var _ = Describe("makeValues", func() {
 	It("creates values successfully", func() {
 		valuesMap := map[string]interface{}{
 			"adminUser": map[string]interface{}{
@@ -285,7 +284,7 @@ var _ = Describe("MakeValues", func() {
 		expected, err := json.Marshal(valuesMap)
 		Expect(err).NotTo(HaveOccurred())
 
-		actual, err := run.MakeValues(secret)
+		actual, err := makeValues(secret)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(actual).To(Equal(expected))
 	})

--- a/pkg/run/install_dashboard_test.go
+++ b/pkg/run/install_dashboard_test.go
@@ -1,0 +1,40 @@
+package run_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/weaveworks/weave-gitops/pkg/logger/loggerfakes"
+	"github.com/weaveworks/weave-gitops/pkg/run"
+)
+
+const (
+	secret    = "some-secret"
+	namespace = "some-namespace"
+)
+
+var _ = Describe("InstallDashboard", func() {
+	var fakeLogger *loggerfakes.FakeLogger
+	var fakeContext context.Context
+
+	BeforeEach(func() {
+		fakeLogger = &loggerfakes.FakeLogger{}
+		fakeContext = context.Background()
+	})
+
+	It("should install dashboard successfully", func() {
+		man := &mockResourceManagerForApply{}
+
+		err := run.InstallDashboard(fakeLogger, fakeContext, man, namespace, secret)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should return an apply all error if the resource manager returns an apply all error", func() {
+		man := &mockResourceManagerForApply{state: stateApplyAllReturnErr}
+
+		err := run.InstallDashboard(fakeLogger, fakeContext, man, namespace, secret)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(Equal(applyAllErrorMsg))
+	})
+})

--- a/pkg/run/install_flux.go
+++ b/pkg/run/install_flux.go
@@ -28,7 +28,7 @@ func InstallFlux(log logger.Logger, ctx context.Context, installOptions install.
 
 	content := []byte(manifests.Content)
 
-	applyOutput, err := Apply(log, ctx, manager, content)
+	applyOutput, err := apply(log, ctx, manager, content)
 	if err != nil {
 		log.Failuref("Flux install failed")
 		return err

--- a/pkg/run/install_flux.go
+++ b/pkg/run/install_flux.go
@@ -14,11 +14,10 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func InstallFlux(log logger.Logger, ctx context.Context, kubeClient client.Client, installOptions install.Options, kubeConfigArgs genericclioptions.RESTClientGetter) error {
+func InstallFlux(log logger.Logger, ctx context.Context, installOptions install.Options, manager ResourceManagerForApply) error {
 	log.Actionf("Installing Flux ...")
 
 	manifests, err := install.Generate(installOptions, "")
@@ -29,7 +28,7 @@ func InstallFlux(log logger.Logger, ctx context.Context, kubeClient client.Clien
 
 	content := []byte(manifests.Content)
 
-	applyOutput, err := apply(log, ctx, kubeClient, kubeConfigArgs, content)
+	applyOutput, err := Apply(log, ctx, manager, content)
 	if err != nil {
 		log.Failuref("Flux install failed")
 		return err

--- a/pkg/run/install_flux_test.go
+++ b/pkg/run/install_flux_test.go
@@ -1,4 +1,4 @@
-package run_test
+package run
 
 import (
 	"context"
@@ -10,7 +10,6 @@ import (
 	coretypes "github.com/weaveworks/weave-gitops/core/server/types"
 	"github.com/weaveworks/weave-gitops/pkg/flux"
 	"github.com/weaveworks/weave-gitops/pkg/logger/loggerfakes"
-	"github.com/weaveworks/weave-gitops/pkg/run"
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -32,14 +31,14 @@ var _ = Describe("InstallFlux", func() {
 	It("should install flux successfully", func() {
 		man := &mockResourceManagerForApply{}
 
-		err := run.InstallFlux(fakeLogger, fakeContext, fakeInstallOptions, man)
+		err := InstallFlux(fakeLogger, fakeContext, fakeInstallOptions, man)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should return an apply all error if the resource manager returns an apply all error", func() {
 		man := &mockResourceManagerForApply{state: stateApplyAllReturnErr}
 
-		err := run.InstallFlux(fakeLogger, fakeContext, fakeInstallOptions, man)
+		err := InstallFlux(fakeLogger, fakeContext, fakeInstallOptions, man)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(Equal(applyAllErrorMsg))
 	})
@@ -47,7 +46,7 @@ var _ = Describe("InstallFlux", func() {
 	It("should return a wait for set error if the resource manager returns a wait for set error", func() {
 		man := &mockResourceManagerForApply{state: stateWaitForSetReturnErr}
 
-		err := run.InstallFlux(fakeLogger, fakeContext, fakeInstallOptions, man)
+		err := InstallFlux(fakeLogger, fakeContext, fakeInstallOptions, man)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(Equal(waitForSetErrorMsg))
 	})
@@ -61,11 +60,11 @@ var _ = Describe("GetFluxVersion", func() {
 	})
 
 	It("gets flux version", func() {
-		kubeClientOpts := run.GetKubeClientOptions()
+		kubeClientOpts := GetKubeClientOptions()
 
 		contextName := "test-context"
 
-		kubeClient, err := run.GetKubeClient(fakeLogger, contextName, k8sEnv.Rest, kubeClientOpts)
+		kubeClient, err := GetKubeClient(fakeLogger, contextName, k8sEnv.Rest, kubeClientOpts)
 		Expect(err).NotTo(HaveOccurred())
 
 		ctx := context.Background()
@@ -79,7 +78,7 @@ var _ = Describe("GetFluxVersion", func() {
 
 		Expect(kubeClient.Create(ctx, fluxNs)).To(Succeed())
 
-		fluxVersion, err := run.GetFluxVersion(fakeLogger, ctx, kubeClient)
+		fluxVersion, err := GetFluxVersion(fakeLogger, ctx, kubeClient)
 
 		Expect(err).NotTo(HaveOccurred())
 		Expect(fluxVersion).To(Equal(testVersion))

--- a/pkg/run/install_flux_test.go
+++ b/pkg/run/install_flux_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	testVersion = "some-version"
+	testVersion = "test-version"
 )
 
 var _ = Describe("InstallFlux", func() {
@@ -63,7 +63,7 @@ var _ = Describe("GetFluxVersion", func() {
 	It("gets flux version", func() {
 		kubeClientOpts := run.GetKubeClientOptions()
 
-		contextName := "some-context"
+		contextName := "test-context"
 
 		kubeClient, err := run.GetKubeClient(fakeLogger, contextName, k8sEnv.Rest, kubeClientOpts)
 		Expect(err).NotTo(HaveOccurred())

--- a/pkg/run/run_suite_test.go
+++ b/pkg/run/run_suite_test.go
@@ -1,4 +1,4 @@
-package run_test
+package run
 
 import (
 	"testing"

--- a/pkg/run/utils.go
+++ b/pkg/run/utils.go
@@ -219,8 +219,8 @@ func IsLocalCluster(kubeClient *kube.KubeHTTP) bool {
 	}
 }
 
-// IsPodStatusConditionPresentAndEqual returns true when conditionType is present and equal to status.
-func IsPodStatusConditionPresentAndEqual(conditions []corev1.PodCondition, conditionType corev1.PodConditionType, status corev1.ConditionStatus) bool {
+// isPodStatusConditionPresentAndEqual returns true when conditionType is present and equal to status.
+func isPodStatusConditionPresentAndEqual(conditions []corev1.PodCondition, conditionType corev1.PodConditionType, status corev1.ConditionStatus) bool {
 	for _, condition := range conditions {
 		if condition.Type == conditionType {
 			return condition.Status == status

--- a/pkg/run/utils_test.go
+++ b/pkg/run/utils_test.go
@@ -1,11 +1,10 @@
-package run_test
+package run
 
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	"github.com/weaveworks/weave-gitops/pkg/kube"
-	"github.com/weaveworks/weave-gitops/pkg/run"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -15,7 +14,7 @@ type isLocalClusterTest struct {
 }
 
 func runIsLocalClusterTest(client *kube.KubeHTTP, test isLocalClusterTest) {
-	actual := run.IsLocalCluster(client)
+	actual := IsLocalCluster(client)
 
 	Expect(actual).To(Equal(test.expected))
 }
@@ -113,12 +112,12 @@ type isPodStatusConditionPresentAndEqualTest struct {
 }
 
 func runIsPodStatusConditionPresentAndEqualTest(test isPodStatusConditionPresentAndEqualTest) {
-	actual := run.IsPodStatusConditionPresentAndEqual(test.conditions, test.conditionType, test.conditionStatus)
+	actual := isPodStatusConditionPresentAndEqual(test.conditions, test.conditionType, test.conditionStatus)
 
 	Expect(actual).To(Equal(test.expected))
 }
 
-var _ = Describe("IsPodStatusConditionPresentAndEqual", func() {
+var _ = Describe("isPodStatusConditionPresentAndEqual", func() {
 	It("returns true if condition statuses are the same and condition is true", func() {
 		test := isPodStatusConditionPresentAndEqualTest{
 			conditions: []corev1.PodCondition{


### PR DESCRIPTION
Closes #2512 

- Moved the `NewManager` function to `apply_manifests` and added passing the mocked `ssa.ResourceManager` to the `Apply` (and related `applySet` and `waitForSet`), `InstallDashboard`, and `InstallFlux` functions to make them more testable.
- Moved generating secret to a separate function (to simplify testing of the `InstallDashboard` function).
- Added very basic tests for the `Apply`, `InstallFlux`, and `InstallDashboard` functions (more like test prototypes for now).
- Added tests for the `MakeValues`, `MakeHelmRepository`, `MakeHelmRelease`, and `GenerateDashboardManifests` functions. I am very open to suggestions on how to improve these tests.
- Split `IsDashboardInstalled` functions to `GetDashboardHelmChart` and `IsDashboardInstalled` functions to be able to test `GetDashboardHelmChart`. Added very basic tests for the `GetDashboardHelmChart` function (not sure if the first test is needed, because it's based on a mocked client response completely).
- Changed test value strings from `"some-` to `"test-` for consistency.

Notes:
- Newly added tests are supposed to be a foundation for testing. I wanted to make the functions easier to test in principle, to test the basic flow, have tests as basic documentation (as @ozamosi said), and if someone is working in this functions in the future and thinks of a useful test to add (to expand testing `InstallDashboard`, for example), it will be easier to do.

- What is the recommended way of dealing with tests with the same names for different functions? Tests are almost the same for a few functions (like `Apply`, `InstallDashboard`, and `InstallFlux`, see `should return an apply all error if the resource manager returns an apply all error`, for example). The basic prototype flow is the same.
