### PR TITLE
Populate the groups field in the oauth2/userinfo API response

### DIFF
--- a/pkg/server/auth/server.go
+++ b/pkg/server/auth/server.go
@@ -407,8 +407,17 @@ func (s *AuthServer) UserInfo() http.HandlerFunc {
 			return
 		}
 
+		var userPrincipal UserPrincipal
+
+		// Extract custom claims
+		if err := info.Claims(&userPrincipal); err != nil {
+			JSONError(s.Log, rw, fmt.Sprintf("failed to decode user claims: %v", err), http.StatusUnauthorized)
+			return
+		}
+
 		ui := UserInfo{
-			Email: info.Email,
+			Email:  info.Email,
+			Groups: userPrincipal.Groups,
 		}
 
 		toJson(rw, ui, s.Log)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
This adds the groups scope from the user principal to the response of the /oauth2/userinfo endpoint.


<!-- Tell your future self why have you made these changes -->
Currently, the /oauth2/userinfo will return `null` as the value of the groups key. When debugging user permission issues, it's useful to have an endpoint to quickly see what groups have been mapped to the current authenticated user.


<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
The change is minor. I have introduced a new variable called `userPrincipal` which is of type `UserPrincipal`. We can then extract the claims from the user provider into this struct to then populate the response JSON.


<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
The changes have been validated by deploying this to a functioning Kubernetes environment with Flux installed, and testing it with a known-good OIDC provider.


<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
I don't believe this is notable for a release.


<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
N/A