### PR TITLE
Add options parameter for hooks

### DIFF
--- a/ui/hooks/automations.ts
+++ b/ui/hooks/automations.ts
@@ -16,21 +16,27 @@ import {
   Kustomization,
 } from "../lib/api/core/types.pb";
 import {
+  MultiRequestError,
   NoNamespace,
+  ReactQueryOptions,
   RequestError,
   Syncable,
-  MultiRequestError,
 } from "../lib/types";
 
 export type Automation = Kustomization & HelmRelease & { kind: FluxObjectKind };
 
-export function useListAutomations(namespace = NoNamespace) {
+type Res = { result: Automation[]; errors: MultiRequestError[] };
+
+export function useListAutomations(
+  namespace = NoNamespace,
+  opts: ReactQueryOptions<Res, RequestError> = {
+    retry: false,
+    refetchInterval: 5000,
+  }
+) {
   const { api } = useContext(CoreClientContext);
 
-  return useQuery<
-    { result: Automation[]; errors: MultiRequestError[] },
-    RequestError
-  >(
+  return useQuery<Res, RequestError>(
     "automations",
     () => {
       const p = [
@@ -71,7 +77,7 @@ export function useListAutomations(namespace = NoNamespace) {
         };
       });
     },
-    { retry: false, refetchInterval: 5000 }
+    opts
   );
 }
 

--- a/ui/hooks/events.ts
+++ b/ui/hooks/events.ts
@@ -3,10 +3,17 @@ import { useQuery } from "react-query";
 import { CoreClientContext } from "../contexts/CoreClientContext";
 import { ListEventsResponse } from "../lib/api/core/core.pb";
 import { ObjectRef } from "../lib/api/core/types.pb";
-import { RequestError } from "../lib/types";
+import { ReactQueryOptions, RequestError } from "../lib/types";
 import { removeKind } from "../lib/utils";
 
-export function useListEvents(obj: ObjectRef) {
+export function useListEvents(
+  obj: ObjectRef,
+  opts: ReactQueryOptions<ListEventsResponse, RequestError> = {
+    retry: false,
+    refetchOnWindowFocus: false,
+    refetchInterval: 5000,
+  }
+) {
   const { api } = useContext(CoreClientContext);
 
   return useQuery<ListEventsResponse, RequestError>(
@@ -15,10 +22,6 @@ export function useListEvents(obj: ObjectRef) {
       api.ListEvents({
         involvedObject: { ...obj, kind: removeKind(obj.kind) },
       }),
-    {
-      retry: false,
-      refetchOnWindowFocus: false,
-      refetchInterval: 5000,
-    }
+    opts
   );
 }

--- a/ui/hooks/flux.ts
+++ b/ui/hooks/flux.ts
@@ -13,18 +13,27 @@ import {
   UnstructuredObject,
 } from "../lib/api/core/types.pb";
 import { getChildren } from "../lib/graph";
-import { DefaultCluster, NoNamespace, RequestError } from "../lib/types";
+import {
+  DefaultCluster,
+  NoNamespace,
+  ReactQueryOptions,
+  RequestError,
+} from "../lib/types";
 
 export function useListFluxRuntimeObjects(
   clusterName = DefaultCluster,
-  namespace = NoNamespace
+  namespace = NoNamespace,
+  opts: ReactQueryOptions<ListFluxRuntimeObjectsResponse, RequestError> = {
+    retry: false,
+    refetchInterval: 5000,
+  }
 ) {
   const { api } = useContext(CoreClientContext);
 
   return useQuery<ListFluxRuntimeObjectsResponse, RequestError>(
     "flux_runtime_objects",
     () => api.ListFluxRuntimeObjects({ namespace, clusterName }),
-    { retry: false, refetchInterval: 5000 }
+    opts
   );
 }
 
@@ -43,14 +52,18 @@ export function useGetReconciledObjects(
   namespace: string,
   type: FluxObjectKind,
   kinds: GroupVersionKind[],
-  clusterName = DefaultCluster
+  clusterName = DefaultCluster,
+  opts: ReactQueryOptions<UnstructuredObject[], RequestError> = {
+    retry: false,
+    refetchInterval: 5000,
+  }
 ) {
   const { api } = useContext(CoreClientContext);
 
   return useQuery<UnstructuredObject[], RequestError>(
     ["reconciled_objects", { name, namespace, type, kinds }],
     () => getChildren(api, name, namespace, type, kinds, clusterName),
-    { retry: false, refetchOnWindowFocus: false, refetchInterval: 5000 }
+    opts
   );
 }
 

--- a/ui/hooks/objects.ts
+++ b/ui/hooks/objects.ts
@@ -6,12 +6,12 @@ import { Object as ResponseObject } from "../lib/api/core/types.pb";
 import {
   Bucket,
   FluxObject,
-  HelmChart,
   GitRepository,
+  HelmChart,
   HelmRepository,
   Kind,
 } from "../lib/objects";
-import { RequestError } from "../lib/types";
+import { ReactQueryOptions, RequestError } from "../lib/types";
 
 function convertResponse(kind: Kind, response: ResponseObject) {
   if (kind == Kind.HelmRepository) {
@@ -34,7 +34,11 @@ export function useGetObject<T extends FluxObject>(
   name: string,
   namespace: string,
   kind: Kind,
-  clusterName: string
+  clusterName: string,
+  opts: ReactQueryOptions<T, RequestError> = {
+    retry: false,
+    refetchInterval: 5000,
+  }
 ) {
   const { api } = useContext(CoreClientContext);
 
@@ -47,6 +51,6 @@ export function useGetObject<T extends FluxObject>(
           (result: GetObjectResponse) =>
             convertResponse(kind, result.object) as T
         ),
-    { retry: false, refetchInterval: 5000 }
+    opts
   );
 }

--- a/ui/hooks/sources.ts
+++ b/ui/hooks/sources.ts
@@ -10,22 +10,26 @@ import {
 } from "../lib/api/core/core.pb";
 import { FluxObjectKind } from "../lib/api/core/types.pb";
 import {
+  MultiRequestError,
   NoNamespace,
+  ReactQueryOptions,
   RequestError,
   Source,
-  MultiRequestError,
 } from "../lib/types";
+
+type Res = { result: Source[]; errors: MultiRequestError[] };
 
 export function useListSources(
   appName?: string,
-  namespace: string = NoNamespace
+  namespace: string = NoNamespace,
+  opts: ReactQueryOptions<Res, RequestError> = {
+    retry: false,
+    refetchInterval: 5000,
+  }
 ) {
   const { api } = useContext(CoreClientContext);
 
-  return useQuery<
-    { result: Source[]; errors: MultiRequestError[] },
-    RequestError
-  >(
+  return useQuery<Res, RequestError>(
     "sources",
     () => {
       const p = [
@@ -81,6 +85,6 @@ export function useListSources(
         };
       });
     },
-    { retry: false, refetchInterval: 5000 }
+    opts
   );
 }

--- a/ui/lib/types.ts
+++ b/ui/lib/types.ts
@@ -1,3 +1,4 @@
+import { UseQueryOptions } from "react-query";
 import { ListError } from "./api/core/core.pb";
 import { Condition, FluxObjectKind, Interval } from "./api/core/types.pb";
 
@@ -59,3 +60,9 @@ export interface Syncable {
 export type MultiRequestError = ListError & {
   kind?: FluxObjectKind;
 };
+
+// Helper type to work around the weird react-query typedef/api shape
+export type ReactQueryOptions<T, E> = Omit<
+  UseQueryOptions<T, E>,
+  "queryKey" | "queryFn"
+>;


### PR DESCRIPTION
Part of https://github.com/weaveworks/weave-gitops-enterprise/issues/1243

Adds a way for consumers of the Core hooks to control how and when they get run