### PR TITLE
ui: Sort events by newest first

### DIFF
--- a/ui/components/EventsTable.tsx
+++ b/ui/components/EventsTable.tsx
@@ -49,7 +49,9 @@ function EventsTable({ className, involvedObject }: Props) {
         {
           label: "Timestamp",
           value: (e: Event) => <Timestamp time={e.timestamp} />,
-          sortValue: (e: Event) => e.timestamp,
+          sortValue: (e: Event) => -Date.parse(e.timestamp),
+          defaultSort: true,
+          secondarySort: true,
         },
       ]}
       rows={data.events}


### PR DESCRIPTION
Closes #2534 

- Added support for the secondary sort.
- Added sorting the Events table by timestamp by default (earliest events first).
- Added secondary sort by timestamp to the Events table. If sorting on another column where some values are the same, values with the earlier timestamp will come first (no matter what direction the first column is sorted on).