### PR TITLE
Log when a resource is suspended or synced

### DIFF
--- a/core/server/suspend.go
+++ b/core/server/suspend.go
@@ -11,7 +11,9 @@ import (
 )
 
 func (cs *coreServer) ToggleSuspendResource(ctx context.Context, msg *pb.ToggleSuspendResourceRequest) (*pb.ToggleSuspendResourceResponse, error) {
-	clustersClient, err := cs.clientsFactory.GetImpersonatedClientForCluster(ctx, auth.Principal(ctx), msg.ClusterName)
+	principal := auth.Principal(ctx)
+
+	clustersClient, err := cs.clientsFactory.GetImpersonatedClientForCluster(ctx, principal, msg.ClusterName)
 	if err != nil {
 		return nil, fmt.Errorf("error getting impersonating client: %w", err)
 	}
@@ -31,6 +33,13 @@ func (cs *coreServer) ToggleSuspendResource(ctx context.Context, msg *pb.ToggleS
 		return nil, fmt.Errorf("converting to reconcilable source: %w", err)
 	}
 
+	log := cs.logger.WithValues(
+		"user", principal.ID,
+		"kind", obj.GroupVersionKind().Kind,
+		"name", msg.Name,
+		"namespace", msg.Namespace,
+	)
+
 	if err := c.Get(ctx, key, obj.AsClientObject()); err != nil {
 		return nil, fmt.Errorf("getting reconcilable object: %w", err)
 	}
@@ -38,6 +47,12 @@ func (cs *coreServer) ToggleSuspendResource(ctx context.Context, msg *pb.ToggleS
 	patch := client.MergeFrom(obj.DeepCopyClientObject())
 
 	obj.SetSuspended(msg.Suspend)
+
+	if msg.Suspend {
+		log.Info("Suspending resource")
+	} else {
+		log.Info("Resuming resource")
+	}
 
 	if err := c.Patch(ctx, obj.AsClientObject(), patch); err != nil {
 		return nil, fmt.Errorf("patching object: %w", err)


### PR DESCRIPTION
When we patch an object (via sync or suspend), we now log an info
level message (thus enabled by default) that describes the action
(suspend, resume or sync), with structured fields containing the kind,
namespace and name of the resource, as well as the user ID (e.g. oidc
email, or just the local username) that performed the action.

This means that the message field itself is static and easy to search
for, and a specific object is easy to index and filter out.

For this "searching for" reason, I've chosen to implement "sync with
source" as 2 messages - there should be an entry for each object that
we patch.

This resolves #2436.