### PR TITLE
Make feature flags part of context

### DIFF
--- a/ui/components/__tests__/Page.test.tsx
+++ b/ui/components/__tests__/Page.test.tsx
@@ -18,7 +18,7 @@ describe("Page", () => {
           withTheme(
             withContext(
               <CoreClientContext.Provider
-                value={{ api: createCoreMockClient({}) }}
+                value={{ api: createCoreMockClient({}), featureFlags: {} }}
               >
                 <Page />
               </CoreClientContext.Provider>,

--- a/ui/contexts/__tests__/CoreClientContext.test.tsx
+++ b/ui/contexts/__tests__/CoreClientContext.test.tsx
@@ -1,3 +1,4 @@
+import { QueryClient, QueryClientProvider } from "react-query";
 import * as React from "react";
 import renderer from "react-test-renderer";
 import { Core } from "../../lib/api/core/core.pb";
@@ -13,10 +14,14 @@ describe("CoreContextProvider", () => {
       return <div />;
     }
 
+    const queryClient = new QueryClient();
+
     renderer.create(
-      <CoreClientContextProvider api={Core}>
-        <TestComponent />
-      </CoreClientContextProvider>
+      <QueryClientProvider client={queryClient}>
+        <CoreClientContextProvider api={Core}>
+          <TestComponent />
+        </CoreClientContextProvider>
+      </QueryClientProvider>
     );
   });
 });

--- a/ui/hooks/featureflags.ts
+++ b/ui/hooks/featureflags.ts
@@ -1,32 +1,9 @@
 import { useContext } from "react";
-import { useQuery } from "react-query";
-import { RequestError } from "../lib/types";
-import { GetFeatureFlagsResponse } from "../lib/api/core/core.pb";
 import { CoreClientContext } from "../contexts/CoreClientContext";
 
-// Taken straight from the TS docs:
-// https://www.typescriptlang.org/docs/handbook/2/mapped-types.html
-type OptionsFlags<Type> = {
-  [Property in keyof Type]: boolean;
-};
-
-type FeatureFlags = {
-  CLUSTER_USER_AUTH: () => void;
-  OIDC_AUTH: () => void;
-  WEAVE_GITOPS_FEATURE_TENANCY: () => void;
-  WEAVE_GITOPS_FEATURE_CLUSTER: () => void;
-};
-
-export type Flags = OptionsFlags<FeatureFlags>;
+export type FeatureFlags = { [key: string]: string };
 
 export function useFeatureFlags() {
-  const { api } = useContext(CoreClientContext);
-  return useQuery<GetFeatureFlagsResponse, RequestError>(
-    "feature_flags",
-    () => api.GetFeatureFlags({}),
-    {
-      staleTime: Infinity,
-      cacheTime: Infinity,
-    }
-  );
+  const { featureFlags } = useContext(CoreClientContext);
+  return { data: { flags: featureFlags } };
 }


### PR DESCRIPTION
This way they are loaded at page load time, so they're instantly
available at any page. They won't change dynamically, so they don't
need to be refetched. Contexts are "slow", but network requests are
slower.

This should fix optional frontend features jumping out after the rest
of the page has already loaded.

I've implemented this in a "funny" way - I left the API from
    `useFeatureFlags` the same, so it looks a bit silly. It's failing
    silently - if feature flags are broken, you get no feature flags. I
    think I'd rather that happened than a crash.
