### PR TITLE
Return Added and Removed Clusters in Clusters.Set()

### DIFF
--- a/core/clustersmngr/factory_caches_test.go
+++ b/core/clustersmngr/factory_caches_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/cheshir/ttlcache"
+	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
 	"github.com/weaveworks/weave-gitops/core/clustersmngr"
 	"github.com/weaveworks/weave-gitops/pkg/server/auth"
@@ -79,4 +80,39 @@ func TestClustersNamespaces(t *testing.T) {
 	cs.Clear()
 
 	g.Expect(cs.Get(clusterName)).To(HaveLen(0))
+}
+
+func TestClusterSet_Set(t *testing.T) {
+	cs := clustersmngr.Clusters{}
+	cluster1 := newTestCluster("cluster1", "server1")
+	cluster2 := newTestCluster("cluster2", "server2")
+
+	clusters := []clustersmngr.Cluster{cluster1, cluster2}
+
+	added, removed := cs.Set(clusters)
+	if diff := cmp.Diff([]clustersmngr.Cluster{cluster1, cluster2}, added); diff != "" {
+		t.Fatalf("failed to calculate added:\n%s", diff)
+	}
+
+	if diff := cmp.Diff([]clustersmngr.Cluster{}, removed); diff != "" {
+		t.Fatalf("failed to calculate removed:\n%s", diff)
+	}
+
+	clusters = []clustersmngr.Cluster{cluster1}
+
+	added, removed = cs.Set(clusters)
+	if diff := cmp.Diff([]clustersmngr.Cluster{}, added); diff != "" {
+		t.Fatalf("failed to calculate added:\n%s", diff)
+	}
+
+	if diff := cmp.Diff([]clustersmngr.Cluster{cluster2}, removed); diff != "" {
+		t.Fatalf("failed to calculate removed:\n%s", diff)
+	}
+}
+
+func newTestCluster(name, server string) clustersmngr.Cluster {
+	return clustersmngr.Cluster{
+		Name:   name,
+		Server: server,
+	}
 }

--- a/core/clustersmngr/factory_caches_test.go
+++ b/core/clustersmngr/factory_caches_test.go
@@ -86,11 +86,12 @@ func TestClusterSet_Set(t *testing.T) {
 	cs := clustersmngr.Clusters{}
 	cluster1 := newTestCluster("cluster1", "server1")
 	cluster2 := newTestCluster("cluster2", "server2")
+	cluster3 := newTestCluster("cluster2", "server3")
 
-	clusters := []clustersmngr.Cluster{cluster1, cluster2}
+	clusters := []clustersmngr.Cluster{cluster1, cluster2, cluster3}
 
 	added, removed := cs.Set(clusters)
-	if diff := cmp.Diff([]clustersmngr.Cluster{cluster1, cluster2}, added); diff != "" {
+	if diff := cmp.Diff([]clustersmngr.Cluster{cluster1, cluster2, cluster3}, added); diff != "" {
 		t.Fatalf("failed to calculate added:\n%s", diff)
 	}
 
@@ -105,7 +106,7 @@ func TestClusterSet_Set(t *testing.T) {
 		t.Fatalf("failed to calculate added:\n%s", diff)
 	}
 
-	if diff := cmp.Diff([]clustersmngr.Cluster{cluster2}, removed); diff != "" {
+	if diff := cmp.Diff([]clustersmngr.Cluster{cluster2, cluster3}, removed); diff != "" {
 		t.Fatalf("failed to calculate removed:\n%s", diff)
 	}
 }


### PR DESCRIPTION
Part of: https://github.com/weaveworks/weave-gitops-enterprise/issues/1282

<!-- Describe what has changed in this PR -->
**What changed?**
Updated Set() method to return added and removed clusters.

**Why was this change made?**
To allow `GetProfiles` and `GetProfileValues` to work with any HelmRepository CR and on any cluster, in order to allow a user to select a Chart from a HelmRepository on a leaf cluster.

**How did you validate the change?**
Added unit tests.
