### PR TITLE
Move some functions from `gitops/beta/run/cmd` and `pkg/run/utils` to more appropriate files

### DIFF
--- a/pkg/run/install_bucket_source_and_ks_test.go
+++ b/pkg/run/install_bucket_source_and_ks_test.go
@@ -96,7 +96,7 @@ func (c *mockClientForFindConditionMessages) List(_ context.Context, list client
 	return nil
 }
 
-var _ = Describe("FindConditionMessages", func() {
+var _ = Describe("findConditionMessages", func() {
 	It("returns the condition messages", func() {
 		client := &mockClientForFindConditionMessages{}
 		ks := &kustomizev1.Kustomization{
@@ -120,7 +120,7 @@ var _ = Describe("FindConditionMessages", func() {
 				},
 			},
 		}
-		messages, err := FindConditionMessages(client, ks)
+		messages, err := findConditionMessages(client, ks)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(messages).To(Equal([]string{
 			"Deployment default/deployment: This is message",

--- a/pkg/run/install_dashboard.go
+++ b/pkg/run/install_dashboard.go
@@ -161,7 +161,7 @@ func ReconcileDashboard(kubeClient client.Client, namespace string, timeout time
 
 	if err := wait.Poll(interval, timeout, func() (bool, error) {
 		var err error
-		sourceRequestedAt, err = RequestReconciliation(context.Background(), kubeClient,
+		sourceRequestedAt, err = requestReconciliation(context.Background(), kubeClient,
 			namespacedName, gvk)
 
 		return err == nil, nil

--- a/pkg/run/install_flux.go
+++ b/pkg/run/install_flux.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/utils/strings/slices"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -79,6 +80,19 @@ func GetFluxVersion(log logger.Logger, ctx context.Context, kubeClient client.Cl
 	}
 
 	return fluxVersion, nil
+}
+
+func ValidateComponents(components []string) error {
+	defaults := install.MakeDefaultOptions()
+	bootstrapAllComponents := append(defaults.Components, defaults.ComponentsExtra...)
+
+	for _, component := range components {
+		if !slices.Contains(bootstrapAllComponents, component) {
+			return fmt.Errorf("component %s is not available", component)
+		}
+	}
+
+	return nil
 }
 
 func WaitForDeploymentToBeReady(log logger.Logger, kubeClient client.Client, deploymentName string, namespace string) error {

--- a/pkg/run/utils.go
+++ b/pkg/run/utils.go
@@ -2,18 +2,11 @@ package run
 
 import (
 	"context"
-	"errors"
-	"fmt"
-	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
 	"github.com/fluxcd/pkg/apis/meta"
-	"github.com/fsnotify/fsnotify"
-	"github.com/minio/minio-go/v7"
 	"github.com/weaveworks/weave-gitops/pkg/kube"
-	"github.com/weaveworks/weave-gitops/pkg/logger"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -22,155 +15,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// FindGitRepoDir finds git repo root directory
-func FindGitRepoDir() (string, error) {
-	gitDir := "."
-
-	for {
-		if _, err := os.Stat(filepath.Join(gitDir, ".git")); err == nil {
-			break
-		}
-
-		gitDir = filepath.Join(gitDir, "..")
-
-		if gitDir == "/" {
-			return "", errors.New("not in a git repo")
-		}
-	}
-
-	return filepath.Abs(gitDir)
-}
-
-// GetRelativePathToRootDir gets relative path to a directory from the git root. It returns an error if there's no git repo.
-func GetRelativePathToRootDir(rootDir string, path string) (string, error) {
-	absGitDir, err := filepath.Abs(rootDir)
-
-	if err != nil { // not in a git repo
-		return "", err
-	}
-
-	return filepath.Rel(absGitDir, path)
-}
-
-// WatchAndSync watches files recursively, and re-sync the whole directory to the bucket using minio library
-func WatchAndSync(log logger.Logger, dir string, bucket string, client *minio.Client) (chan<- bool, error) {
-	watcher, err := fsnotify.NewWatcher()
-	if err != nil {
-		return nil, err
-	}
-
-	cancel := make(chan bool)
-
-	go func() {
-		for {
-			select {
-			case <-watcher.Events:
-				if err := SyncDir(log, dir, bucket, client); err != nil {
-					log.Failuref("Error syncing directory: %v", err)
-				}
-			case err := <-watcher.Errors:
-				log.Failuref("Error: %v", err)
-			case <-cancel:
-				if err := watcher.Close(); err != nil {
-					log.Failuref("Error closing watcher: %v", err)
-				}
-			}
-		}
-	}()
-
-	err = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-
-		if info.IsDir() {
-			// if it's a hidden directory, ignore it
-			if strings.HasPrefix(info.Name(), ".") {
-				return filepath.SkipDir
-			}
-
-			if err := watcher.Add(path); err != nil {
-				return err
-			}
-		}
-		return nil
-	})
-
-	if err != nil {
-		close(cancel)
-
-		if err := watcher.Close(); err != nil {
-			log.Failuref("Error closing watcher: %v", err)
-		}
-
-		return nil, err
-	}
-
-	return cancel, nil
-}
-
-// SyncDir recursively uploads all files in a directory to an S3 bucket with minio library
-func SyncDir(log logger.Logger, dir string, bucket string, client *minio.Client) error {
-	log.Actionf("Refreshing bucket %s ...", bucket)
-
-	if err := client.RemoveBucketWithOptions(context.Background(), bucket, minio.RemoveBucketOptions{
-		ForceDelete: true,
-	}); err != nil {
-		// if error is not bucket not found, return error
-		if !strings.Contains(err.Error(), "NoSuchBucket") {
-			return err
-		}
-	}
-
-	if err := client.MakeBucket(context.Background(), bucket, minio.MakeBucketOptions{}); err != nil {
-		return err
-	}
-
-	uploadCount := 0
-	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			log.Failuref("Error walking directory: %v", err)
-			return err
-		}
-
-		if info.IsDir() {
-			// if it's a hidden directory, ignore it
-			if strings.HasPrefix(info.Name(), ".") {
-				return filepath.SkipDir
-			}
-
-			return nil
-		}
-
-		objectName, err := filepath.Rel(dir, path)
-		if err != nil {
-			log.Failuref("Error getting relative path: %v", err)
-			return err
-		}
-		// upload the file
-		_, err = client.FPutObject(context.Background(), bucket, objectName, path, minio.PutObjectOptions{})
-		if err != nil {
-			return err
-		}
-		uploadCount = uploadCount + 1
-		if uploadCount%10 == 0 {
-			fmt.Print(".")
-		}
-		return nil
-	})
-
-	fmt.Println()
-	log.Actionf("Uploaded %d files", uploadCount)
-
-	if err != nil {
-		log.Failuref("Error syncing directory: %v", err)
-		return err
-	}
-
-	return nil
-}
-
-func RequestReconciliation(ctx context.Context, kubeClient client.Client, namespacedName types.NamespacedName, gvk schema.GroupVersionKind) (string, error) {
+func requestReconciliation(ctx context.Context, kubeClient client.Client, namespacedName types.NamespacedName, gvk schema.GroupVersionKind) (string, error) {
 	requestAt := time.Now().Format(time.RFC3339Nano)
 
 	return requestAt, retry.RetryOnConflict(retry.DefaultBackoff, func() (err error) {


### PR DESCRIPTION
- Removed unused function `WatchAndSync`.

- Moved some functions from  `gitops/beta/run/cmd.go` to appropriate files. This will make `cmd.go` file 140 lines shorter. It was getting huge.

- Also moved several functions from `pkg/run/utils.go` to corresponding files (depending on whether they are related to flux install, devbucket, or dashboard install).

Notes:
- Now `pkg/run/utils.go` contains functions which are used by both devbucket- and dashboard-related bit of code or the command itself. Only `isPodStatusConditionPresentAndEqual` is used by the dashboard only, but it's very generic.

If you would like to get rid of `pkg/run/utils` completely, please let me know which location is more suitable for the remaining utility functions.