### PR TITLE
fix log message

### DIFF
--- a/cmd/gitops-server/cmd/cmd.go
+++ b/cmd/gitops-server/cmd/cmd.go
@@ -306,7 +306,7 @@ func listenAndServe(log logr.Logger, srv *http.Server, options Options) error {
 			ClientAuth: tls.RequireAndVerifyClientCert,
 		}
 	} else {
-		log.Info("Using TLS from %q and %q", options.TLSCertFile, options.TLSKeyFile)
+		log.Info("Using TLS", "cert_file", options.TLSCertFile, "key_file", options.TLSKeyFile)
 	}
 
 	// if tlsCert and tlsKey are both empty (""), ListenAndServeTLS will ignore


### PR DESCRIPTION
Before:

```
{"level":"info","ts":1660831632.8747694,"logger":"gitops","caller":"cmd/cmd.go:325","msg":"Using TLS from %q and %q","/home/max/dev/local-ca/ca.pem":"/home/max/dev/local-ca/ca.key"}
```

After:

```
{"level":"info","ts":1660831799.359499,"logger":"gitops","caller":"cmd/cmd.go:325","msg":"Using TLS","cert_file":"/home/max/dev/local-ca/ca.pem","key_file":"/home/max/dev/local-ca/ca.key"}
```
