### PR TITLE
Fixes occasional panic when leaf cluster unreachable

### DIFF
--- a/cmd/gitops-server/cmd/cmd.go
+++ b/cmd/gitops-server/cmd/cmd.go
@@ -175,7 +175,7 @@ func runCmd(cmd *cobra.Command, args []string) error {
 
 	fetcher := fetcher.NewSingleClusterFetcher(rest)
 
-	clusterClientsFactory := clustersmngr.NewClientFactory(fetcher, nsaccess.NewChecker(nsaccess.DefautltWegoAppRules), log, scheme, clustersmngr.NewClustersClientsPool, []clustersmngr.KubeConfigOption{clustersmngr.WithFlowControl})
+	clusterClientsFactory := clustersmngr.NewClientFactory(fetcher, nsaccess.NewChecker(nsaccess.DefautltWegoAppRules), log, scheme, clustersmngr.NewClustersClientsPool, clustersmngr.DefaultKubeConfigOptions)
 	clusterClientsFactory.Start(ctx)
 
 	coreConfig := core.NewCoreConfig(log, rest, clusterName, clusterClientsFactory)

--- a/cmd/gitops-server/cmd/cmd.go
+++ b/cmd/gitops-server/cmd/cmd.go
@@ -175,7 +175,7 @@ func runCmd(cmd *cobra.Command, args []string) error {
 
 	fetcher := fetcher.NewSingleClusterFetcher(rest)
 
-	clusterClientsFactory := clustersmngr.NewClientFactory(fetcher, nsaccess.NewChecker(nsaccess.DefautltWegoAppRules), log, scheme, clustersmngr.NewClustersClientsPool)
+	clusterClientsFactory := clustersmngr.NewClientFactory(fetcher, nsaccess.NewChecker(nsaccess.DefautltWegoAppRules), log, scheme, clustersmngr.NewClustersClientsPool, []clustersmngr.KubeConfigOption{clustersmngr.WithFlowControl})
 	clusterClientsFactory.Start(ctx)
 
 	coreConfig := core.NewCoreConfig(log, rest, clusterName, clusterClientsFactory)

--- a/core/clustersmngr/clustersmngr_test.go
+++ b/core/clustersmngr/clustersmngr_test.go
@@ -51,7 +51,7 @@ func TestClientConfigWithUser(t *testing.T) {
 			// Set up
 			clusterName := fmt.Sprintf("clustersmngr-test-%d-%s", idx, rand.String(5))
 
-			clusterCfgFunc := clustersmngr.ClientConfigWithUser(tt.principal)
+			clusterCfgFunc := clustersmngr.ClientConfigWithUser(tt.principal, clustersmngr.WithFlowControl)
 
 			cluster := makeLeafCluster(t, clusterName)
 

--- a/core/clustersmngr/clustersmngr_test.go
+++ b/core/clustersmngr/clustersmngr_test.go
@@ -51,7 +51,7 @@ func TestClientConfigWithUser(t *testing.T) {
 			// Set up
 			clusterName := fmt.Sprintf("clustersmngr-test-%d-%s", idx, rand.String(5))
 
-			clusterCfgFunc := clustersmngr.ClientConfigWithUser(tt.principal, clustersmngr.WithFlowControl)
+			clusterCfgFunc := clustersmngr.ClientConfigWithUser(tt.principal, clustersmngr.DefaultKubeConfigOptions...)
 
 			cluster := makeLeafCluster(t, clusterName)
 

--- a/core/clustersmngr/factory.go
+++ b/core/clustersmngr/factory.go
@@ -354,11 +354,13 @@ func (cf *clientsFactory) UpdateUserNamespaces(ctx context.Context, user *auth.U
 			cfg, err := ClientConfigWithUser(user)(cluster)
 			if err != nil {
 				cf.log.Error(err, "failed creating client config", "cluster", cluster.Name, "user", user.ID)
+				return
 			}
 
 			filteredNs, err := cf.nsChecker.FilterAccessibleNamespaces(ctx, cfg, clusterNs)
 			if err != nil {
 				cf.log.Error(err, "failed filtering namespaces", "cluster", cluster.Name, "user", user.ID)
+				return
 			}
 
 			cf.usersNamespaces.Set(user, cluster.Name, filteredNs)

--- a/core/clustersmngr/factory.go
+++ b/core/clustersmngr/factory.go
@@ -450,7 +450,7 @@ func ClientConfigAsServer(options ...KubeConfigOption) ClusterClientConfigFunc {
 
 		config.BearerToken = cluster.BearerToken
 
-		return config, nil
+		return ApplyKubeConfigOptions(config, options...)
 	}
 }
 

--- a/core/clustersmngr/factory.go
+++ b/core/clustersmngr/factory.go
@@ -73,6 +73,8 @@ type ClientsFactory interface {
 	Start(ctx context.Context)
 }
 
+var DefaultKubeConfigOptions = []KubeConfigOption{WithFlowControl}
+
 type ClusterPoolFactoryFn func(*apiruntime.Scheme) ClientsPool
 type KubeConfigOption func(*rest.Config) (*rest.Config, error)
 

--- a/core/clustersmngr/factory.go
+++ b/core/clustersmngr/factory.go
@@ -397,6 +397,7 @@ func ApplyKubeConfigOptions(config *rest.Config, options ...KubeConfigOption) (*
 			return nil, err
 		}
 	}
+
 	return config, nil
 }
 

--- a/core/clustersmngr/factory_test.go
+++ b/core/clustersmngr/factory_test.go
@@ -32,7 +32,7 @@ func TestGetImpersonatedClient(t *testing.T) {
 	scheme, err := kube.CreateScheme()
 	g.Expect(err).To(BeNil())
 
-	clientsFactory := clustersmngr.NewClientFactory(clustersFetcher, nsChecker, logger, scheme, clustersmngr.NewClustersClientsPool, nil)
+	clientsFactory := clustersmngr.NewClientFactory(clustersFetcher, nsChecker, logger, scheme, clustersmngr.NewClustersClientsPool, clustersmngr.DefaultKubeConfigOptions)
 	err = clientsFactory.UpdateClusters(ctx)
 	g.Expect(err).To(BeNil())
 
@@ -72,7 +72,7 @@ func TestGetImpersonatedDiscoveryClient(t *testing.T) {
 	scheme, err := kube.CreateScheme()
 	g.Expect(err).To(BeNil())
 
-	clientsFactory := clustersmngr.NewClientFactory(clustersFetcher, nsChecker, logger, scheme, clustersmngr.NewClustersClientsPool, nil)
+	clientsFactory := clustersmngr.NewClientFactory(clustersFetcher, nsChecker, logger, scheme, clustersmngr.NewClustersClientsPool, clustersmngr.DefaultKubeConfigOptions)
 	err = clientsFactory.UpdateClusters(ctx)
 	g.Expect(err).To(BeNil())
 
@@ -96,7 +96,7 @@ func TestUpdateNamespaces(t *testing.T) {
 	scheme, err := kube.CreateScheme()
 	g.Expect(err).To(BeNil())
 
-	clientsFactory := clustersmngr.NewClientFactory(clustersFetcher, nsChecker, logger, scheme, clustersmngr.NewClustersClientsPool, nil)
+	clientsFactory := clustersmngr.NewClientFactory(clustersFetcher, nsChecker, logger, scheme, clustersmngr.NewClustersClientsPool, clustersmngr.DefaultKubeConfigOptions)
 
 	clusterName1 := "foo"
 	clusterName2 := "bar"
@@ -156,7 +156,7 @@ func TestUpdateUsers(t *testing.T) {
 	scheme, err := kube.CreateScheme()
 	g.Expect(err).To(BeNil())
 
-	clientsFactory := clustersmngr.NewClientFactory(clustersFetcher, nsChecker, logger, scheme, clustersmngr.NewClustersClientsPool, nil)
+	clientsFactory := clustersmngr.NewClientFactory(clustersFetcher, nsChecker, logger, scheme, clustersmngr.NewClustersClientsPool, clustersmngr.DefaultKubeConfigOptions)
 
 	clusterName1 := "foo"
 	clusterName2 := "bar"
@@ -202,7 +202,7 @@ func TestUpdateUsersFailsToConnect(t *testing.T) {
 	scheme, err := kube.CreateScheme()
 	g.Expect(err).To(BeNil())
 
-	clientsFactory := clustersmngr.NewClientFactory(clustersFetcher, nsChecker, logger, scheme, clustersmngr.NewClustersClientsPool, nil)
+	clientsFactory := clustersmngr.NewClientFactory(clustersFetcher, nsChecker, logger, scheme, clustersmngr.NewClustersClientsPool, clustersmngr.DefaultKubeConfigOptions)
 
 	clusterName1 := "foo"
 

--- a/core/clustersmngr/factory_test.go
+++ b/core/clustersmngr/factory_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/weaveworks/weave-gitops/core/clustersmngr"
 	"github.com/weaveworks/weave-gitops/core/clustersmngr/clustersmngrfakes"
 	"github.com/weaveworks/weave-gitops/core/clustersmngr/fetcher"
+	"github.com/weaveworks/weave-gitops/core/nsaccess"
 	"github.com/weaveworks/weave-gitops/core/nsaccess/nsaccessfakes"
 	"github.com/weaveworks/weave-gitops/pkg/kube"
 	"github.com/weaveworks/weave-gitops/pkg/server/auth"
@@ -131,10 +132,7 @@ func TestUpdateNamespaces(t *testing.T) {
 
 	t.Run("UpdateNamespaces will return partial results if a single cluster fails to connect", func(t *testing.T) {
 		clusterName3 := "foobar"
-		c3 := makeLeafCluster(t, clusterName3)
-		// hopefully no k8s server is listening here
-		// FIXME: better addresses?
-		c3.Server = "0.0.0.0:65535"
+		c3 := makeUnreachableLeafCluster(t, clusterName3)
 		clustersFetcher.FetchReturns([]clustersmngr.Cluster{c1, c2, c3}, nil)
 
 		g.Expect(clientsFactory.UpdateClusters(ctx)).To(Succeed())
@@ -191,5 +189,39 @@ func TestUpdateUsers(t *testing.T) {
 		g.Expect(contents).To(HaveLen(1))
 		g.Expect(contents).To(HaveKey(clusterName1))
 		g.Expect(contents).NotTo(HaveKey(clusterName2))
+	})
+}
+
+func TestUpdateUsersFailsToConnect(t *testing.T) {
+	g := NewGomegaWithT(t)
+	logger := logr.Discard()
+	ctx := context.Background()
+	nsChecker := nsaccess.NewChecker(nil)
+	clustersFetcher := new(clustersmngrfakes.FakeClusterFetcher)
+
+	scheme, err := kube.CreateScheme()
+	g.Expect(err).To(BeNil())
+
+	clientsFactory := clustersmngr.NewClientFactory(clustersFetcher, nsChecker, logger, scheme, clustersmngr.NewClustersClientsPool)
+
+	clusterName1 := "foo"
+
+	c1 := makeLeafCluster(t, clusterName1)
+
+	u1 := &auth.UserPrincipal{ID: "drstrange"}
+
+	t.Run("UpdateUserNamespaces remains unchanged if a connection failure occurs", func(t *testing.T) {
+		clustersFetcher.FetchReturns([]clustersmngr.Cluster{c1}, nil)
+		g.Expect(clientsFactory.UpdateClusters(ctx)).To(Succeed())
+		g.Expect(clientsFactory.UpdateNamespaces(ctx)).To(Succeed())
+		g.Expect(clientsFactory.GetClustersNamespaces()).To(HaveLen(1))
+
+		c1 = makeUnreachableLeafCluster(t, clusterName1)
+		clustersFetcher.FetchReturns([]clustersmngr.Cluster{c1}, nil)
+		g.Expect(clientsFactory.UpdateClusters(ctx)).To(Succeed())
+		clientsFactory.UpdateUserNamespaces(ctx, u1)
+
+		// Get clusters namespace hasn't been changed.
+		g.Expect(clientsFactory.GetClustersNamespaces()).To(HaveLen(1))
 	})
 }

--- a/core/clustersmngr/factory_test.go
+++ b/core/clustersmngr/factory_test.go
@@ -32,7 +32,7 @@ func TestGetImpersonatedClient(t *testing.T) {
 	scheme, err := kube.CreateScheme()
 	g.Expect(err).To(BeNil())
 
-	clientsFactory := clustersmngr.NewClientFactory(clustersFetcher, nsChecker, logger, scheme, clustersmngr.NewClustersClientsPool)
+	clientsFactory := clustersmngr.NewClientFactory(clustersFetcher, nsChecker, logger, scheme, clustersmngr.NewClustersClientsPool, nil)
 	err = clientsFactory.UpdateClusters(ctx)
 	g.Expect(err).To(BeNil())
 
@@ -72,7 +72,7 @@ func TestGetImpersonatedDiscoveryClient(t *testing.T) {
 	scheme, err := kube.CreateScheme()
 	g.Expect(err).To(BeNil())
 
-	clientsFactory := clustersmngr.NewClientFactory(clustersFetcher, nsChecker, logger, scheme, clustersmngr.NewClustersClientsPool)
+	clientsFactory := clustersmngr.NewClientFactory(clustersFetcher, nsChecker, logger, scheme, clustersmngr.NewClustersClientsPool, nil)
 	err = clientsFactory.UpdateClusters(ctx)
 	g.Expect(err).To(BeNil())
 
@@ -96,7 +96,7 @@ func TestUpdateNamespaces(t *testing.T) {
 	scheme, err := kube.CreateScheme()
 	g.Expect(err).To(BeNil())
 
-	clientsFactory := clustersmngr.NewClientFactory(clustersFetcher, nsChecker, logger, scheme, clustersmngr.NewClustersClientsPool)
+	clientsFactory := clustersmngr.NewClientFactory(clustersFetcher, nsChecker, logger, scheme, clustersmngr.NewClustersClientsPool, nil)
 
 	clusterName1 := "foo"
 	clusterName2 := "bar"
@@ -156,7 +156,7 @@ func TestUpdateUsers(t *testing.T) {
 	scheme, err := kube.CreateScheme()
 	g.Expect(err).To(BeNil())
 
-	clientsFactory := clustersmngr.NewClientFactory(clustersFetcher, nsChecker, logger, scheme, clustersmngr.NewClustersClientsPool)
+	clientsFactory := clustersmngr.NewClientFactory(clustersFetcher, nsChecker, logger, scheme, clustersmngr.NewClustersClientsPool, nil)
 
 	clusterName1 := "foo"
 	clusterName2 := "bar"
@@ -202,7 +202,7 @@ func TestUpdateUsersFailsToConnect(t *testing.T) {
 	scheme, err := kube.CreateScheme()
 	g.Expect(err).To(BeNil())
 
-	clientsFactory := clustersmngr.NewClientFactory(clustersFetcher, nsChecker, logger, scheme, clustersmngr.NewClustersClientsPool)
+	clientsFactory := clustersmngr.NewClientFactory(clustersFetcher, nsChecker, logger, scheme, clustersmngr.NewClustersClientsPool, nil)
 
 	clusterName1 := "foo"
 

--- a/core/clustersmngr/suite_test.go
+++ b/core/clustersmngr/suite_test.go
@@ -42,5 +42,6 @@ func makeUnreachableLeafCluster(t *testing.T, name string) clustersmngr.Cluster 
 	// hopefully no k8s server is listening here
 	// FIXME: better addresses?
 	c.Server = "0.0.0.0:65535"
+
 	return c
 }

--- a/core/clustersmngr/suite_test.go
+++ b/core/clustersmngr/suite_test.go
@@ -36,3 +36,11 @@ func makeLeafCluster(t *testing.T, name string) clustersmngr.Cluster {
 		TLSConfig:   k8sEnv.Rest.TLSClientConfig,
 	}
 }
+
+func makeUnreachableLeafCluster(t *testing.T, name string) clustersmngr.Cluster {
+	c := makeLeafCluster(t, name)
+	// hopefully no k8s server is listening here
+	// FIXME: better addresses?
+	c.Server = "0.0.0.0:65535"
+	return c
+}

--- a/core/server/suite_test.go
+++ b/core/server/suite_test.go
@@ -61,7 +61,7 @@ func makeGRPCServer(cfg *rest.Config, t *testing.T) (pb.CoreClient, server.CoreS
 		t.Fatal(err)
 	}
 
-	clientsFactory := clustersmngr.NewClientFactory(fetcher, &nsChecker, log, scheme, clustersmngr.NewClustersClientsPool)
+	clientsFactory := clustersmngr.NewClientFactory(fetcher, &nsChecker, log, scheme, clustersmngr.NewClustersClientsPool, []clustersmngr.KubeConfigOption{clustersmngr.WithFlowControl})
 
 	coreCfg := server.NewCoreConfig(log, cfg, "foobar", clientsFactory)
 	coreCfg.NSAccess = &nsChecker
@@ -156,7 +156,7 @@ func makeServerConfig(fakeClient client.Client, t *testing.T) server.CoreServerC
 		f.ClientStub = func(clusterName string) (client.Client, error) { return fakeClient, nil }
 		f.ClientsStub = func() map[string]client.Client { return map[string]client.Client{"Default": fakeClient} }
 		return f
-	})
+	}, nil)
 
 	coreCfg := server.NewCoreConfig(log, &rest.Config{}, "foobar", clientsFactory)
 	coreCfg.NSAccess = &nsChecker

--- a/core/server/suite_test.go
+++ b/core/server/suite_test.go
@@ -61,7 +61,7 @@ func makeGRPCServer(cfg *rest.Config, t *testing.T) (pb.CoreClient, server.CoreS
 		t.Fatal(err)
 	}
 
-	clientsFactory := clustersmngr.NewClientFactory(fetcher, &nsChecker, log, scheme, clustersmngr.NewClustersClientsPool, []clustersmngr.KubeConfigOption{clustersmngr.WithFlowControl})
+	clientsFactory := clustersmngr.NewClientFactory(fetcher, &nsChecker, log, scheme, clustersmngr.NewClustersClientsPool, clustersmngr.DefaultKubeConfigOptions)
 
 	coreCfg := server.NewCoreConfig(log, cfg, "foobar", clientsFactory)
 	coreCfg.NSAccess = &nsChecker
@@ -151,6 +151,8 @@ func makeServerConfig(fakeClient client.Client, t *testing.T) server.CoreServerC
 		t.Fatal(err)
 	}
 
+	// Don't include the clustersmngr.DefaultKubeConfigOptions here as we're using a fake kubeclient
+	// and the default options include the Flowcontrol setup which is not mocked out
 	clientsFactory := clustersmngr.NewClientFactory(fetcher, &nsChecker, log, scheme, func(scheme *apiruntime.Scheme) clustersmngr.ClientsPool {
 		f := &clustersmngrfakes.FakeClientsPool{}
 		f.ClientStub = func(clusterName string) (client.Client, error) { return fakeClient, nil }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

- Don't try to continue updating namespaces if we cannot create a kubeconfig.
- This exposed some errors being raised when using the fake kubeclient, so refactored flowcontrol so it doesn't need to run on those tests.

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**

To stop the occasional panic popping up and bring down the server.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x103ee3420]

goroutine 91965 [running]:
k8s.io/client-go/kubernetes.NewForConfig(0x13c?)
        /Users/simon/go/pkg/mod/k8s.io/client-go@v0.25.0/kubernetes/clientset.go:422 +0x20
github.com/weaveworks/weave-gitops/core/nsaccess.newAuthClient(0x0?)
        /Users/simon/weave/weave-gitops/core/nsaccess/nsaccess.go:176 +0x1c
github.com/weaveworks/weave-gitops/core/nsaccess.userCanUseNamespace({_, _}, _, {{{0x0, 0x0}, {0x0, 0x0}}, {{0x14005595d00, 0x7}, {0x0, ...}, ...}, ...}, ...)
        /Users/simon/weave/weave-gitops/core/nsaccess/nsaccess.go:85 +0x38
github.com/weaveworks/weave-gitops/core/nsaccess.simpleChecker.FilterAccessibleNamespaces({{0x106aa46e0?, 0x105436360?, 0x1400605a940?}}, {0x10545b468, 0x14004d37080}, 0x140037b83c0?, {0x14001f89500?, 0x5, 0x14000c96c60?})
        /Users/simon/weave/weave-gitops/core/nsaccess/nsaccess.go:71 +0x13c
github.com/weaveworks/weave-gitops/core/clustersmngr.(*clientsFactory).UpdateUserNamespaces.func1({{0x14000a148e8, 0x18}, {0x14000a147b0, 0x17}, {0x0, 0x0}, {0x0, 0x0}, {0x0, {0x0, ...}, ...}})
        /Users/simon/weave/weave-gitops/core/clustersmngr/factory.go:359 +0x22c
created by github.com/weaveworks/weave-gitops/core/clustersmngr.(*clientsFactory).UpdateUserNamespaces
        /Users/simon/weave/weave-gitops/core/clustersmngr/factory.go:349 +0x21c
exit status 2
```

<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**

Bail out w/ a `return` instead of continuing, maybe there are linting rules around for this? We need to be a bit careful on logging on err instead of returning err.

<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**

Just w/ tests.
