### PR TITLE
Fix bcrypt-hash example in more places

### DIFF
--- a/cmd/gitops/get/bcrypt/cmd.go
+++ b/cmd/gitops/get/bcrypt/cmd.go
@@ -17,7 +17,7 @@ func HashCommand(opts *config.Options) *cobra.Command {
 		Short: "Generates a hashed secret",
 		Example: `
 # PASSWORD="<your password>"
-# echo $PASSWORD | gitops get bcrypt-hash
+# echo -n $PASSWORD | gitops get bcrypt-hash
 `,
 		SilenceUsage:  true,
 		SilenceErrors: true,

--- a/website/docs/configuration/securing-access-to-the-dashboard.mdx
+++ b/website/docs/configuration/securing-access-to-the-dashboard.mdx
@@ -55,7 +55,7 @@ Generate the password by running:
 
 ```sh
 PASSWORD="<your password>"
-echo  $PASSWORD | gitops get bcrypt-hash
+echo -n $PASSWORD | gitops get bcrypt-hash
 $2a$10$OS5NJmPNEb13UgTOSKnMxOWlmS7mlxX77hv4yAiISvZ71Dc7IuN3q
 ```
 

--- a/website/docs/installation.mdx
+++ b/website/docs/installation.mdx
@@ -363,7 +363,7 @@ There are several different ways to generate a bcrypt hash, this guide uses `git
 
 ```bash
 PASSWORD="<your password>"
-echo  $PASSWORD | gitops get bcrypt-hash
+echo -n $PASSWORD | gitops get bcrypt-hash
 $2a$10$OS5NJmPNEb13UgTOSKnMxOWlmS7mlxX77hv4yAiISvZ71Dc7IuN3q
 ```
 

--- a/website/versioned_docs/version-0.9.1/configuration/securing-access-to-the-dashboard.mdx
+++ b/website/versioned_docs/version-0.9.1/configuration/securing-access-to-the-dashboard.mdx
@@ -55,7 +55,7 @@ Generate the password by running:
 
 ```sh
 PASSWORD="<your password>"
-echo  $PASSWORD | gitops get bcrypt-hash
+echo -n $PASSWORD | gitops get bcrypt-hash
 $2a$10$OS5NJmPNEb13UgTOSKnMxOWlmS7mlxX77hv4yAiISvZ71Dc7IuN3q
 ```
 

--- a/website/versioned_docs/version-0.9.1/getting-started.mdx
+++ b/website/versioned_docs/version-0.9.1/getting-started.mdx
@@ -90,7 +90,7 @@ cd fleet-infra
 
 ```
 PASSWORD="<your password>"
-echo  $PASSWORD | gitops get bcrypt-hash
+echo -n $PASSWORD | gitops get bcrypt-hash
 $2a$10$OS5NJmPNEb13UgTOSKnMxOWlmS7mlxX77hv4yAiISvZ71Dc7IuN3q
 ```
 

--- a/website/versioned_docs/version-0.9.1/installation.mdx
+++ b/website/versioned_docs/version-0.9.1/installation.mdx
@@ -358,7 +358,7 @@ There are several different ways to generate a bcrypt hash, this guide uses `git
 
 ```bash
 PASSWORD="<your password>"
-echo  $PASSWORD | gitops get bcrypt-hash
+echo -n $PASSWORD | gitops get bcrypt-hash
 $2a$10$OS5NJmPNEb13UgTOSKnMxOWlmS7mlxX77hv4yAiISvZ71Dc7IuN3q
 ```
 

--- a/website/versioned_docs/version-0.9.1/references/cli-reference/gitops_get_bcrypt-hash.md
+++ b/website/versioned_docs/version-0.9.1/references/cli-reference/gitops_get_bcrypt-hash.md
@@ -11,7 +11,7 @@ gitops get bcrypt-hash [flags]
 ```
 
 # PASSWORD="<your password>"
-# echo $PASSWORD | gitops get bcrypt-hash
+# echo -n $PASSWORD | gitops get bcrypt-hash
 
 ```
 


### PR DESCRIPTION
This does the same fix as #2543, but to another few places, including
the stable docs and the command help text.