### PR TITLE
Exit more gracefully in ListHelmReleases when a HelmRelease revision is missing

### DIFF
--- a/core/server/helm_release.go
+++ b/core/server/helm_release.go
@@ -58,7 +58,8 @@ func (cs *coreServer) ListHelmReleases(ctx context.Context, msg *pb.ListHelmRele
 			for _, helmrelease := range list.Items {
 				inv, err := getHelmReleaseInventory(ctx, helmrelease, clustersClient, clusterName)
 				if err != nil {
-					return nil, err
+					respErrors = append(respErrors, &pb.ListError{ClusterName: clusterName, Message: err.Error()})
+					continue
 				}
 
 				tenant := GetTenant(helmrelease.Namespace, clusterName, clusterUserNamespaces)


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Fixes #2664 (kind of, see below)

<!-- Describe what has changed in this PR -->

In #2664, @amulyakish and I show how a missing Helm release causes WGO to render _no_ applications.

This patch will cause the HelmRelease listing in WGO Applications to omit the missing release in its list view.

<!-- Tell your future self why have you made these changes -->

As explained in #2664 , this is an error view that should not be shown to users.

<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**

We disabled an early-return in `ListHelmReleases`, and instead send errors to the `respErrors` accumulator. Note again that this has the effect of *hiding* releases that are misconfigured. This patch, therefore, is a stop-gap in hope of a more comprehensive review of error handling, also noted in #2664 .

<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**

We included a unit test that simulates the behavior that we saw in #2664 .

<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**

This is Bugfix level, in SemVer terms. Amulya and I would appreciate a short bugfix note somewhere, so that we know when a fix is made.


<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**

None that I would suggest.