### PR TITLE
Fix install

### DIFF
--- a/website/docs/installation.mdx
+++ b/website/docs/installation.mdx
@@ -41,11 +41,10 @@ spec:
   chart:
     spec:
       chart: weave-gitops
-      spec: 65m
       sourceRef:
         kind: HelmRepository
         name: ww-gitops
-  interval: 50m
+  interval: 1h0m0s
   values:
     adminUser:
       create: true
@@ -59,7 +58,7 @@ metadata:
   name: ww-gitops
   namespace: flux-system
 spec:
-  interval: 60m0s
+  interval: 1h0m0s
   type: oci
   url: oci://ghcr.io/weaveworks/charts
 ```

--- a/website/versioned_docs/version-0.9.3/installation.mdx
+++ b/website/versioned_docs/version-0.9.3/installation.mdx
@@ -41,11 +41,10 @@ spec:
   chart:
     spec:
       chart: weave-gitops
-      spec: 65m
       sourceRef:
         kind: HelmRepository
         name: ww-gitops
-  interval: 50m
+  interval: 1h0m0s
   values:
     adminUser:
       create: true
@@ -59,7 +58,7 @@ metadata:
   name: ww-gitops
   namespace: flux-system
 spec:
-  interval: 60m0s
+  interval: 1h0m0s
   type: oci
   url: oci://ghcr.io/weaveworks/charts
 ```


### PR DESCRIPTION
When updating intervals we accidentally added spec rather than interval 🤦 we will double check whether to have both spec.interval and spec.chart.interval and update again as necessary. This fixes broken docs and consolidates with what you'd get from the getting started guide.