### PR TITLE
implement installer and exec packages for flux cli

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -162,7 +162,7 @@ require (
 	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/gosuri/uitable v0.0.4 // indirect
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
-	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-retryablehttp v0.7.1 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/huandu/xstrings v1.3.2 // indirect

--- a/pkg/fluxexec/README.md
+++ b/pkg/fluxexec/README.md
@@ -1,0 +1,72 @@
+# Flux Exec (fluxexec)
+
+## Introduction
+
+This package provides a wrapper of the command line interface to execute Flux commands.
+
+## How to add new flags
+
+Add the new type `Option` struct to the `options.go` of `fluxexec` package. 
+Then create a function to represent it.
+
+The below example shows how to add the `--export` flag.
+We have `ExportOption` struct to whole the value of the `--export` flag, 
+and we have `Export` function to represent this flag during the command creation.
+
+```go
+type ExportOption struct {
+	export bool
+}
+
+// Export represents the --export flag.
+func Export(export bool) *ExportOption {
+	return &ExportOption{export}
+}
+```
+
+After that we go to each command wrapper file, for example we have `install.go` file as the wrapper of `flux install` command,
+and we have `bootstrap_github.go` file as the wrapper of the `flux bootstrap github` command.
+
+Following the above example, we add the `--export` flag to the wrapper of the `install` command.
+
+First, find the `installConfig` struct in the `install.go` file.
+Then, add the `export` field to the struct.
+
+```go
+type installConfig struct {
+	clusterDomain      string
+	components         []string
+	componentsExtra    []string
+	export             bool     // Here's our new export field
+	imagePullSecret    string
+	logLevel           string
+	networkPolicy      bool
+	registry           string
+	tolerationKeys     []string
+	watchAllNamespaces bool
+}
+```
+
+Then, we add the `configureInstall` function for the `ExportOption` struct.
+This function will be called to configure the `installConfig` struct, by setting the value of the `export` field.
+
+```go
+func (opt *ExportOption) configureInstall(conf *installConfig) {
+	conf.export = opt.export
+}
+```
+
+Next, locate the `installCmd` function.
+
+```go
+func (flux *Flux) installCmd(ctx context.Context, opts ...InstallOption) (*exec.Cmd, error) {
+```
+
+This function will be called to create the command, with all the flags as args.
+We add the following if statement to help this command generate the `--export` flag.
+
+```go
+	if c.export {
+		args = append(args, "--export")
+	}
+```

--- a/pkg/fluxexec/bootstrap.go
+++ b/pkg/fluxexec/bootstrap.go
@@ -1,0 +1,294 @@
+package fluxexec
+
+import (
+	"strconv"
+	"strings"
+)
+
+type bootstrapConfig struct {
+	authorEmail           string
+	authorName            string
+	branch                string
+	caFile                string
+	clusterDomain         string
+	commitMessageAppendix string
+	components            []Component
+	componentsExtra       []ComponentExtra
+	gpgKeyID              string
+	gpgKeyRing            string
+	gpgPassphrase         string
+	imagePullSecret       string
+	logLevel              string
+	networkPolicy         bool
+	privateKeyFile        string
+	recurseSubmodules     bool
+	registry              string
+	secretName            string
+	sshEcdsaCurve         EcdsaCurve
+	sshHostname           string
+	sshKeyAlgorithm       KeyAlgorithm
+	sshRsaBits            int
+	tokenAuth             bool
+	tolerationKeys        []string
+	watchAllNamespaces    bool
+}
+
+var defaultBootstrapOptions = bootstrapConfig{
+	authorName:         "Flux",
+	branch:             "main",
+	clusterDomain:      "cluster.local",
+	components:         []Component{ComponentSourceController, ComponentKustomizeController, ComponentHelmController, ComponentNotificationController},
+	componentsExtra:    []ComponentExtra{},
+	logLevel:           "info",
+	networkPolicy:      true,
+	recurseSubmodules:  false,
+	registry:           "ghcr.io/fluxcd",
+	secretName:         "flux-system",
+	sshEcdsaCurve:      EcdsaCurveP384,
+	sshKeyAlgorithm:    KeyAlgorithmECDSA,
+	sshRsaBits:         2048,
+	tokenAuth:          false,
+	tolerationKeys:     []string{},
+	watchAllNamespaces: true,
+}
+
+// BootstrapOption represents options used in the Bootstrap* methods.
+type BootstrapOption interface {
+	configureBootstrap(*bootstrapConfig)
+}
+
+func (opt *AuthorEmailOption) configureBootstrap(conf *bootstrapConfig) {
+	conf.authorEmail = opt.authorEmail
+}
+
+func (opt *AuthorNameOption) configureBootstrap(conf *bootstrapConfig) {
+	conf.authorName = opt.authorName
+}
+
+func (opt *BranchOption) configureBootstrap(conf *bootstrapConfig) {
+	conf.branch = opt.branch
+}
+
+func (opt *CaFileOption) configureBootstrap(conf *bootstrapConfig) {
+	conf.caFile = opt.caFile
+}
+
+func (opt *ClusterDomainOption) configureBootstrap(conf *bootstrapConfig) {
+	conf.clusterDomain = opt.clusterDomain
+}
+
+func (opt *CommitMessageAppendixOption) configureBootstrap(conf *bootstrapConfig) {
+	conf.commitMessageAppendix = opt.commitMessageAppendix
+}
+
+func (opt *ComponentsOption) configureBootstrap(conf *bootstrapConfig) {
+	// allows only source-controller, kustomize-controller, helm-controller, notification-controller
+	conf.components = opt.components
+}
+
+func (opt *ComponentsExtraOption) configureBootstrap(conf *bootstrapConfig) {
+	conf.componentsExtra = opt.componentsExtra
+}
+
+func (opt *GpgKeyIdOption) configureBootstrap(conf *bootstrapConfig) {
+	conf.gpgKeyID = opt.gpgKeyId
+}
+
+func (opt *GpgKeyRingOption) configureBootstrap(conf *bootstrapConfig) {
+	conf.gpgKeyRing = opt.gpgKeyRing
+}
+
+func (opt *GpgPassphraseOption) configureBootstrap(conf *bootstrapConfig) {
+	conf.gpgPassphrase = opt.gpgPassphrase
+}
+
+func (opt *ImagePullSecretOption) configureBootstrap(conf *bootstrapConfig) {
+	conf.imagePullSecret = opt.imagePullSecret
+}
+
+func (opt *LogLevelOption) configureBootstrap(conf *bootstrapConfig) {
+	conf.logLevel = opt.logLevel
+}
+
+func (opt *NetworkPolicyOption) configureBootstrap(conf *bootstrapConfig) {
+	conf.networkPolicy = opt.networkPolicy
+}
+
+func (opt *PrivateKeyFileOption) configureBootstrap(conf *bootstrapConfig) {
+	conf.privateKeyFile = opt.privateKeyFile
+}
+
+func (opt *RecurseSubmodulesOption) configureBootstrap(conf *bootstrapConfig) {
+	conf.recurseSubmodules = opt.recurseSubmodules
+}
+
+func (opt *RegistryOption) configureBootstrap(conf *bootstrapConfig) {
+	conf.registry = opt.registry
+}
+
+func (opt *SecretNameOption) configureBootstrap(conf *bootstrapConfig) {
+	conf.secretName = opt.secretName
+}
+
+func (opt *SshEcdsaCurveOption) configureBootstrap(conf *bootstrapConfig) {
+	conf.sshEcdsaCurve = opt.sshEcdsaCurve
+}
+
+func (opt *SshHostnameOption) configureBootstrap(conf *bootstrapConfig) {
+	conf.sshHostname = opt.sshHostname
+}
+
+func (opt *SshKeyAlgorithmOption) configureBootstrap(conf *bootstrapConfig) {
+	conf.sshKeyAlgorithm = opt.sshKeyAlgorithm
+}
+
+func (opt *SshRsaBitsOption) configureBootstrap(conf *bootstrapConfig) {
+	conf.sshRsaBits = opt.sshRsaBits
+}
+
+func (opt *TokenAuthOption) configureBootstrap(conf *bootstrapConfig) {
+	conf.tokenAuth = opt.tokenAuth
+}
+
+func (opt *TolerationKeysOption) configureBootstrap(conf *bootstrapConfig) {
+	conf.tolerationKeys = opt.tolerationKeys
+}
+
+func (opt *WatchAllNamespacesOption) configureBootstrap(conf *bootstrapConfig) {
+	conf.watchAllNamespaces = opt.watchAllNamespaces
+}
+
+// BootstrapOptions is a special set of options for the (parent) bootstrap command.
+type BootstrapOptions struct {
+	bootstrapOptions []BootstrapOption
+}
+
+// TODO: add more git provider options for the bootstrap command.
+func (opt *BootstrapOptions) configureBootstrapGitHub(conf *bootstrapGitHubConfig) {
+	conf.bootstrapOptions = opt.bootstrapOptions
+}
+
+func WithBootstrapOptions(opts ...BootstrapOption) *BootstrapOptions {
+	return &BootstrapOptions{opts}
+}
+
+func (flux *Flux) bootstrapArgs(opts ...BootstrapOption) []string {
+	c := defaultBootstrapOptions
+	for _, o := range opts {
+		o.configureBootstrap(&c)
+	}
+
+	args := []string{}
+
+	if c.authorEmail != "" {
+		args = append(args, "--author-email", c.authorEmail)
+	}
+
+	if c.authorName != "" {
+		args = append(args, "--author-name", c.authorName)
+	}
+
+	if c.branch != "" {
+		args = append(args, "--branch", c.branch)
+	}
+
+	if c.caFile != "" {
+		args = append(args, "--ca-file", c.caFile)
+	}
+
+	if c.clusterDomain != "" {
+		args = append(args, "--cluster-domain", c.clusterDomain)
+	}
+
+	if c.commitMessageAppendix != "" {
+		args = append(args, "--commit-message-appendix", c.commitMessageAppendix)
+	}
+
+	if c.components != nil {
+		var comps []string
+		for _, c := range c.components {
+			comps = append(comps, string(c))
+		}
+
+		args = append(args, "--components", strings.Join(comps, ","))
+	}
+
+	if len(c.componentsExtra) > 0 {
+		var extras []string
+		for _, c := range c.componentsExtra {
+			extras = append(extras, string(c))
+		}
+
+		args = append(args, "--components-extra", strings.Join(extras, ","))
+	}
+
+	if c.gpgKeyID != "" {
+		args = append(args, "--gpg-key-id", c.gpgKeyID)
+	}
+
+	if c.gpgKeyRing != "" {
+		args = append(args, "--gpg-key-ring", c.gpgKeyRing)
+	}
+
+	if c.gpgPassphrase != "" {
+		args = append(args, "--gpg-passphrase", c.gpgPassphrase)
+	}
+
+	if c.imagePullSecret != "" {
+		args = append(args, "--image-pull-secret", c.imagePullSecret)
+	}
+
+	if c.logLevel != "" {
+		args = append(args, "--log-level", c.logLevel)
+	}
+
+	if c.networkPolicy {
+		args = append(args, "--network-policy")
+	}
+
+	if c.privateKeyFile != "" {
+		args = append(args, "--private-key-file", c.privateKeyFile)
+	}
+
+	if c.recurseSubmodules {
+		args = append(args, "--recurse-submodules")
+	}
+
+	if c.registry != "" {
+		args = append(args, "--registry", c.registry)
+	}
+
+	if c.secretName != "" {
+		args = append(args, "--secret-name", c.secretName)
+	}
+
+	if c.sshEcdsaCurve != "" {
+		args = append(args, "--ssh-ecdsa-curve", string(c.sshEcdsaCurve))
+	}
+
+	if c.sshHostname != "" {
+		args = append(args, "--ssh-hostname", c.sshHostname)
+	}
+
+	if c.sshKeyAlgorithm != "" {
+		args = append(args, "--ssh-key-algorithm", string(c.sshKeyAlgorithm))
+	}
+
+	if c.sshRsaBits != 0 {
+		args = append(args, "--ssh-rsa-bits", strconv.Itoa(c.sshRsaBits))
+	}
+
+	if c.tokenAuth {
+		args = append(args, "--token-auth")
+	}
+
+	if len(c.tolerationKeys) > 0 {
+		args = append(args, "--toleration-keys", strings.Join(c.tolerationKeys, ","))
+	}
+
+	if c.watchAllNamespaces {
+		args = append(args, "--watch-all-namespaces")
+	}
+
+	return args
+}

--- a/pkg/fluxexec/bootstrap_github.go
+++ b/pkg/fluxexec/bootstrap_github.go
@@ -1,0 +1,145 @@
+package fluxexec
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+)
+
+type bootstrapGitHubConfig struct {
+	bootstrapOptions []BootstrapOption
+
+	hostname     string
+	interval     string
+	owner        string
+	path         string
+	personal     bool
+	private      bool
+	readWriteKey bool
+	reconcile    bool
+	repository   string
+	team         []string
+}
+
+var defaultBootstrapGitHubOptions = bootstrapGitHubConfig{
+	hostname:     "github.com",
+	interval:     "1m0s",
+	personal:     false,
+	private:      true,
+	readWriteKey: true,
+	reconcile:    true,
+}
+
+// BootstrapGitHubOption represents options used in the BootstrapGitHub method.
+type BootstrapGitHubOption interface {
+	configureBootstrapGitHub(*bootstrapGitHubConfig)
+}
+
+func (opt *HostnameOption) configureBootstrapGitHub(conf *bootstrapGitHubConfig) {
+	conf.hostname = opt.hostname
+}
+
+func (opt *IntervalOption) configureBootstrapGitHub(conf *bootstrapGitHubConfig) {
+	conf.interval = opt.interval
+}
+
+func (opt *OwnerOption) configureBootstrapGitHub(conf *bootstrapGitHubConfig) {
+	conf.owner = opt.owner
+}
+
+func (opt *PathOption) configureBootstrapGitHub(conf *bootstrapGitHubConfig) {
+	conf.path = opt.path
+}
+
+func (opt *PersonalOption) configureBootstrapGitHub(conf *bootstrapGitHubConfig) {
+	conf.personal = opt.personal
+}
+
+func (opt *PrivateOption) configureBootstrapGitHub(conf *bootstrapGitHubConfig) {
+	conf.private = opt.private
+}
+
+func (opt *ReadWriteKeyOption) configureBootstrapGitHub(conf *bootstrapGitHubConfig) {
+	conf.readWriteKey = opt.readWriteKey
+}
+
+func (opt *ReconcileOption) configureBootstrapGitHub(conf *bootstrapGitHubConfig) {
+	conf.reconcile = opt.reconcile
+}
+
+func (opt *RepositoryOption) configureBootstrapGitHub(conf *bootstrapGitHubConfig) {
+	conf.repository = opt.repository
+}
+
+func (opt *TeamOption) configureBootstrapGitHub(conf *bootstrapGitHubConfig) {
+	conf.team = append(conf.team, opt.team...)
+}
+
+func (flux *Flux) BootstrapGitHub(ctx context.Context, opts ...BootstrapGitHubOption) error {
+	bootstrapGitHubCmd, err := flux.bootstrapGitHubCmd(ctx, opts...)
+	if err != nil {
+		return err
+	}
+
+	if err := flux.runFluxCmd(ctx, bootstrapGitHubCmd); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (flux *Flux) bootstrapGitHubCmd(ctx context.Context, opts ...BootstrapGitHubOption) (*exec.Cmd, error) {
+	c := defaultBootstrapGitHubOptions
+	for _, o := range opts {
+		o.configureBootstrapGitHub(&c)
+	}
+
+	args := []string{"bootstrap", "github"}
+
+	// Add the bootstrap args first.
+	bootstrapArgs := flux.bootstrapArgs(c.bootstrapOptions...)
+	args = append(args, bootstrapArgs...)
+
+	if c.hostname != "" {
+		args = append(args, "--hostname", c.hostname)
+	}
+
+	if c.interval != "" {
+		args = append(args, "--interval", c.interval)
+	}
+
+	if c.owner != "" {
+		args = append(args, "--owner", c.owner)
+	}
+
+	if c.path != "" {
+		args = append(args, "--path", c.path)
+	}
+
+	if c.personal {
+		args = append(args, "--personal")
+	}
+
+	if c.private {
+		args = append(args, "--private")
+	}
+
+	if c.readWriteKey {
+		args = append(args, "--read-write-key")
+	}
+
+	if c.reconcile {
+		args = append(args, "--reconcile")
+	}
+
+	if c.repository != "" {
+		args = append(args, "--repository", c.repository)
+	}
+
+	if len(c.team) > 0 {
+		args = append(args, "--team", strings.Join(c.team, ","))
+	}
+
+	// TODO how to deal with the env
+	return flux.buildFluxCmd(ctx, nil, args...), nil
+}

--- a/pkg/fluxexec/bootstrap_github_test.go
+++ b/pkg/fluxexec/bootstrap_github_test.go
@@ -1,0 +1,96 @@
+package fluxexec
+
+import (
+	"context"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("bootstrapGitHubCmd", func() {
+	It("should be able to generate correct install commands", func() {
+		By("generating the default command", func() {
+			flux, err := NewFlux(".", "/path/to/flux")
+			Expect(err).To(BeNil())
+
+			initCmd, err := flux.bootstrapGitHubCmd(context.TODO())
+			Expect(err).To(BeNil())
+			Expect(initCmd.Args[1:]).To(Equal([]string{
+				"bootstrap",
+				"github",
+				"--author-name",
+				"Flux",
+				"--branch",
+				"main",
+				"--cluster-domain",
+				"cluster.local",
+				"--components",
+				"source-controller,kustomize-controller,helm-controller,notification-controller",
+				"--log-level",
+				"info",
+				"--network-policy",
+				"--registry",
+				"ghcr.io/fluxcd",
+				"--secret-name",
+				"flux-system",
+				"--ssh-ecdsa-curve",
+				"p384",
+				"--ssh-key-algorithm",
+				"ecdsa",
+				"--ssh-rsa-bits",
+				"2048",
+				"--watch-all-namespaces",
+				"--hostname",
+				"github.com",
+				"--interval",
+				"1m0s",
+				"--private",
+				"--read-write-key",
+				"--reconcile",
+			}))
+		})
+
+		By("generating the command without network-policy, without private, but with token-auth", func() {
+			flux, err := NewFlux(".", "/path/to/flux")
+			Expect(err).To(BeNil())
+
+			initCmd, err := flux.bootstrapGitHubCmd(context.TODO(),
+				WithBootstrapOptions(
+					TokenAuth(true),
+					NetworkPolicy(false)),
+				Private(false))
+			Expect(err).To(BeNil())
+			Expect(initCmd.Args[1:]).To(Equal([]string{
+				"bootstrap",
+				"github",
+				"--author-name",
+				"Flux",
+				"--branch",
+				"main",
+				"--cluster-domain",
+				"cluster.local",
+				"--components",
+				"source-controller,kustomize-controller,helm-controller,notification-controller",
+				"--log-level",
+				"info",
+				"--registry",
+				"ghcr.io/fluxcd",
+				"--secret-name",
+				"flux-system",
+				"--ssh-ecdsa-curve",
+				"p384",
+				"--ssh-key-algorithm",
+				"ecdsa",
+				"--ssh-rsa-bits",
+				"2048",
+				"--token-auth",
+				"--watch-all-namespaces",
+				"--hostname",
+				"github.com",
+				"--interval",
+				"1m0s",
+				"--read-write-key",
+				"--reconcile",
+			}))
+		})
+	})
+})

--- a/pkg/fluxexec/cmd.go
+++ b/pkg/fluxexec/cmd.go
@@ -1,0 +1,100 @@
+package fluxexec
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"io"
+	"io/ioutil"
+	"os"
+	"os/exec"
+)
+
+func envSlice(environ map[string]string) []string {
+	env := []string{}
+	for k, v := range environ {
+		env = append(env, k+"="+v)
+	}
+
+	return env
+}
+
+// TODO merge good, or filter out some forbidden env vars
+func (flux *Flux) buildEnv(mergeEnv map[string]string) []string {
+	return envSlice(mergeEnv)
+}
+
+func (flux *Flux) buildFluxCmd(ctx context.Context, mergeEnv map[string]string, args ...string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, flux.execPath, args...)
+
+	// Use the inherited environment if mergeEnv is nil
+	if mergeEnv == nil {
+		cmd.Env = os.Environ()
+	} else {
+		cmd.Env = append(os.Environ(), flux.buildEnv(mergeEnv)...)
+	}
+
+	cmd.Dir = flux.workingDir
+
+	if flux.logger != nil {
+		flux.logger.Printf("[INFO] running Flux command: %s", cmd.String())
+	}
+
+	return cmd
+}
+
+func mergeWriters(writers ...io.Writer) io.Writer {
+	compact := []io.Writer{}
+
+	for _, w := range writers {
+		if w != nil {
+			compact = append(compact, w)
+		}
+	}
+
+	if len(compact) == 0 {
+		return ioutil.Discard
+	}
+
+	if len(compact) == 1 {
+		return compact[0]
+	}
+
+	return io.MultiWriter(compact...)
+}
+
+func writeOutput(ctx context.Context, r io.ReadCloser, w io.Writer) error {
+	// ReadBytes will block until bytes are read, which can cause a delay in
+	// returning even if the command's context has been canceled. Use a separate
+	// goroutine to prompt ReadBytes to return on cancel
+	closeCtx, closeCancel := context.WithCancel(ctx)
+	defer closeCancel()
+
+	go func() {
+		select {
+		case <-ctx.Done():
+			r.Close()
+		case <-closeCtx.Done():
+			return
+		}
+	}()
+
+	buf := bufio.NewReader(r)
+
+	for {
+		line, err := buf.ReadBytes('\n')
+		if len(line) > 0 {
+			if _, err := w.Write(line); err != nil {
+				return err
+			}
+		}
+
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+
+			return err
+		}
+	}
+}

--- a/pkg/fluxexec/cmd_default.go
+++ b/pkg/fluxexec/cmd_default.go
@@ -1,0 +1,92 @@
+package fluxexec
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"sync"
+)
+
+func (flux *Flux) runFluxCmd(ctx context.Context, cmd *exec.Cmd) error {
+	var errBuf strings.Builder
+
+	// check for early cancellation
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
+	// Read stdout / stderr logs from pipe instead of setting cmd.Stdout and
+	// cmd.Stderr because it can cause hanging when killing the command
+	// https://github.com/golang/go/issues/23019
+	stdoutWriter := mergeWriters(cmd.Stdout, flux.stdout)
+	stderrWriter := mergeWriters(flux.stderr, &errBuf)
+
+	cmd.Stderr = nil
+	cmd.Stdout = nil
+
+	stdoutPipe, err := cmd.StdoutPipe()
+	if err != nil {
+		return err
+	}
+
+	stderrPipe, err := cmd.StderrPipe()
+	if err != nil {
+		return err
+	}
+
+	err = cmd.Start()
+	if err == nil && ctx.Err() != nil {
+		err = ctx.Err()
+	}
+
+	if err != nil {
+		return flux.wrapExitError(ctx, err, "")
+	}
+
+	var (
+		errStdout, errStderr error
+		wg                   sync.WaitGroup
+	)
+
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+
+		errStdout = writeOutput(ctx, stdoutPipe, stdoutWriter)
+	}()
+
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+
+		errStderr = writeOutput(ctx, stderrPipe, stderrWriter)
+	}()
+
+	// Reads from pipes must be completed before calling cmd.Wait(). Otherwise
+	// can cause a race condition
+	wg.Wait()
+
+	err = cmd.Wait()
+	if err == nil && ctx.Err() != nil {
+		err = ctx.Err()
+	}
+
+	if err != nil {
+		return flux.wrapExitError(ctx, err, errBuf.String())
+	}
+
+	// Return error if there was an issue reading the std out/err
+	if errStdout != nil && ctx.Err() != nil {
+		return flux.wrapExitError(ctx, errStdout, errBuf.String())
+	}
+
+	if errStderr != nil && ctx.Err() != nil {
+		return flux.wrapExitError(ctx, errStderr, errBuf.String())
+	}
+
+	return nil
+}

--- a/pkg/fluxexec/errors.go
+++ b/pkg/fluxexec/errors.go
@@ -1,0 +1,15 @@
+package fluxexec
+
+import "fmt"
+
+type ErrNoSuitableBinary struct {
+	err error
+}
+
+func (e *ErrNoSuitableBinary) Error() string {
+	return fmt.Sprintf("no suitable flux binary could be found: %s", e.err.Error())
+}
+
+func (e *ErrNoSuitableBinary) Unwrap() error {
+	return e.err
+}

--- a/pkg/fluxexec/exit_errors.go
+++ b/pkg/fluxexec/exit_errors.go
@@ -1,0 +1,51 @@
+package fluxexec
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+func (flux *Flux) wrapExitError(ctx context.Context, err error, stderr string) error {
+	exitErr, ok := err.(*exec.ExitError)
+	if !ok {
+		// not an exit error, short circuit, nothing to wrap
+		return err
+	}
+
+	ctxErr := ctx.Err()
+
+	// nothing to parse, return early
+	errString := strings.TrimSpace(stderr)
+	if errString == "" {
+		return &unwrapper{exitErr, ctxErr}
+	}
+
+	// TODO parse stderr for error message here
+
+	return fmt.Errorf("%w\n%s", &unwrapper{exitErr, ctxErr}, stderr)
+}
+
+type unwrapper struct {
+	err    error
+	ctxErr error
+}
+
+func (u *unwrapper) Unwrap() error {
+	return u.err
+}
+
+func (u *unwrapper) Is(target error) bool {
+	switch target {
+	case context.DeadlineExceeded, context.Canceled:
+		return u.ctxErr == context.DeadlineExceeded ||
+			u.ctxErr == context.Canceled
+	}
+
+	return false
+}
+
+func (u *unwrapper) Error() string {
+	return u.err.Error()
+}

--- a/pkg/fluxexec/fluxexec.go
+++ b/pkg/fluxexec/fluxexec.go
@@ -1,0 +1,79 @@
+// This package is a port of TF-Exec, but for Flux.
+
+package fluxexec
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/weaveworks/weave-gitops/pkg/logger"
+)
+
+type Flux struct {
+	execPath   string
+	workingDir string
+	env        map[string]string
+
+	stdout io.Writer
+	stderr io.Writer
+	logger logger.Logger
+}
+
+func NewFlux(workingDir string, execPath string) (*Flux, error) {
+	if workingDir == "" {
+		return nil, fmt.Errorf("flux cannot be initialised with empty workdir")
+	}
+
+	if _, err := os.Stat(workingDir); err != nil {
+		return nil, fmt.Errorf("error initialising Flux with workdir %s: %s", workingDir, err)
+	}
+
+	if execPath == "" {
+		err := fmt.Errorf("please supply the path to a Flux executable using execPath, e.g. using the github.com/weaveworks/weave-gitops/pkg/flux-install module")
+
+		return nil, &ErrNoSuitableBinary{
+			err: err,
+		}
+	}
+
+	flux := Flux{
+		execPath:   execPath,
+		workingDir: workingDir,
+		env:        nil, // explicit nil means copy os.Environ
+		logger:     nil,
+	}
+
+	return &flux, nil
+}
+
+// WorkingDir returns the working directory for Flux.
+func (flux *Flux) WorkingDir() string {
+	return flux.workingDir
+}
+
+// ExecPath returns the path to the Flux executable.
+func (flux *Flux) ExecPath() string {
+	return flux.execPath
+}
+
+// SetLogger specifies a logger for tfexec to use.
+func (flux *Flux) SetLogger(logger logger.Logger) {
+	flux.logger = logger
+}
+
+// SetStdout specifies a writer to stream stdout to for every command.
+//
+// This should be used for information or logging purposes only, not control
+// flow. Any parsing necessary should be added as functionality to this package.
+func (flux *Flux) SetStdout(w io.Writer) {
+	flux.stdout = w
+}
+
+// SetStderr specifies a writer to stream stderr to for every command.
+//
+// This should be used for information or logging purposes only, not control
+// flow. Any parsing necessary should be added as functionality to this package.
+func (flux *Flux) SetStderr(w io.Writer) {
+	flux.stderr = w
+}

--- a/pkg/fluxexec/fluxexec_suite_test.go
+++ b/pkg/fluxexec/fluxexec_suite_test.go
@@ -1,0 +1,13 @@
+package fluxexec
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestFluxExec(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Flux Exec Suite")
+}

--- a/pkg/fluxexec/install.go
+++ b/pkg/fluxexec/install.go
@@ -1,0 +1,151 @@
+package fluxexec
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+)
+
+type installConfig struct {
+	clusterDomain      string
+	components         []Component
+	componentsExtra    []ComponentExtra
+	export             bool
+	imagePullSecret    string
+	logLevel           string
+	networkPolicy      bool
+	registry           string
+	tolerationKeys     []string
+	watchAllNamespaces bool
+}
+
+var defaultInstallOptions = installConfig{
+	clusterDomain:      "cluster.local",
+	components:         []Component{ComponentSourceController, ComponentKustomizeController, ComponentHelmController, ComponentNotificationController},
+	componentsExtra:    []ComponentExtra{},
+	export:             false,
+	logLevel:           "info",
+	networkPolicy:      true,
+	registry:           "ghcr.io/fluxcd",
+	tolerationKeys:     []string{},
+	watchAllNamespaces: true,
+}
+
+// InstallOption represents options used in the Install method.
+type InstallOption interface {
+	configureInstall(*installConfig)
+}
+
+func (opt *ClusterDomainOption) configureInstall(conf *installConfig) {
+	conf.clusterDomain = opt.clusterDomain
+}
+
+func (opt *ComponentsOption) configureInstall(conf *installConfig) {
+	conf.components = opt.components
+}
+
+func (opt *ComponentsExtraOption) configureInstall(conf *installConfig) {
+	conf.componentsExtra = opt.componentsExtra
+}
+
+func (opt *ExportOption) configureInstall(conf *installConfig) {
+	conf.export = opt.export
+}
+
+func (opt *ImagePullSecretOption) configureInstall(conf *installConfig) {
+	conf.imagePullSecret = opt.imagePullSecret
+}
+
+func (opt *LogLevelOption) configureInstall(conf *installConfig) {
+	conf.logLevel = opt.logLevel
+}
+
+func (opt *NetworkPolicyOption) configureInstall(conf *installConfig) {
+	conf.networkPolicy = opt.networkPolicy
+}
+
+func (opt *RegistryOption) configureInstall(conf *installConfig) {
+	conf.registry = opt.registry
+}
+
+func (opt *TolerationKeysOption) configureInstall(conf *installConfig) {
+	conf.tolerationKeys = opt.tolerationKeys
+}
+
+func (opt *WatchAllNamespacesOption) configureInstall(conf *installConfig) {
+	conf.watchAllNamespaces = opt.watchAllNamespaces
+}
+
+func (flux *Flux) Install(ctx context.Context, opts ...InstallOption) error {
+	installCmd, err := flux.installCmd(ctx, opts...)
+	if err != nil {
+		return err
+	}
+
+	if err := flux.runFluxCmd(ctx, installCmd); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (flux *Flux) installCmd(ctx context.Context, opts ...InstallOption) (*exec.Cmd, error) {
+	c := defaultInstallOptions
+	for _, o := range opts {
+		o.configureInstall(&c)
+	}
+
+	args := []string{"install"}
+
+	if c.watchAllNamespaces {
+		args = append(args, "--watch-all-namespaces")
+	}
+
+	if c.clusterDomain != "" {
+		args = append(args, "--cluster-domain", c.clusterDomain)
+	}
+
+	if c.export {
+		args = append(args, "--export")
+	}
+
+	if c.imagePullSecret != "" {
+		args = append(args, "--image-pull-secret", c.imagePullSecret)
+	}
+
+	if c.logLevel != "" {
+		args = append(args, "--log-level", c.logLevel)
+	}
+
+	if c.networkPolicy {
+		args = append(args, "--network-policy")
+	}
+
+	if c.registry != "" {
+		args = append(args, "--registry", c.registry)
+	}
+
+	if len(c.tolerationKeys) > 0 {
+		args = append(args, "--toleration-keys", strings.Join(c.tolerationKeys, ","))
+	}
+
+	if len(c.components) > 0 {
+		var comps []string
+		for _, c := range c.components {
+			comps = append(comps, string(c))
+		}
+
+		args = append(args, "--components", strings.Join(comps, ","))
+	}
+
+	if len(c.componentsExtra) > 0 {
+		var extras []string
+		for _, e := range c.componentsExtra {
+			extras = append(extras, string(e))
+		}
+
+		args = append(args, "--components-extra", strings.Join(extras, ","))
+	}
+
+	return flux.buildFluxCmd(ctx, nil, args...), nil
+}

--- a/pkg/fluxexec/install_test.go
+++ b/pkg/fluxexec/install_test.go
@@ -1,0 +1,87 @@
+package fluxexec
+
+import (
+	"context"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("installCmd", func() {
+	It("should be able to generate correct install commands", func() {
+		By("generating the default command", func() {
+			flux, err := NewFlux(".", "/mock/path/to/flux")
+			Expect(err).To(BeNil())
+
+			initCmd, err := flux.installCmd(context.TODO())
+			Expect(err).To(BeNil())
+			Expect(initCmd.Args[1:]).To(Equal([]string{
+				"install",
+				"--watch-all-namespaces",
+				"--cluster-domain",
+				"cluster.local",
+				"--log-level",
+				"info",
+				"--network-policy",
+				"--registry",
+				"ghcr.io/fluxcd",
+				"--components",
+				"source-controller,kustomize-controller,helm-controller,notification-controller",
+			}))
+		})
+		By("generating the command without network policy", func() {
+			flux, err := NewFlux(".", "/mock/path/to/flux")
+			Expect(err).To(BeNil())
+
+			initCmd, err := flux.installCmd(context.TODO(), NetworkPolicy(false))
+			Expect(err).To(BeNil())
+			Expect(initCmd.Args[1:]).To(Equal([]string{
+				"install",
+				"--watch-all-namespaces",
+				"--cluster-domain", "cluster.local",
+				"--log-level", "info",
+				"--registry", "ghcr.io/fluxcd",
+				"--components", "source-controller,kustomize-controller,helm-controller,notification-controller",
+			}))
+		})
+		By("generating the command to install only source controller", func() {
+			flux, err := NewFlux(".", "/mock/path/to/flux")
+			Expect(err).To(BeNil())
+
+			initCmd, err := flux.installCmd(context.TODO(), Components(ComponentSourceController))
+			Expect(err).To(BeNil())
+			Expect(initCmd.Args[1:]).To(Equal([]string{
+				"install",
+				"--watch-all-namespaces",
+				"--cluster-domain", "cluster.local",
+				"--log-level", "info",
+				"--network-policy",
+				"--registry", "ghcr.io/fluxcd",
+				"--components", "source-controller",
+			}))
+		})
+
+		By("generating the command to install extra controllers", func() {
+			flux, err := NewFlux(".", "/mock/path/to/flux")
+			Expect(err).To(BeNil())
+
+			initCmd, err := flux.installCmd(context.TODO(), ComponentsExtra(ComponentImageReflectorController, ComponentImageReflectorController))
+			Expect(err).To(BeNil())
+			Expect(initCmd.Args[1:]).To(Equal([]string{
+				"install",
+				"--watch-all-namespaces",
+				"--cluster-domain",
+				"cluster.local",
+				"--log-level",
+				"info",
+				"--network-policy",
+				"--registry",
+				"ghcr.io/fluxcd",
+				"--components",
+				"source-controller,kustomize-controller,helm-controller,notification-controller",
+				"--components-extra",
+				"image-reflector-controller,image-reflector-controller",
+			}))
+		})
+
+	})
+})

--- a/pkg/fluxexec/option_consts.go
+++ b/pkg/fluxexec/option_consts.go
@@ -1,0 +1,33 @@
+package fluxexec
+
+type KeyAlgorithm string
+
+const (
+	KeyAlgorithmRSA     KeyAlgorithm = "rsa"
+	KeyAlgorithmECDSA   KeyAlgorithm = "ecdsa"
+	KeyAlgorithmED25519 KeyAlgorithm = "ed25519"
+)
+
+type EcdsaCurve string
+
+const (
+	EcdsaCurveP256 EcdsaCurve = "p256"
+	EcdsaCurveP384 EcdsaCurve = "p384"
+	EcdsaCurveP521 EcdsaCurve = "p521"
+)
+
+type Component string
+
+const (
+	ComponentSourceController       Component = "source-controller"
+	ComponentKustomizeController    Component = "kustomize-controller"
+	ComponentHelmController         Component = "helm-controller"
+	ComponentNotificationController Component = "notification-controller"
+)
+
+type ComponentExtra string
+
+const (
+	ComponentImageReflectorController  ComponentExtra = "image-reflector-controller"
+	ComponentImageAutomationController ComponentExtra = "image-automation-controller"
+)

--- a/pkg/fluxexec/options.go
+++ b/pkg/fluxexec/options.go
@@ -1,0 +1,357 @@
+package fluxexec
+
+type ClusterDomainOption struct {
+	clusterDomain string
+}
+
+// ClusterDomain represents the --cluster-domain flag.
+func ClusterDomain(clusterDomain string) *ClusterDomainOption {
+	return &ClusterDomainOption{clusterDomain}
+}
+
+type ComponentsOption struct {
+	components []Component
+}
+
+// Components represents the --components flag.
+func Components(components ...Component) *ComponentsOption {
+	allowedComponents := map[Component]struct{}{
+		ComponentSourceController:       {},
+		ComponentKustomizeController:    {},
+		ComponentHelmController:         {},
+		ComponentNotificationController: {},
+	}
+	// validate components
+	validatedComponents := []Component{}
+
+	for _, c := range components {
+		if _, ok := allowedComponents[c]; !ok {
+			continue
+		}
+
+		validatedComponents = append(validatedComponents, c)
+	}
+
+	return &ComponentsOption{validatedComponents}
+}
+
+type ComponentsExtraOption struct {
+	componentsExtra []ComponentExtra
+}
+
+// ComponentsExtra represents the --components-extra flag.
+func ComponentsExtra(componentsExtra ...ComponentExtra) *ComponentsExtraOption {
+	allowedComponents := map[ComponentExtra]struct{}{
+		ComponentImageAutomationController: {},
+		ComponentImageReflectorController:  {},
+	}
+	// validate components
+	validatedComponents := []ComponentExtra{}
+
+	for _, c := range componentsExtra {
+		if _, ok := allowedComponents[c]; !ok {
+			continue
+		}
+
+		validatedComponents = append(validatedComponents, c)
+	}
+
+	return &ComponentsExtraOption{validatedComponents}
+}
+
+type ExportOption struct {
+	export bool
+}
+
+// Export represents the --export flag.
+func Export(export bool) *ExportOption {
+	return &ExportOption{export}
+}
+
+type ImagePullSecretOption struct {
+	imagePullSecret string
+}
+
+// ImagePullSecret represents the --image-pull-secret flag.
+func ImagePullSecret(imagePullSecret string) *ImagePullSecretOption {
+	return &ImagePullSecretOption{imagePullSecret}
+}
+
+type LogLevelOption struct {
+	logLevel string
+}
+
+// LogLevel represents the --log-level flag.
+func LogLevel(logLevel string) *LogLevelOption {
+	return &LogLevelOption{logLevel}
+}
+
+type NetworkPolicyOption struct {
+	networkPolicy bool
+}
+
+// NetworkPolicy represents the --network-policy flag.
+func NetworkPolicy(networkPolicy bool) *NetworkPolicyOption {
+	return &NetworkPolicyOption{networkPolicy}
+}
+
+type RegistryOption struct {
+	registry string
+}
+
+// Registry represents the --registry flag.
+func Registry(registry string) *RegistryOption {
+	return &RegistryOption{registry}
+}
+
+type TolerationKeysOption struct {
+	tolerationKeys []string
+}
+
+// TolerationKeys represents the --toleration-keys flag.
+func TolerationKeys(tolerationKeys ...string) *TolerationKeysOption {
+	return &TolerationKeysOption{tolerationKeys}
+}
+
+type WatchAllNamespacesOption struct {
+	watchAllNamespaces bool
+}
+
+// WatchAllNamespaces represents the --watch-all-namespaces flag.
+func WatchAllNamespaces(watchAllNamespaces bool) *WatchAllNamespacesOption {
+	return &WatchAllNamespacesOption{watchAllNamespaces}
+}
+
+type HostnameOption struct {
+	hostname string
+}
+
+// Hostname represents the --hostname flag.
+func Hostname(hostname string) *HostnameOption {
+	return &HostnameOption{hostname}
+}
+
+type IntervalOption struct {
+	interval string
+}
+
+// Interval represents the --interval flag.
+func Interval(interval string) *IntervalOption {
+	return &IntervalOption{interval}
+}
+
+type OwnerOption struct {
+	owner string
+}
+
+// Owner represents the --owner flag.
+func Owner(owner string) *OwnerOption {
+	return &OwnerOption{owner}
+}
+
+type PathOption struct {
+	path string
+}
+
+// Path represents the --path flag.
+func Path(path string) *PathOption {
+	return &PathOption{path}
+}
+
+type PersonalOption struct {
+	personal bool
+}
+
+// Personal represents the --personal flag.
+func Personal(personal bool) *PersonalOption {
+	return &PersonalOption{personal}
+}
+
+type PrivateOption struct {
+	private bool
+}
+
+// Private represents the --private flag.
+func Private(private bool) *PrivateOption {
+	return &PrivateOption{private}
+}
+
+type ReadWriteKeyOption struct {
+	readWriteKey bool
+}
+
+// ReadWriteKey represents the --read-write-key flag.
+func ReadWriteKey(readWriteKey bool) *ReadWriteKeyOption {
+	return &ReadWriteKeyOption{readWriteKey}
+}
+
+type ReconcileOption struct {
+	reconcile bool
+}
+
+// Reconcile represents the --reconcile flag.
+func Reconcile(reconcile bool) *ReconcileOption {
+	return &ReconcileOption{reconcile}
+}
+
+type RepositoryOption struct {
+	repository string
+}
+
+// Repository represents the --repository flag.
+func Repository(repository string) *RepositoryOption {
+	return &RepositoryOption{repository}
+}
+
+type TeamOption struct {
+	team []string
+}
+
+// Team represents the --team flag.
+func Team(team ...string) *TeamOption {
+	return &TeamOption{team}
+}
+
+type AuthorEmailOption struct {
+	authorEmail string
+}
+
+// AuthorEmail represents the --author-email flag.
+func AuthorEmail(authorEmail string) *AuthorEmailOption {
+	return &AuthorEmailOption{authorEmail}
+}
+
+type AuthorNameOption struct {
+	authorName string
+}
+
+// AuthorName represents the --author-name flag.
+func AuthorName(authorName string) *AuthorNameOption {
+	return &AuthorNameOption{authorName}
+}
+
+type BranchOption struct {
+	branch string
+}
+
+// Branch represents the --branch flag.
+func Branch(branch string) *BranchOption {
+	return &BranchOption{branch}
+}
+
+type CaFileOption struct {
+	caFile string
+}
+
+// CaFile represents the --ca-file flag.
+func CaFile(caFile string) *CaFileOption {
+	return &CaFileOption{caFile}
+}
+
+type CommitMessageAppendixOption struct {
+	commitMessageAppendix string
+}
+
+// CommitMessageAppendix represents the --commit-message-appendix flag.
+func CommitMessageAppendix(commitMessageAppendix string) *CommitMessageAppendixOption {
+	return &CommitMessageAppendixOption{commitMessageAppendix}
+}
+
+type GpgKeyIdOption struct {
+	gpgKeyId string
+}
+
+// GpgKeyId represents the --gpg-key-id flag.
+func GpgKeyId(gpgKeyId string) *GpgKeyIdOption {
+	return &GpgKeyIdOption{gpgKeyId}
+}
+
+type GpgKeyRingOption struct {
+	gpgKeyRing string
+}
+
+// GpgKeyRing represents the --gpg-key-ring flag.
+func GpgKeyRing(gpgKeyRing string) *GpgKeyRingOption {
+	return &GpgKeyRingOption{gpgKeyRing}
+}
+
+type GpgPassphraseOption struct {
+	gpgPassphrase string
+}
+
+// GpgPassphrase represents the --gpg-passphrase flag.
+func GpgPassphrase(gpgPassphrase string) *GpgPassphraseOption {
+	return &GpgPassphraseOption{gpgPassphrase}
+}
+
+type PrivateKeyFileOption struct {
+	privateKeyFile string
+}
+
+// PrivateKeyFile represents the --private-key-file flag.
+func PrivateKeyFile(privateKeyFile string) *PrivateKeyFileOption {
+	return &PrivateKeyFileOption{privateKeyFile}
+}
+
+type RecurseSubmodulesOption struct {
+	recurseSubmodules bool
+}
+
+// RecurseSubmodules represents the --recurse-submodules flag.
+func RecurseSubmodules(recurseSubmodules bool) *RecurseSubmodulesOption {
+	return &RecurseSubmodulesOption{recurseSubmodules}
+}
+
+type SecretNameOption struct {
+	secretName string
+}
+
+// SecretName represents the --secret-name flag.
+func SecretName(secretName string) *SecretNameOption {
+	return &SecretNameOption{secretName}
+}
+
+type SshEcdsaCurveOption struct {
+	sshEcdsaCurve EcdsaCurve
+}
+
+// SshEcdsaCurve represents the --ssh-ecdsa-curve flag.
+func SshEcdsaCurve(ecdsaCurve EcdsaCurve) *SshEcdsaCurveOption {
+	return &SshEcdsaCurveOption{ecdsaCurve}
+}
+
+type SshHostnameOption struct {
+	sshHostname string
+}
+
+// SshHostname represents the --ssh-hostname flag.
+func SshHostname(sshHostname string) *SshHostnameOption {
+	return &SshHostnameOption{sshHostname}
+}
+
+type SshKeyAlgorithmOption struct {
+	sshKeyAlgorithm KeyAlgorithm
+}
+
+// SshKeyAlgorithm represents the --ssh-key-algorithm flag.
+func SshKeyAlgorithm(sshKeyAlgorithm KeyAlgorithm) *SshKeyAlgorithmOption {
+	return &SshKeyAlgorithmOption{sshKeyAlgorithm}
+}
+
+type SshRsaBitsOption struct {
+	sshRsaBits int
+}
+
+// SshRsaBits represents the --ssh-rsa-bits flag.
+func SshRsaBits(sshRsaBits int) *SshRsaBitsOption {
+	return &SshRsaBitsOption{sshRsaBits}
+}
+
+type TokenAuthOption struct {
+	tokenAuth bool
+}
+
+// TokenAuth represents the --token-auth flag.
+func TokenAuth(tokenAuth bool) *TokenAuthOption {
+	return &TokenAuthOption{tokenAuth}
+}

--- a/pkg/fluxinstall/errors/errors.go
+++ b/pkg/fluxinstall/errors/errors.go
@@ -1,0 +1,18 @@
+package errors
+
+type skippableErr struct {
+	Err error
+}
+
+func (e skippableErr) Error() string {
+	return e.Err.Error()
+}
+
+func SkippableErr(err error) skippableErr {
+	return skippableErr{Err: err}
+}
+
+func IsErrorSkippable(err error) bool {
+	_, ok := err.(skippableErr)
+	return ok
+}

--- a/pkg/fluxinstall/fluxinstall_suite_test.go
+++ b/pkg/fluxinstall/fluxinstall_suite_test.go
@@ -1,0 +1,13 @@
+package fluxinstall
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestFluxInstall(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Flux Install Suite")
+}

--- a/pkg/fluxinstall/installer.go
+++ b/pkg/fluxinstall/installer.go
@@ -1,0 +1,104 @@
+package fluxinstall
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/weaveworks/weave-gitops/pkg/fluxinstall/errors"
+	"github.com/weaveworks/weave-gitops/pkg/fluxinstall/src"
+)
+
+type Installer struct {
+	removableSources []src.Removable
+}
+
+type RemoveFunc func(ctx context.Context) error
+
+func NewInstaller() *Installer {
+	return &Installer{}
+}
+
+func (i *Installer) Ensure(ctx context.Context, sources []src.Source) (string, error) {
+	var errs *multierror.Error
+
+	i.removableSources = make([]src.Removable, 0)
+
+	for _, source := range sources {
+		if s, ok := source.(src.Removable); ok {
+			i.removableSources = append(i.removableSources, s)
+		}
+
+		switch s := source.(type) {
+		case src.Findable:
+			execPath, err := s.Find(ctx)
+			if err != nil {
+				if errors.IsErrorSkippable(err) {
+					errs = multierror.Append(errs, err)
+					continue
+				}
+
+				return "", err
+			}
+
+			return execPath, nil
+		case src.Installable:
+			execPath, err := s.Install(ctx)
+			if err != nil {
+				if errors.IsErrorSkippable(err) {
+					errs = multierror.Append(errs, err)
+					continue
+				}
+
+				return "", err
+			}
+
+			return execPath, nil
+		default:
+			return "", fmt.Errorf("unknown source: %T", s)
+		}
+	}
+
+	return "", fmt.Errorf("unable to find, or install from %d sources: %s", len(sources), errs.ErrorOrNil())
+}
+
+func (i *Installer) Install(ctx context.Context, sources []src.Installable) (string, error) {
+	var errs *multierror.Error
+
+	i.removableSources = make([]src.Removable, 0)
+
+	for _, source := range sources {
+		if s, ok := source.(src.Removable); ok {
+			i.removableSources = append(i.removableSources, s)
+		}
+
+		execPath, err := source.Install(ctx)
+		if err != nil {
+			if errors.IsErrorSkippable(err) {
+				errs = multierror.Append(errs, err)
+				continue
+			}
+
+			return "", err
+		}
+
+		return execPath, nil
+	}
+
+	return "", fmt.Errorf("unable install from %d sources: %s", len(sources), errs.ErrorOrNil())
+}
+
+func (i *Installer) Remove(ctx context.Context) error {
+	var errs *multierror.Error
+
+	if i.removableSources != nil {
+		for _, rs := range i.removableSources {
+			err := rs.Remove(ctx)
+			if err != nil {
+				errs = multierror.Append(errs, err)
+			}
+		}
+	}
+
+	return errs.ErrorOrNil()
+}

--- a/pkg/fluxinstall/installer_test.go
+++ b/pkg/fluxinstall/installer_test.go
@@ -1,0 +1,51 @@
+package fluxinstall
+
+import (
+	"context"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"os"
+	"path/filepath"
+
+	"github.com/weaveworks/weave-gitops/pkg/fluxinstall/src"
+)
+
+var _ = Describe("Install Flux CLI", func() {
+	cacheDir, err := os.UserCacheDir()
+	Expect(err).To(BeNil())
+	gitopsCacheFluxDir := filepath.Join(cacheDir, ".gitops", "flux", "0.32.0")
+
+	It("should be able to manage lifecycle of a Flux binary", func() {
+		By("creating an installer with a version, and call install", func() {
+			ctx := context.TODO()
+
+			product := &Product{
+				Version: "0.32.0",
+				cli:     &MockProductHttpClient{},
+			}
+
+			installer := NewInstaller()
+			execPath, err := installer.Install(ctx, []src.Installable{product})
+			Expect(err).To(BeNil())
+			Expect(execPath).To(Equal(filepath.Join(gitopsCacheFluxDir, "flux")))
+		})
+
+		By("ensure that there's a version installed", func() {
+			ctx := context.TODO()
+
+			product := &Product{
+				Version: "0.32.0",
+				cli:     &MockProductHttpClient{},
+			}
+
+			installer := NewInstaller()
+			execPath, err := installer.Ensure(ctx, []src.Source{product})
+			Expect(err).To(BeNil())
+			Expect(execPath).To(Equal(filepath.Join(gitopsCacheFluxDir, "flux")))
+
+			err = installer.Remove(context.TODO())
+			Expect(err).To(BeNil())
+		})
+	})
+
+})

--- a/pkg/fluxinstall/internal/httpclient/httpclient.go
+++ b/pkg/fluxinstall/internal/httpclient/httpclient.go
@@ -1,0 +1,34 @@
+package httpclient
+
+import (
+	"net/http"
+
+	"github.com/hashicorp/go-cleanhttp"
+)
+
+// NewHTTPClient provides a pre-configured http.Client
+// e.g. with relevant User-Agent header
+func NewHTTPClient() *http.Client {
+	client := cleanhttp.DefaultClient()
+
+	cli := cleanhttp.DefaultPooledClient()
+	cli.Transport = &userAgentRoundTripper{
+		userAgent: "flux-install/0.1.0",
+		inner:     cli.Transport,
+	}
+
+	return client
+}
+
+type userAgentRoundTripper struct {
+	inner     http.RoundTripper
+	userAgent string
+}
+
+func (rt *userAgentRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if _, ok := req.Header["User-Agent"]; !ok {
+		req.Header.Set("User-Agent", rt.userAgent)
+	}
+
+	return rt.inner.RoundTrip(req)
+}

--- a/pkg/fluxinstall/internal/src/src.go
+++ b/pkg/fluxinstall/internal/src/src.go
@@ -1,0 +1,4 @@
+package src
+
+// InstallSrcSigil is used as the part of a marker interface for installer
+type InstallSrcSigil struct{}

--- a/pkg/fluxinstall/product.go
+++ b/pkg/fluxinstall/product.go
@@ -1,0 +1,210 @@
+package fluxinstall
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/weaveworks/weave-gitops/pkg/fluxinstall/internal/httpclient"
+	isrc "github.com/weaveworks/weave-gitops/pkg/fluxinstall/internal/src"
+)
+
+type HttpGetter interface {
+	Get(url string) (resp *http.Response, err error)
+}
+
+type Product struct {
+	Version string
+	cli     HttpGetter
+}
+
+func NewProduct(version string) *Product {
+	return &Product{
+		Version: version,
+		cli:     httpclient.NewHTTPClient(),
+	}
+}
+
+func NewProductWithHttpClient(version string, cli HttpGetter) *Product {
+	return &Product{
+		Version: version,
+		cli:     cli,
+	}
+}
+
+func (p *Product) IsSourceImpl() isrc.InstallSrcSigil {
+	return isrc.InstallSrcSigil{}
+}
+
+func (p *Product) Install(ctx context.Context) (string, error) {
+	gitopsCacheFluxDir, err := getFluxBinaryDir(p.Version)
+	if err != nil {
+		return "", err
+	}
+
+	// check if the dir not found
+	if _, err := os.Stat(gitopsCacheFluxDir); os.IsNotExist(err) {
+		if err := os.MkdirAll(gitopsCacheFluxDir, 0755); err != nil {
+			return "", err
+		}
+	}
+
+	// TODO enable windows support
+	extension := "tar.gz"
+	binaryUrl := fmt.Sprintf("https://github.com/fluxcd/flux2/releases/download/v%s/flux_%s_%s_%s.%s", p.Version, p.Version, runtime.GOOS, runtime.GOARCH, extension)
+	client := p.cli
+	resp, err := client.Get(binaryUrl)
+
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	h := sha256.New()
+	h.Write(body)
+	sha256sum := fmt.Sprintf("%x", h.Sum(nil))
+	filename := fmt.Sprintf("flux_%s_%s_%s.%s", p.Version, runtime.GOOS, runtime.GOARCH, extension)
+
+	if err := p.verifyChecksum(filename, sha256sum); err != nil {
+		return "", err
+	}
+
+	binary, err := extractTarGz(body)
+	if err != nil {
+		return "", err
+	}
+
+	binaryPath := filepath.Join(gitopsCacheFluxDir, "flux")
+	if err := ioutil.WriteFile(binaryPath, binary, 0744); err != nil {
+		return "", err
+	}
+
+	return binaryPath, nil
+}
+
+func (p *Product) Remove(ctx context.Context) error {
+	dir, err := getFluxBinaryDir(p.Version)
+	if err != nil {
+		return err
+	}
+
+	return os.RemoveAll(dir)
+}
+
+func (p *Product) Find(ctx context.Context) (string, error) {
+	dir, err := getFluxBinaryDir(p.Version)
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(dir, "flux"), nil
+}
+
+func (p *Product) verifyChecksum(filename string, sum string) error {
+	checkSumUrl := fmt.Sprintf("https://github.com/fluxcd/flux2/releases/download/v%s/flux_%s_checksums.txt", p.Version, p.Version)
+	client := p.cli
+	resp, err := client.Get(checkSumUrl)
+
+	if err != nil {
+		return err
+	}
+
+	// read string from response body
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	checksum := map[string]string{}
+	lines := strings.Split(string(body), "\n")
+
+	for _, line := range lines {
+		parts := strings.SplitN(line, "  ", 2)
+
+		if len(parts) != 2 {
+			continue
+		}
+
+		checksum[parts[1]] = parts[0]
+	}
+
+	if checksum[filename] != sum {
+		return fmt.Errorf("checksum mismatch for %s", filename)
+	}
+
+	return nil
+}
+
+// extractTarGz accepts an io.Reader of Flux's .tar.gz and extract it to a byte array
+func extractTarGz(b []byte) ([]byte, error) {
+	// ungzip
+	gr, err := gzip.NewReader(bytes.NewReader(b))
+	if err != nil {
+		return nil, err
+	}
+	defer gr.Close()
+
+	// untar the "flux" entry
+	tr := tar.NewReader(gr)
+
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+
+		if err != nil {
+			return nil, err
+		}
+
+		if hdr.Typeflag != tar.TypeReg {
+			continue
+		}
+
+		if hdr.Name != "flux" {
+			continue
+		}
+
+		var bytesBuffer bytes.Buffer
+		if _, err := io.Copy(&bytesBuffer, tr); err != nil {
+			return nil, err
+		}
+
+		if err != nil {
+			return nil, err
+		}
+
+		return bytesBuffer.Bytes(), nil
+	}
+
+	return nil, fmt.Errorf("no flux binary found in archive")
+}
+
+func getFluxBinaryDir(version string) (string, error) {
+	// get cache dir
+	cacheDir, err := os.UserCacheDir()
+	if err != nil {
+		return "", err
+	}
+
+	gitopsCacheFluxDir := filepath.Join(cacheDir, ".gitops", "flux", version)
+
+	return gitopsCacheFluxDir, nil
+}

--- a/pkg/fluxinstall/product_test.go
+++ b/pkg/fluxinstall/product_test.go
@@ -1,0 +1,128 @@
+package fluxinstall
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"io"
+	"io/ioutil"
+	"net/http"
+)
+
+func createMockFluxArchive(data []byte) ([]byte, error) {
+	buf := &bytes.Buffer{}
+
+	// Create new Writers for gzip and tar
+	// These writers are chained. Writing to the tar writer will
+	// write to the gzip writer which in turn will write to
+	// the "buf" writer
+	gw := gzip.NewWriter(buf)
+	tw := tar.NewWriter(gw)
+
+	if err := addToArchive(tw, "flux", data); err != nil {
+		return nil, err
+	}
+
+	if err := tw.Flush(); err != nil {
+		return nil, err
+	}
+
+	if err := tw.Close(); err != nil {
+		return nil, err
+	}
+
+	if err := gw.Flush(); err != nil {
+		return nil, err
+	}
+
+	if err := gw.Close(); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+func addToArchive(tw *tar.Writer, filename string, data []byte) error {
+	// Create a tar Header from the FileInfo data
+	header := &tar.Header{
+		Typeflag:   tar.TypeReg,
+		Name:       filename,
+		Linkname:   filename,
+		Size:       int64(len(data)),
+		Mode:       644,
+		Devmajor:   0,
+		Devminor:   0,
+		PAXRecords: nil,
+		Format:     0,
+	}
+
+	// Use full path as name (FileInfoHeader only takes the basename)
+	// If we don't do this the directory strucuture would
+	// not be preserved
+	// https://golang.org/src/archive/tar/common.go?#L626
+	header.Name = filename
+
+	// Write file header to the tar archive
+	err := tw.WriteHeader(header)
+	if err != nil {
+		return err
+	}
+
+	// Copy file content to tar archive
+	_, err = io.Copy(tw, bytes.NewReader(data))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+type MockProductHttpClient struct {
+}
+
+func (m *MockProductHttpClient) Get(url string) (resp *http.Response, err error) {
+	if url == "https://github.com/fluxcd/flux2/releases/download/v0.32.0/flux_0.32.0_linux_amd64.tar.gz" {
+		body, err := createMockFluxArchive([]byte("flux"))
+
+		if err != nil {
+			return nil, err
+		}
+
+		return &http.Response{
+			Body: ioutil.NopCloser(bytes.NewReader(body)),
+		}, nil
+	} else if url == "https://github.com/fluxcd/flux2/releases/download/v0.32.0/flux_0.32.0_checksums.txt" {
+		body := []byte(`77622fd02dd5ad9377e17ecb59fa4f9598016bf0bf9761d09c9ed633840d7c7d  flux_0.32.0_linux_amd64.tar.gz
+`)
+
+		return &http.Response{
+			Body: ioutil.NopCloser(bytes.NewReader(body)),
+		}, nil
+	}
+
+	return nil, nil
+}
+
+var _ = Describe("Product", func() {
+
+	var product *Product
+
+	It("should verify checksum of flux product", func() {
+		By("creating product, and verify checksum", func() {
+			product = &Product{
+				Version: "0.32.0",
+				cli:     &MockProductHttpClient{},
+			}
+			_, err := product.Install(context.Background())
+			Expect(err).To(BeNil())
+
+			err = product.verifyChecksum("flux_0.32.0_linux_amd64.tar.gz", "77622fd02dd5ad9377e17ecb59fa4f9598016bf0bf9761d09c9ed633840d7c7d")
+			Expect(err).To(BeNil())
+		})
+	})
+
+})

--- a/pkg/fluxinstall/src/src.go
+++ b/pkg/fluxinstall/src/src.go
@@ -1,0 +1,42 @@
+package src
+
+import (
+	"context"
+	"log"
+
+	isrc "github.com/weaveworks/weave-gitops/pkg/fluxinstall/internal/src"
+)
+
+// Source represents an installer, finder, or builder
+type Source interface {
+	IsSourceImpl() isrc.InstallSrcSigil
+}
+
+type Installable interface {
+	Source
+	Install(ctx context.Context) (string, error)
+}
+
+type Findable interface {
+	Source
+	Find(ctx context.Context) (string, error)
+}
+
+type Buildable interface {
+	Source
+	Build(ctx context.Context) (string, error)
+}
+
+type Validatable interface {
+	Source
+	Validate() error
+}
+
+type Removable interface {
+	Source
+	Remove(ctx context.Context) error
+}
+
+type LoggerSettable interface {
+	SetLogger(logger *log.Logger)
+}


### PR DESCRIPTION
This PR implements two packages, Flux's installer and Flux's exec.

Flux installer is a package for installing a specific version of Flux. It downloads a Flux binary to a cached directory. It checksums during the process to ensure that we get the correct binary.

Flux exec is a type-safe wrapper to execute Flux binary. It has an option that implements each flag one by one.

Fixes #2610 
Fixes #2592 