### PR TITLE
Fix spacing of nodes with child nodes

### DIFF
--- a/ui/components/ReconciliationGraph.tsx
+++ b/ui/components/ReconciliationGraph.tsx
@@ -89,7 +89,8 @@ function ReconciliationGraph({
     .nodeSize([
       nodeSize.width + nodeSize.horizontalSeparation,
       nodeSize.height + nodeSize.verticalSeparation,
-    ]);
+    ])
+    .separation(() => 1);
   const tree = makeTree(root);
   const descendants = tree.descendants();
   const links = tree.links();


### PR DESCRIPTION
Closes #2506 

Made all nodes (with or without children) have the same "horizontal separation".

The fix is based on:

https://github.com/d3/d3-hierarchy/blob/v3.1.2/README.md#tree_separation

```
tree.separation([separation])

If separation is specified, sets the separation accessor to the specified function and returns this tree layout. If separation is not specified, returns the current separation accessor, which defaults to:

function separation(a, b) {
  return a.parent == b.parent ? 1 : 2;
}
```

By default, d3.js separates nodes with children into "clusters". Instead of the default horizontal separation, we just return 1 for all nodes, so the horizontal distance between neighboring nodes will be the same.

Before:

<img width="1532" alt="Screenshot 2022-08-17 at 01 37 52" src="https://user-images.githubusercontent.com/8824708/185004878-f4ae82f5-9f89-46b0-a885-83f68ef3282b.png">

After:

<img width="1531" alt="Screenshot 2022-08-17 at 01 41 44" src="https://user-images.githubusercontent.com/8824708/185004886-aee40a6c-3ad9-4568-b051-0863c2283a3f.png">

During testing, a different issue was discovered: #2614 