### PR TITLE
doc: Add oci repository feature flags to to manual

### DIFF
--- a/website/docs/getting-started.mdx
+++ b/website/docs/getting-started.mdx
@@ -101,13 +101,14 @@ We will generate a bcrypt hash for your chosen password and store it as a secret
    $2a$10$OS5NJmPNEb13UgTOSKnMxOWlmS7mlxX77hv4yAiISvZ71Dc7IuN3q
    ```
 
-1. Save this [bcrypt-hash](https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/Password_Storage_Cheat_Sheet.md) in a values file:
+1. Save this [bcrypt-hash](https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/Password_Storage_Cheat_Sheet.md) in a values file, together with any other settings:
 
    ```yaml title="./weave-gitops-values.yaml"
    adminUser:
      create: true
      username: admin
      passwordHash: $2a$10$OS5NJmPNEb13UgTOSKnMxOWlmS7mlxX77hv4yAiISvZ71Dc7IuN3q
+   listOCIRepositories: true # Display OCI Repositories, requires flux 0.32
    ```
 
    :::info

--- a/website/docs/installation.mdx
+++ b/website/docs/installation.mdx
@@ -51,6 +51,7 @@ spec:
       create: true
       username: <UPDATE>
       passwordHash: <UPDATE>
+    listOCIRepositories: true # Display OCI Repositories, requires flux 0.32
 ---
 apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmRepository


### PR DESCRIPTION
As this is turned off by default right now (to avoid errors), it needs
to be very visible how to turn it on.