### PR TITLE
Add cluster kind annotations in getting started docs

### DIFF
--- a/website/docs/cluster-management/getting-started.mdx
+++ b/website/docs/cluster-management/getting-started.mdx
@@ -242,7 +242,7 @@ where the **CLUSTER_KIND** can be one of the following supported ones:
   - AzureCluster
   - AzureManagedCluster
   - GCPCluster
-  - LiquidMetal
+  - MicrovmCluster
   - Rancher
   - Openshift
   - Tanzu

--- a/website/docs/cluster-management/getting-started.mdx
+++ b/website/docs/cluster-management/getting-started.mdx
@@ -242,6 +242,11 @@ where the **CLUSTER_KIND** can be one of the following supported ones:
   - AzureCluster
   - AzureManagedCluster
   - GCPCluster
+  - LiquidMetal
+  - Rancher
+  - Openshift
+  - Tanzu
+  - OtherOnprem
 
 ## Test
 

--- a/website/docs/cluster-management/getting-started.mdx
+++ b/website/docs/cluster-management/getting-started.mdx
@@ -224,6 +224,25 @@ metadata:
     metadata.weave.works/dashboard.prometheus: https://prometheus.io/
 ```
 
+#### Specifying CAPI cluster kinds
+
+To be able to explicitly specify the type of cluster, you need to use metadata annotations using `weave.works/cluster-kind` for the annotation key as the below pattern:
+
+```
+apiVersion: gitops.weave.works/v1alpha1
+kind: GitopsCluster
+metadata:
+  annotations:
+      weave.works/cluster-kind: <CLUSTER_KIND>
+```
+where the **CLUSTER_KIND** can be one of the following supported ones:
+  - DockerCluster
+  - AWSCluster
+  - AWSManagedCluster
+  - AzureCluster
+  - AzureManagedCluster
+  - GCPCluster
+
 ## Test
 
 You should now be able to create a new cluster from your template and install profiles onto it with a single Pull Request via the WGE UI!


### PR DESCRIPTION
Fixes https://github.com/weaveworks/weave-gitops-enterprise/issues/1165

**Documentation Changes**
Add cluster kind annotations supported in getting started docs (cluster-management)