### PR TITLE
Initial pendo integration

### DIFF
--- a/cmd/gitops-server/cmd/cmd.go
+++ b/cmd/gitops-server/cmd/cmd.go
@@ -100,8 +100,6 @@ func NewCommand() *cobra.Command {
 	cmd.Flags().StringVar(&options.OIDC.IssuerURL, "oidc-issuer-url", "", "The URL of the OpenID Connect issuer")
 	cmd.Flags().StringVar(&options.OIDC.RedirectURL, "oidc-redirect-url", "", "The OAuth2 redirect URL")
 	cmd.Flags().DurationVar(&options.OIDC.TokenDuration, "oidc-token-duration", time.Hour, "The duration of the ID token. It should be set in the format: number + time unit (s,m,h) e.g., 20m")
-	// Dev mode
-	cmd.Flags().BoolVar(&options.DevMode, "dev-mode", false, "Enables development mode - this disables verifying cookie signatures, do not use")
 	// Metrics
 	cmd.Flags().BoolVar(&options.EnableMetrics, "enable-metrics", false, "Starts the metrics listener")
 	cmd.Flags().StringVar(&options.MetricsAddress, "metrics-address", ":2112", "If the metrics listener is enabled, bind to this address")
@@ -160,7 +158,7 @@ func runCmd(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("Couldn't get current namespace")
 	}
 
-	authServer, err := auth.InitAuthServer(cmd.Context(), log, rawClient, options.OIDC, options.OIDCSecret, options.DevMode, namespace, options.AuthMethods)
+	authServer, err := auth.InitAuthServer(cmd.Context(), log, rawClient, options.OIDC, options.OIDCSecret, namespace, options.AuthMethods)
 
 	if err != nil {
 		return fmt.Errorf("could not initialise authentication server: %w", err)

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "jest-worker": "^27.5.1",
         "lodash": "^4.17.21",
         "luxon": "^1.27.0",
+        "mnemonic-browser": "^0.0.1",
         "postcss": "^8.3.11",
         "query-string": "^7.0.0",
         "react": "^17.0.2",
@@ -26,6 +27,7 @@
         "react-query": "^3.34.7",
         "react-router-dom": "^5.2.0",
         "react-toastify": "^7.0.4",
+        "sha3": "^2.1.4",
         "styled-components": "^5.3.0",
         "yaml": "^1.10.2"
       },
@@ -4832,7 +4834,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4951,7 +4952,6 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
       "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -7512,7 +7512,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -11109,6 +11108,11 @@
       "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
+    "node_modules/mnemonic-browser": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/mnemonic-browser/-/mnemonic-browser-0.0.1.tgz",
+      "integrity": "sha512-VXtngkArcYSDk1ZcClVPAsY670VUuE8+2bTPerfK+BLq4tij3cvn49TkCftQjHNBpF8sfF6N145D3DgNw4OuQA=="
+    },
     "node_modules/moo-color": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/moo-color/-/moo-color-1.0.3.tgz",
@@ -12714,6 +12718,14 @@
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/sha3": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/sha3/-/sha3-2.1.4.tgz",
+      "integrity": "sha512-S8cNxbyb0UGUM2VhRD4Poe5N58gJnJsLJ5vC7FYWGUmGhcsj4++WaIOBFVDxlG0W3To6xBuiRh+i0Qp2oNCOtg==",
+      "dependencies": {
+        "buffer": "6.0.3"
       }
     },
     "node_modules/shallowequal": {
@@ -17320,8 +17332,7 @@
     "base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
     "big-integer": {
       "version": "1.6.51",
@@ -17407,7 +17418,6 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
       "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "dev": true,
       "requires": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
@@ -19369,8 +19379,7 @@
     "ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
     "ignore": {
       "version": "4.0.6",
@@ -22116,6 +22125,11 @@
       "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
+    "mnemonic-browser": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/mnemonic-browser/-/mnemonic-browser-0.0.1.tgz",
+      "integrity": "sha512-VXtngkArcYSDk1ZcClVPAsY670VUuE8+2bTPerfK+BLq4tij3cvn49TkCftQjHNBpF8sfF6N145D3DgNw4OuQA=="
+    },
     "moo-color": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/moo-color/-/moo-color-1.0.3.tgz",
@@ -23256,6 +23270,14 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
       "dev": true
+    },
+    "sha3": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/sha3/-/sha3-2.1.4.tgz",
+      "integrity": "sha512-S8cNxbyb0UGUM2VhRD4Poe5N58gJnJsLJ5vC7FYWGUmGhcsj4++WaIOBFVDxlG0W3To6xBuiRh+i0Qp2oNCOtg==",
+      "requires": {
+        "buffer": "6.0.3"
+      }
     },
     "shallowequal": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "jest-worker": "^27.5.1",
     "lodash": "^4.17.21",
     "luxon": "^1.27.0",
+    "mnemonic-browser": "^0.0.1",
     "postcss": "^8.3.11",
     "query-string": "^7.0.0",
     "react": "^17.0.2",
@@ -65,6 +66,7 @@
     "react-query": "^3.34.7",
     "react-router-dom": "^5.2.0",
     "react-toastify": "^7.0.4",
+    "sha3": "^2.1.4",
     "styled-components": "^5.3.0",
     "yaml": "^1.10.2"
   },

--- a/pkg/server/auth/init.go
+++ b/pkg/server/auth/init.go
@@ -6,12 +6,13 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/weaveworks/weave-gitops/core/logger"
+	"github.com/weaveworks/weave-gitops/pkg/featureflags"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func InitAuthServer(ctx context.Context, log logr.Logger, rawKubernetesClient ctrlclient.Client, oidcConfig OIDCConfig, oidcSecret string, devMode bool, namespace string, authMethodStrings []string) (*AuthServer, error) {
+func InitAuthServer(ctx context.Context, log logr.Logger, rawKubernetesClient ctrlclient.Client, oidcConfig OIDCConfig, oidcSecret string, namespace string, authMethodStrings []string) (*AuthServer, error) {
 	log.V(logger.LogLevelDebug).Info("Registering authentication methods", "methods", authMethodStrings)
 
 	authMethods, err := ParseAuthMethodArray(authMethodStrings)
@@ -57,9 +58,9 @@ func InitAuthServer(ctx context.Context, log logr.Logger, rawKubernetesClient ct
 		return nil, fmt.Errorf("could not create HMAC token signer: %w", err)
 	}
 
-	if devMode {
+	if featureflags.Get("WEAVE_GITOPS_FEATURE_DEV_MODE") == "true" {
 		log.V(logger.LogLevelWarn).Info("Dev-mode is enabled. This should be used for local work only.")
-		tsv.SetDevMode(devMode)
+		tsv.SetDevMode(true)
 	}
 
 	authCfg, err := NewAuthServerConfig(log, oidcConfig, rawKubernetesClient, tsv, namespace, authMethods)

--- a/pkg/server/auth/init_test.go
+++ b/pkg/server/auth/init_test.go
@@ -126,7 +126,7 @@ func TestInitAuthServer(t *testing.T) {
 
 			fakeKubernetesClient := partialKubernetesClient.Build()
 
-			srv, err := auth.InitAuthServer(context.Background(), logr.Discard(), fakeKubernetesClient, tt.cliOIDCConfig, tt.oidcSecretName, false, "test-namespace", tt.authMethods)
+			srv, err := auth.InitAuthServer(context.Background(), logr.Discard(), fakeKubernetesClient, tt.cliOIDCConfig, tt.oidcSecretName, "test-namespace", tt.authMethods)
 
 			if tt.expectErr {
 				g.Expect(err).To(gomega.HaveOccurred())

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -1,0 +1,47 @@
+package telemetry
+
+import (
+	"encoding/hex"
+
+	"github.com/weaveworks/weave-gitops/core/clustersmngr"
+	"github.com/weaveworks/weave-gitops/pkg/featureflags"
+	"golang.org/x/crypto/sha3"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func InitTelemetry(factory clustersmngr.ClientsFactory) error {
+	if featureflags.Get("WEAVE_GITOPS_FEATURE_TELEMETRY") == "true" {
+		var namespace types.UID
+
+		namespaces := factory.GetClustersNamespaces()["Default"]
+		for _, ns := range namespaces {
+			if ns.GetName() == "kube-system" {
+				namespace = ns.GetUID()
+			}
+		}
+
+		key := []byte("VyzGoWoKvtJHyTnU+GVhDe+wU9bwZDH87bp505/0f/2UIpHzB+tmyZmfsH8/iJoH")
+		buf := []byte(namespace)
+		h := make([]byte, 32)
+		d := sha3.NewShake128()
+
+		_, err := d.Write(key)
+		if err != nil {
+			return err
+		}
+
+		_, err = d.Write(buf)
+		if err != nil {
+			return err
+		}
+
+		_, err = d.Read(h)
+		if err != nil {
+			return err
+		}
+
+		featureflags.Set("ACCOUNT_ID", hex.EncodeToString(h))
+	}
+
+	return nil
+}

--- a/tools/helm-values-dev.yaml
+++ b/tools/helm-values-dev.yaml
@@ -23,5 +23,7 @@ envVars:
     value: "true"
   - name: WEAVE_GITOPS_FEATURE_CLUSTER
     value: "false"
+  - name: WEAVE_GITOPS_FEATURE_TELEMETRY
+    value: "true"
   - name: WEAVE_GITOPS_FEATURE_DEV_MODE
     value: "true"

--- a/tools/helm-values-dev.yaml
+++ b/tools/helm-values-dev.yaml
@@ -15,9 +15,6 @@ adminUser:
   # 'dev'
   passwordHash: $2y$10$pcy9FV0WMQZUHFDcud8JuecIxlUS/Eh9X.iitZtJEYYHUhKyzlJYm
 
-additionalArgs:
-  - "--dev-mode"
-
 metrics:
   enabled: true
 
@@ -25,4 +22,6 @@ envVars:
   - name: WEAVE_GITOPS_FEATURE_TENANCY
     value: "true"
   - name: WEAVE_GITOPS_FEATURE_CLUSTER
-    value: "false"  
+    value: "false"
+  - name: WEAVE_GITOPS_FEATURE_DEV_MODE
+    value: "true"

--- a/ui/App.tsx
+++ b/ui/App.tsx
@@ -13,6 +13,7 @@ import "react-toastify/dist/ReactToastify.css";
 import { ThemeProvider } from "styled-components";
 import ErrorBoundary from "./components/ErrorBoundary";
 import Layout from "./components/Layout";
+import Pendo from "./components/Pendo";
 import AppContextProvider from "./contexts/AppContext";
 import AuthContextProvider, { AuthCheck } from "./contexts/AuthContext";
 import CoreClientContextProvider from "./contexts/CoreClientContext";
@@ -101,6 +102,7 @@ export default function AppContainer() {
             <AppContextProvider renderFooter>
               <AuthContextProvider>
                 <CoreClientContextProvider api={Core}>
+                  <Pendo />
                   <Switch>
                     {/* <Signin> does not use the base page <Layout> so pull it up here */}
                     <Route component={SignIn} exact path="/sign_in" />

--- a/ui/components/Pendo.tsx
+++ b/ui/components/Pendo.tsx
@@ -1,0 +1,73 @@
+import React, { useContext } from "react";
+import { shake128 } from "js-sha3";
+import Mnemonic from "mnemonic-browser";
+import { useFeatureFlags } from "../hooks/featureflags";
+import { Auth } from "../contexts/AuthContext";
+
+declare global {
+  interface Window {
+    pendo: any;
+  }
+}
+
+export default function Pendo() {
+  const { data } = useFeatureFlags();
+  const flags = data?.flags || {};
+  const { userInfo } = useContext(Auth);
+
+  if (flags.WEAVE_GITOPS_FEATURE_TELEMETRY == "true") {
+    if (!userInfo || !userInfo.email) {
+      return <></>;
+    }
+
+    const key =
+      "VyzGoWoKvtJHyTnU+GVhDe+wU9bwZDH87bp505/0f/2UIpHzB+tmyZmfsH8/iJoH";
+
+    const hasher = shake128.create(128);
+    hasher.update(key);
+    hasher.update(userInfo.email);
+
+    const visitorId = Mnemonic.fromHex(hasher.hex()).toWords().join("-");
+    const accountId = Mnemonic.fromHex(flags.ACCOUNT_ID).toWords().join("-");
+
+    // This is copied from the pendo docs
+    // eslint unwrapps it, and the initialize call has been customized
+    /* eslint-disable */
+    (function (apiKey) {
+      (function (p, e, n, d, o) {
+        let v, w, x, y, z;
+        o = p[d] = p[d] || {};
+        o._q = o._q || [];
+        v = ["initialize", "identify", "updateOptions", "pageLoad", "track"];
+        for (w = 0, x = v.length; w < x; ++w)
+          (function (m) {
+            o[m] =
+              o[m] ||
+              function () {
+                o._q[m === v[0] ? "unshift" : "push"](
+                  [m].concat([].slice.call(arguments, 0))
+                );
+              };
+          })(v[w]);
+        y = e.createElement(n);
+        y.async = !0;
+        y.src = "https://cdn.pendo.io/agent/static/" + apiKey + "/pendo.js";
+        z = e.getElementsByTagName(n)[0];
+        z.parentNode.insertBefore(y, z);
+      })(window, document, "script", "pendo");
+
+      window.pendo.initialize({
+        visitor: {
+          id: visitorId,
+        },
+
+        account: {
+          id: accountId,
+          devMode: flags.WEAVE_GITOPS_FEATURE_DEV_MODE == "true",
+        },
+      });
+    })("7a83d612-fa5b-4bfe-4544-861a89ceaf89");
+  }
+
+  return <></>;
+}


### PR DESCRIPTION
This first of all turns dev-mode into a feature flag, because I wanted it available on the front end to tag traffic from developer machines separately from end-users - anyway, we might want to flash something if someone has turned off cookie verification that they really shouldn't.

Then, it adds an inital pendo integration for extra telemetry data. It is completely, 100% turned off by default - the javascript isn't even loaded unless the user opts in.

This turns on the feature in tilt, so we can see that it actually works - but I expect we'll turn it off eventually.

The frontend integration is done using a "component" that does nothing - I don't think this is good react, and I'm happy to try something else, but I need it to run after contexts have been initialized so the feature flags are in place, which this seems to accomplish.

There's a backend bit to it to get a unique cluster value. This completely abuses the feature flag system to smuggle out a unique string value using this mechanism we already have. Again, this is not enabled or active unless the user opts in.

There's two "secret-looking" things - one is the pendo application id, the other is the key I've hashed all user data with. Both are committed in the open:
 * The pendo application ID is write-only - the worst you could do is to push fake data.
 * While the key are used together with user info (emails), it is only there to make sure we can't use the hash against a password dump to cross-reference users - there is no way to figure out who is who other than complete brute force.

Both the visitor ID and the account ID have been mnemonic encoded, so that they're easier to remember - they're probably unnecessarily long, but we can always make changes later. 

This resolves #2451.