### PR TITLE
ui: PageStatus should display Failed when state is bad

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -14,7 +14,11 @@
         "@typescript-eslint/explicit-module-boundary-types": 0,
         "@typescript-eslint/no-explicit-any": 0,
         "@typescript-eslint/ban-ts-comment": 0,
-        "import/no-named-as-default": 0
+        "import/no-named-as-default": 0,
+        "@typescript-eslint/switch-exhaustiveness-check": "error"
     },
-    "ignorePatterns": "rpc"
+    "ignorePatterns": "rpc",
+    "parserOptions": {
+        "project": "./tsconfig.json"
+     }
 }

--- a/ui/components/PageStatus.tsx
+++ b/ui/components/PageStatus.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import styled from "styled-components";
 import { Condition } from "../lib/api/core/types.pb";
+import { colors } from "../typedefs/styled.d";
 import Flex from "./Flex";
 import Icon, { IconType } from "./Icon";
 import { computeMessage, computeReady, ReadyType } from "./KubeStatusIndicator";
@@ -14,20 +15,34 @@ type StatusProps = {
 };
 
 function PageStatus({ conditions, suspended, className }: StatusProps) {
-  const ok = suspended ? false : computeReady(conditions);
   const msg = suspended ? "Suspended" : computeMessage(conditions);
 
-  let iconType;
-  if (suspended) iconType = IconType.SuspendedIcon;
-  else if (ok)
-    ok === ReadyType.Reconciling
-      ? (iconType = IconType.ReconcileIcon)
-      : (iconType = IconType.CheckCircleIcon);
-  else iconType = IconType.FailedIcon;
+  let iconType: IconType;
+  let iconColor: keyof typeof colors;
+  if (suspended) {
+    iconType = IconType.SuspendedIcon;
+    iconColor = "suspended";
+  } else {
+    const ok = computeReady(conditions);
+    switch (ok) {
+      case ReadyType.Reconciling:
+        iconType = IconType.ReconcileIcon;
+        iconColor = "primary";
+        break;
+      case ReadyType.Ready:
+        iconType = IconType.CheckCircleIcon;
+        iconColor = "success";
+        break;
+      case ReadyType.NotReady:
+        iconType = IconType.FailedIcon;
+        iconColor = "alert";
+        break;
+    }
+  }
 
   return (
     <Flex align className={className}>
-      <Icon type={iconType} color={ok ? "success" : "alert"} size="medium" />
+      <Icon type={iconType} color={iconColor} size="medium" />
       <Spacer padding="xs" />
       <Text color="neutral30">{msg}</Text>
     </Flex>

--- a/ui/components/SourcesTable.tsx
+++ b/ui/components/SourcesTable.tsx
@@ -114,12 +114,13 @@ function SourcesTable({ className, sources }: Props) {
           case FluxObjectKind.KindOCIRepository:
             text = (s as OCIRepository).url;
             break;
-          case FluxObjectKind.KindHelmChart:
-            return "-";
           case FluxObjectKind.KindHelmRepository:
             text = (s as HelmRepository).url;
             url = text;
             link = true;
+            break;
+          default:
+            text = "-";
             break;
         }
         return link ? (


### PR DESCRIPTION
This checked if the return value was truthy or falsy to determine
whether to show a green or a red icon - however, the return value
these days is an enum, so it's always truthy.

Use a good, ol' fashioned switch case, because we need to test every
case it can return.