### PR TITLE
Make the whole release flow use the release commit

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -86,7 +86,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-node@v2
         with:
           node-version: "16.X"
@@ -105,8 +107,10 @@ jobs:
       contents: read
       packages: write
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Unshallow
         run: |
           git fetch --prune --unshallow
@@ -158,7 +162,9 @@ jobs:
       - build-and-push-image
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: "Merge release"
         run: |
           curl --request PUT \


### PR DESCRIPTION
I fixed this for the CLI binary in d9a07b437, and that worked - but I
didn't fix it for e.g. docker images, so now the released version of
the images are tagged with the wrong commit, even though they're built
from an identical commit to the release.

Check out the right one everywhere.