### PR TITLE
Fixes cluster-admin seeing a completely empty UI

### DIFF
--- a/core/nsaccess/nsaccess.go
+++ b/core/nsaccess/nsaccess.go
@@ -8,6 +8,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes"
 	typedauth "k8s.io/client-go/kubernetes/typed/authorization/v1"
 	"k8s.io/client-go/rest"
@@ -50,6 +51,7 @@ var DefautltWegoAppRules = []rbacv1.PolicyRule{
 }
 
 // Checker contains methods for validing user access to Kubernetes namespaces, based on a set of PolicyRules
+//
 //counterfeiter:generate . Checker
 type Checker interface {
 	// FilterAccessibleNamespaces returns a filtered list of namespaces to which a user has access to
@@ -103,42 +105,101 @@ func userCanUseNamespace(ctx context.Context, cfg *rest.Config, ns corev1.Namesp
 
 var allK8sVerbs = []string{"create", "get", "list", "watch", "patch", "delete", "deletecollection"}
 
+func allResources(rules []rbacv1.PolicyRule) []string {
+	resources := sets.NewString()
+	for _, r := range rules {
+		resources.Insert(r.Resources...)
+	}
+	return resources.List()
+}
+
+func allAPIGroups(rules []rbacv1.PolicyRule) []string {
+	apiGroups := sets.NewString()
+	for _, r := range rules {
+		apiGroups.Insert(r.APIGroups...)
+	}
+	return apiGroups.List()
+}
+
 // hasAll rules determines if a set of SubjectRulesReview rules match a minimum set of policy rules
 func hasAllRules(status authorizationv1.SubjectRulesReviewStatus, rules []rbacv1.PolicyRule, ns string) bool {
-	hasAccess := true
-	// We need to understand the "sum" of all the rules for a role.
-	// Convert to a hash lookup to make it easier to tell what a user can do.
-	// Looks like { "apps": { "deployments": { get: true, list: true } } }
-	derivedAccess := map[string]map[string]map[string]bool{}
+	/*
+		We need to understand the "sum" of all the rules for a role.
+		Convert to a hash lookup to make it easier to tell what a user can do.
+		Looks like { "apps": { "deployments": { get: true, list: true } } }
 
-	for _, statusRule := range status.ResourceRules {
-		// cluster-admin etc
-		if containsWildcard(statusRule.APIGroups) && containsWildcard(statusRule.Resources) && containsWildcard(statusRule.Verbs) {
-			return true
+		We handle wildcards by expanding them out to all the types of resources/APIGroups
+		that are relevant to the provided rules.
+		This creates slightly nonsensical sets sometimes, for example given:
+
+		PolicyRules:
+		{
+			APIGroups: []string{""},
+			Resources: []string{"secrets"},
+			Verbs:     []string{"get"},
+		},
+		{
+			APIGroups: []string{"apps"},
+			Resources: []string{"deployment"}",
+			Verbs:     []string{"get"},
+		},
+
+		SubjectRulesReviewStatus:
+		["*", "*", "get"]
+
+		We get:
+		{
+			"": {
+				"secrets": { get: true }
+				"deployments": { get: true }
+			},
+			"apps": {
+				"secrets": { get: true }
+				"deployments", "secrets": { get: true }
+			}
 		}
 
-		for _, apiGroup := range statusRule.APIGroups {
+		Secrets don't exist in "apps" according to k8s,
+		but the "index checker" that checks this struct does not mind.
+	*/
+
+	derivedAccess := map[string]map[string]map[string]bool{}
+
+	allResourcesInRules := allResources(rules)
+	allAPIGroupsInRules := allAPIGroups(rules)
+
+	for _, statusRule := range status.ResourceRules {
+
+		apiGroups := statusRule.APIGroups
+		if containsWildcard(apiGroups) {
+			apiGroups = allAPIGroupsInRules
+		}
+		for _, apiGroup := range apiGroups {
 			if _, ok := derivedAccess[apiGroup]; !ok {
 				derivedAccess[apiGroup] = map[string]map[string]bool{}
 			}
 
-			for _, resource := range statusRule.Resources {
+			resources := statusRule.Resources
+			if containsWildcard(resources) {
+				resources = allResourcesInRules
+			}
+			for _, resource := range resources {
 				if _, ok := derivedAccess[apiGroup][resource]; !ok {
 					derivedAccess[apiGroup][resource] = map[string]bool{}
 				}
 
-				if containsWildcard(statusRule.Verbs) {
-					for _, v := range allK8sVerbs {
-						derivedAccess[apiGroup][resource][v] = true
-					}
-				} else {
-					for _, verb := range statusRule.Verbs {
-						derivedAccess[apiGroup][resource][verb] = true
-					}
+				verbs := statusRule.Verbs
+				if containsWildcard(verbs) {
+					verbs = allK8sVerbs
+				}
+				for _, v := range verbs {
+					derivedAccess[apiGroup][resource][v] = true
 				}
 			}
 		}
 	}
+
+	hasAccess := true
 
 Rules:
 	for _, rule := range rules {

--- a/core/nsaccess/nsaccess_test.go
+++ b/core/nsaccess/nsaccess_test.go
@@ -208,115 +208,75 @@ func TestFilterAccessibleNamespaces(t *testing.T) {
 
 		g.Expect(filtered).To(HaveLen(1))
 	})
-	t.Run("works when a user has * permissions on verbs", func(t *testing.T) {
-		g := NewGomegaWithT(t)
-		ns := newNamespace(context.Background(), adminClient, NewGomegaWithT(t))
-		defer removeNs(t, adminClient, ns)
-
-		userName = userName + "-" + rand.String(5)
-
-		roleName := makeRole(ns)
-
-		roleRules := []rbacv1.PolicyRule{
-			{
-				APIGroups: []string{""},
-				Resources: []string{"secrets", "events", "namespaces"},
-				Verbs:     []string{"*"},
+	t.Run("works when a user has * permissions on api/group/verb", func(t *testing.T) {
+		testCases := map[string][]rbacv1.PolicyRule{
+			"_ _ *": {
+				{
+					APIGroups: []string{""},
+					Resources: []string{"secrets", "events", "namespaces"},
+					Verbs:     []string{"*"},
+				},
+			},
+			"_ * _": {
+				{
+					APIGroups: []string{""},
+					Resources: []string{"*"},
+					Verbs:     []string{"get", "list"},
+				},
+			},
+			"* _ _": {
+				{
+					APIGroups: []string{"*"},
+					Resources: []string{"secrets", "events", "namespaces"},
+					Verbs:     []string{"get", "list"},
+				},
+			},
+			"_ * *": {
+				{
+					APIGroups: []string{""},
+					Resources: []string{"*"},
+					Verbs:     []string{"*"},
+				},
+			},
+			"* * *": {
+				{
+					APIGroups: []string{"*"},
+					Resources: []string{"*"},
+					Verbs:     []string{"*"},
+				},
 			},
 		}
 
-		userCfg := newRestConfigWithRole(t, testCfg, roleName, roleRules)
+		for name, roleRules := range testCases {
+			t.Run(name, func(t *testing.T) {
+				g := NewGomegaWithT(t)
+				ns := newNamespace(context.Background(), adminClient, NewGomegaWithT(t))
+				defer removeNs(t, adminClient, ns)
 
-		requiredRules := []rbacv1.PolicyRule{
-			{
-				APIGroups: []string{""},
-				Resources: []string{"secrets", "events", "namespaces"},
-				Verbs:     []string{"get", "list"},
-			},
+				userName = userName + "-" + rand.String(5)
+
+				roleName := makeRole(ns)
+
+				userCfg := newRestConfigWithRole(t, testCfg, roleName, roleRules)
+
+				requiredRules := []rbacv1.PolicyRule{
+					{
+						APIGroups: []string{""},
+						Resources: []string{"secrets", "events", "namespaces"},
+						Verbs:     []string{"get", "list"},
+					},
+				}
+
+				list := &corev1.NamespaceList{}
+				g.Expect(adminClient.List(ctx, list)).To(Succeed())
+
+				checker := NewChecker(requiredRules)
+				filtered, err := checker.FilterAccessibleNamespaces(ctx, userCfg, list.Items)
+				g.Expect(err).NotTo(HaveOccurred())
+
+				g.Expect(filtered).To(HaveLen(1))
+			})
 		}
-
-		list := &corev1.NamespaceList{}
-		g.Expect(adminClient.List(ctx, list)).To(Succeed())
-
-		checker := NewChecker(requiredRules)
-		filtered, err := checker.FilterAccessibleNamespaces(ctx, userCfg, list.Items)
-		g.Expect(err).NotTo(HaveOccurred())
-
-		g.Expect(filtered).To(HaveLen(1))
-	})
-	t.Run("works when a user has * permissions on a resource", func(t *testing.T) {
-		t.Skip("Doesn't work right now")
-
-		g := NewGomegaWithT(t)
-		ns := newNamespace(context.Background(), adminClient, NewGomegaWithT(t))
-		defer removeNs(t, adminClient, ns)
-
-		userName = userName + "-" + rand.String(5)
-
-		roleName := makeRole(ns)
-
-		roleRules := []rbacv1.PolicyRule{
-			{
-				APIGroups: []string{""},
-				Resources: []string{"*"},
-				Verbs:     []string{"*"},
-			},
-		}
-
-		userCfg := newRestConfigWithRole(t, testCfg, roleName, roleRules)
-
-		requiredRules := []rbacv1.PolicyRule{
-			{
-				APIGroups: []string{""},
-				Resources: []string{"secrets", "events", "namespaces"},
-				Verbs:     []string{"get", "list"},
-			},
-		}
-
-		list := &corev1.NamespaceList{}
-		g.Expect(adminClient.List(ctx, list)).To(Succeed())
-
-		checker := NewChecker(requiredRules)
-		filtered, err := checker.FilterAccessibleNamespaces(ctx, userCfg, list.Items)
-		g.Expect(err).NotTo(HaveOccurred())
-
-		g.Expect(filtered).To(HaveLen(1))
-	})
-	t.Run("works with cluster-admin who have * for everything", func(t *testing.T) {
-		g := NewGomegaWithT(t)
-		ns := newNamespace(context.Background(), adminClient, NewGomegaWithT(t))
-		defer removeNs(t, adminClient, ns)
-
-		userName = userName + "-" + rand.String(5)
-
-		roleName := makeRole(ns)
-
-		roleRules := []rbacv1.PolicyRule{
-			{
-				APIGroups: []string{"*"},
-				Resources: []string{"*"},
-				Verbs:     []string{"*"},
-			},
-		}
-
-		userCfg := newRestConfigWithRole(t, testCfg, roleName, roleRules)
-
-		requiredRules := []rbacv1.PolicyRule{
-			{
-				APIGroups: []string{""},
-				Resources: []string{"secrets", "events", "namespaces"},
-				Verbs:     []string{"get", "list"},
-			},
-		}
-
-		list := &corev1.NamespaceList{}
-		g.Expect(adminClient.List(ctx, list)).To(Succeed())
-
-		checker := NewChecker(requiredRules)
-		filtered, err := checker.FilterAccessibleNamespaces(ctx, userCfg, list.Items)
-		g.Expect(err).NotTo(HaveOccurred())
-
-		g.Expect(filtered).To(HaveLen(1))
 	})
 }
 

--- a/pkg/fluxinstall/product_test.go
+++ b/pkg/fluxinstall/product_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"regexp"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -85,8 +86,8 @@ type MockProductHttpClient struct {
 }
 
 func (m *MockProductHttpClient) Get(url string) (resp *http.Response, err error) {
-	if url == "https://github.com/fluxcd/flux2/releases/download/v0.32.0/flux_0.32.0_linux_amd64.tar.gz" ||
-		url == "https://github.com/fluxcd/flux2/releases/download/v0.32.0/flux_0.32.0_darwin_amd64.tar.gz" {
+	var archivePattern = regexp.MustCompile(`https://github.com/fluxcd/flux2/releases/download/v0.32.0/flux_0.32.0_(linux|darwin)_(amd64|arm64).tar.gz`)
+	if archivePattern.MatchString(url) {
 		body, err := createMockFluxArchive([]byte("flux"))
 
 		if err != nil {
@@ -99,6 +100,7 @@ func (m *MockProductHttpClient) Get(url string) (resp *http.Response, err error)
 	} else if url == "https://github.com/fluxcd/flux2/releases/download/v0.32.0/flux_0.32.0_checksums.txt" {
 		body := []byte(`77622fd02dd5ad9377e17ecb59fa4f9598016bf0bf9761d09c9ed633840d7c7d  flux_0.32.0_linux_amd64.tar.gz
 77622fd02dd5ad9377e17ecb59fa4f9598016bf0bf9761d09c9ed633840d7c7d  flux_0.32.0_darwin_amd64.tar.gz
+77622fd02dd5ad9377e17ecb59fa4f9598016bf0bf9761d09c9ed633840d7c7d  flux_0.32.0_darwin_arm64.tar.gz
 `)
 
 		return &http.Response{


### PR DESCRIPTION
Fixes allowing `cluster-admin` and other users with `*` permissions in their RBAC rules from using the UI.

Prior to this our rule engine determined that `cluster-admin` couldn't see _any_ namespaces as we didn't take `*` into account.

<!-- Describe what has changed in this PR -->
**What changed?**

Adds support for evaluating `*` in the various positions it can appear (`{ "verbs": ["*"], "apiGroups": ["*"], "resources": ["*"] }`) when evaluating the rules that determine which Namespaces we think a user has access to.

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**

Its common for people to use `cluster-admin` when debugging permissions as `cluster-admin` should be able to see everything.

**How was this change implemented?**

Updates to our rules engine.

**How did you validate the change?**

Only with unit tests so far.