### PR TITLE
Remove extra top padding

### DIFF
--- a/ui/components/Layout.tsx
+++ b/ui/components/Layout.tsx
@@ -56,10 +56,9 @@ const topBarHeight = "60px";
 const NavContainer = styled.div`
   width: ${navWidth};
   min-width: ${navWidth};
-  height: calc(100% - 24px);
-  margin-top: ${(props) => props.theme.spacing.small};
-  //topBarHeight + small margin
-  transform: translateY(72);
+  height: calc(100% - 12px);
+  //topBarHeight
+  transform: translateY(60);
 `;
 
 const ContentContainer = styled.div`
@@ -69,7 +68,6 @@ const ContentContainer = styled.div`
   //without a hard value in the height property, min-height in the Page component doesn't work
   height: 1px;
   min-height: 100%;
-  padding-top: ${(props) => props.theme.spacing.small};
   padding-bottom: ${(props) => props.theme.spacing.small};
   padding-right: ${(props) => props.theme.spacing.medium};
   padding-left: ${(props) => props.theme.spacing.medium};

--- a/ui/components/UserSettings.tsx
+++ b/ui/components/UserSettings.tsx
@@ -27,6 +27,8 @@ const SettingsMenu = styled(Menu)`
 `;
 
 const PersonButton = styled(IconButton)<{ open: boolean }>`
+  height: 40px;
+  width: 40px;
   &.MuiIconButton-root {
     background-color: ${(props) => props.theme.colors.white};
     ${(props) =>


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes #2598

<!-- Describe what has changed in this PR -->
The new header background meant we could get rid of some padding above the main content and nav - here's a vid showing the result:

https://user-images.githubusercontent.com/65822698/186760572-b3962e4c-d54f-4ffd-b589-9e5b3530b378.mov

Currently on main:
<img width="1320" alt="image" src="https://user-images.githubusercontent.com/65822698/186760938-87f9e174-4890-4ac8-a6f6-2f5a6180bea4.png">
