### PR TITLE
Fix `get bycrypt-hash` reading of stdin

### DIFF
--- a/cmd/gitops/get/bcrypt/cmd.go
+++ b/cmd/gitops/get/bcrypt/cmd.go
@@ -38,16 +38,19 @@ func hashCommandRunE() func(*cobra.Command, []string) error {
 
 		var p []byte
 
-		if stats.Size() == 0 {
-			fmt.Print("error: no password found\nEnter Password: ")
+		if (stats.Mode() & os.ModeCharDevice) == 0 {
+			p, err = io.ReadAll(os.Stdin)
+
+			if err != nil {
+				return err
+			}
+		} else {
+			fmt.Print("Enter Password: ")
 
 			p, err = term.ReadPassword(int(os.Stdin.Fd()))
 
-			if err != nil {
-				return nil
-			}
-		} else {
-			p, err = io.ReadAll(os.Stdin)
+			fmt.Println()
+
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Fixes #2597

#### What changed?

Fix detection of data being piped into `gitops get bcrypt-hash` on linux systems.

#### Why was this change made?

Fixes an issue where the `gitops get bcrypt-hash` call doesn't properly read from stdin on linux machines because the size property of the stdin file is 0.

#### How was this change implemented?

Instead of checking the size of stdin, check the mode on stdin to determine whether to read from stdin or get user input.

#### How did you validate the change?

Locally tested on ubuntu.

Stdin from pipe:

```
# echo -n test | ./bin/gitops get bcrypt-hash
$2a$10$n3Waub.Sz.1BKao/8226x.Vsd3nayfeGKeQmjGiKpnPWGf37FX4tm
```

Getting user input:

```
# ./bin/gitops get bcrypt-hash
Enter Password: 
$2a$10$K9PNrYXxRg/ZyMvHcm/0Uer45R3WPoCujiEb0Pwb04iUeyxb/V./e
```

Redirecting stdin from a file:

```
# echo -n test > password.txt && ./bin/gitops get bcrypt-hash < password.txt
$2a$10$HLoQ0F/gzvf6Bdqhw1H69.2ZPfSAbStr3xTSIlT2RLbHOytRdNG.W
```

Here string:

```
# ./bin/gitops get bcrypt-hash <<< test
$2a$10$aPUM5C.E.vO4ckJLoW5BMuoJgjrCa0VZCKfugi/VWxBX7KCMwWH.2
```