### PR TITLE
Hide the cluster column in WG OSS

### DIFF
--- a/charts/gitops-server/values.yaml
+++ b/charts/gitops-server/values.yaml
@@ -22,6 +22,8 @@ logLevel: info
 envVars:
   - name: WEAVE_GITOPS_FEATURE_TENANCY
     value: "true"
+  - name: WEAVE_GITOPS_FEATURE_CLUSTER
+    value: "false"
 
 # Should the 'oidc-auth' secret be created. For a detailed
 # explanation of these attributes please see our documentation:

--- a/tools/helm-values-dev.yaml
+++ b/tools/helm-values-dev.yaml
@@ -24,3 +24,5 @@ metrics:
 envVars:
   - name: WEAVE_GITOPS_FEATURE_TENANCY
     value: "true"
+  - name: WEAVE_GITOPS_FEATURE_CLUSTER
+    value: "false"  

--- a/ui/components/AutomationsTable.tsx
+++ b/ui/components/AutomationsTable.tsx
@@ -33,7 +33,6 @@ function AutomationsTable({ className, automations, hideSource }: Props) {
   let initialFilterState = {
     ...filterConfig(automations, "type"),
     ...filterConfig(automations, "namespace"),
-    ...filterConfig(automations, "clusterName"),
     ...filterConfig(automations, "status", filterByStatusCallback),
   };
 
@@ -41,6 +40,13 @@ function AutomationsTable({ className, automations, hideSource }: Props) {
     initialFilterState = {
       ...initialFilterState,
       ...filterConfig(automations, "tenant"),
+    };
+  }
+
+  if (flags.WEAVE_GITOPS_FEATURE_CLUSTER === "true") {
+    initialFilterState = {
+      ...initialFilterState,
+      ...filterConfig(automations, "clusterName"),
     };
   }
 
@@ -79,10 +85,9 @@ function AutomationsTable({ className, automations, hideSource }: Props) {
     ...(flags.WEAVE_GITOPS_FEATURE_TENANCY === "true"
       ? [{ label: "Tenant", value: "tenant" }]
       : []),
-    {
-      label: "Cluster",
-      value: "clusterName",
-    },
+    ...(flags.WEAVE_GITOPS_FEATURE_CLUSTER === "true"
+      ? [{ label: "Cluster", value: "clusterName" }]
+      : []),
     {
       label: "Source",
       value: (a: Automation) => {

--- a/ui/components/BucketDetail.tsx
+++ b/ui/components/BucketDetail.tsx
@@ -23,6 +23,11 @@ function BucketDetail({ className, bucket }: Props) {
       ? [["Tenant", bucket.tenant]]
       : [];
 
+  const clusterInfo: InfoField[] =
+    flags.WEAVE_GITOPS_FEATURE_CLUSTER === "true"
+      ? [["Cluster", bucket.clusterName]]
+      : [];
+
   return (
     <SourceDetail
       className={className}
@@ -34,7 +39,7 @@ function BucketDetail({ className, bucket }: Props) {
         ["Bucket Name", bucket.name],
         ["Last Updated", <Timestamp time={bucket.lastUpdatedAt} />],
         ["Interval", <Interval interval={bucket.interval} />],
-        ["Cluster", bucket.clusterName],
+        ...clusterInfo,
         ["Namespace", bucket.namespace],
         ...tenancyInfo,
       ]}

--- a/ui/components/CrdsTable.tsx
+++ b/ui/components/CrdsTable.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import styled from "styled-components";
 import { Crd } from "../lib/api/core/types.pb";
+import { useFeatureFlags } from "../hooks/featureflags";
 import { filterConfig } from "./FilterableTable";
 import URLAddressableTable from "./URLAddressableTable";
 
@@ -10,11 +11,21 @@ type Props = {
 };
 
 function CrdsTable({ className, crds = [] }: Props) {
-  const initialFilterState = {
+  const { data } = useFeatureFlags();
+  const flags = data?.flags || {};
+
+  let initialFilterState = {
     ...filterConfig(crds, "version"),
     ...filterConfig(crds, "kind"),
-    ...filterConfig(crds, "clusterName"),
   };
+
+  if (flags.WEAVE_GITOPS_FEATURE_CLUSTER === "true") {
+    initialFilterState = {
+      ...initialFilterState,
+      ...filterConfig(crds, "clusterName"),
+    };
+  }
+
   return (
     <URLAddressableTable
       className={className}
@@ -35,10 +46,9 @@ function CrdsTable({ className, crds = [] }: Props) {
           label: "Version",
           value: "version",
         },
-        {
-          label: "Cluster",
-          value: "clusterName",
-        },
+        ...(flags.WEAVE_GITOPS_FEATURE_CLUSTER === "true"
+          ? [{ label: "Cluster", value: "clusterName" }]
+          : []),
       ]}
     />
   );

--- a/ui/components/GitRepositoryDetail.tsx
+++ b/ui/components/GitRepositoryDetail.tsx
@@ -22,6 +22,10 @@ function GitRepositoryDetail({ className, gitRepository }: Props) {
     flags.WEAVE_GITOPS_FEATURE_TENANCY === "true" && gitRepository.tenant
       ? [["Tenant", gitRepository.tenant]]
       : [];
+  const clusterInfo: InfoField[] =
+    flags.WEAVE_GITOPS_FEATURE_CLUSTER === "true"
+      ? [["Cluster", gitRepository.clusterName]]
+      : [];
 
   return (
     <SourceDetail
@@ -38,7 +42,7 @@ function GitRepositoryDetail({ className, gitRepository }: Props) {
         ],
         ["Ref", gitRepository.reference?.branch],
         ["Last Updated", <Timestamp time={gitRepository.lastUpdatedAt} />],
-        ["Cluster", gitRepository.clusterName],
+        ...clusterInfo,
         ["Namespace", gitRepository.namespace],
         ...tenancyInfo,
       ]}

--- a/ui/components/HelmChartDetail.tsx
+++ b/ui/components/HelmChartDetail.tsx
@@ -22,6 +22,10 @@ function HelmChartDetail({ className, helmChart }: Props) {
     flags.WEAVE_GITOPS_FEATURE_TENANCY === "true" && helmChart.tenant
       ? [["Tenant", helmChart.tenant]]
       : [];
+  const clusterInfo: InfoField[] =
+    flags.WEAVE_GITOPS_FEATURE_CLUSTER === "true"
+      ? [["Cluster", helmChart.clusterName]]
+      : [];
 
   return (
     <SourceDetail
@@ -34,7 +38,7 @@ function HelmChartDetail({ className, helmChart }: Props) {
         ["Ref", helmChart.sourceRef?.name],
         ["Last Updated", <Timestamp time={helmChart.lastUpdatedAt} />],
         ["Interval", <Interval interval={helmChart.interval} />],
-        ["Cluster", helmChart.clusterName],
+        ...clusterInfo,
         ["Namespace", helmChart.namespace],
         ...tenancyInfo,
       ]}

--- a/ui/components/HelmReleaseDetail.tsx
+++ b/ui/components/HelmReleaseDetail.tsx
@@ -56,6 +56,10 @@ function HelmReleaseDetail({ helmRelease, className, customTabs }: Props) {
     flags.WEAVE_GITOPS_FEATURE_TENANCY === "true" && helmRelease?.tenant
       ? [["Tenant", helmRelease?.tenant]]
       : [];
+  const clusterInfo: InfoField[] =
+    flags.WEAVE_GITOPS_FEATURE_CLUSTER === "true"
+      ? [["Cluster", helmRelease?.clusterName]]
+      : [];
 
   return (
     <AutomationDetail
@@ -65,7 +69,7 @@ function HelmReleaseDetail({ helmRelease, className, customTabs }: Props) {
       info={[
         ["Source", helmChartLink(helmRelease)],
         ["Chart", helmRelease?.helmChart.chart],
-        ["Cluster", helmRelease?.clusterName],
+        ...clusterInfo,
         ...tenancyInfo,
         ["Interval", <Interval interval={helmRelease?.interval} />],
         [

--- a/ui/components/HelmRepositoryDetail.tsx
+++ b/ui/components/HelmRepositoryDetail.tsx
@@ -23,6 +23,10 @@ function HelmRepositoryDetail({ className, helmRepository }: Props) {
     flags.WEAVE_GITOPS_FEATURE_TENANCY === "true" && helmRepository.tenant
       ? [["Tenant", helmRepository.tenant]]
       : [];
+  const clusterInfo: InfoField[] =
+    flags.WEAVE_GITOPS_FEATURE_CLUSTER === "true"
+      ? [["Cluster", helmRepository.clusterName]]
+      : [];
 
   return (
     <SourceDetail
@@ -42,7 +46,7 @@ function HelmRepositoryDetail({ className, helmRepository }: Props) {
           ),
         ],
         ["Interval", <Interval interval={helmRepository.interval} />],
-        ["Cluster", helmRepository.clusterName],
+        ...clusterInfo,
         ["Namespace", helmRepository.namespace],
         ...tenancyInfo,
       ]}

--- a/ui/components/KustomizationDetail.tsx
+++ b/ui/components/KustomizationDetail.tsx
@@ -32,6 +32,11 @@ function KustomizationDetail({ kustomization, className, customTabs }: Props) {
       ? [["Tenant", kustomization?.tenant]]
       : [];
 
+  const clusterInfo: InfoField[] =
+    flags.WEAVE_GITOPS_FEATURE_CLUSTER === "true"
+      ? [["Cluster", kustomization?.clusterName]]
+      : [];
+
   return (
     <AutomationDetail
       className={className}
@@ -49,7 +54,7 @@ function KustomizationDetail({ kustomization, className, customTabs }: Props) {
           />,
         ],
         ["Applied Revision", kustomization?.lastAppliedRevision],
-        ["Cluster", kustomization?.clusterName],
+        ...clusterInfo,
         ...tenancyInfo,
         ["Path", kustomization?.path],
         ["Interval", <Interval interval={kustomization?.interval} />],

--- a/ui/components/OCIRepositoryDetail.tsx
+++ b/ui/components/OCIRepositoryDetail.tsx
@@ -23,6 +23,10 @@ function OCIRepositoryDetail({ className, ociRepository }: Props) {
     flags.WEAVE_GITOPS_FEATURE_TENANCY === "true" && ociRepository.tenant
       ? [["Tenant", ociRepository.tenant]]
       : [];
+  const clusterInfo: InfoField[] =
+    flags.WEAVE_GITOPS_FEATURE_CLUSTER === "true"
+      ? [["Cluster", ociRepository.clusterName]]
+      : [];
 
   return (
     <SourceDetail
@@ -41,7 +45,7 @@ function OCIRepositoryDetail({ className, ociRepository }: Props) {
           ),
         ],
         ["Interval", <Interval interval={ociRepository.interval} />],
-        ["Cluster", ociRepository.clusterName],
+        ...clusterInfo,
         ["Namespace", ociRepository.namespace],
         [
           "Source",

--- a/ui/components/SourcesTable.tsx
+++ b/ui/components/SourcesTable.tsx
@@ -42,13 +42,19 @@ function SourcesTable({ className, sources }: Props) {
     ...filterConfig(sources, "type"),
     ...filterConfig(sources, "namespace"),
     ...filterConfig(sources, "status", filterByStatusCallback),
-    ...filterConfig(sources, "clusterName"),
   };
 
   if (flags.WEAVE_GITOPS_FEATURE_TENANCY === "true") {
     initialFilterState = {
       ...initialFilterState,
       ...filterConfig(sources, "tenant"),
+    };
+  }
+
+  if (flags.WEAVE_GITOPS_FEATURE_CLUSTER === "true") {
+    initialFilterState = {
+      ...initialFilterState,
+      ...filterConfig(sources, "clusterName"),
     };
   }
 
@@ -75,10 +81,9 @@ function SourcesTable({ className, sources }: Props) {
     ...(flags.WEAVE_GITOPS_FEATURE_TENANCY === "true"
       ? [{ label: "Tenant", value: "tenant" }]
       : []),
-    {
-      label: "Cluster",
-      value: (s: Source) => s.clusterName,
-    },
+    ...(flags.WEAVE_GITOPS_FEATURE_CLUSTER === "true"
+      ? [{ label: "Cluster", value: (s: Source) => s.clusterName }]
+      : []),
     {
       label: "Status",
       value: (s: Source) => (

--- a/ui/hooks/featureflags.ts
+++ b/ui/hooks/featureflags.ts
@@ -14,6 +14,7 @@ type FeatureFlags = {
   CLUSTER_USER_AUTH: () => void;
   OIDC_AUTH: () => void;
   WEAVE_GITOPS_FEATURE_TENANCY: () => void;
+  WEAVE_GITOPS_FEATURE_CLUSTER: () => void;
 };
 
 export type Flags = OptionsFlags<FeatureFlags>;


### PR DESCRIPTION
Closes #2456

- Added `WEAVE_GITOPS_FEATURE_CLUSTER` feature flag.
- Added hiding the Cluster column by default in WG OSS.

Notes:
- Is the name of the flag OK or should it be more generic? (Similar to what @joshri mentioned, WEAVE_GITOPS_FEATURE_ENTERPRISE ). I created a separate flag for this feature only based on an assumption that we need more granular control.
- I could also rename the flag to `WEAVE_GITOPS_FEATURE_CLUSTER` or `WEAVE_GITOPS_FEATURE_CLUSTER_INFO` if it needs to be more specific.
- The flag `WEAVE_GITOPS_FEATURE_CLUSTER` is set to `false` by default in `charts/gitops-server/values.yaml` and `tools/helm-values-dev.yaml`. Is it the expected behavior? Or should I make it `true` in one of these files?
