### PR TITLE
Raise an error if an empty `UserPrincipal` is passed to `ClientConfigWithUser`

### DIFF
--- a/core/clustersmngr/client_test.go
+++ b/core/clustersmngr/client_test.go
@@ -33,18 +33,7 @@ func TestClientGet(t *testing.T) {
 
 	appName := "myapp" + rand.String(5)
 
-	clientsPool := createClusterClientsPool(g)
-
-	err := clientsPool.Add(
-		clustersmngr.ClientConfigWithUser(&auth.UserPrincipal{}),
-		clustersmngr.Cluster{
-			Name:      clusterName,
-			Server:    k8sEnv.Rest.Host,
-			TLSConfig: k8sEnv.Rest.TLSClientConfig,
-		},
-	)
-
-	g.Expect(err).To(BeNil())
+	clientsPool := createClusterClientsPool(g, clusterName)
 
 	nsMap := map[string][]corev1.Namespace{
 		clusterName: {*ns},
@@ -80,17 +69,7 @@ func TestClientClusteredList(t *testing.T) {
 	clusterName := "mycluster"
 	appName := "myapp" + rand.String(5)
 
-	clientsPool := createClusterClientsPool(g)
-
-	err := clientsPool.Add(
-		clustersmngr.ClientConfigWithUser(&auth.UserPrincipal{}),
-		clustersmngr.Cluster{
-			Name:      clusterName,
-			Server:    k8sEnv.Rest.Host,
-			TLSConfig: k8sEnv.Rest.TLSClientConfig,
-		},
-	)
-	g.Expect(err).To(BeNil())
+	clientsPool := createClusterClientsPool(g, clusterName)
 
 	nsMap := map[string][]corev1.Namespace{
 		clusterName: {*ns},
@@ -185,17 +164,7 @@ func TestClientClusteredListPagination(t *testing.T) {
 		createKust(appName, ns2.Name)
 	}
 
-	clientsPool := createClusterClientsPool(g)
-
-	err := clientsPool.Add(
-		clustersmngr.ClientConfigWithUser(&auth.UserPrincipal{}),
-		clustersmngr.Cluster{
-			Name:      clusterName,
-			Server:    k8sEnv.Rest.Host,
-			TLSConfig: k8sEnv.Rest.TLSClientConfig,
-		},
-	)
-	g.Expect(err).To(BeNil())
+	clientsPool := createClusterClientsPool(g, clusterName)
 
 	nsMap := map[string][]corev1.Namespace{
 		clusterName: {*ns1, *ns2},
@@ -238,17 +207,7 @@ func TestClientClusteredListClusterScoped(t *testing.T) {
 	clusterName := "mycluster"
 	appName := "myapp" + rand.String(5)
 
-	clientsPool := createClusterClientsPool(g)
-
-	err := clientsPool.Add(
-		clustersmngr.ClientConfigWithUser(&auth.UserPrincipal{}),
-		clustersmngr.Cluster{
-			Name:      clusterName,
-			Server:    k8sEnv.Rest.Host,
-			TLSConfig: k8sEnv.Rest.TLSClientConfig,
-		},
-	)
-	g.Expect(err).To(BeNil())
+	clientsPool := createClusterClientsPool(g, clusterName)
 
 	nsMap := map[string][]corev1.Namespace{
 		clusterName: {},
@@ -290,17 +249,7 @@ func TestClientCLusteredListErrors(t *testing.T) {
 
 	clusterName := "mycluster"
 
-	clientsPool := createClusterClientsPool(g)
-
-	err := clientsPool.Add(
-		clustersmngr.ClientConfigWithUser(&auth.UserPrincipal{}),
-		clustersmngr.Cluster{
-			Name:      clusterName,
-			Server:    k8sEnv.Rest.Host,
-			TLSConfig: k8sEnv.Rest.TLSClientConfig,
-		},
-	)
-	g.Expect(err).To(BeNil())
+	clientsPool := createClusterClientsPool(g, clusterName)
 
 	nsMap := map[string][]corev1.Namespace{
 		clusterName: {*ns},
@@ -331,17 +280,7 @@ func TestClientList(t *testing.T) {
 	clusterName := "mycluster"
 	appName := "myapp" + rand.String(5)
 
-	clientsPool := createClusterClientsPool(g)
-
-	err := clientsPool.Add(
-		clustersmngr.ClientConfigWithUser(&auth.UserPrincipal{}),
-		clustersmngr.Cluster{
-			Name:      clusterName,
-			Server:    k8sEnv.Rest.Host,
-			TLSConfig: k8sEnv.Rest.TLSClientConfig,
-		},
-	)
-	g.Expect(err).To(BeNil())
+	clientsPool := createClusterClientsPool(g, clusterName)
 
 	nsMap := map[string][]corev1.Namespace{
 		clusterName: {*ns},
@@ -378,17 +317,7 @@ func TestClientCreate(t *testing.T) {
 	clusterName := "mycluster"
 	appName := "myapp" + rand.String(5)
 
-	clientsPool := createClusterClientsPool(g)
-
-	err := clientsPool.Add(
-		clustersmngr.ClientConfigWithUser(&auth.UserPrincipal{}),
-		clustersmngr.Cluster{
-			Name:      clusterName,
-			Server:    k8sEnv.Rest.Host,
-			TLSConfig: k8sEnv.Rest.TLSClientConfig,
-		},
-	)
-	g.Expect(err).To(BeNil())
+	clientsPool := createClusterClientsPool(g, clusterName)
 
 	nsMap := map[string][]corev1.Namespace{
 		clusterName: {*ns},
@@ -423,17 +352,7 @@ func TestClientDelete(t *testing.T) {
 	clusterName := "mycluster"
 	appName := "myapp" + rand.String(5)
 
-	clientsPool := createClusterClientsPool(g)
-
-	err := clientsPool.Add(
-		clustersmngr.ClientConfigWithUser(&auth.UserPrincipal{}),
-		clustersmngr.Cluster{
-			Name:      clusterName,
-			Server:    k8sEnv.Rest.Host,
-			TLSConfig: k8sEnv.Rest.TLSClientConfig,
-		},
-	)
-	g.Expect(err).To(BeNil())
+	clientsPool := createClusterClientsPool(g, clusterName)
 
 	nsMap := map[string][]corev1.Namespace{
 		clusterName: {*ns},
@@ -466,17 +385,7 @@ func TestClientUpdate(t *testing.T) {
 	clusterName := "mycluster"
 	appName := "myapp" + rand.String(5)
 
-	clientsPool := createClusterClientsPool(g)
-
-	err := clientsPool.Add(
-		clustersmngr.ClientConfigWithUser(&auth.UserPrincipal{}),
-		clustersmngr.Cluster{
-			Name:      clusterName,
-			Server:    k8sEnv.Rest.Host,
-			TLSConfig: k8sEnv.Rest.TLSClientConfig,
-		},
-	)
-	g.Expect(err).To(BeNil())
+	clientsPool := createClusterClientsPool(g, clusterName)
 
 	nsMap := map[string][]corev1.Namespace{
 		clusterName: {*ns},
@@ -514,17 +423,7 @@ func TestClientPatch(t *testing.T) {
 	clusterName := "mycluster"
 	appName := "myapp" + rand.String(5)
 
-	clientsPool := createClusterClientsPool(g)
-
-	err := clientsPool.Add(
-		clustersmngr.ClientConfigWithUser(&auth.UserPrincipal{}),
-		clustersmngr.Cluster{
-			Name:      clusterName,
-			Server:    k8sEnv.Rest.Host,
-			TLSConfig: k8sEnv.Rest.TLSClientConfig,
-		},
-	)
-	g.Expect(err).To(BeNil())
+	clientsPool := createClusterClientsPool(g, clusterName)
 
 	nsMap := map[string][]corev1.Namespace{
 		clusterName: {*ns},
@@ -570,11 +469,22 @@ func createNamespace(g *GomegaWithT) *corev1.Namespace {
 	return ns
 }
 
-func createClusterClientsPool(g *GomegaWithT) clustersmngr.ClientsPool {
+func createClusterClientsPool(g *GomegaWithT, clusterName string) clustersmngr.ClientsPool {
 	scheme, err := kube.CreateScheme()
 	g.Expect(err).To(BeNil())
 
 	clientsPool := clustersmngr.NewClustersClientsPool(scheme)
+
+	err = clientsPool.Add(
+		clustersmngr.ClientConfigWithUser(&auth.UserPrincipal{}),
+		clustersmngr.Cluster{
+			Name:      clusterName,
+			Server:    k8sEnv.Rest.Host,
+			TLSConfig: k8sEnv.Rest.TLSClientConfig,
+		},
+	)
+
+	g.Expect(err).To(BeNil())
 
 	return clientsPool
 }

--- a/core/clustersmngr/client_test.go
+++ b/core/clustersmngr/client_test.go
@@ -476,7 +476,8 @@ func createClusterClientsPool(g *GomegaWithT, clusterName string) clustersmngr.C
 	clientsPool := clustersmngr.NewClustersClientsPool(scheme)
 
 	err = clientsPool.Add(
-		clustersmngr.ClientConfigWithUser(&auth.UserPrincipal{}),
+		// Put the user in the `system:masters` group to avoid auth errors
+		clustersmngr.ClientConfigWithUser(&auth.UserPrincipal{ID: "anne", Groups: []string{"system:masters"}}),
 		clustersmngr.Cluster{
 			Name:      clusterName,
 			Server:    k8sEnv.Rest.Host,

--- a/core/clustersmngr/clustersmngr.go
+++ b/core/clustersmngr/clustersmngr.go
@@ -90,7 +90,9 @@ func ClientConfigWithUser(user *auth.UserPrincipal) ClusterClientConfigFunc {
 			}).DialContext,
 		}
 
-		if user.Token != "" {
+		if user.Token == "" && user.ID == "" {
+			return nil, fmt.Errorf("No user ID or Token found in UserPrincipal.")
+		} else if user.Token != "" {
 			config.BearerToken = user.Token
 		} else {
 			config.BearerToken = cluster.BearerToken

--- a/core/clustersmngr/clustersmngr.go
+++ b/core/clustersmngr/clustersmngr.go
@@ -90,7 +90,7 @@ func ClientConfigWithUser(user *auth.UserPrincipal) ClusterClientConfigFunc {
 			}).DialContext,
 		}
 
-		if user.Token == "" && user.ID == "" {
+		if !user.Valid() {
 			return nil, fmt.Errorf("No user ID or Token found in UserPrincipal.")
 		} else if user.Token != "" {
 			config.BearerToken = user.Token

--- a/core/clustersmngr/clustersmngr.go
+++ b/core/clustersmngr/clustersmngr.go
@@ -22,7 +22,7 @@ const (
 	ClustersClientCtxKey key = iota
 	// DefaultCluster name
 	DefaultCluster = "Default"
-	// ClientQPS is the QPS to use while creating the k8s clients
+	// ClientQPS is the QPS to use while creating the k8s clients (actually a float32)
 	ClientQPS = 1000
 	// ClientBurst is the burst to use while creating the k8s clients
 	ClientBurst = 2000

--- a/core/clustersmngr/clustersmngr_test.go
+++ b/core/clustersmngr/clustersmngr_test.go
@@ -1,0 +1,87 @@
+package clustersmngr_test
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/client-go/rest"
+
+	"github.com/weaveworks/weave-gitops/core/clustersmngr"
+	"github.com/weaveworks/weave-gitops/pkg/server/auth"
+)
+
+func TestClientConfigWithUser(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	tests := []struct {
+		name                  string
+		principal             *auth.UserPrincipal
+		expectedErr           error
+		expectedToken         string
+		expectedImpersonation *rest.ImpersonationConfig
+	}{
+		{
+			name:                  "good user and cluster in: good config out",
+			principal:             &auth.UserPrincipal{ID: "Juan", Groups: []string{"team-a"}},
+			expectedErr:           nil,
+			expectedToken:         "",
+			expectedImpersonation: &rest.ImpersonationConfig{UserName: "Juan", Groups: []string{"team-a"}},
+		},
+		{
+			name:                  "good token and cluster in: good config out",
+			principal:             &auth.UserPrincipal{Token: "some-token-i-guess"},
+			expectedErr:           nil,
+			expectedToken:         "some-token-i-guess",
+			expectedImpersonation: nil,
+		},
+		{
+			name:                  "No token or user Id should error",
+			principal:             &auth.UserPrincipal{},
+			expectedErr:           fmt.Errorf("No user ID or Token found in UserPrincipal."),
+			expectedToken:         "",
+			expectedImpersonation: nil,
+		},
+	}
+
+	for idx, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set up
+			clusterName := fmt.Sprintf("clustersmngr-test-%d-%s", idx, rand.String(5))
+
+			clusterCfgFunc := clustersmngr.ClientConfigWithUser(tt.principal)
+
+			cluster := makeLeafCluster(t, clusterName)
+
+			// Run
+			res, err := clusterCfgFunc(cluster)
+
+			// Test
+			if tt.expectedErr != nil {
+				g.Expect(err).To(Equal(tt.expectedErr))
+				g.Expect(res).To(BeNil())
+
+			} else {
+				g.Expect(err).To(BeNil())
+
+				if tt.expectedImpersonation != nil {
+					g.Expect(res.Impersonate.UserName).To(Equal(tt.expectedImpersonation.UserName))
+					g.Expect(res.Impersonate.Groups).To(Equal(tt.expectedImpersonation.Groups))
+					g.Expect(res.BearerToken).To(Equal(cluster.BearerToken))
+
+				} else if tt.expectedToken != "" {
+					g.Expect(res.BearerToken).To(Equal(tt.expectedToken))
+					g.Expect(rest.ImpersonationConfig{}).To(Equal(res.Impersonate))
+				}
+
+				// BeEquivalentTo will type cast to float32 for us. Which stops us having
+				// to explicitly declare the type of ClientQPS (which just has to match
+				// whatever is required in the struct)
+				g.Expect(res.QPS).To(BeEquivalentTo(clustersmngr.ClientQPS))
+				g.Expect(res.Burst).To(Equal(clustersmngr.ClientBurst))
+			}
+		})
+	}
+}

--- a/core/server/suite_test.go
+++ b/core/server/suite_test.go
@@ -73,7 +73,8 @@ func makeGRPCServer(cfg *rest.Config, t *testing.T) (pb.CoreClient, server.CoreS
 
 	lis := bufconn.Listen(1024 * 1024)
 
-	principal := &auth.UserPrincipal{}
+	// Put the user in the `system:masters` group to avoid auth errors
+	principal := &auth.UserPrincipal{ID: "anne", Groups: []string{"system:masters"}}
 	s := grpc.NewServer(
 		withClientsPoolInterceptor(clientsFactory, principal),
 	)
@@ -170,7 +171,8 @@ func makeServer(cfg server.CoreServerConfig, t *testing.T) pb.CoreClient {
 
 	lis := bufconn.Listen(1024 * 1024)
 
-	principal := &auth.UserPrincipal{}
+	// Put the user in the `system:masters` group to avoid auth errors
+	principal := &auth.UserPrincipal{ID: "anne", Groups: []string{"system:masters"}}
 	s := grpc.NewServer(
 		withClientsPoolInterceptor(cfg.ClientsFactory, principal),
 	)

--- a/pkg/server/auth/auth.go
+++ b/pkg/server/auth/auth.go
@@ -84,6 +84,14 @@ func (p *UserPrincipal) String() string {
 	return fmt.Sprintf("id=%q groups=%v", p.ID, p.Groups)
 }
 
+func (p *UserPrincipal) Valid() bool {
+	if p.ID == "" && p.Token == "" {
+		return false
+	}
+
+	return true
+}
+
 // WithPrincipal sets the principal into the context.
 func WithPrincipal(ctx context.Context, p *UserPrincipal) context.Context {
 	return context.WithValue(ctx, principalCtxKey{}, p)

--- a/pkg/server/auth/auth_test.go
+++ b/pkg/server/auth/auth_test.go
@@ -282,3 +282,47 @@ func TestRateLimit(t *testing.T) {
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(res4).To(HaveHTTPStatus(http.StatusUnauthorized))
 }
+
+func TestUserPrincipalValid(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	tests := []struct {
+		name    string
+		user    auth.UserPrincipal
+		isValid bool
+	}{
+		{
+			name:    "Full valid OIDC user",
+			user:    auth.UserPrincipal{ID: "Jane", Groups: []string{"team-a", "qa"}},
+			isValid: true,
+		},
+		{
+			name:    "any token",
+			user:    auth.UserPrincipal{Token: "abcdefghi09123"},
+			isValid: true,
+		},
+		{
+			name:    "Just a user id",
+			user:    auth.UserPrincipal{ID: "Samir"},
+			isValid: true,
+		},
+		{
+			name:    "Empty",
+			user:    auth.UserPrincipal{},
+			isValid: false,
+		},
+		{
+			name:    "Group only",
+			user:    auth.UserPrincipal{Groups: []string{"team-b"}},
+			isValid: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := tt.user.Valid()
+
+			g.Expect(res).To(Equal(tt.isValid))
+		})
+	}
+}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Raise an error if an empty `UserPrincipal` is passed to `ClientConfigWithUser`. 

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**

Most callers of `ClientConfigWithUser` check that the user principal they're about to pass isn't `nil` but this doesn't protect against the case when both the `Token` and `ID` are empty strings. If this happens then any calls to the Kubernetes API are made with the application's service account rather than the (incorrectly configured) user.

This is (unlikely) to pose a significant risk as other layers ensure that a principal is set correctly but this provides strength in depth against potential miss-configuration or future extensions.

<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**

A check for empty strings.

<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**

Extended the unit tests and running locally