### PR TITLE
Fix chart publishing

### DIFF
--- a/.github/workflows/chart.yaml
+++ b/.github/workflows/chart.yaml
@@ -11,6 +11,7 @@ on:
       - 'main'
     paths:
       - 'charts/**'
+  workflow_dispatch:
 
 env:
   REGISTRY: ghcr.io
@@ -78,7 +79,7 @@ jobs:
   helm-release:
     runs-on: ubuntu-latest
     needs: helm-new-version
-    if: github.event_name == 'push' && needs.helm-new-version.outputs.old-version != needs.helm-new-version.outputs.new-version
+    if: (github.event_name == 'push' && needs.helm-new-version.outputs.old-version != needs.helm-new-version.outputs.new-version) || github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
       - name: Find new version

--- a/.github/workflows/chart.yaml
+++ b/.github/workflows/chart.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: Find old version
         id: old-version
         run: |
-          git checkout ${{ github.event.pull_request.base.sha }}
+          git checkout ${{ github.event.pull_request.base.sha || github.event.before }}
           OLD_VERSION=$(yq e '.version' charts/gitops-server/Chart.yaml)
           echo "::set-output name=version::$OLD_VERSION"
 


### PR DESCRIPTION
My recent change to only publish the chart when the version is changed was broken, as it used a pull request only event to determine the old version. So in practice, when discovering the old version it just ran `git checkout` which leaves git at the most recent commit, and thus the check if the version had changed always returned false when PRs are merged.

Because of this problem, I put workflow_dispatch in there as well, as I'd like to force-publish the most recent chart.