### PR TITLE
website: Remove extra slash from website URLs

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -3,7 +3,7 @@ const versions = require("./versions.json");
 module.exports = {
   title: "Weave GitOps",
   tagline: "Weave GitOps Documentation",
-  url: "https://docs.gitops.weave.works/",
+  url: "https://docs.gitops.weave.works",
   baseUrl: "/",
   onBrokenLinks: "throw",
   onBrokenMarkdownLinks: "warn",


### PR DESCRIPTION
Algolia has indexed our whole docs website twice, and is returning all
search results twice (#2561). I suspect this is related to how the
generated source code contains an incorrect double-slash:

```
<link data-rh="true" rel="canonical" href="https://docs.gitops.weave.works//docs/installation/">
```

This change appears to make the double-slash go away but still leave
links working, which should fix the problem. Maybe.
