### PR TITLE
ui: Make source details do http requests from the top, too

### DIFF
--- a/ui/components/BucketDetail.tsx
+++ b/ui/components/BucketDetail.tsx
@@ -11,36 +11,33 @@ import { InfoField } from "./InfoList";
 
 type Props = {
   className?: string;
-  name: string;
-  namespace: string;
-  clusterName: string;
+  bucket: Bucket;
 };
 
-function BucketDetail({ name, namespace, className, clusterName }: Props) {
+function BucketDetail({ className, bucket }: Props) {
   const { data } = useFeatureFlags();
   const flags = data?.flags || {};
+
+  const tenancyInfo: InfoField[] =
+    flags.WEAVE_GITOPS_FEATURE_TENANCY === "true" && bucket.tenant
+      ? [["Tenant", bucket.tenant]]
+      : [];
 
   return (
     <SourceDetail
       className={className}
-      name={name}
-      namespace={namespace}
-      clusterName={clusterName}
       type={FluxObjectKind.KindBucket}
-      info={(b: Bucket = new Bucket({})) =>
-        [
-          ["Type", removeKind(FluxObjectKind.KindBucket)],
-          ["Endpoint", b.endpoint],
-          ["Bucket Name", b.name],
-          ["Last Updated", <Timestamp time={b.lastUpdatedAt} />],
-          ["Interval", <Interval interval={b.interval} />],
-          ["Cluster", b.clusterName],
-          ["Namespace", b.namespace],
-          ...(flags.WEAVE_GITOPS_FEATURE_TENANCY === "true" && b.tenant
-            ? [["Tenant", b.tenant]]
-            : []),
-        ] as InfoField[]
-      }
+      source={bucket}
+      info={[
+        ["Type", removeKind(FluxObjectKind.KindBucket)],
+        ["Endpoint", bucket.endpoint],
+        ["Bucket Name", bucket.name],
+        ["Last Updated", <Timestamp time={bucket.lastUpdatedAt} />],
+        ["Interval", <Interval interval={bucket.interval} />],
+        ["Cluster", bucket.clusterName],
+        ["Namespace", bucket.namespace],
+        ...tenancyInfo,
+      ]}
     />
   );
 }

--- a/ui/components/GitRepositoryDetail.tsx
+++ b/ui/components/GitRepositoryDetail.tsx
@@ -11,45 +11,37 @@ import { InfoField } from "./InfoList";
 
 type Props = {
   className?: string;
-  name: string;
-  namespace: string;
-  clusterName: string;
+  gitRepository: GitRepository;
 };
 
-function GitRepositoryDetail({
-  name,
-  namespace,
-  className,
-  clusterName,
-}: Props) {
+function GitRepositoryDetail({ className, gitRepository }: Props) {
   const { data } = useFeatureFlags();
   const flags = data?.flags || {};
+
+  const tenancyInfo: InfoField[] =
+    flags.WEAVE_GITOPS_FEATURE_TENANCY === "true" && gitRepository.tenant
+      ? [["Tenant", gitRepository.tenant]]
+      : [];
 
   return (
     <SourceDetail
       className={className}
-      name={name}
-      namespace={namespace}
-      clusterName={clusterName}
       type={FluxObjectKind.KindGitRepository}
-      info={(s: GitRepository) =>
+      source={gitRepository}
+      info={[
+        ["Type", removeKind(FluxObjectKind.KindGitRepository)],
         [
-          ["Type", removeKind(FluxObjectKind.KindGitRepository)],
-          [
-            "URL",
-            <Link newTab href={convertGitURLToGitProvider(s.url)}>
-              {s.url}
-            </Link>,
-          ],
-          ["Ref", s.reference.branch],
-          ["Last Updated", <Timestamp time={s.lastUpdatedAt} />],
-          ["Cluster", s.clusterName],
-          ["Namespace", s.namespace],
-          ...(flags.WEAVE_GITOPS_FEATURE_TENANCY === "true" && s.tenant
-            ? [["Tenant", s.tenant]]
-            : []),
-        ] as InfoField[]
-      }
+          "URL",
+          <Link newTab href={convertGitURLToGitProvider(gitRepository.url)}>
+            {gitRepository.url}
+          </Link>,
+        ],
+        ["Ref", gitRepository.reference?.branch],
+        ["Last Updated", <Timestamp time={gitRepository.lastUpdatedAt} />],
+        ["Cluster", gitRepository.clusterName],
+        ["Namespace", gitRepository.namespace],
+        ...tenancyInfo,
+      ]}
     />
   );
 }

--- a/ui/components/HelmChartDetail.tsx
+++ b/ui/components/HelmChartDetail.tsx
@@ -11,36 +11,33 @@ import { InfoField } from "./InfoList";
 
 type Props = {
   className?: string;
-  name: string;
-  namespace: string;
-  clusterName: string;
+  helmChart: HelmChart;
 };
 
-function HelmChartDetail({ name, namespace, className, clusterName }: Props) {
+function HelmChartDetail({ className, helmChart }: Props) {
   const { data } = useFeatureFlags();
   const flags = data?.flags || {};
 
+  const tenancyInfo: InfoField[] =
+    flags.WEAVE_GITOPS_FEATURE_TENANCY === "true" && helmChart.tenant
+      ? [["Tenant", helmChart.tenant]]
+      : [];
+
   return (
     <SourceDetail
-      name={name}
-      namespace={namespace}
       type={FluxObjectKind.KindHelmChart}
       className={className}
-      clusterName={clusterName}
-      info={(ch: HelmChart = new HelmChart({})) =>
-        [
-          ["Type", removeKind(FluxObjectKind.KindHelmChart)],
-          ["Chart", ch?.chart],
-          ["Ref", ch?.sourceRef?.name],
-          ["Last Updated", <Timestamp time={ch?.lastUpdatedAt} />],
-          ["Interval", <Interval interval={ch?.interval} />],
-          ["Cluster", ch?.clusterName],
-          ["Namespace", ch?.namespace],
-          ...(flags.WEAVE_GITOPS_FEATURE_TENANCY === "true" && ch.tenant
-            ? [["Tenant", ch.tenant]]
-            : []),
-        ] as InfoField[]
-      }
+      source={helmChart}
+      info={[
+        ["Type", removeKind(FluxObjectKind.KindHelmChart)],
+        ["Chart", helmChart.chart],
+        ["Ref", helmChart.sourceRef?.name],
+        ["Last Updated", <Timestamp time={helmChart.lastUpdatedAt} />],
+        ["Interval", <Interval interval={helmChart.interval} />],
+        ["Cluster", helmChart.clusterName],
+        ["Namespace", helmChart.namespace],
+        ...tenancyInfo,
+      ]}
     />
   );
 }

--- a/ui/components/HelmRepositoryDetail.tsx
+++ b/ui/components/HelmRepositoryDetail.tsx
@@ -12,44 +12,40 @@ import { InfoField } from "./InfoList";
 
 type Props = {
   className?: string;
-  name: string;
-  namespace: string;
-  clusterName: string;
+  helmRepository: HelmRepository;
 };
 
-function HelmRepositoryDetail({
-  name,
-  namespace,
-  className,
-  clusterName,
-}: Props) {
+function HelmRepositoryDetail({ className, helmRepository }: Props) {
   const { data } = useFeatureFlags();
   const flags = data?.flags || {};
+
+  const tenancyInfo: InfoField[] =
+    flags.WEAVE_GITOPS_FEATURE_TENANCY === "true" && helmRepository.tenant
+      ? [["Tenant", helmRepository.tenant]]
+      : [];
 
   return (
     <SourceDetail
       className={className}
-      name={name}
-      namespace={namespace}
-      clusterName={clusterName}
       type={FluxObjectKind.KindHelmRepository}
-      info={(hr: HelmRepository = new HelmRepository({})) =>
+      source={helmRepository}
+      info={[
+        ["Type", removeKind(FluxObjectKind.KindHelmRepository)],
+        ["Repository Type", helmRepository.repositoryType.toLowerCase()],
+        ["URL", <Link href={helmRepository.url}>{helmRepository.url}</Link>],
         [
-          ["Type", removeKind(FluxObjectKind.KindHelmRepository)],
-          ["Repository Type", hr.repositoryType.toLowerCase()],
-          ["URL", <Link href={hr.url}>{hr.url}</Link>],
-          [
-            "Last Updated",
-            hr.lastUpdatedAt ? <Timestamp time={hr.lastUpdatedAt} /> : "-",
-          ],
-          ["Interval", <Interval interval={hr.interval} />],
-          ["Cluster", hr.clusterName],
-          ["Namespace", hr.namespace],
-          ...(flags.WEAVE_GITOPS_FEATURE_TENANCY === "true" && hr.tenant
-            ? [["Tenant", hr.tenant]]
-            : []),
-        ] as InfoField[]
-      }
+          "Last Updated",
+          helmRepository.lastUpdatedAt ? (
+            <Timestamp time={helmRepository.lastUpdatedAt} />
+          ) : (
+            "-"
+          ),
+        ],
+        ["Interval", <Interval interval={helmRepository.interval} />],
+        ["Cluster", helmRepository.clusterName],
+        ["Namespace", helmRepository.namespace],
+        ...tenancyInfo,
+      ]}
     />
   );
 }

--- a/ui/components/OCIRepositoryDetail.tsx
+++ b/ui/components/OCIRepositoryDetail.tsx
@@ -12,45 +12,44 @@ import { InfoField } from "./InfoList";
 
 type Props = {
   className?: string;
-  name: string;
-  namespace: string;
-  clusterName: string;
+  ociRepository: OCIRepository;
 };
 
-function OCIRepositoryDetail({
-  name,
-  namespace,
-  className,
-  clusterName,
-}: Props) {
+function OCIRepositoryDetail({ className, ociRepository }: Props) {
   const { data } = useFeatureFlags();
   const flags = data?.flags || {};
+
+  const tenancyInfo: InfoField[] =
+    flags.WEAVE_GITOPS_FEATURE_TENANCY === "true" && ociRepository.tenant
+      ? [["Tenant", ociRepository.tenant]]
+      : [];
 
   return (
     <SourceDetail
       className={className}
-      name={name}
-      namespace={namespace}
-      clusterName={clusterName}
       type={FluxObjectKind.KindOCIRepository}
-      info={(oci: OCIRepository = new OCIRepository({})) => {
-        return [
-          ["Type", removeKind(FluxObjectKind.KindOCIRepository)],
-          ["URL", <Link href={oci.url}>{oci.url}</Link>],
-          [
-            "Last Updated",
-            oci.lastUpdatedAt ? <Timestamp time={oci.lastUpdatedAt} /> : "-",
-          ],
-          ["Interval", <Interval interval={oci.interval} />],
-          ["Cluster", oci.clusterName],
-          ["Namespace", oci.namespace],
-          ["Source", <Link href={oci.source}>{oci.source}</Link>],
-          ["Revision", oci.revision],
-          ...(flags.WEAVE_GITOPS_FEATURE_TENANCY === "true" && oci.tenant
-            ? [["Tenant", oci.tenant]]
-            : []),
-        ] as InfoField[];
-      }}
+      source={ociRepository}
+      info={[
+        ["Type", removeKind(FluxObjectKind.KindOCIRepository)],
+        ["URL", <Link href={ociRepository.url}>{ociRepository.url}</Link>],
+        [
+          "Last Updated",
+          ociRepository.lastUpdatedAt ? (
+            <Timestamp time={ociRepository.lastUpdatedAt} />
+          ) : (
+            "-"
+          ),
+        ],
+        ["Interval", <Interval interval={ociRepository.interval} />],
+        ["Cluster", ociRepository.clusterName],
+        ["Namespace", ociRepository.namespace],
+        [
+          "Source",
+          <Link href={ociRepository.source}>{ociRepository.source}</Link>,
+        ],
+        ["Revision", ociRepository.revision],
+        ...tenancyInfo,
+      ]}
     />
   );
 }

--- a/ui/components/SourceDetail.tsx
+++ b/ui/components/SourceDetail.tsx
@@ -5,9 +5,8 @@ import styled from "styled-components";
 import { AppContext } from "../contexts/AppContext";
 import { useListAutomations, useSyncFluxObject } from "../hooks/automations";
 import { useToggleSuspend } from "../hooks/flux";
-import { useGetObject } from "../hooks/objects";
 import { FluxObjectKind } from "../lib/api/core/types.pb";
-import { FluxObject, fluxObjectKindToKind } from "../lib/objects";
+import { Source } from "../lib/objects";
 import Alert from "./Alert";
 import AutomationsTable from "./AutomationsTable";
 import Button from "./Button";
@@ -23,40 +22,26 @@ import SyncButton from "./SyncButton";
 import Text from "./Text";
 import YamlView from "./YamlView";
 
-type Props<T> = {
+type Props = {
   className?: string;
   type: FluxObjectKind;
-  name: string;
-  namespace: string;
-  clusterName: string;
   children?: JSX.Element;
-  info: (s: T) => InfoField[];
+  source: Source;
+  info: InfoField[];
 };
 
-function SourceDetail<T extends FluxObject>({
-  className,
-  name,
-  namespace,
-  clusterName,
-  info,
-  type,
-}: Props<T>) {
+function SourceDetail({ className, source, info, type }: Props) {
   const { notifySuccess } = React.useContext(AppContext);
   const { data: automations, isLoading: automationsLoading } =
     useListAutomations();
   const { path } = useRouteMatch();
-  const {
-    data: source,
-    isLoading,
-    error,
-  } = useGetObject<T>(name, namespace, fluxObjectKindToKind(type), clusterName);
   const [isSuspended, setIsSuspended] = React.useState(false);
 
   const suspend = useToggleSuspend(
     {
-      name,
-      namespace,
-      clusterName,
+      name: source.name,
+      namespace: source.namespace,
+      clusterName: source.clusterName,
       kind: type,
       suspend: !isSuspended,
     },
@@ -64,35 +49,33 @@ function SourceDetail<T extends FluxObject>({
   );
 
   const sync = useSyncFluxObject({
-    name,
-    namespace,
-    clusterName,
+    name: source.name,
+    namespace: source.namespace,
+    clusterName: source.clusterName,
     kind: type,
   });
 
-  if (isLoading || automationsLoading) {
+  if (automationsLoading) {
     return <LoadingPage />;
   }
 
-  if (isSuspended != source?.suspended) {
-    setIsSuspended(source?.suspended);
+  if (isSuspended != source.suspended) {
+    setIsSuspended(source.suspended);
   }
 
-  const items = info(source);
-
   const isNameRelevant = (expectedName) => {
-    return expectedName == name;
+    return expectedName == source.name;
   };
 
   const isRelevant = (expectedType, expectedName) => {
-    return expectedType == source?.kind && isNameRelevant(expectedName);
+    return expectedType == source.kind && isNameRelevant(expectedName);
   };
 
   const relevantAutomations = _.filter(automations?.result, (a) => {
     if (!source) {
       return false;
     }
-    if (a.clusterName != clusterName) {
+    if (a.clusterName != source.clusterName) {
       return false;
     }
 
@@ -118,24 +101,17 @@ function SourceDetail<T extends FluxObject>({
   return (
     <Flex wide tall column className={className}>
       <Text size="large" semiBold titleHeight>
-        {source?.name}
+        {source.name}
       </Text>
-      {(error || suspend.error) && (
-        <Alert
-          severity="error"
-          title="Error"
-          message={error.message || suspend.error.message}
-        />
+      {suspend.error && (
+        <Alert severity="error" title="Error" message={suspend.error.message} />
       )}
-      <PageStatus
-        conditions={source?.conditions}
-        suspended={source?.suspended}
-      />
+      <PageStatus conditions={source.conditions} suspended={source.suspended} />
       <Flex wide start>
         <SyncButton
           onClick={handleSyncClicked}
           loading={sync.isLoading}
-          disabled={source?.suspended}
+          disabled={source.suspended}
           hideDropdown={true}
         />
         <Spacer padding="xs" />
@@ -150,28 +126,28 @@ function SourceDetail<T extends FluxObject>({
       <SubRouterTabs rootPath={`${path}/details`}>
         <RouterTab name="Details" path={`${path}/details`}>
           <>
-            <InfoList items={items} />
-            <Metadata metadata={source?.metadata} />
+            <InfoList items={info} />
+            <Metadata metadata={source.metadata} />
             <AutomationsTable automations={relevantAutomations} hideSource />
           </>
         </RouterTab>
         <RouterTab name="Events" path={`${path}/events`}>
           <EventsTable
-            namespace={source?.namespace}
+            namespace={source.namespace}
             involvedObject={{
-              kind: type,
-              name,
-              namespace: source?.namespace,
+              kind: source.kind,
+              name: source.name,
+              namespace: source.namespace,
             }}
           />
         </RouterTab>
         <RouterTab name="yaml" path={`${path}/yaml`}>
           <YamlView
-            yaml={source?.yaml}
+            yaml={source.yaml}
             object={{
-              kind: source?.kind,
-              name: source?.name,
-              namespace: source?.namespace,
+              kind: source.kind,
+              name: source.name,
+              namespace: source.namespace,
             }}
           />
         </RouterTab>

--- a/ui/hooks/objects.ts
+++ b/ui/hooks/objects.ts
@@ -14,7 +14,7 @@ import {
 } from "../lib/objects";
 import { ReactQueryOptions, RequestError } from "../lib/types";
 
-function convertResponse(kind: Kind, response: ResponseObject) {
+function convertResponse(kind: Kind, response?: ResponseObject) {
   if (kind == Kind.HelmRepository) {
     return new HelmRepository(response);
   }
@@ -46,7 +46,7 @@ export function useGetObject<T extends FluxObject>(
 ) {
   const { api } = useContext(CoreClientContext);
 
-  return useQuery<T, RequestError>(
+  const response = useQuery<T, RequestError>(
     ["object", clusterName, kind, namespace, name],
     () =>
       api
@@ -57,4 +57,8 @@ export function useGetObject<T extends FluxObject>(
         ),
     opts
   );
+  if (response.error) {
+    return { ...response, data: convertResponse(kind) as T };
+  }
+  return response;
 }

--- a/ui/lib/__tests__/utils.test.ts
+++ b/ui/lib/__tests__/utils.test.ts
@@ -119,12 +119,10 @@ describe("utils lib", () => {
         )
       ).toEqual("https://github.com/weaveworks/weave-gitops-clusters");
     });
-    it("throws error on invalid Git URL", () => {
+    it("returns nothing on invalid Git URL", () => {
       const uri = "github.com/weaveworks/weave-gitops-clusters";
 
-      expect(() => {
-        convertGitURLToGitProvider(uri);
-      }).toThrow(new Error(`could not parse url "${uri}"`));
+      expect(convertGitURLToGitProvider(uri)).toEqual("");
     });
     it("returns the original HTTP URL", () => {
       expect(

--- a/ui/lib/objects.ts
+++ b/ui/lib/objects.ts
@@ -19,6 +19,13 @@ export enum Kind {
   OCIRepository = "OCIRepository",
 }
 
+export type Source =
+  | HelmRepository
+  | HelmChart
+  | GitRepository
+  | Bucket
+  | OCIRepository;
+
 export function fluxObjectKindToKind(fok: FluxObjectKind): Kind {
   return Kind[FluxObjectKind[fok].slice(4)];
 }
@@ -34,9 +41,9 @@ export class FluxObject {
     } catch {
       this.obj = {};
     }
-    this.clusterName = response.clusterName;
+    this.clusterName = response?.clusterName;
 
-    this.tenant = response.tenant;
+    this.tenant = response?.tenant;
   }
 
   get yaml(): string {

--- a/ui/lib/utils.ts
+++ b/ui/lib/utils.ts
@@ -59,7 +59,7 @@ export function convertGitURLToGitProvider(uri: string): string {
 
   const matches = uri.match(/git@(.*)[/|:](.*)\/(.*)/);
   if (!matches) {
-    throw new Error(`could not parse url "${uri}"`);
+    return "";
   }
   const [, provider, org, repo] = matches;
 

--- a/ui/pages/v2/BucketDetail.tsx
+++ b/ui/pages/v2/BucketDetail.tsx
@@ -2,6 +2,8 @@ import * as React from "react";
 import styled from "styled-components";
 import BucketDetailComponent from "../../components/BucketDetail";
 import Page from "../../components/Page";
+import { useGetObject } from "../../hooks/objects";
+import { Bucket, Kind } from "../../lib/objects";
 
 type Props = {
   className?: string;
@@ -11,13 +13,15 @@ type Props = {
 };
 
 function BucketDetail({ className, name, namespace, clusterName }: Props) {
+  const {
+    data: bucket,
+    isLoading,
+    error,
+  } = useGetObject<Bucket>(name, namespace, Kind.Bucket, clusterName);
+
   return (
-    <Page error={null} className={className}>
-      <BucketDetailComponent
-        name={name}
-        namespace={namespace}
-        clusterName={clusterName}
-      />
+    <Page error={error} loading={isLoading} className={className} title={name}>
+      <BucketDetailComponent bucket={bucket} />
     </Page>
   );
 }

--- a/ui/pages/v2/GitRepositoryDetail.tsx
+++ b/ui/pages/v2/GitRepositoryDetail.tsx
@@ -2,6 +2,8 @@ import * as React from "react";
 import styled from "styled-components";
 import GitRepositoryDetailComponent from "../../components/GitRepositoryDetail";
 import Page from "../../components/Page";
+import { useGetObject } from "../../hooks/objects";
+import { GitRepository, Kind } from "../../lib/objects";
 
 type Props = {
   className?: string;
@@ -16,13 +18,20 @@ function GitRepositoryDetail({
   namespace,
   clusterName,
 }: Props) {
+  const {
+    data: gitRepository,
+    isLoading,
+    error,
+  } = useGetObject<GitRepository>(
+    name,
+    namespace,
+    Kind.GitRepository,
+    clusterName
+  );
+
   return (
-    <Page error={null} className={className}>
-      <GitRepositoryDetailComponent
-        name={name}
-        namespace={namespace}
-        clusterName={clusterName}
-      />
+    <Page error={error} loading={isLoading} className={className} title={name}>
+      <GitRepositoryDetailComponent gitRepository={gitRepository} />
     </Page>
   );
 }

--- a/ui/pages/v2/HelmChartDetail.tsx
+++ b/ui/pages/v2/HelmChartDetail.tsx
@@ -2,6 +2,8 @@ import * as React from "react";
 import styled from "styled-components";
 import HelmChartDetailComponent from "../../components/HelmChartDetail";
 import Page from "../../components/Page";
+import { useGetObject } from "../../hooks/objects";
+import { HelmChart, Kind } from "../../lib/objects";
 
 type Props = {
   className?: string;
@@ -11,13 +13,15 @@ type Props = {
 };
 
 function HelmChartDetail({ className, name, namespace, clusterName }: Props) {
+  const {
+    data: helmChart,
+    isLoading,
+    error,
+  } = useGetObject<HelmChart>(name, namespace, Kind.HelmChart, clusterName);
+
   return (
-    <Page error={null} className={className}>
-      <HelmChartDetailComponent
-        name={name}
-        namespace={namespace}
-        clusterName={clusterName}
-      />
+    <Page error={error} loading={isLoading} className={className} title={name}>
+      <HelmChartDetailComponent helmChart={helmChart} />
     </Page>
   );
 }

--- a/ui/pages/v2/HelmRepositoryDetail.tsx
+++ b/ui/pages/v2/HelmRepositoryDetail.tsx
@@ -2,6 +2,8 @@ import * as React from "react";
 import styled from "styled-components";
 import HelmRepositoryDetailComponent from "../../components/HelmRepositoryDetail";
 import Page from "../../components/Page";
+import { useGetObject } from "../../hooks/objects";
+import { HelmRepository, Kind } from "../../lib/objects";
 
 type Props = {
   className?: string;
@@ -16,13 +18,20 @@ function HelmRepositoryDetail({
   namespace,
   clusterName,
 }: Props) {
+  const {
+    data: helmRepository,
+    isLoading,
+    error,
+  } = useGetObject<HelmRepository>(
+    name,
+    namespace,
+    Kind.HelmRepository,
+    clusterName
+  );
+
   return (
-    <Page error={null} className={className}>
-      <HelmRepositoryDetailComponent
-        name={name}
-        namespace={namespace}
-        clusterName={clusterName}
-      />
+    <Page error={error} loading={isLoading} className={className} title={name}>
+      <HelmRepositoryDetailComponent helmRepository={helmRepository} />
     </Page>
   );
 }

--- a/ui/pages/v2/OCIRepositoryPage.tsx
+++ b/ui/pages/v2/OCIRepositoryPage.tsx
@@ -2,6 +2,8 @@ import * as React from "react";
 import styled from "styled-components";
 import OCIRepositoryDetail from "../../components/OCIRepositoryDetail";
 import Page from "../../components/Page";
+import { useGetObject } from "../../hooks/objects";
+import { OCIRepository, Kind } from "../../lib/objects";
 
 type Props = {
   className?: string;
@@ -11,13 +13,20 @@ type Props = {
 };
 
 function OCIRepositoryPage({ className, name, namespace, clusterName }: Props) {
+  const {
+    data: ociRepository,
+    isLoading,
+    error,
+  } = useGetObject<OCIRepository>(
+    name,
+    namespace,
+    Kind.OCIRepository,
+    clusterName
+  );
+
   return (
-    <Page error={null} className={className}>
-      <OCIRepositoryDetail
-        name={name}
-        namespace={namespace}
-        clusterName={clusterName}
-      />
+    <Page error={error} loading={isLoading} className={className} title={name}>
+      <OCIRepositoryDetail ociRepository={ociRepository} />
     </Page>
   );
 }


### PR DESCRIPTION
We always try to resolve HTTP requests at the page, so that we
can wrap them in the Page component, and that will handle displaying
loading state and errors so we don't have to.

We do this for automation details, and then we pass in the info prop
as a map of label and value.

However, sources was different - instead of an object and a map of
info, we passed down information about the object we wanted, and a
bunch of callbacks.

This makes source pages behave more like automation
pages, and like the table views.

While I'm at it, set an empty object of the right type as initial
    data, and that way we don't need question marks.
