### PR TITLE
Fix error logs in UI tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "history": "^5.0.0",
         "http-proxy-middleware": "^2.0.3",
         "jest-canvas-mock": "^2.4.0",
+        "jest-fail-on-console": "^3.0.1",
         "jest-worker": "^27.5.1",
         "lodash": "^4.17.21",
         "luxon": "^1.27.0",
@@ -8975,6 +8976,78 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-fail-on-console": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/jest-fail-on-console/-/jest-fail-on-console-3.0.1.tgz",
+      "integrity": "sha512-1811WQIY9lZN9wGkp7S6y69vw9+u6I21dmnRwXo6jSuF6Xv5OlN4msNCeKEVlc/C2H5N8dqLKuQlTAzQZ0mJlw==",
+      "dependencies": {
+        "chalk": "^4.1.0"
+      }
+    },
+    "node_modules/jest-fail-on-console/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-fail-on-console/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-fail-on-console/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/jest-fail-on-console/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/jest-fail-on-console/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-fail-on-console/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -20451,6 +20524,59 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
           "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-fail-on-console": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/jest-fail-on-console/-/jest-fail-on-console-3.0.1.tgz",
+      "integrity": "sha512-1811WQIY9lZN9wGkp7S6y69vw9+u6I21dmnRwXo6jSuF6Xv5OlN4msNCeKEVlc/C2H5N8dqLKuQlTAzQZ0mJlw==",
+      "requires": {
+        "chalk": "^4.1.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "requires": {
             "has-flag": "^4.0.0"
           }

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "history": "^5.0.0",
     "http-proxy-middleware": "^2.0.3",
     "jest-canvas-mock": "^2.4.0",
+    "jest-fail-on-console": "^3.0.1",
     "jest-worker": "^27.5.1",
     "lodash": "^4.17.21",
     "luxon": "^1.27.0",

--- a/ui/contexts/CoreClientContext.tsx
+++ b/ui/contexts/CoreClientContext.tsx
@@ -20,8 +20,8 @@ export type CoreClientContextType = {
 export const CoreClientContext =
   React.createContext<CoreClientContextType | null>(null);
 
-export function UnAuthorizedInterceptor(api: any) {
-  const wrapped = {} as any;
+export function UnAuthorizedInterceptor(api: typeof Core): typeof Core {
+  const wrapped = {};
   //   Wrap each API method in a check that redirects to the signin page if a 401 is returned.
   for (const method of Object.getOwnPropertyNames(api)) {
     if (typeof api[method] != "function") {
@@ -42,7 +42,7 @@ export function UnAuthorizedInterceptor(api: any) {
       });
     };
   }
-  return wrapped;
+  return wrapped as typeof Core;
 }
 
 function FeatureFlags(api) {
@@ -58,7 +58,7 @@ function FeatureFlags(api) {
 }
 
 export default function CoreClientContextProvider({ api, children }: Props) {
-  const wrapped = UnAuthorizedInterceptor(api) as typeof Core;
+  const wrapped = UnAuthorizedInterceptor(api);
 
   return (
     <CoreClientContext.Provider

--- a/ui/lib/test-utils.tsx
+++ b/ui/lib/test-utils.tsx
@@ -6,7 +6,7 @@ import { QueryClient, QueryClientProvider } from "react-query";
 import { Router } from "react-router-dom";
 import { ThemeProvider } from "styled-components";
 import AppContextProvider, { AppProps } from "../contexts/AppContext";
-import CoreClientContextProvider from "../contexts/CoreClientContext";
+import { CoreClientContext } from "../contexts/CoreClientContext";
 import {
   Applications,
   GetGithubAuthStatusRequest,
@@ -104,12 +104,12 @@ export function withTheme(element) {
   );
 }
 
-type TestContextProps = AppProps & { api?: Core };
+type TestContextProps = AppProps & { api?: typeof Core };
 
 export function withContext(
   TestComponent,
   url: string,
-  { api = {}, ...appProps }: TestContextProps
+  { api, ...appProps }: TestContextProps
 ) {
   const history = createMemoryHistory();
   history.push(url);
@@ -119,9 +119,9 @@ export function withContext(
     <Router history={history}>
       <AppContextProvider renderFooter {...appProps}>
         <QueryClientProvider client={queryClient}>
-          <CoreClientContextProvider api={api as any}>
+          <CoreClientContext.Provider value={{ api, featureFlags: {} }}>
             {isElement ? TestComponent : <TestComponent />}
-          </CoreClientContextProvider>
+          </CoreClientContext.Provider>
         </QueryClientProvider>
       </AppContextProvider>
     </Router>


### PR DESCRIPTION
This fixes a few errors that were logged but didn't cause failures in the UI tests. The cause was that by making feature flags part of the context, I triggered requests to happen where they weren't allowed in tests. My solution is to make the tests initialize the parameters directly (e.g. use the `CoreContext.Provider` directly instead of the `CoreContextProvider` helper). While I was messing with types, I also removed a couple of `any`.

This also makes the UI tests fail the next time this happens, so I don't make this mistake again.