### PR TITLE
Make OCI repositories opt-in, fix OCI repository permissions, fix rendering errors for sources

### DIFF
--- a/charts/gitops-server/templates/admin-user-roles.yaml
+++ b/charts/gitops-server/templates/admin-user-roles.yaml
@@ -28,7 +28,7 @@ rules:
     resources: ["events"]
     verbs: ["get", "watch", "list"]
   - apiGroups: ["source.toolkit.fluxcd.io"]
-    resources: [ "buckets", "helmcharts", "gitrepositories", "helmrepositories" ]
+    resources: [ "buckets", "helmcharts", "gitrepositories", "helmrepositories", "ocirepositories" ]
     verbs: [ "get", "list", "patch" ]
   - apiGroups: ["kustomize.toolkit.fluxcd.io"]
     resources: [ "kustomizations" ]

--- a/charts/gitops-server/templates/deployment.yaml
+++ b/charts/gitops-server/templates/deployment.yaml
@@ -71,6 +71,10 @@ spec:
           env:
             - name: WEAVE_GITOPS_AUTH_ENABLED
               value: "true"
+          {{- if .Values.listOCIRepositories }}
+            - name: WEAVE_GITOPS_FEATURE_OCI_REPOSITORIES
+              value: "true"
+          {{- end }}
           {{- if .Values.envVars }}
           {{- with .Values.envVars }}
             {{- toYaml . | nindent 12 }}

--- a/charts/gitops-server/values.yaml
+++ b/charts/gitops-server/values.yaml
@@ -90,6 +90,11 @@ securityContext: {}
 # runAsNonRoot: true
 # runAsUser: 1000
 
+
+# -- If set to true, OCI repositories will be included in the source view.
+# This requires flux 0.32 or later.
+listOCIRepositories: false
+
 service:
   create: true
   type: ClusterIP

--- a/core/server/sources.go
+++ b/core/server/sources.go
@@ -8,6 +8,7 @@ import (
 	"github.com/weaveworks/weave-gitops/core/clustersmngr"
 	"github.com/weaveworks/weave-gitops/core/server/types"
 	pb "github.com/weaveworks/weave-gitops/pkg/api/core"
+	"github.com/weaveworks/weave-gitops/pkg/featureflags"
 	"github.com/weaveworks/weave-gitops/pkg/server/auth"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -186,6 +187,13 @@ func (cs *coreServer) ListBuckets(ctx context.Context, msg *pb.ListBucketRequest
 
 func (cs *coreServer) ListOCIRepositories(ctx context.Context, msg *pb.ListOCIRepositoriesRequest) (*pb.ListOCIRepositoriesResponse, error) {
 	respErrors := []*pb.ListError{}
+
+	if featureflags.Get("WEAVE_GITOPS_FEATURE_OCI_REPOSITORIES") == "" {
+		return &pb.ListOCIRepositoriesResponse{
+			OciRepositories: []*pb.OCIRepository{},
+			Errors:          respErrors,
+		}, nil
+	}
 
 	clustersClient, err := cs.clientsFactory.GetImpersonatedClient(ctx, auth.Principal(ctx))
 	if err != nil {

--- a/ui/components/SourceDetail.tsx
+++ b/ui/components/SourceDetail.tsx
@@ -120,14 +120,13 @@ function SourceDetail<T extends FluxObject>({
       <Text size="large" semiBold titleHeight>
         {source.name}
       </Text>
-      {error ||
-        (suspend.error && (
-          <Alert
-            severity="error"
-            title="Error"
-            message={error.message || suspend.error.message}
-          />
-        ))}
+      {(error || suspend.error) && (
+        <Alert
+          severity="error"
+          title="Error"
+          message={error.message || suspend.error.message}
+        />
+      )}
       <PageStatus conditions={source.conditions} suspended={source.suspended} />
       <Flex wide start>
         <SyncButton

--- a/ui/components/SourceDetail.tsx
+++ b/ui/components/SourceDetail.tsx
@@ -74,8 +74,8 @@ function SourceDetail<T extends FluxObject>({
     return <LoadingPage />;
   }
 
-  if (isSuspended != source.suspended) {
-    setIsSuspended(source.suspended);
+  if (isSuspended != source?.suspended) {
+    setIsSuspended(source?.suspended);
   }
 
   const items = info(source);
@@ -85,7 +85,7 @@ function SourceDetail<T extends FluxObject>({
   };
 
   const isRelevant = (expectedType, expectedName) => {
-    return expectedType == source.kind && isNameRelevant(expectedName);
+    return expectedType == source?.kind && isNameRelevant(expectedName);
   };
 
   const relevantAutomations = _.filter(automations?.result, (a) => {
@@ -118,7 +118,7 @@ function SourceDetail<T extends FluxObject>({
   return (
     <Flex wide tall column className={className}>
       <Text size="large" semiBold titleHeight>
-        {source.name}
+        {source?.name}
       </Text>
       {(error || suspend.error) && (
         <Alert
@@ -127,7 +127,10 @@ function SourceDetail<T extends FluxObject>({
           message={error.message || suspend.error.message}
         />
       )}
-      <PageStatus conditions={source.conditions} suspended={source.suspended} />
+      <PageStatus
+        conditions={source?.conditions}
+        suspended={source?.suspended}
+      />
       <Flex wide start>
         <SyncButton
           onClick={handleSyncClicked}
@@ -154,17 +157,17 @@ function SourceDetail<T extends FluxObject>({
         </RouterTab>
         <RouterTab name="Events" path={`${path}/events`}>
           <EventsTable
-            namespace={source.namespace}
+            namespace={source?.namespace}
             involvedObject={{
               kind: type,
               name,
-              namespace: source.namespace,
+              namespace: source?.namespace,
             }}
           />
         </RouterTab>
         <RouterTab name="yaml" path={`${path}/yaml`}>
           <YamlView
-            yaml={source.yaml}
+            yaml={source?.yaml}
             object={{
               kind: source?.kind,
               name: source?.name,


### PR DESCRIPTION
This fixes a whole bunch of errors:
 * Adds question marks to the source detail page. I reset my cluster and was swamped in errors, and went through them all.
 * Fix the rendering of errors on the source detail page. This was broken by a recent commit that got the parenthesis backwards.
 * Fix merge error in permissions for OCI repositories - they would only have worked if gitops was installed inside the flux-system namespace.
 * Add a feature flag that is turned off by default, that unless enabled makes the list OCI repositories endpoint just return nothing. This stops it returning errors when flux is < 0.32 - since this is not released yet, I've opted to make it a manual opt in/out, in case something changes that would break this completely.