### PR TITLE
Update various versions that aren't automated

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ BUILD_TIME?=$(shell date +'%Y-%m-%d_%T')
 BRANCH?=$(shell which git > /dev/null && git rev-parse --abbrev-ref HEAD)
 GIT_COMMIT?=$(shell which git > /dev/null && git log -n1 --pretty='%h')
 VERSION?=$(shell which git > /dev/null && git describe --always --match "v*")
-FLUX_VERSION=0.31.0
+FLUX_VERSION=0.31.5
 DEV_BUCKET_CONTAINER_IMAGE=ghcr.io/weaveworks/gitops-bucket-server@sha256:b0446a6c645b5d39cf0db558958bf28363aca3ea80dc9d593983173613a4f290
 
 # Go build args

--- a/pkg/run/install_dashboard.go
+++ b/pkg/run/install_dashboard.go
@@ -271,7 +271,7 @@ func makeHelmRelease(log logger.Logger, secret string, namespace string) (*helmv
 			Chart: helmv2.HelmChartTemplate{
 				Spec: helmv2.HelmChartTemplateSpec{
 					Chart:   helmChartName,
-					Version: "2.0.6",
+					Version: "3.0.0",
 					SourceRef: helmv2.CrossNamespaceObjectReference{
 						Kind: "HelmRepository",
 						Name: helmRepositoryName,

--- a/pkg/run/install_dashboard_test.go
+++ b/pkg/run/install_dashboard_test.go
@@ -154,7 +154,7 @@ var _ = Describe("generateManifestsForDashboard", func() {
 				Chart: helmv2.HelmChartTemplate{
 					Spec: helmv2.HelmChartTemplateSpec{
 						Chart:   "weave-gitops",
-						Version: "2.0.6",
+						Version: "3.0.0",
 						SourceRef: helmv2.CrossNamespaceObjectReference{
 							Kind: "HelmRepository",
 							Name: "ww-gitops",
@@ -219,7 +219,7 @@ var _ = Describe("makeHelmRelease", func() {
 				Chart: helmv2.HelmChartTemplate{
 					Spec: helmv2.HelmChartTemplateSpec{
 						Chart:   "weave-gitops",
-						Version: "2.0.6",
+						Version: "3.0.0",
 						SourceRef: helmv2.CrossNamespaceObjectReference{
 							Kind: "HelmRepository",
 							Name: "ww-gitops",

--- a/website/docs/installation.mdx
+++ b/website/docs/installation.mdx
@@ -15,8 +15,6 @@ This section details the steps required to install Weave GitOps on a Kubernetes 
 
 #### Kubernetes Cluster
 This version of Weave GitOps is tested against the following Kubernetes releases:
-* 1.20
-* 1.21
 * 1.22
 * 1.23
 * 1.24
@@ -24,16 +22,12 @@ This version of Weave GitOps is tested against the following Kubernetes releases
 Note that the version of [Flux](https://fluxcd.io/docs/installation/#prerequisites) that you use might impose further minimum version requirements.
 
 #### Install Flux
-Weave GitOps is an extension to Flux and therefore requires that Flux 0.29 or later has already been installed on your Kubernetes cluster. Full documentation is avilable at: [https://fluxcd.io/docs/installation/](https://fluxcd.io/docs/installation/).
+Weave GitOps is an extension to Flux and therefore requires that Flux 0.31 or later has already been installed on your Kubernetes cluster. Full documentation is avilable at: [https://fluxcd.io/docs/installation/](https://fluxcd.io/docs/installation/).
 
 This version of Weave GitOps is tested against the following Flux releases:
-* 0.29
-* 0.30
 * 0.31
 
 ### Install the Helm Chart
-
-⚠️ Note that the following instructions require Flux version 0.31.0 or later to make use of the OCI registry for Helm chart storage. If your Flux version is older, please upgrade prior to following the instructions below. ⚠️.
 
 Weave GitOps is provided through a Helm Chart and installed as a Flux resource through a `HelmRepository` and `HelmRelease`. To install on your cluster, adjust the following so that `username` is the username you want and `passwordHash` is a bcrypt hash of your password, and commit the file to the location bootstrapped with Flux so that it is synchronized to your Cluster.
 


### PR DESCRIPTION
* Remove unsupported k8s releases.
* Remove flux versions prior to 0.31.
* Update the chart version in `gitops run`
* Update the flux version in the Makefile

At least some of these ought to be automated, but I've done them manually today.