### PR TITLE
Fix titles overflowing graph nodes

### DIFF
--- a/ui/components/GraphNode.tsx
+++ b/ui/components/GraphNode.tsx
@@ -91,9 +91,8 @@ function GraphNode({ className, object }: Props) {
           {getStatusIcon(computeReady(object.conditions), object.suspended)}
           <div style={{ padding: 4 }} />
           <Tooltip
-            open={true}
             placement="top"
-            title={object.name.length > 20 ? object.name : ""}
+            title={object.name.length > 25 ? object.name : ""}
           >
             <span>{object.name}</span>
           </Tooltip>

--- a/ui/components/GraphNode.tsx
+++ b/ui/components/GraphNode.tsx
@@ -91,6 +91,7 @@ function GraphNode({ className, object }: Props) {
           {getStatusIcon(computeReady(object.conditions), object.suspended)}
           <div style={{ padding: 4 }} />
           <Tooltip
+            open={true}
             placement="top"
             title={object.name.length > 20 ? object.name : ""}
           >

--- a/ui/components/GraphNode.tsx
+++ b/ui/components/GraphNode.tsx
@@ -90,7 +90,10 @@ function GraphNode({ className, object }: Props) {
         <Title start wide align>
           {getStatusIcon(computeReady(object.conditions), object.suspended)}
           <div style={{ padding: 4 }} />
-          <Tooltip placement="top" title={object.name}>
+          <Tooltip
+            placement="top"
+            title={object.name.length > 20 ? object.name : ""}
+          >
             <span>{object.name}</span>
           </Tooltip>
         </Title>

--- a/ui/components/GraphNode.tsx
+++ b/ui/components/GraphNode.tsx
@@ -92,7 +92,7 @@ function GraphNode({ className, object }: Props) {
           <div style={{ padding: 4 }} />
           <Tooltip
             placement="top"
-            title={object.name.length > 25 ? object.name : ""}
+            title={object.name.length > 23 ? object.name : ""}
           >
             <span>{object.name}</span>
           </Tooltip>

--- a/ui/components/GraphNode.tsx
+++ b/ui/components/GraphNode.tsx
@@ -1,3 +1,4 @@
+import { Tooltip } from "@material-ui/core";
 import * as React from "react";
 import styled from "styled-components";
 import { UnstructuredObjectWithChildren } from "../lib/graph";
@@ -36,13 +37,11 @@ const NodeText = styled(Flex)`
 
 const Title = styled(Flex)`
   font-size: ${titleFontSize};
-  text-overflow: ellipsis;
 `;
 
 const Kinds = styled(Flex)`
   font-size: ${kindFontSize};
   color: ${(props) => props.theme.colors.neutral30};
-  text-overflow: ellipsis;
 `;
 
 type StatusLineProps = {
@@ -91,17 +90,26 @@ function GraphNode({ className, object }: Props) {
         <Title start wide align>
           {getStatusIcon(computeReady(object.conditions), object.suspended)}
           <div style={{ padding: 4 }} />
-          {object.name}
+          <Tooltip placement="top" title={object.name}>
+            <span>{object.name}</span>
+          </Tooltip>
         </Title>
         <Kinds start wide align>
           {object.kind || object.groupVersionKind.kind || ""}
         </Kinds>
         <Kinds start wide align>
-          {object.namespace}
+          <span>{object.namespace}</span>
         </Kinds>
       </NodeText>
     </Node>
   );
 }
 
-export default styled(GraphNode).attrs({ className: GraphNode.name })``;
+export default styled(GraphNode).attrs({ className: GraphNode.name })`
+  span {
+    width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+`;

--- a/ui/lib/theme.ts
+++ b/ui/lib/theme.ts
@@ -147,5 +147,10 @@ export const muiTheme = createTheme({
         color: theme.colors.primary,
       },
     },
+    MuiTooltip: {
+      tooltip: {
+        fontSize: "1rem",
+      },
+    },
   },
 });


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes #2614

<!-- Describe what has changed in this PR -->
"The text-overflow property only affects content that is overflowing a block container element in its inline progression direction (not text overflowing at the bottom of a box, for example)."
I shamefully broke this rule when carrying over my old node styling to the new graph node component
https://developer.mozilla.org/en-US/docs/Web/CSS/text-overflow
 
adding spans was also convenient for the MUI tooltip which expects a component that's not customized

<img width="1322" alt="image" src="https://user-images.githubusercontent.com/65822698/187280294-b9d987ae-a009-4822-abd2-57b1b0d73643.png">
