### PR TITLE
Makes the UI UnAuthorizedInterceptor TS generic

### DIFF
--- a/ui/contexts/CoreClientContext.tsx
+++ b/ui/contexts/CoreClientContext.tsx
@@ -21,7 +21,7 @@ export const CoreClientContext =
   React.createContext<CoreClientContextType | null>(null);
 
 // From https://www.typescriptlang.org/docs/handbook/decorators.html#class-decorators
-type GenericClassType = { new (...args: any[]): {} };
+type GenericClassType = { new (...args: any[]): any };
 export function UnAuthorizedInterceptor<T extends GenericClassType>(api: T) {
   const wrapped = {} as T;
   // Wrap each API method in a check that redirects to the signin page if a 401 is returned.

--- a/ui/contexts/CoreClientContext.tsx
+++ b/ui/contexts/CoreClientContext.tsx
@@ -20,9 +20,11 @@ export type CoreClientContextType = {
 export const CoreClientContext =
   React.createContext<CoreClientContextType | null>(null);
 
-export function UnAuthorizedInterceptor(api: typeof Core): typeof Core {
-  const wrapped = {};
-  //   Wrap each API method in a check that redirects to the signin page if a 401 is returned.
+// From https://www.typescriptlang.org/docs/handbook/decorators.html#class-decorators
+type GenericClassType = { new (...args: any[]): {} };
+export function UnAuthorizedInterceptor<T extends GenericClassType>(api: T) {
+  const wrapped = {} as T;
+  // Wrap each API method in a check that redirects to the signin page if a 401 is returned.
   for (const method of Object.getOwnPropertyNames(api)) {
     if (typeof api[method] != "function") {
       continue;
@@ -42,7 +44,7 @@ export function UnAuthorizedInterceptor(api: typeof Core): typeof Core {
       });
     };
   }
-  return wrapped as typeof Core;
+  return wrapped;
 }
 
 function FeatureFlags(api) {


### PR DESCRIPTION
- So that consuming libs can more easily use it with additional API providers

<!-- Describe what has changed in this PR -->
**What changed?**

Switch to some generic types in the UnAuthorizedInterceptor so it can be used by other consuming projects which also use the Auth middleware in the BE.

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**

To avoid having to:

```ts
  const wrapped = UnAuthorizedInterceptor(api as unknown as typeof Core) as unknown as typeof MyService;
```