### PR TITLE
CLI command for creating GitOps Dashboard

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -9,3 +9,6 @@
 
 # Ignore JSON files
 *.json
+
+# Ignore MDX files
+*.mdx

--- a/cmd/gitops/beta/run/cmd.go
+++ b/cmd/gitops/beta/run/cmd.go
@@ -25,6 +25,11 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
+const (
+	adminUsername    = "admin"
+	helmChartVersion = "3.0.0"
+)
+
 type RunCommandFlags struct {
 	FluxVersion     string
 	AllowK8sContext string
@@ -279,7 +284,7 @@ func betaRunCommandRunE(opts *config.Options) func(*cobra.Command, []string) err
 					return err
 				}
 
-				err = run.InstallDashboard(log, ctx, man, flags.Namespace, secret)
+				err = run.InstallDashboard(log, ctx, man, flags.Namespace, adminUsername, secret, helmChartVersion)
 				if err != nil {
 					return fmt.Errorf("gitops dashboard installation failed: %w", err)
 				} else {

--- a/cmd/gitops/beta/run/cmd.go
+++ b/cmd/gitops/beta/run/cmd.go
@@ -22,6 +22,7 @@ import (
 	"github.com/weaveworks/weave-gitops/pkg/kube"
 	"github.com/weaveworks/weave-gitops/pkg/run"
 	"github.com/weaveworks/weave-gitops/pkg/version"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
@@ -310,7 +311,7 @@ func betaRunCommandRunE(opts *config.Options) func(*cobra.Command, []string) err
 		if dashboardInstalled {
 			log.Actionf("Request reconciliation of dashboard (timeout %v) ...", flags.Timeout)
 
-			if err := run.ReconcileDashboard(kubeClient, dashboardName, flags.Namespace, dashboardPodName, flags.Timeout, flags.DashboardPort); err != nil {
+			if err := run.ReconcileDashboard(kubeClient, dashboardName, flags.Namespace, dashboardPodName, flags.Timeout); err != nil {
 				log.Failuref("Error requesting reconciliation of dashboard: %v", err.Error())
 			} else {
 				log.Successf("Dashboard reconciliation is done.")
@@ -443,7 +444,9 @@ func betaRunCommandRunE(opts *config.Options) func(*cobra.Command, []string) err
 							}
 
 							// get pod from specMap
-							pod, err := run.GetPodFromSpecMap(specMap, kubeClient)
+							namespacedName := types.NamespacedName{Namespace: specMap.Namespace, Name: specMap.Name}
+
+							pod, err := run.GetPodFromResourceDescription(namespacedName, specMap.Kind, kubeClient)
 							if err != nil {
 								log.Failuref("Error getting pod from specMap: %v", err)
 							}

--- a/cmd/gitops/beta/run/cmd.go
+++ b/cmd/gitops/beta/run/cmd.go
@@ -26,6 +26,8 @@ import (
 )
 
 const (
+	dashboardName    = "ww-gitops"
+	dashboardPodName = "ww-gitops-weave-gitops"
 	adminUsername    = "admin"
 	helmChartVersion = "3.0.0"
 )
@@ -261,7 +263,7 @@ func betaRunCommandRunE(opts *config.Options) func(*cobra.Command, []string) err
 
 		log.Actionf("Checking if GitOps Dashboard is already installed ...")
 
-		dashboardInstalled := run.IsDashboardInstalled(log, ctx, kubeClient, flags.Namespace)
+		dashboardInstalled := run.IsDashboardInstalled(log, ctx, kubeClient, dashboardName, flags.Namespace)
 
 		if dashboardInstalled {
 			log.Successf("GitOps Dashboard is found")
@@ -284,7 +286,7 @@ func betaRunCommandRunE(opts *config.Options) func(*cobra.Command, []string) err
 					return err
 				}
 
-				err = run.InstallDashboard(log, ctx, man, flags.Namespace, adminUsername, secret, helmChartVersion)
+				err = run.InstallDashboard(log, ctx, man, dashboardName, flags.Namespace, adminUsername, secret, helmChartVersion)
 				if err != nil {
 					return fmt.Errorf("gitops dashboard installation failed: %w", err)
 				} else {
@@ -298,7 +300,7 @@ func betaRunCommandRunE(opts *config.Options) func(*cobra.Command, []string) err
 		if dashboardInstalled {
 			log.Actionf("Request reconciliation of dashboard (timeout %v) ...", flags.Timeout)
 
-			if err := run.ReconcileDashboard(kubeClient, flags.Namespace, flags.Timeout, flags.DashboardPort); err != nil {
+			if err := run.ReconcileDashboard(kubeClient, dashboardName, flags.Namespace, dashboardPodName, flags.Timeout, flags.DashboardPort); err != nil {
 				log.Failuref("Error requesting reconciliation of dashboard: %v", err.Error())
 			} else {
 				log.Successf("Dashboard reconciliation is done.")
@@ -313,7 +315,7 @@ func betaRunCommandRunE(opts *config.Options) func(*cobra.Command, []string) err
 		var cancelDashboardPortForwarding func() = nil
 
 		if dashboardInstalled {
-			cancelDashboardPortForwarding, err = run.EnablePortForwardingForDashboard(log, kubeClient, cfg, flags.Namespace, flags.DashboardPort)
+			cancelDashboardPortForwarding, err = run.EnablePortForwardingForDashboard(log, kubeClient, cfg, flags.Namespace, dashboardPodName, flags.DashboardPort)
 			if err != nil {
 				return err
 			}

--- a/cmd/gitops/cmderrors/errors.go
+++ b/cmd/gitops/cmderrors/errors.go
@@ -11,6 +11,6 @@ var (
 	ErrNoContextForKubeConfig = errors.New("no context provided for the kubeconfig")
 	ErrNoCluster              = errors.New("no cluster in the kube config")
 	ErrGetKubeClient          = errors.New("error getting Kube HTTP client")
-	ErrNoDashboardName        = errors.New("the dashboard name has not been set")
-	ErrMultipleDashboardNames = errors.New("only one dashboard name is allowed")
+	ErrNoName                 = errors.New("name is required")
+	ErrMultipleNames          = errors.New("only one name is allowed")
 )

--- a/cmd/gitops/cmderrors/errors.go
+++ b/cmd/gitops/cmderrors/errors.go
@@ -11,4 +11,6 @@ var (
 	ErrNoContextForKubeConfig = errors.New("no context provided for the kubeconfig")
 	ErrNoCluster              = errors.New("no cluster in the kube config")
 	ErrGetKubeClient          = errors.New("error getting Kube HTTP client")
+	ErrNoDashboardName        = errors.New("the dashboard name has not been set")
+	ErrMultipleDashboardNames = errors.New("only one dashboard name is allowed")
 )

--- a/cmd/gitops/create/cmd.go
+++ b/cmd/gitops/create/cmd.go
@@ -28,7 +28,7 @@ gitops create dashboard ww-gitops \
 	}
 
 	cmd.PersistentFlags().BoolVar(&flags.Export, "export", false, "Export in YAML format to stdout.")
-	cmd.PersistentFlags().DurationVar(&flags.Timeout, "timeout", 30*time.Second, "The timeout for operations during resource creation.")
+	cmd.PersistentFlags().DurationVar(&flags.Timeout, "timeout", 3*time.Minute, "The timeout for operations during resource creation.")
 
 	cmd.AddCommand(dashboard.DashboardCommand(opts))
 

--- a/cmd/gitops/create/cmd.go
+++ b/cmd/gitops/create/cmd.go
@@ -1,15 +1,20 @@
 package create
 
 import (
+	"fmt"
+	"regexp"
+
 	"github.com/spf13/cobra"
+	"github.com/weaveworks/weave-gitops/cmd/gitops/cmderrors"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/config"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/create/dashboard"
 )
 
 func GetCommand(opts *config.Options) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "create",
-		Short: "Creates a resource",
+		Use:     "create",
+		Short:   "Creates a resource",
+		PreRunE: createCommandPreRunE(&opts.Endpoint),
 		Example: `
 # Create a HelmRepository and HelmRelease to deploy Weave GitOps
 gitops create dashboard ww-gitops \
@@ -21,4 +26,30 @@ gitops create dashboard ww-gitops \
 	cmd.AddCommand(dashboard.DashboardCommand(opts))
 
 	return cmd
+}
+
+func createCommandPreRunE(endpoint *string) func(*cobra.Command, []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		numArgs := len(args)
+
+		if numArgs == 0 {
+			return cmderrors.ErrNoName
+		}
+
+		if numArgs > 1 {
+			return cmderrors.ErrMultipleNames
+		}
+
+		name := args[0]
+		if !validateObjectName(name) {
+			return fmt.Errorf("name '%s' is invalid, it should adhere to standard defined in RFC 1123, the name can only contain alphanumeric characters or '-'", name)
+		}
+
+		return nil
+	}
+}
+
+func validateObjectName(name string) bool {
+	r := regexp.MustCompile(`^[a-z0-9]([a-z0-9\\-]){0,61}[a-z0-9]$`)
+	return r.MatchString(name)
 }

--- a/cmd/gitops/create/cmd.go
+++ b/cmd/gitops/create/cmd.go
@@ -9,7 +9,7 @@ import (
 )
 
 type CreateCommandFlags struct {
-	Export  string
+	Export  bool
 	Timeout time.Duration
 }
 
@@ -27,7 +27,7 @@ gitops create dashboard ww-gitops \
 		`,
 	}
 
-	cmd.PersistentFlags().StringVar(&flags.Export, "export", "", "The path to export manifests to.")
+	cmd.PersistentFlags().BoolVar(&flags.Export, "export", false, "Export in YAML format to stdout.")
 	cmd.PersistentFlags().DurationVar(&flags.Timeout, "timeout", 30*time.Second, "The timeout for operations during resource creation.")
 
 	cmd.AddCommand(dashboard.DashboardCommand(opts))

--- a/cmd/gitops/create/cmd.go
+++ b/cmd/gitops/create/cmd.go
@@ -1,12 +1,9 @@
 package create
 
 import (
-	"fmt"
-	"regexp"
 	"time"
 
 	"github.com/spf13/cobra"
-	"github.com/weaveworks/weave-gitops/cmd/gitops/cmderrors"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/config"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/create/dashboard"
 )
@@ -20,9 +17,8 @@ var flags CreateCommandFlags
 
 func GetCommand(opts *config.Options) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "create",
-		Short:   "Creates a resource",
-		PreRunE: createCommandPreRunE(&opts.Endpoint),
+		Use:   "create",
+		Short: "Creates a resource",
 		Example: `
 # Create a HelmRepository and HelmRelease to deploy Weave GitOps
 gitops create dashboard ww-gitops \
@@ -37,30 +33,4 @@ gitops create dashboard ww-gitops \
 	cmd.AddCommand(dashboard.DashboardCommand(opts))
 
 	return cmd
-}
-
-func createCommandPreRunE(endpoint *string) func(*cobra.Command, []string) error {
-	return func(cmd *cobra.Command, args []string) error {
-		numArgs := len(args)
-
-		if numArgs == 0 {
-			return cmderrors.ErrNoName
-		}
-
-		if numArgs > 1 {
-			return cmderrors.ErrMultipleNames
-		}
-
-		name := args[0]
-		if !validateObjectName(name) {
-			return fmt.Errorf("name '%s' is invalid, it should adhere to standard defined in RFC 1123, the name can only contain alphanumeric characters or '-'", name)
-		}
-
-		return nil
-	}
-}
-
-func validateObjectName(name string) bool {
-	r := regexp.MustCompile(`^[a-z0-9]([a-z0-9\\-]){0,61}[a-z0-9]$`)
-	return r.MatchString(name)
 }

--- a/cmd/gitops/create/cmd.go
+++ b/cmd/gitops/create/cmd.go
@@ -1,0 +1,24 @@
+package create
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/weaveworks/weave-gitops/cmd/gitops/config"
+	"github.com/weaveworks/weave-gitops/cmd/gitops/create/dashboard"
+)
+
+func GetCommand(opts *config.Options) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Creates a resource",
+		Example: `
+# Create a HelmRepository and HelmRelease to deploy Weave GitOps
+gitops create dashboard ww-gitops \
+  --password=$PASSWORD \
+  --export > ./clusters/my-cluster/weave-gitops-dashboard.yaml
+		`,
+	}
+
+	cmd.AddCommand(dashboard.DashboardCommand(opts))
+
+	return cmd
+}

--- a/cmd/gitops/create/cmd.go
+++ b/cmd/gitops/create/cmd.go
@@ -3,12 +3,20 @@ package create
 import (
 	"fmt"
 	"regexp"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/cmderrors"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/config"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/create/dashboard"
 )
+
+type CreateCommandFlags struct {
+	Export  string
+	Timeout time.Duration
+}
+
+var flags CreateCommandFlags
 
 func GetCommand(opts *config.Options) *cobra.Command {
 	cmd := &cobra.Command{
@@ -22,6 +30,9 @@ gitops create dashboard ww-gitops \
   --export > ./clusters/my-cluster/weave-gitops-dashboard.yaml
 		`,
 	}
+
+	cmd.PersistentFlags().StringVar(&flags.Export, "export", "", "The path to export manifests to.")
+	cmd.PersistentFlags().DurationVar(&flags.Timeout, "timeout", 30*time.Second, "The timeout for operations during resource creation.")
 
 	cmd.AddCommand(dashboard.DashboardCommand(opts))
 

--- a/cmd/gitops/create/dashboard/cmd.go
+++ b/cmd/gitops/create/dashboard/cmd.go
@@ -16,6 +16,10 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
+const (
+	helmChartName = "weave-gitops"
+)
+
 type DashboardCommandFlags struct {
 	Version string
 	Export  string
@@ -173,7 +177,9 @@ func createDashboardCommandRunE(opts *config.Options) func(*cobra.Command, []str
 
 		log.Actionf("Checking if GitOps Dashboard is already installed ...")
 
-		dashboardInstalled := run.IsDashboardInstalled(log, ctx, kubeClient, flags.Namespace)
+		dashboardName := args[0]
+
+		dashboardInstalled := run.IsDashboardInstalled(log, ctx, kubeClient, dashboardName, flags.Namespace)
 
 		if dashboardInstalled {
 			log.Successf("GitOps Dashboard is found")
@@ -215,8 +221,9 @@ func createDashboardCommandRunE(opts *config.Options) func(*cobra.Command, []str
 			log.Actionf("Request reconciliation of dashboard (timeout %v) ...", timeout)
 
 			dashboardPort := "9001"
+			dashboardPodName := dashboardName + "-" + helmChartName
 
-			if err := run.ReconcileDashboard(kubeClient, flags.Namespace, timeout, dashboardPort); err != nil {
+			if err := run.ReconcileDashboard(kubeClient, dashboardName, flags.Namespace, dashboardPodName, timeout, dashboardPort); err != nil {
 				log.Failuref("Error requesting reconciliation of dashboard: %v", err.Error())
 			} else {
 				log.Successf("Dashboard reconciliation is done.")

--- a/cmd/gitops/create/dashboard/cmd.go
+++ b/cmd/gitops/create/dashboard/cmd.go
@@ -150,13 +150,14 @@ func createDashboardCommandRunE(opts *config.Options) func(*cobra.Command, []str
 		manifests, err := run.CreateDashboardObjects(log, dashboardName, flags.Namespace, adminUsername, secret, "")
 		if err != nil {
 			return fmt.Errorf("error creating dashboard objects: %w", err)
-		} else {
-			log.Successf("Generated GitOps Dashboard manifests")
-			fmt.Println("---")
-			fmt.Println(resourceToString(manifests))
 		}
 
+		log.Successf("Generated GitOps Dashboard manifests")
+
 		if flags.Export {
+			fmt.Println("---")
+			fmt.Println(resourceToString(manifests))
+
 			return nil
 		}
 

--- a/cmd/gitops/create/dashboard/cmd.go
+++ b/cmd/gitops/create/dashboard/cmd.go
@@ -51,7 +51,6 @@ gitops create dashboard ww-gitops \
 		`,
 		SilenceUsage:      true,
 		SilenceErrors:     true,
-		PreRunE:           createDashboardCommandPreRunE(&opts.Endpoint),
 		RunE:              createDashboardCommandRunE(opts),
 		DisableAutoGenTag: true,
 	}
@@ -69,22 +68,6 @@ gitops create dashboard ww-gitops \
 	kubeConfigArgs.AddFlags(cmd.Flags())
 
 	return cmd
-}
-
-func createDashboardCommandPreRunE(endpoint *string) func(*cobra.Command, []string) error {
-	return func(cmd *cobra.Command, args []string) error {
-		numArgs := len(args)
-
-		if numArgs == 0 {
-			return cmderrors.ErrNoName
-		}
-
-		if numArgs > 1 {
-			return cmderrors.ErrMultipleNames
-		}
-
-		return nil
-	}
 }
 
 func createDashboardCommandRunE(opts *config.Options) func(*cobra.Command, []string) error {

--- a/cmd/gitops/create/dashboard/cmd.go
+++ b/cmd/gitops/create/dashboard/cmd.go
@@ -22,8 +22,6 @@ const (
 
 type DashboardCommandFlags struct {
 	Version string
-	Export  string
-	Timeout time.Duration
 	// Overriden global flags.
 	Username string
 	Password string
@@ -60,8 +58,6 @@ gitops create dashboard ww-gitops \
 	cmdFlags.StringVar(&flags.Username, "username", "admin", "The username of the admin user.")
 	cmdFlags.StringVar(&flags.Password, "password", "", "The password of the admin user.")
 	cmdFlags.StringVar(&flags.Version, "version", "", "The version of the dashboard that should be installed.")
-	cmdFlags.StringVar(&flags.Export, "export", "", "The path to export manifests to.")
-	cmdFlags.DurationVar(&flags.Timeout, "timeout", 30*time.Second, "The timeout for operations during GitOps Run.")
 
 	kubeConfigArgs = run.GetKubeConfigArgs()
 

--- a/cmd/gitops/create/dashboard/cmd.go
+++ b/cmd/gitops/create/dashboard/cmd.go
@@ -1,0 +1,300 @@
+package dashboard
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/fluxcd/flux2/pkg/manifestgen/install"
+	"github.com/manifoldco/promptui"
+	"github.com/spf13/cobra"
+	"github.com/weaveworks/weave-gitops/cmd/gitops/cmderrors"
+	"github.com/weaveworks/weave-gitops/cmd/gitops/config"
+	clilogger "github.com/weaveworks/weave-gitops/cmd/gitops/logger"
+	"github.com/weaveworks/weave-gitops/pkg/kube"
+	"github.com/weaveworks/weave-gitops/pkg/run"
+	"github.com/weaveworks/weave-gitops/pkg/version"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/utils/strings/slices"
+)
+
+type DashboardCommandFlags struct {
+	FluxVersion     string
+	AllowK8sContext string
+	Components      []string
+	ComponentsExtra []string
+	Timeout         time.Duration
+	PortForward     string // port forward specifier, e.g. "port=8080:8080,resource=svc/app"
+	DashboardPort   string
+	RootDir         string
+	// Global flags.
+	Namespace  string
+	KubeConfig string
+	// Flags, created by genericclioptions.
+	Context string
+}
+
+var flags DashboardCommandFlags
+
+var kubeConfigArgs *genericclioptions.ConfigFlags
+
+func DashboardCommand(opts *config.Options) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "dashboard",
+		Short: "Create a HelmRepository and HelmRelease to deploy Weave GitOps",
+		Long:  "Create a HelmRepository and HelmRelease to deploy Weave GitOps",
+		Example: `
+# Create a HelmRepository and HelmRelease to deploy Weave GitOps
+gitops create dashboard ww-gitops \
+  --password=$PASSWORD \
+  --export > ./clusters/my-cluster/weave-gitops-dashboard.yaml
+		`,
+		SilenceUsage:      true,
+		SilenceErrors:     true,
+		PreRunE:           createDashboardCommandPreRunE(&opts.Endpoint),
+		RunE:              createDashboardCommandRunE(opts),
+		DisableAutoGenTag: true,
+	}
+
+	cmdFlags := cmd.Flags()
+
+	cmdFlags.StringVar(&flags.FluxVersion, "flux-version", version.FluxVersion, "The version of Flux to install.")
+	cmdFlags.StringVar(&flags.AllowK8sContext, "allow-k8s-context", "", "The name of the KubeConfig context to explicitly allow.")
+	cmdFlags.StringSliceVar(&flags.Components, "components", []string{"source-controller", "kustomize-controller", "helm-controller", "notification-controller"}, "The Flux components to install.")
+	cmdFlags.StringSliceVar(&flags.ComponentsExtra, "components-extra", []string{}, "Additional Flux components to install, allowed values are image-reflector-controller,image-automation-controller.")
+	cmdFlags.DurationVar(&flags.Timeout, "timeout", 30*time.Second, "The timeout for operations during GitOps Run.")
+	cmdFlags.StringVar(&flags.PortForward, "port-forward", "", "Forward the port from a cluster's resource to your local machine i.e. 'port=8080:8080,resource=svc/app'.")
+	cmdFlags.StringVar(&flags.DashboardPort, "dashboard-port", "9001", "GitOps Dashboard port")
+	cmdFlags.StringVar(&flags.RootDir, "root-dir", "", "Specify the root directory to watch for changes. If not specified, the root of Git repository will be used.")
+
+	kubeConfigArgs = run.GetKubeConfigArgs()
+
+	kubeConfigArgs.AddFlags(cmd.Flags())
+
+	return cmd
+}
+
+func createDashboardCommandPreRunE(endpoint *string) func(*cobra.Command, []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		numArgs := len(args)
+
+		if numArgs == 0 {
+			return cmderrors.ErrNoFilePath
+		}
+
+		if numArgs > 1 {
+			return cmderrors.ErrMultipleFilePaths
+		}
+
+		return nil
+	}
+}
+
+func createDashboardCommandRunE(opts *config.Options) func(*cobra.Command, []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		var err error
+
+		if flags.Namespace, err = cmd.Flags().GetString("namespace"); err != nil {
+			return err
+		}
+
+		kubeConfigArgs.Namespace = &flags.Namespace
+
+		if flags.KubeConfig, err = cmd.Flags().GetString("kubeconfig"); err != nil {
+			return err
+		}
+
+		if flags.Context, err = cmd.Flags().GetString("context"); err != nil {
+			return err
+		}
+
+		gitRepoRoot, err := run.FindGitRepoDir()
+		if err != nil {
+			return err
+		}
+
+		rootDir := flags.RootDir
+		if rootDir == "" {
+			rootDir = gitRepoRoot
+		}
+
+		// check if rootDir is valid
+		if _, err := os.Stat(rootDir); err != nil {
+			return fmt.Errorf("root directory %s does not exist", rootDir)
+		}
+
+		// // find absolute path of the root Dir
+		// rootDir, err = filepath.Abs(rootDir)
+		// if err != nil {
+		// 	return err
+		// }
+
+		// currentDir, err := os.Getwd()
+		// if err != nil {
+		// 	return err
+		// }
+
+		// targetPath, err := filepath.Abs(filepath.Join(currentDir, args[0]))
+		// if err != nil {
+		// 	return err
+		// }
+
+		// relativePathForKs, err := run.GetRelativePathToRootDir(rootDir, targetPath)
+		// if err != nil { // if there is no git repo, we return an error
+		// 	return err
+		// }
+
+		log := clilogger.NewCLILogger(os.Stdout)
+
+		if flags.KubeConfig != "" {
+			kubeConfigArgs.KubeConfig = &flags.KubeConfig
+
+			if flags.Context == "" {
+				log.Failuref("A context should be provided if a kubeconfig is provided")
+				return cmderrors.ErrNoContextForKubeConfig
+			}
+		}
+
+		log.Actionf("Checking for a cluster in the kube config ...")
+
+		var contextName string
+
+		if flags.Context != "" {
+			contextName = flags.Context
+		} else {
+			_, contextName, err = kube.RestConfig()
+			if err != nil {
+				log.Failuref("Error getting a restconfig: %v", err.Error())
+				return cmderrors.ErrNoCluster
+			}
+		}
+
+		cfg, err := kubeConfigArgs.ToRESTConfig()
+		if err != nil {
+			return fmt.Errorf("error getting a restconfig from kube config args: %w", err)
+		}
+
+		kubeClientOpts := run.GetKubeClientOptions()
+		kubeClientOpts.BindFlags(cmd.Flags())
+
+		kubeClient, err := run.GetKubeClient(log, contextName, cfg, kubeClientOpts)
+		if err != nil {
+			return cmderrors.ErrGetKubeClient
+		}
+
+		contextName = kubeClient.ClusterName
+		if flags.AllowK8sContext == contextName {
+			log.Actionf("Explicitly allow GitOps Run on %s context", contextName)
+		} else if !run.IsLocalCluster(kubeClient) {
+			return fmt.Errorf("to run against a remote cluster, use --allow-k8s-context=%s", contextName)
+		}
+
+		ctx := context.Background()
+
+		log.Actionf("Checking if Flux is already installed ...")
+
+		if fluxVersion, err := run.GetFluxVersion(log, ctx, kubeClient); err != nil {
+			log.Warningf("Flux is not found: %v", err.Error())
+
+			components := flags.Components
+			components = append(components, flags.ComponentsExtra...)
+
+			if err := ValidateComponents(components); err != nil {
+				return fmt.Errorf("can't install flux: %w", err)
+			}
+
+			installOpts := install.MakeDefaultOptions()
+			installOpts.Version = flags.FluxVersion
+			installOpts.Namespace = flags.Namespace
+			installOpts.Components = components
+			installOpts.ManifestFile = "flux-system.yaml"
+			installOpts.Timeout = flags.Timeout
+
+			man, err := run.NewManager(log, ctx, kubeClient, kubeConfigArgs)
+			if err != nil {
+				log.Failuref("Error creating resource manager")
+				return err
+			}
+
+			if err := run.InstallFlux(log, ctx, installOpts, man); err != nil {
+				return fmt.Errorf("flux installation failed: %w", err)
+			} else {
+				log.Successf("Flux has been installed")
+			}
+
+			for _, controllerName := range components {
+				log.Actionf("Waiting for %s/%s to be ready ...", flags.Namespace, controllerName)
+
+				if err := run.WaitForDeploymentToBeReady(log, kubeClient, controllerName, flags.Namespace); err != nil {
+					return err
+				}
+
+				log.Successf("%s/%s is now ready ...", flags.Namespace, controllerName)
+			}
+		} else {
+			log.Successf("Flux version %s is found", fluxVersion)
+		}
+
+		log.Actionf("Checking if GitOps Dashboard is already installed ...")
+
+		dashboardInstalled := run.IsDashboardInstalled(log, ctx, kubeClient, flags.Namespace)
+
+		if dashboardInstalled {
+			log.Successf("GitOps Dashboard is found")
+		} else {
+			prompt := promptui.Prompt{
+				Label:     "Would you like to install the GitOps Dashboard",
+				IsConfirm: true,
+				Default:   "Y",
+			}
+			_, err = prompt.Run()
+			if err == nil {
+				secret, err := run.GenerateSecret(log)
+				if err != nil {
+					return err
+				}
+
+				man, err := run.NewManager(log, ctx, kubeClient, kubeConfigArgs)
+				if err != nil {
+					log.Failuref("Error creating resource manager")
+					return err
+				}
+
+				err = run.InstallDashboard(log, ctx, man, flags.Namespace, secret)
+				if err != nil {
+					return fmt.Errorf("gitops dashboard installation failed: %w", err)
+				} else {
+					dashboardInstalled = true
+
+					log.Successf("GitOps Dashboard has been installed")
+				}
+			}
+		}
+
+		if dashboardInstalled {
+			log.Actionf("Request reconciliation of dashboard (timeout %v) ...", flags.Timeout)
+
+			if err := run.ReconcileDashboard(kubeClient, flags.Namespace, flags.Timeout, flags.DashboardPort); err != nil {
+				log.Failuref("Error requesting reconciliation of dashboard: %v", err.Error())
+			} else {
+				log.Successf("Dashboard reconciliation is done.")
+			}
+		}
+
+		return nil
+	}
+}
+
+func ValidateComponents(components []string) error {
+	defaults := install.MakeDefaultOptions()
+	bootstrapAllComponents := append(defaults.Components, defaults.ComponentsExtra...)
+
+	for _, component := range components {
+		if !slices.Contains(bootstrapAllComponents, component) {
+			return fmt.Errorf("component %s is not available", component)
+		}
+	}
+
+	return nil
+}

--- a/cmd/gitops/create/dashboard/cmd.go
+++ b/cmd/gitops/create/dashboard/cmd.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/manifoldco/promptui"
 	"github.com/spf13/cobra"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/cmderrors"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/config"
@@ -155,7 +154,6 @@ func createDashboardCommandRunE(opts *config.Options) func(*cobra.Command, []str
 		if fluxVersion, err := run.GetFluxVersion(log, ctx, kubeClient); err != nil {
 			log.Warningf("Flux is not found")
 			return err
-
 		} else {
 			log.Successf("Flux version %s is found", fluxVersion)
 		}
@@ -166,35 +164,37 @@ func createDashboardCommandRunE(opts *config.Options) func(*cobra.Command, []str
 
 		if dashboardInstalled {
 			log.Successf("GitOps Dashboard is found")
-		} else {
-			prompt := promptui.Prompt{
-				Label:     "Would you like to install the GitOps Dashboard",
-				IsConfirm: true,
-				Default:   "Y",
-			}
-			_, err = prompt.Run()
-			if err == nil {
-				secret, err := run.GenerateSecret(log)
-				if err != nil {
-					return err
-				}
-
-				man, err := run.NewManager(log, ctx, kubeClient, kubeConfigArgs)
-				if err != nil {
-					log.Failuref("Error creating resource manager")
-					return err
-				}
-
-				err = run.InstallDashboard(log, ctx, man, flags.Namespace, secret)
-				if err != nil {
-					return fmt.Errorf("gitops dashboard installation failed: %w", err)
-				} else {
-					dashboardInstalled = true
-
-					log.Successf("GitOps Dashboard has been installed")
-				}
-			}
 		}
+
+		// else {
+		// 	prompt := promptui.Prompt{
+		// 		Label:     "Would you like to install the GitOps Dashboard",
+		// 		IsConfirm: true,
+		// 		Default:   "Y",
+		// 	}
+		// 	_, err = prompt.Run()
+		// 	if err == nil {
+		// 		secret, err := run.GenerateSecret(log)
+		// 		if err != nil {
+		// 			return err
+		// 		}
+
+		// 		man, err := run.NewManager(log, ctx, kubeClient, kubeConfigArgs)
+		// 		if err != nil {
+		// 			log.Failuref("Error creating resource manager")
+		// 			return err
+		// 		}
+
+		// 		err = run.InstallDashboard(log, ctx, man, flags.Namespace, secret)
+		// 		if err != nil {
+		// 			return fmt.Errorf("gitops dashboard installation failed: %w", err)
+		// 		} else {
+		// 			dashboardInstalled = true
+
+		// 			log.Successf("GitOps Dashboard has been installed")
+		// 		}
+		// 	}
+		// }
 
 		if dashboardInstalled {
 			timeout := time.Minute * 3

--- a/cmd/gitops/create/dashboard/cmd.go
+++ b/cmd/gitops/create/dashboard/cmd.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"time"
 
-	"github.com/fluxcd/flux2/pkg/manifestgen/install"
 	"github.com/manifoldco/promptui"
 	"github.com/spf13/cobra"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/cmderrors"
@@ -14,25 +14,17 @@ import (
 	clilogger "github.com/weaveworks/weave-gitops/cmd/gitops/logger"
 	"github.com/weaveworks/weave-gitops/pkg/kube"
 	"github.com/weaveworks/weave-gitops/pkg/run"
-	"github.com/weaveworks/weave-gitops/pkg/version"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
-	"k8s.io/utils/strings/slices"
 )
 
 type DashboardCommandFlags struct {
-	FluxVersion     string
-	AllowK8sContext string
-	Components      []string
-	ComponentsExtra []string
-	Timeout         time.Duration
-	PortForward     string // port forward specifier, e.g. "port=8080:8080,resource=svc/app"
-	DashboardPort   string
-	RootDir         string
+	Version string
+	Export  string
+	// Overriden global flags.
+	Username string
+	Password string
 	// Global flags.
-	Namespace  string
-	KubeConfig string
-	// Flags, created by genericclioptions.
-	Context string
+	Namespace string
 }
 
 var flags DashboardCommandFlags
@@ -59,14 +51,10 @@ gitops create dashboard ww-gitops \
 
 	cmdFlags := cmd.Flags()
 
-	cmdFlags.StringVar(&flags.FluxVersion, "flux-version", version.FluxVersion, "The version of Flux to install.")
-	cmdFlags.StringVar(&flags.AllowK8sContext, "allow-k8s-context", "", "The name of the KubeConfig context to explicitly allow.")
-	cmdFlags.StringSliceVar(&flags.Components, "components", []string{"source-controller", "kustomize-controller", "helm-controller", "notification-controller"}, "The Flux components to install.")
-	cmdFlags.StringSliceVar(&flags.ComponentsExtra, "components-extra", []string{}, "Additional Flux components to install, allowed values are image-reflector-controller,image-automation-controller.")
-	cmdFlags.DurationVar(&flags.Timeout, "timeout", 30*time.Second, "The timeout for operations during GitOps Run.")
-	cmdFlags.StringVar(&flags.PortForward, "port-forward", "", "Forward the port from a cluster's resource to your local machine i.e. 'port=8080:8080,resource=svc/app'.")
-	cmdFlags.StringVar(&flags.DashboardPort, "dashboard-port", "9001", "GitOps Dashboard port")
-	cmdFlags.StringVar(&flags.RootDir, "root-dir", "", "Specify the root directory to watch for changes. If not specified, the root of Git repository will be used.")
+	cmdFlags.StringVar(&flags.Username, "username", "admin", "The username of the admin user.")
+	cmdFlags.StringVar(&flags.Password, "password", "", "The password of the admin user.")
+	cmdFlags.StringVar(&flags.Version, "version", "", "The version of the dashboard that should be installed.")
+	cmdFlags.StringVar(&flags.Export, "export", "", "The path to export manifests to.")
 
 	kubeConfigArgs = run.GetKubeConfigArgs()
 
@@ -80,11 +68,11 @@ func createDashboardCommandPreRunE(endpoint *string) func(*cobra.Command, []stri
 		numArgs := len(args)
 
 		if numArgs == 0 {
-			return cmderrors.ErrNoFilePath
+			return cmderrors.ErrNoDashboardName
 		}
 
 		if numArgs > 1 {
-			return cmderrors.ErrMultipleFilePaths
+			return cmderrors.ErrMultipleDashboardNames
 		}
 
 		return nil
@@ -101,73 +89,50 @@ func createDashboardCommandRunE(opts *config.Options) func(*cobra.Command, []str
 
 		kubeConfigArgs.Namespace = &flags.Namespace
 
-		if flags.KubeConfig, err = cmd.Flags().GetString("kubeconfig"); err != nil {
-			return err
-		}
-
-		if flags.Context, err = cmd.Flags().GetString("context"); err != nil {
-			return err
-		}
-
 		gitRepoRoot, err := run.FindGitRepoDir()
 		if err != nil {
 			return err
 		}
 
-		rootDir := flags.RootDir
-		if rootDir == "" {
-			rootDir = gitRepoRoot
-		}
+		rootDir := gitRepoRoot
 
 		// check if rootDir is valid
 		if _, err := os.Stat(rootDir); err != nil {
 			return fmt.Errorf("root directory %s does not exist", rootDir)
 		}
 
-		// // find absolute path of the root Dir
-		// rootDir, err = filepath.Abs(rootDir)
-		// if err != nil {
-		// 	return err
-		// }
+		// find absolute path of the root Dir
+		rootDir, err = filepath.Abs(rootDir)
+		if err != nil {
+			return err
+		}
 
-		// currentDir, err := os.Getwd()
-		// if err != nil {
-		// 	return err
-		// }
+		currentDir, err := os.Getwd()
+		if err != nil {
+			return err
+		}
 
-		// targetPath, err := filepath.Abs(filepath.Join(currentDir, args[0]))
-		// if err != nil {
-		// 	return err
-		// }
+		targetPath, err := filepath.Abs(filepath.Join(currentDir, args[0]))
+		if err != nil {
+			return err
+		}
 
+		_, err = run.GetRelativePathToRootDir(rootDir, targetPath)
 		// relativePathForKs, err := run.GetRelativePathToRootDir(rootDir, targetPath)
-		// if err != nil { // if there is no git repo, we return an error
-		// 	return err
-		// }
+		if err != nil { // if there is no git repo, we return an error
+			return err
+		}
 
 		log := clilogger.NewCLILogger(os.Stdout)
-
-		if flags.KubeConfig != "" {
-			kubeConfigArgs.KubeConfig = &flags.KubeConfig
-
-			if flags.Context == "" {
-				log.Failuref("A context should be provided if a kubeconfig is provided")
-				return cmderrors.ErrNoContextForKubeConfig
-			}
-		}
 
 		log.Actionf("Checking for a cluster in the kube config ...")
 
 		var contextName string
 
-		if flags.Context != "" {
-			contextName = flags.Context
-		} else {
-			_, contextName, err = kube.RestConfig()
-			if err != nil {
-				log.Failuref("Error getting a restconfig: %v", err.Error())
-				return cmderrors.ErrNoCluster
-			}
+		_, contextName, err = kube.RestConfig()
+		if err != nil {
+			log.Failuref("Error getting a restconfig: %v", err.Error())
+			return cmderrors.ErrNoCluster
 		}
 
 		cfg, err := kubeConfigArgs.ToRESTConfig()
@@ -183,55 +148,14 @@ func createDashboardCommandRunE(opts *config.Options) func(*cobra.Command, []str
 			return cmderrors.ErrGetKubeClient
 		}
 
-		contextName = kubeClient.ClusterName
-		if flags.AllowK8sContext == contextName {
-			log.Actionf("Explicitly allow GitOps Run on %s context", contextName)
-		} else if !run.IsLocalCluster(kubeClient) {
-			return fmt.Errorf("to run against a remote cluster, use --allow-k8s-context=%s", contextName)
-		}
-
 		ctx := context.Background()
 
 		log.Actionf("Checking if Flux is already installed ...")
 
 		if fluxVersion, err := run.GetFluxVersion(log, ctx, kubeClient); err != nil {
-			log.Warningf("Flux is not found: %v", err.Error())
+			log.Warningf("Flux is not found")
+			return err
 
-			components := flags.Components
-			components = append(components, flags.ComponentsExtra...)
-
-			if err := ValidateComponents(components); err != nil {
-				return fmt.Errorf("can't install flux: %w", err)
-			}
-
-			installOpts := install.MakeDefaultOptions()
-			installOpts.Version = flags.FluxVersion
-			installOpts.Namespace = flags.Namespace
-			installOpts.Components = components
-			installOpts.ManifestFile = "flux-system.yaml"
-			installOpts.Timeout = flags.Timeout
-
-			man, err := run.NewManager(log, ctx, kubeClient, kubeConfigArgs)
-			if err != nil {
-				log.Failuref("Error creating resource manager")
-				return err
-			}
-
-			if err := run.InstallFlux(log, ctx, installOpts, man); err != nil {
-				return fmt.Errorf("flux installation failed: %w", err)
-			} else {
-				log.Successf("Flux has been installed")
-			}
-
-			for _, controllerName := range components {
-				log.Actionf("Waiting for %s/%s to be ready ...", flags.Namespace, controllerName)
-
-				if err := run.WaitForDeploymentToBeReady(log, kubeClient, controllerName, flags.Namespace); err != nil {
-					return err
-				}
-
-				log.Successf("%s/%s is now ready ...", flags.Namespace, controllerName)
-			}
 		} else {
 			log.Successf("Flux version %s is found", fluxVersion)
 		}
@@ -273,9 +197,13 @@ func createDashboardCommandRunE(opts *config.Options) func(*cobra.Command, []str
 		}
 
 		if dashboardInstalled {
-			log.Actionf("Request reconciliation of dashboard (timeout %v) ...", flags.Timeout)
+			timeout := time.Minute * 3
 
-			if err := run.ReconcileDashboard(kubeClient, flags.Namespace, flags.Timeout, flags.DashboardPort); err != nil {
+			log.Actionf("Request reconciliation of dashboard (timeout %v) ...", timeout)
+
+			dashboardPort := "9001"
+
+			if err := run.ReconcileDashboard(kubeClient, flags.Namespace, timeout, dashboardPort); err != nil {
 				log.Failuref("Error requesting reconciliation of dashboard: %v", err.Error())
 			} else {
 				log.Successf("Dashboard reconciliation is done.")
@@ -284,17 +212,4 @@ func createDashboardCommandRunE(opts *config.Options) func(*cobra.Command, []str
 
 		return nil
 	}
-}
-
-func ValidateComponents(components []string) error {
-	defaults := install.MakeDefaultOptions()
-	bootstrapAllComponents := append(defaults.Components, defaults.ComponentsExtra...)
-
-	for _, component := range components {
-		if !slices.Contains(bootstrapAllComponents, component) {
-			return fmt.Errorf("component %s is not available", component)
-		}
-	}
-
-	return nil
 }

--- a/cmd/gitops/create/dashboard/cmd.go
+++ b/cmd/gitops/create/dashboard/cmd.go
@@ -156,7 +156,7 @@ func createDashboardCommandRunE(opts *config.Options) func(*cobra.Command, []str
 
 		if flags.Export {
 			fmt.Println("---")
-			fmt.Println(resourceToString(manifests))
+			fmt.Println(string(manifests))
 
 			return nil
 		}
@@ -245,11 +245,4 @@ func createDashboardCommandRunE(opts *config.Options) func(*cobra.Command, []str
 func validateObjectName(name string) bool {
 	r := regexp.MustCompile(`^[a-z0-9]([a-z0-9\\-]){0,61}[a-z0-9]$`)
 	return r.MatchString(name)
-}
-
-func resourceToString(data []byte) string {
-	data = bytes.ReplaceAll(data, []byte("  creationTimestamp: null\n"), []byte(""))
-	data = bytes.ReplaceAll(data, []byte("status: {}\n"), []byte(""))
-
-	return string(data)
 }

--- a/cmd/gitops/create/dashboard/cmd.go
+++ b/cmd/gitops/create/dashboard/cmd.go
@@ -228,10 +228,9 @@ func createDashboardCommandRunE(opts *config.Options) func(*cobra.Command, []str
 
 		log.Waitingf("Waiting for GitOps Dashboard reconciliation")
 
-		dashboardPort := "9001"
 		dashboardPodName := dashboardName + "-" + helmChartName
 
-		if err := run.ReconcileDashboard(kubeClient, dashboardName, flags.Namespace, dashboardPodName, flags.Timeout, dashboardPort); err != nil {
+		if err := run.ReconcileDashboard(kubeClient, dashboardName, flags.Namespace, dashboardPodName, flags.Timeout); err != nil {
 			log.Failuref("Error requesting reconciliation of dashboard: %v", err.Error())
 		} else {
 			log.Successf("GitOps Dashboard %s is ready", dashboardName)

--- a/cmd/gitops/root/cmd.go
+++ b/cmd/gitops/root/cmd.go
@@ -12,6 +12,7 @@ import (
 	"github.com/weaveworks/weave-gitops/cmd/gitops/beta"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/check"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/config"
+	"github.com/weaveworks/weave-gitops/cmd/gitops/create"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/delete"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/docs"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/get"
@@ -111,6 +112,7 @@ func RootCmd(client *adapters.HTTPClient) *cobra.Command {
 	rootCmd.AddCommand(docs.Cmd)
 	rootCmd.AddCommand(check.Cmd)
 	rootCmd.AddCommand(beta.GetCommand(options))
+	rootCmd.AddCommand(create.GetCommand(options))
 
 	return rootCmd
 }

--- a/go.mod
+++ b/go.mod
@@ -58,6 +58,7 @@ require (
 	k8s.io/client-go v0.24.2
 	sigs.k8s.io/cli-utils v0.31.2
 	sigs.k8s.io/controller-runtime v0.11.2
+	sigs.k8s.io/kustomize/api v0.11.5
 	sigs.k8s.io/kustomize/kstatus v0.0.2
 	sigs.k8s.io/yaml v1.3.0
 )
@@ -97,7 +98,6 @@ require (
 	github.com/sirupsen/logrus v1.9.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gotest.tools/v3 v3.1.0 // indirect
-	sigs.k8s.io/kustomize/api v0.11.5 // indirect
 )
 
 require (
@@ -253,7 +253,7 @@ require (
 	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9
 	oras.land/oras-go v1.2.0 // indirect
 	sigs.k8s.io/json v0.0.0-20220525155127-227cbc7cc124 // indirect
-	sigs.k8s.io/kustomize/kyaml v0.13.7 // indirect
+	sigs.k8s.io/kustomize/kyaml v0.13.7
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect
 )
 

--- a/pkg/run/forward_port.go
+++ b/pkg/run/forward_port.go
@@ -117,10 +117,8 @@ func ForwardPort(pod *corev1.Pod, cfg *rest.Config, specMap *PortForwardSpec, wa
 	return fw.ForwardPorts()
 }
 
-func GetPodFromSpecMap(specMap *PortForwardSpec, kubeClient client.Client) (*corev1.Pod, error) {
-	namespacedName := types.NamespacedName{Name: specMap.Name, Namespace: specMap.Namespace}
-
-	switch specMap.Kind {
+func GetPodFromResourceDescription(namespacedName types.NamespacedName, kind string, kubeClient client.Client) (*corev1.Pod, error) {
+	switch kind {
 	case "pod":
 		pod := &corev1.Pod{}
 		if err := kubeClient.Get(context.Background(), namespacedName, pod); err != nil {

--- a/pkg/run/install_dashboard.go
+++ b/pkg/run/install_dashboard.go
@@ -154,10 +154,12 @@ func EnablePortForwardingForDashboard(log logger.Logger, kubeClient client.Clien
 func ReconcileDashboard(kubeClient client.Client, name string, namespace string, podName string, timeout time.Duration, dashboardPort string) error {
 	const interval = 3 * time.Second / 2
 
+	helmChartName := namespace + "-" + name
+
 	// reconcile dashboard
 	namespacedName := types.NamespacedName{
 		Namespace: namespace,
-		Name:      namespace + "-" + name,
+		Name:      helmChartName,
 	}
 	gvk := schema.GroupVersionKind{
 		Group:   "source.toolkit.fluxcd.io",
@@ -182,7 +184,7 @@ func ReconcileDashboard(kubeClient client.Client, name string, namespace string,
 		dashboard := &sourcev1.HelmChart{}
 		if err := kubeClient.Get(context.Background(), types.NamespacedName{
 			Namespace: namespace,
-			Name:      namespace + "-" + name,
+			Name:      helmChartName,
 		}, dashboard); err != nil {
 			return false, err
 		}

--- a/pkg/run/install_dashboard.go
+++ b/pkg/run/install_dashboard.go
@@ -253,7 +253,6 @@ func makeHelmRepository(name string, namespace string) *sourcev1.HelmRepository 
 				"app.kubernetes.io/name":       "weave-gitops-dashboard",
 				"app.kubernetes.io/component":  "ui",
 				"app.kubernetes.io/part-of":    "weave-gitops",
-				"app.kubernetes.io/managed-by": "flux",
 				"app.kubernetes.io/created-by": "weave-gitops-cli",
 			},
 			Annotations: map[string]string{

--- a/pkg/run/install_dashboard_test.go
+++ b/pkg/run/install_dashboard_test.go
@@ -46,14 +46,14 @@ var _ = Describe("InstallDashboard", func() {
 	It("should install dashboard successfully", func() {
 		man := &mockResourceManagerForApply{}
 
-		err := InstallDashboard(fakeLogger, fakeContext, man, namespace, secret)
+		err := InstallDashboard(fakeLogger, fakeContext, man, namespace, "admin", secret, "3.0.0")
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should return an apply all error if the resource manager returns an apply all error", func() {
 		man := &mockResourceManagerForApply{state: stateApplyAllReturnErr}
 
-		err := InstallDashboard(fakeLogger, fakeContext, man, namespace, secret)
+		err := InstallDashboard(fakeLogger, fakeContext, man, namespace, "admin", secret, "3.0.0")
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(Equal(applyAllErrorMsg))
 	})
@@ -234,7 +234,7 @@ var _ = Describe("makeHelmRelease", func() {
 		expected, err := json.Marshal(helmRelease)
 		Expect(err).NotTo(HaveOccurred())
 
-		actualHelmRelease, err := makeHelmRelease(fakeLogger, secret, namespace)
+		actualHelmRelease, err := makeHelmRelease(fakeLogger, namespace, "admin", secret, "3.0.0")
 		Expect(err).NotTo(HaveOccurred())
 
 		actual, err := json.Marshal(actualHelmRelease)
@@ -277,14 +277,14 @@ var _ = Describe("makeValues", func() {
 			"adminUser": map[string]interface{}{
 				"create":       true,
 				"passwordHash": "test-secret",
-				"username":     "admin",
+				"username":     "testUser",
 			},
 		}
 
 		expected, err := json.Marshal(valuesMap)
 		Expect(err).NotTo(HaveOccurred())
 
-		actual, err := makeValues(secret)
+		actual, err := makeValues("testUser", secret)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(actual).To(Equal(expected))
 	})

--- a/pkg/run/install_dashboard_test.go
+++ b/pkg/run/install_dashboard_test.go
@@ -238,3 +238,49 @@ var _ = Describe("makeValues", func() {
 		Expect(adminUser["passwordHash"]).To(Equal(testSecret))
 	})
 })
+
+var _ = Describe("sanitizeResourceData", func() {
+	var fakeLogger *loggerfakes.FakeLogger
+
+	BeforeEach(func() {
+		fakeLogger = &loggerfakes.FakeLogger{}
+	})
+
+	It("sanitizes helmrepository data", func() {
+		helmRepository := makeHelmRepository(testDashboardName, testNamespace)
+
+		resData, err := yaml.Marshal(helmRepository)
+		Expect(err).NotTo(HaveOccurred())
+
+		resStr := string(resData)
+		Expect(strings.Contains(resStr, "status")).To(BeTrue())
+		Expect(strings.Contains(resStr, "creationTimestamp")).To(BeTrue())
+
+		sanitizedResData, err := sanitizeResourceData(fakeLogger, resData)
+		Expect(err).NotTo(HaveOccurred())
+
+		sanitizedResStr := string(sanitizedResData)
+		Expect(strings.Contains(sanitizedResStr, "status")).To(BeFalse())
+		Expect(strings.Contains(sanitizedResStr, "creationTimestamp")).To(BeFalse())
+	})
+
+	It("sanitizes helmrelease data", func() {
+		helmChartVersion := "3.0.0"
+		helmRelease, err := makeHelmRelease(fakeLogger, testDashboardName, testNamespace, testAdminUser, testSecret, helmChartVersion)
+		Expect(err).NotTo(HaveOccurred())
+
+		resData, err := yaml.Marshal(helmRelease)
+		Expect(err).NotTo(HaveOccurred())
+
+		resStr := string(resData)
+		Expect(strings.Contains(resStr, "status")).To(BeTrue())
+		Expect(strings.Contains(resStr, "creationTimestamp")).To(BeTrue())
+
+		sanitizedResData, err := sanitizeResourceData(fakeLogger, resData)
+		Expect(err).NotTo(HaveOccurred())
+
+		sanitizedResStr := string(sanitizedResData)
+		Expect(strings.Contains(sanitizedResStr, "status")).To(BeFalse())
+		Expect(strings.Contains(sanitizedResStr, "creationTimestamp")).To(BeFalse())
+	})
+})

--- a/pkg/run/install_dashboard_test.go
+++ b/pkg/run/install_dashboard_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"time"
 
 	helmv2 "github.com/fluxcd/helm-controller/api/v2beta1"
@@ -11,7 +12,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/weaveworks/weave-gitops/pkg/logger/loggerfakes"
-	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
@@ -26,8 +26,10 @@ type mockClientForGetDashboardHelmChart struct {
 type stateGetDashboardHelmChart string
 
 const (
-	secret    = "test-secret"
-	namespace = "test-namespace"
+	testDashboardName = "ww-gitops"
+	testNamespace     = "test-namespace"
+	testAdminUser     = "testUser"
+	testSecret        = "test-secret"
 
 	stateGetDashboardHelmChartGetReturnErr stateGetDashboardHelmChart = "get-return-err"
 
@@ -46,14 +48,14 @@ var _ = Describe("InstallDashboard", func() {
 	It("should install dashboard successfully", func() {
 		man := &mockResourceManagerForApply{}
 
-		err := InstallDashboard(fakeLogger, fakeContext, man, namespace, "admin", secret, "3.0.0")
+		err := InstallDashboard(fakeLogger, fakeContext, man, testDashboardName, testNamespace, testAdminUser, testSecret, "3.0.0")
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should return an apply all error if the resource manager returns an apply all error", func() {
 		man := &mockResourceManagerForApply{state: stateApplyAllReturnErr}
 
-		err := InstallDashboard(fakeLogger, fakeContext, man, namespace, "admin", secret, "3.0.0")
+		err := InstallDashboard(fakeLogger, fakeContext, man, testDashboardName, testNamespace, testAdminUser, testSecret, "3.0.0")
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(Equal(applyAllErrorMsg))
 	})
@@ -90,14 +92,14 @@ var _ = Describe("getDashboardHelmChart", func() {
 	})
 
 	It("returns the dashboard helmchart if there is no error when getting the helmchart", func() {
-		helmChart := getDashboardHelmChart(fakeLogger, fakeContext, &mockClientForGetDashboardHelmChart{}, namespace)
+		helmChart := getDashboardHelmChart(fakeLogger, fakeContext, &mockClientForGetDashboardHelmChart{}, testDashboardName, testNamespace)
 		Expect(helmChart).ToNot(BeNil())
 		Expect(helmChart.Namespace).To(Equal("test-namespace"))
 		Expect(helmChart.Name).To(Equal("test-namespace-ww-gitops"))
 	})
 
 	It("returns nil if there is an error when getting the helmchart", func() {
-		helmChart := getDashboardHelmChart(fakeLogger, fakeContext, &mockClientForGetDashboardHelmChart{state: stateGetDashboardHelmChartGetReturnErr}, namespace)
+		helmChart := getDashboardHelmChart(fakeLogger, fakeContext, &mockClientForGetDashboardHelmChart{state: stateGetDashboardHelmChartGetReturnErr}, testDashboardName, testNamespace)
 		Expect(helmChart).To(BeNil())
 	})
 })
@@ -110,77 +112,37 @@ var _ = Describe("generateManifestsForDashboard", func() {
 	})
 
 	It("generates manifests successfully", func() {
-		valuesMap := map[string]interface{}{
-			"adminUser": map[string]interface{}{
-				"create":       true,
-				"passwordHash": "test-secret",
-				"username":     "admin",
-			},
-		}
+		helmRepository := makeHelmRepository(testDashboardName, testNamespace)
 
-		helmRepository := &sourcev1.HelmRepository{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       sourcev1.HelmRepositoryKind,
-				APIVersion: sourcev1.GroupVersion.Identifier(),
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "ww-gitops",
-				Namespace: "test-namespace",
-			},
-			Spec: sourcev1.HelmRepositorySpec{
-				URL: "https://helm.gitops.weave.works",
-				Interval: metav1.Duration{
-					Duration: time.Minute,
-				},
-			},
-		}
-
-		values, err := json.Marshal(valuesMap)
+		helmChartVersion := "3.0.0"
+		helmRelease, err := makeHelmRelease(fakeLogger, testDashboardName, testNamespace, testAdminUser, testSecret, helmChartVersion)
 		Expect(err).NotTo(HaveOccurred())
 
-		helmRelease := &helmv2.HelmRelease{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       helmv2.HelmReleaseKind,
-				APIVersion: helmv2.GroupVersion.Identifier(),
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "ww-gitops",
-				Namespace: "test-namespace",
-			},
-			Spec: helmv2.HelmReleaseSpec{
-				Interval: metav1.Duration{
-					Duration: time.Minute,
-				},
-				Chart: helmv2.HelmChartTemplate{
-					Spec: helmv2.HelmChartTemplateSpec{
-						Chart:   "weave-gitops",
-						Version: "3.0.0",
-						SourceRef: helmv2.CrossNamespaceObjectReference{
-							Kind: "HelmRepository",
-							Name: "ww-gitops",
-						},
-						ReconcileStrategy: "ChartVersion",
-					},
-				},
-				Values: &v1.JSON{Raw: values},
-			},
-		}
-
-		expectedHelmRepository, err := yaml.Marshal(helmRepository)
+		manifestsData, err := generateManifestsForDashboard(fakeLogger, helmRepository, helmRelease)
 		Expect(err).NotTo(HaveOccurred())
+		Expect(manifestsData).NotTo(BeNil())
 
-		expectedHelmRelease, err := yaml.Marshal(helmRelease)
+		manifests := strings.Split(string(manifestsData), "---\n")
+		Expect(len(manifests)).To(Equal(2))
+
+		var actualHelmRepository sourcev1.HelmRepository
+		err = yaml.Unmarshal([]byte(manifests[0]), &actualHelmRepository)
 		Expect(err).NotTo(HaveOccurred())
+		Expect(actualHelmRepository.Name).To(Equal(testDashboardName))
+		Expect(actualHelmRepository.Namespace).To(Equal(testNamespace))
 
-		divider := []byte("---\n")
-
-		expected := append(divider, expectedHelmRepository...)
-		expected = append(expected, divider...)
-		expected = append(expected, expectedHelmRelease...)
-
-		actual, err := generateManifestsForDashboard(fakeLogger, secret, helmRepository, helmRelease)
+		var actualHelmRelease helmv2.HelmRelease
+		err = yaml.Unmarshal([]byte(manifests[1]), &actualHelmRelease)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(actual).To(Equal(expected))
+		Expect(actualHelmRelease.Name).To(Equal(testDashboardName))
+		Expect(actualHelmRelease.Namespace).To(Equal(testNamespace))
+
+		Expect(actualHelmRelease.Spec.Interval.Duration).To(Equal(60 * time.Minute))
+
+		chart := actualHelmRelease.Spec.Chart
+		Expect(chart.Spec.Chart).To(Equal(helmChartName))
+		Expect(chart.Spec.SourceRef.Name).To(Equal(testDashboardName))
+		Expect(chart.Spec.Version).To(Equal(helmChartVersion))
 	})
 })
 
@@ -191,101 +153,83 @@ var _ = Describe("makeHelmRelease", func() {
 		fakeLogger = &loggerfakes.FakeLogger{}
 	})
 
-	It("creates helmrelease successfully", func() {
-		valuesMap := map[string]interface{}{
-			"adminUser": map[string]interface{}{
-				"create":       true,
-				"passwordHash": "test-secret",
-				"username":     "admin",
-			},
-		}
+	It("creates helmrelease with chart version and values successfully", func() {
+		helmChartVersion := "3.0.0"
+		actual, err := makeHelmRelease(fakeLogger, testDashboardName, testNamespace, testAdminUser, testSecret, helmChartVersion)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(actual.Kind).To(Equal(helmv2.HelmReleaseKind))
+		Expect(actual.APIVersion).To(Equal(helmv2.GroupVersion.Identifier()))
+		Expect(actual.Name).To(Equal(testDashboardName))
+		Expect(actual.Namespace).To(Equal(testNamespace))
 
-		values, err := json.Marshal(valuesMap)
+		Expect(actual.Spec.Interval.Duration).To(Equal(60 * time.Minute))
+
+		chart := actual.Spec.Chart
+		Expect(chart.Spec.Chart).To(Equal(helmChartName))
+		Expect(chart.Spec.SourceRef.Name).To(Equal(testDashboardName))
+		Expect(chart.Spec.SourceRef.Kind).To(Equal("HelmRepository"))
+		Expect(chart.Spec.Version).To(Equal(helmChartVersion))
+
+		values := map[string]interface{}{}
+		err = json.Unmarshal(actual.Spec.Values.Raw, &values)
 		Expect(err).NotTo(HaveOccurred())
 
-		helmRelease := &helmv2.HelmRelease{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       helmv2.HelmReleaseKind,
-				APIVersion: helmv2.GroupVersion.Identifier(),
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "ww-gitops",
-				Namespace: "test-namespace",
-			},
-			Spec: helmv2.HelmReleaseSpec{
-				Interval: metav1.Duration{
-					Duration: time.Minute,
-				},
-				Chart: helmv2.HelmChartTemplate{
-					Spec: helmv2.HelmChartTemplateSpec{
-						Chart:   "weave-gitops",
-						Version: "3.0.0",
-						SourceRef: helmv2.CrossNamespaceObjectReference{
-							Kind: "HelmRepository",
-							Name: "ww-gitops",
-						},
-						ReconcileStrategy: "ChartVersion",
-					},
-				},
-				Values: &v1.JSON{Raw: values},
-			},
-		}
+		adminUser := values["adminUser"].(map[string]interface{})
+		Expect(adminUser["create"]).To(BeTrue())
+		Expect(adminUser["username"]).To(Equal(testAdminUser))
+		Expect(adminUser["passwordHash"]).To(Equal(testSecret))
+	})
 
-		expected, err := json.Marshal(helmRelease)
+	It("creates helmrelease without chart version successfully", func() {
+		actual, err := makeHelmRelease(fakeLogger, testDashboardName, testNamespace, testAdminUser, testSecret, "")
 		Expect(err).NotTo(HaveOccurred())
 
-		actualHelmRelease, err := makeHelmRelease(fakeLogger, namespace, "admin", secret, "3.0.0")
-		Expect(err).NotTo(HaveOccurred())
+		chart := actual.Spec.Chart
+		Expect(chart.Spec.Version).To(BeEmpty())
+	})
 
-		actual, err := json.Marshal(actualHelmRelease)
+	It("does not add values to helmrelease if both username and secret are empty successfully", func() {
+		actual, err := makeHelmRelease(fakeLogger, testDashboardName, testNamespace, "", "", "3.0.0")
 		Expect(err).NotTo(HaveOccurred())
-		Expect(actual).To(Equal(expected))
+		Expect(actual.Spec.Values).To(BeNil())
 	})
 })
 
 var _ = Describe("makeHelmRepository", func() {
 	It("creates helmrepository successfully", func() {
-		helmRepository := &sourcev1.HelmRepository{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       sourcev1.HelmRepositoryKind,
-				APIVersion: sourcev1.GroupVersion.Identifier(),
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "ww-gitops",
-				Namespace: "test-namespace",
-			},
-			Spec: sourcev1.HelmRepositorySpec{
-				URL: "https://helm.gitops.weave.works",
-				Interval: metav1.Duration{
-					Duration: time.Minute,
-				},
-			},
-		}
+		actual := makeHelmRepository(testDashboardName, testNamespace)
+		Expect(actual.Kind).To(Equal(sourcev1.HelmRepositoryKind))
+		Expect(actual.APIVersion).To(Equal(sourcev1.GroupVersion.Identifier()))
+		Expect(actual.Name).To(Equal(testDashboardName))
+		Expect(actual.Namespace).To(Equal(testNamespace))
 
-		expected, err := json.Marshal(helmRepository)
-		Expect(err).NotTo(HaveOccurred())
+		labels := actual.Labels
+		Expect(labels["app.kubernetes.io/name"]).NotTo(BeEmpty())
+		Expect(labels["app.kubernetes.io/component"]).NotTo(BeEmpty())
+		Expect(labels["app.kubernetes.io/part-of"]).NotTo(BeEmpty())
+		Expect(labels["app.kubernetes.io/managed-by"]).NotTo(BeEmpty())
+		Expect(labels["app.kubernetes.io/created-by"]).NotTo(BeEmpty())
 
-		actual, err := json.Marshal(makeHelmRepository(namespace))
-		Expect(err).NotTo(HaveOccurred())
-		Expect(actual).To(Equal(expected))
+		annotations := actual.Annotations
+		Expect(annotations["metadata.weave.works/description"]).NotTo(BeEmpty())
+
+		Expect(actual.Spec.URL).To(Equal(helmRepositoryUrl))
+		Expect(actual.Spec.Interval.Duration).To(Equal(60 * time.Minute))
 	})
 })
 
 var _ = Describe("makeValues", func() {
 	It("creates values successfully", func() {
-		valuesMap := map[string]interface{}{
-			"adminUser": map[string]interface{}{
-				"create":       true,
-				"passwordHash": "test-secret",
-				"username":     "testUser",
-			},
-		}
-
-		expected, err := json.Marshal(valuesMap)
+		values, err := makeValues(testAdminUser, testSecret)
 		Expect(err).NotTo(HaveOccurred())
 
-		actual, err := makeValues("testUser", secret)
+		actual := map[string]interface{}{}
+		err = json.Unmarshal(values, &actual)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(actual).To(Equal(expected))
+
+		adminUser := actual["adminUser"].(map[string]interface{})
+		Expect(adminUser["create"]).To(BeTrue())
+		Expect(adminUser["username"]).To(Equal(testAdminUser))
+		Expect(adminUser["passwordHash"]).To(Equal(testSecret))
 	})
 })

--- a/pkg/run/install_dashboard_test.go
+++ b/pkg/run/install_dashboard_test.go
@@ -213,7 +213,6 @@ var _ = Describe("makeHelmRepository", func() {
 		Expect(labels["app.kubernetes.io/name"]).NotTo(BeEmpty())
 		Expect(labels["app.kubernetes.io/component"]).NotTo(BeEmpty())
 		Expect(labels["app.kubernetes.io/part-of"]).NotTo(BeEmpty())
-		Expect(labels["app.kubernetes.io/managed-by"]).NotTo(BeEmpty())
 		Expect(labels["app.kubernetes.io/created-by"]).NotTo(BeEmpty())
 
 		annotations := actual.Annotations

--- a/pkg/run/install_dashboard_test.go
+++ b/pkg/run/install_dashboard_test.go
@@ -48,14 +48,20 @@ var _ = Describe("InstallDashboard", func() {
 	It("should install dashboard successfully", func() {
 		man := &mockResourceManagerForApply{}
 
-		err := InstallDashboard(fakeLogger, fakeContext, man, testDashboardName, testNamespace, testAdminUser, testSecret, "3.0.0")
+		manifests, err := CreateDashboardObjects(fakeLogger, testDashboardName, testNamespace, testAdminUser, testSecret, "3.0.0")
+		Expect(err).NotTo(HaveOccurred())
+
+		err = InstallDashboard(fakeLogger, fakeContext, man, manifests)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should return an apply all error if the resource manager returns an apply all error", func() {
 		man := &mockResourceManagerForApply{state: stateApplyAllReturnErr}
 
-		err := InstallDashboard(fakeLogger, fakeContext, man, testDashboardName, testNamespace, testAdminUser, testSecret, "3.0.0")
+		manifests, err := CreateDashboardObjects(fakeLogger, testDashboardName, testNamespace, testAdminUser, testSecret, "3.0.0")
+		Expect(err).NotTo(HaveOccurred())
+
+		err = InstallDashboard(fakeLogger, fakeContext, man, manifests)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(Equal(applyAllErrorMsg))
 	})

--- a/pkg/run/install_dev_bucket_server.go
+++ b/pkg/run/install_dev_bucket_server.go
@@ -10,6 +10,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -181,7 +182,9 @@ func InstallDevBucketServer(log logger.Logger, kubeClient client.Client, config 
 		ContainerPort: "9000",
 	}
 	// get pod from specMap
-	pod, err := GetPodFromSpecMap(specMap, kubeClient)
+	namespacedName := types.NamespacedName{Namespace: specMap.Namespace, Name: specMap.Name}
+
+	pod, err := GetPodFromResourceDescription(namespacedName, specMap.Kind, kubeClient)
 	if err != nil {
 		log.Failuref("Error getting pod from specMap: %v", err)
 	}

--- a/website/docs/getting-started.mdx
+++ b/website/docs/getting-started.mdx
@@ -80,44 +80,14 @@ The bootstrap command above does following:
 - Deploys Flux Components to your Kubernetes Cluster
 - Configures Flux components to track the path /clusters/my-cluster/ in the repository
 
-### Configure access to the dashboard
-
-For this guide we will use the cluster user, for complete documentation including how to configure an OIDC provider see the documentation [here](./configuration/securing-access-to-the-dashboard.mdx).
-
-We will generate a bcrypt hash for your chosen password and store it as a secret in Kubernetes. There are several different ways to generate a bcrypt hash, this guide uses `gitops get bcrypt-hash` from our CLI.
-
-1. Clone your git repository where Flux has been bootstrapped (you could skip this step if you performed previous steps in this doc).
-
-   ```
-   git clone https://github.com/$GITHUB_USER/fleet-infra
-   cd fleet-infra
-   ```
-
-1. Generate the password:
-
-   ```
-   PASSWORD="<your password>"
-   echo -n $PASSWORD | gitops get bcrypt-hash
-   $2a$10$OS5NJmPNEb13UgTOSKnMxOWlmS7mlxX77hv4yAiISvZ71Dc7IuN3q
-   ```
-
-1. Save this [bcrypt-hash](https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/Password_Storage_Cheat_Sheet.md) in a values file, together with any other settings:
-
-   ```yaml title="./weave-gitops-values.yaml"
-   adminUser:
-     create: true
-     username: admin
-     passwordHash: $2a$10$OS5NJmPNEb13UgTOSKnMxOWlmS7mlxX77hv4yAiISvZ71Dc7IuN3q
-   listOCIRepositories: true # Display OCI Repositories, requires flux 0.32
-   ```
-
-   :::info
-   Storing a hash of a password is relatively safe for demo and testing purposes but it is recommend that you look at more secure methods of storing secrets (such as [Flux's SOPS integration](https://fluxcd.io/docs/guides/mozilla-sops/)) for production systems.
-   :::
-
 ### Install Weave GitOps
 
-Weave GitOps is installable via a Helm Chart and as such can be managed by Flux.
+For this guide we will use the cluster user, for complete documentation including how to configure an OIDC provider see the documentation here.
+
+1. Install the Weave GitOps CLI
+   ```
+   brew install weaveworks/tap/weave-gitops 
+   ```
 
 1. Clone your git repository where Flux has been bootstrapped.
 
@@ -126,51 +96,23 @@ Weave GitOps is installable via a Helm Chart and as such can be managed by Flux.
    cd fleet-infra
    ```
 
-1. Create a `HelmRepository` Source for Weave GitOps
+1. Run the following command which will create a `HelmRepository` and `HelmRelease` to deploy Weave GitOps
 
    ```
-   flux create source helm ww-gitops \
-     --interval=60m \
-     --url=oci://ghcr.io/weaveworks/charts \
-     --export > ./clusters/my-cluster/weave-gitops-source.yaml
+   PASSWORD="<your password>"
+   gitops create dashboard ww-gitops \
+     --password=$PASSWORD \
+     --export > ./clusters/my-cluster/weave-gitops-dashboard.yaml
    ```
 
-   The generated file should look like this:
+:::warning
+This command stores a hash of a password.  While this is relatively safe for demo and testing purposes it is recommend that you look at more secure methods of storing secrets (such as [Flux's SOPS integration](https://fluxcd.io/docs/guides/mozilla-sops/)) for production systems.
+:::
 
-   ```yaml title="./clusters/my-cluster/weave-gitops-source.yaml"
-   apiVersion: source.toolkit.fluxcd.io/v1beta2
-   kind: HelmRepository
-   metadata:
-     name: ww-gitops
-     namespace: flux-system
-   spec:
-     interval: 1h0m0s
-     type: oci
-     url: oci://ghcr.io/weaveworks/charts
-   ```
-
-1. Commit and push the `weave-gitops-source.yaml` to the `fleet-infra` repository
+1. Commit and push the `weave-gitops-dashboard.yaml` to the `fleet-infra` repository
 
    ```
-   git add -A && git commit -m "Add Weave GitOps HelmRepository"
-   git push
-   ```
-
-1. Create a `HelmRelease` to deploy Weave GitOps
-
-   ```
-   flux create helmrelease ww-gitops \
-     --interval=60m \
-     --source=HelmRepository/ww-gitops \
-     --chart=weave-gitops \
-     --values=<path to weave-gitops-values.yaml> \
-     --export > ./clusters/my-cluster/weave-gitops-helmrelease.yaml
-   ```
-
-1. Commit and push the `weave-gitops-helmrelease.yaml` to the `fleet-infra` repository
-
-   ```
-   git add -A && git commit -m "Add Weave GitOps HelmRelease"
+   git add -A && git commit -m "Add Weave GitOps Dashboard"
    git push
    ```
 


### PR DESCRIPTION
Closes #2414 
 
- Added the `gitops create dashboard` command and command flags.
- Reworked generation of dashboard manifests, made it more flexible and configurable.
- Reworked dashboard manifests generation tests to make them easier to maintain based on @ozamosi 's suggestion.
- Split some functions into two:` GenerateSecret` into `ReadPassword` and `GenerateSecret` (to be able to generate secret programmatically without displaying a prompt) and `InstallDashboard` into `CreateDashboardObjects` and `InstallDashboard` for easier export of manifests without dashboard installation.
- Slightly refactored passing params to dashboard functions to make it more consistent (for example with `name` always passed before the `namespace` argument).

Notes:
- How should users install Flux in case of using a custom namespace? The dashboard is installed successfully with the custom namespace flag, if on a clean cluster the new namespace is added but flux is installed with just `flux install`. (But it is possible that after that dashboard installation hangs if trying to install the dashboard to another namespace.)
But if on a clean cluster flux is installed with `flux install -n custom-1` and then the dashboard is installed with the custom namespace, the install hangs with the chart OK but the helm release `install retries exhausted`.

Command I use for testing creating the dashboard with the custom namespace:
```
<you path to gitops>/gitops create dashboard ww-gitops   --password=123 --namespace=custom-1
```
- The `version` flag will be added in the second PR, after we define, how it should work.
- Any naming, wording, descriptions suggestions are most welcome!
- What should be short and long `dashboard` command descriptions?
- I have not tested the command with the custom kubeconfig and context yet.
