### PR TITLE
Fix the changelog generation

### DIFF
--- a/.github/changelog/changelog_configuration.json
+++ b/.github/changelog/changelog_configuration.json
@@ -30,5 +30,11 @@
     ],
     "template": "${{CHANGELOG}}\n\n<details>\n<summary>Uncategorized</summary>\n\n${{UNCATEGORIZED}}\n</details>",
     "pr_template": "- PR: #${{NUMBER}} - ${{TITLE}}",
-    "empty_template": "- no changes"
+    "empty_template": "- no changes",
+    "tag_resolver": {
+      "method": "semver",
+      "filter": {
+        "pattern": "^v[0-9.]+$"
+      }
+    }
 }

--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -77,18 +77,13 @@ jobs:
           git commit -am "Update README to point download link to $GITOPS_VERSION"
         if: ${{ !contains(github.event.inputs.version, '-') }}
 
-      - name: Set tag for building changelog
-        run: |
-          git config user.name weave-gitops-bot
-          git config user.email weave-gitops-bot@weave.works
-          git tag -a ${{ github.event.inputs.version }} -m ${{ github.event.inputs.version }}
-          # Do not push tag - we'll push it when approved
       - name: Build Changelog
         id: github_release
         uses: mikepenz/release-changelog-builder-action@v3
         with:
           configuration: "${{ github.workspace }}/.github/changelog/changelog_configuration.json"
           ignorePreReleases: true
+          toTag: ${{ github.sha }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create Pull Request


### PR DESCRIPTION
The changelog generation doesn't use the local git repository to find
the final tag, it uses the github API, so setting a tag in the local
repo doesn't help. Explicitly specify the toTag to be the current
commit instead.

However, doing that breaks the ignorePrereleases option so that the
    release changelog only contains the changes since the last RC. Fix
    that by adding a regex to filter out prereleases.