### PR TITLE
flux-exec: implement bootstrap gitlab and global flags

### DIFF
--- a/pkg/fluxexec/bootstrap_github.go
+++ b/pkg/fluxexec/bootstrap_github.go
@@ -7,6 +7,7 @@ import (
 )
 
 type bootstrapGitHubConfig struct {
+	globalOptions    []GlobalOption
 	bootstrapOptions []BootstrapOption
 
 	hostname     string
@@ -22,12 +23,9 @@ type bootstrapGitHubConfig struct {
 }
 
 var defaultBootstrapGitHubOptions = bootstrapGitHubConfig{
-	hostname:     "github.com",
-	interval:     "1m0s",
-	personal:     false,
-	private:      true,
-	readWriteKey: true,
-	reconcile:    true,
+	hostname: "github.com",
+	interval: "1m0s",
+	private:  true,
 }
 
 // BootstrapGitHubOption represents options used in the BootstrapGitHub method.
@@ -96,10 +94,15 @@ func (flux *Flux) bootstrapGitHubCmd(ctx context.Context, opts ...BootstrapGitHu
 
 	args := []string{"bootstrap", "github"}
 
-	// Add the bootstrap args first.
+	// Add the global args first.
+	globalArgs := flux.globalArgs(c.globalOptions...)
+	args = append(args, globalArgs...)
+
+	// The add the bootstrap args.
 	bootstrapArgs := flux.bootstrapArgs(c.bootstrapOptions...)
 	args = append(args, bootstrapArgs...)
 
+	// Then follow with the bootstrap github args.
 	if c.hostname != "" {
 		args = append(args, "--hostname", c.hostname)
 	}
@@ -140,6 +143,5 @@ func (flux *Flux) bootstrapGitHubCmd(ctx context.Context, opts ...BootstrapGitHu
 		args = append(args, "--team", strings.Join(c.team, ","))
 	}
 
-	// TODO how to deal with the env
 	return flux.buildFluxCmd(ctx, nil, args...), nil
 }

--- a/pkg/fluxexec/bootstrap_github_test.go
+++ b/pkg/fluxexec/bootstrap_github_test.go
@@ -2,6 +2,9 @@ package fluxexec
 
 import (
 	"context"
+	"os"
+	"path/filepath"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -12,11 +15,24 @@ var _ = Describe("bootstrapGitHubCmd", func() {
 			flux, err := NewFlux(".", "/path/to/flux")
 			Expect(err).To(BeNil())
 
+			homedir, err := os.UserHomeDir()
+			Expect(err).To(BeNil())
+
 			initCmd, err := flux.bootstrapGitHubCmd(context.TODO())
 			Expect(err).To(BeNil())
 			Expect(initCmd.Args[1:]).To(Equal([]string{
 				"bootstrap",
 				"github",
+				"--cache-dir",
+				filepath.Join(homedir, ".kube", "cache"),
+				"--kube-api-burst",
+				"100",
+				"--kube-api-qps",
+				"50",
+				"--namespace",
+				"flux-system",
+				"--timeout",
+				"5m0s",
 				"--author-name",
 				"Flux",
 				"--branch",
@@ -44,13 +60,14 @@ var _ = Describe("bootstrapGitHubCmd", func() {
 				"--interval",
 				"1m0s",
 				"--private",
-				"--read-write-key",
-				"--reconcile",
 			}))
 		})
 
 		By("generating the command without network-policy, without private, but with token-auth", func() {
 			flux, err := NewFlux(".", "/path/to/flux")
+			Expect(err).To(BeNil())
+
+			homedir, err := os.UserHomeDir()
 			Expect(err).To(BeNil())
 
 			initCmd, err := flux.bootstrapGitHubCmd(context.TODO(),
@@ -62,6 +79,16 @@ var _ = Describe("bootstrapGitHubCmd", func() {
 			Expect(initCmd.Args[1:]).To(Equal([]string{
 				"bootstrap",
 				"github",
+				"--cache-dir",
+				filepath.Join(homedir, ".kube", "cache"),
+				"--kube-api-burst",
+				"100",
+				"--kube-api-qps",
+				"50",
+				"--namespace",
+				"flux-system",
+				"--timeout",
+				"5m0s",
 				"--author-name",
 				"Flux",
 				"--branch",
@@ -88,8 +115,64 @@ var _ = Describe("bootstrapGitHubCmd", func() {
 				"github.com",
 				"--interval",
 				"1m0s",
-				"--read-write-key",
-				"--reconcile",
+			}))
+		})
+
+		By("generating the command for the different flux namespace", func() {
+			flux, err := NewFlux(".", "/path/to/flux")
+			Expect(err).To(BeNil())
+
+			homedir, err := os.UserHomeDir()
+			Expect(err).To(BeNil())
+
+			initCmd, err := flux.bootstrapGitHubCmd(context.TODO(),
+				WithGlobalOptions(
+					Namespace("weave-gitops-system"),
+				),
+				WithBootstrapOptions(
+					NetworkPolicy(false),
+					SecretName("weave-gitops-system"),
+				),
+				Private(false))
+			Expect(err).To(BeNil())
+			Expect(initCmd.Args[1:]).To(Equal([]string{
+				"bootstrap",
+				"github",
+				"--cache-dir",
+				filepath.Join(homedir, ".kube", "cache"),
+				"--kube-api-burst",
+				"100",
+				"--kube-api-qps",
+				"50",
+				"--namespace",
+				"weave-gitops-system",
+				"--timeout",
+				"5m0s",
+				"--author-name",
+				"Flux",
+				"--branch",
+				"main",
+				"--cluster-domain",
+				"cluster.local",
+				"--components",
+				"source-controller,kustomize-controller,helm-controller,notification-controller",
+				"--log-level",
+				"info",
+				"--registry",
+				"ghcr.io/fluxcd",
+				"--secret-name",
+				"weave-gitops-system",
+				"--ssh-ecdsa-curve",
+				"p384",
+				"--ssh-key-algorithm",
+				"ecdsa",
+				"--ssh-rsa-bits",
+				"2048",
+				"--watch-all-namespaces",
+				"--hostname",
+				"github.com",
+				"--interval",
+				"1m0s",
 			}))
 		})
 	})

--- a/pkg/fluxexec/bootstrap_gitlab.go
+++ b/pkg/fluxexec/bootstrap_gitlab.go
@@ -1,0 +1,146 @@
+package fluxexec
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+)
+
+type bootstrapGitLabConfig struct {
+	globalOptions    []GlobalOption
+	bootstrapOptions []BootstrapOption
+
+	hostname     string
+	interval     string
+	owner        string
+	path         string
+	personal     bool
+	private      bool
+	readWriteKey bool
+	reconcile    bool
+	repository   string
+	team         []string
+}
+
+var defaultBootstrapGitLabOptions = bootstrapGitLabConfig{
+	hostname: "gitlab.com",
+	interval: "1m0s",
+	private:  true,
+}
+
+// BootstrapGitLabOption represents options used in the BootstrapGitLab method.
+type BootstrapGitLabOption interface {
+	configureBootstrapGitLab(*bootstrapGitLabConfig)
+}
+
+func (opt *HostnameOption) configureBootstrapGitLab(conf *bootstrapGitLabConfig) {
+	conf.hostname = opt.hostname
+}
+
+func (opt *IntervalOption) configureBootstrapGitLab(conf *bootstrapGitLabConfig) {
+	conf.interval = opt.interval
+}
+
+func (opt *OwnerOption) configureBootstrapGitLab(conf *bootstrapGitLabConfig) {
+	conf.owner = opt.owner
+}
+
+func (opt *PathOption) configureBootstrapGitLab(conf *bootstrapGitLabConfig) {
+	conf.path = opt.path
+}
+
+func (opt *PersonalOption) configureBootstrapGitLab(conf *bootstrapGitLabConfig) {
+	conf.personal = opt.personal
+}
+
+func (opt *PrivateOption) configureBootstrapGitLab(conf *bootstrapGitLabConfig) {
+	conf.private = opt.private
+}
+
+func (opt *ReadWriteKeyOption) configureBootstrapGitLab(conf *bootstrapGitLabConfig) {
+	conf.readWriteKey = opt.readWriteKey
+}
+
+func (opt *ReconcileOption) configureBootstrapGitLab(conf *bootstrapGitLabConfig) {
+	conf.reconcile = opt.reconcile
+}
+
+func (opt *RepositoryOption) configureBootstrapGitLab(conf *bootstrapGitLabConfig) {
+	conf.repository = opt.repository
+}
+
+func (opt *TeamOption) configureBootstrapGitLab(conf *bootstrapGitLabConfig) {
+	conf.team = opt.team
+}
+
+func (flux *Flux) bootstrapGitLabCmd(ctx context.Context, opts ...BootstrapGitLabOption) (*exec.Cmd, error) {
+	c := defaultBootstrapGitLabOptions
+	for _, opt := range opts {
+		opt.configureBootstrapGitLab(&c)
+	}
+
+	args := []string{"bootstrap", "gitlab"}
+
+	// Add the global args first.
+	globalArgs := flux.globalArgs(c.globalOptions...)
+	args = append(args, globalArgs...)
+
+	// The add the bootstrap args.
+	bootstrapArgs := flux.bootstrapArgs(c.bootstrapOptions...)
+	args = append(args, bootstrapArgs...)
+
+	if c.hostname != "" {
+		args = append(args, "--hostname", c.hostname)
+	}
+
+	if c.interval != "" {
+		args = append(args, "--interval", c.interval)
+	}
+
+	if c.owner != "" {
+		args = append(args, "--owner", c.owner)
+	}
+
+	if c.path != "" {
+		args = append(args, "--path", c.path)
+	}
+
+	if c.personal {
+		args = append(args, "--personal")
+	}
+
+	if c.private {
+		args = append(args, "--private")
+	}
+
+	if c.readWriteKey {
+		args = append(args, "--read-write-key")
+	}
+
+	if c.reconcile {
+		args = append(args, "--reconcile")
+	}
+
+	if c.repository != "" {
+		args = append(args, "--repository", c.repository)
+	}
+
+	if len(c.team) > 0 {
+		args = append(args, "--team", strings.Join(c.team, ","))
+	}
+
+	return flux.buildFluxCmd(ctx, nil, args...), nil
+}
+
+func (flux *Flux) BootstrapGitlab(ctx context.Context, opts ...BootstrapGitLabOption) error {
+	bootstrapGitLabCmd, err := flux.bootstrapGitLabCmd(ctx, opts...)
+	if err != nil {
+		return err
+	}
+
+	if err := flux.runFluxCmd(ctx, bootstrapGitLabCmd); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/fluxexec/bootstrap_gitlab_test.go
+++ b/pkg/fluxexec/bootstrap_gitlab_test.go
@@ -1,0 +1,67 @@
+package fluxexec
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("bootstrapGitLabCmd", func() {
+	It("should be able to generate correct install commands", func() {
+		By("generating the default command", func() {
+			flux, err := NewFlux(".", "/path/to/flux")
+			Expect(err).To(BeNil())
+
+			homedir, err := os.UserHomeDir()
+			Expect(err).To(BeNil())
+
+			initCmd, err := flux.bootstrapGitLabCmd(context.TODO())
+			Expect(err).To(BeNil())
+			Expect(initCmd.Args[1:]).To(Equal([]string{
+				"bootstrap",
+				"gitlab",
+				"--cache-dir",
+				filepath.Join(homedir, ".kube", "cache"),
+				"--kube-api-burst",
+				"100",
+				"--kube-api-qps",
+				"50",
+				"--namespace",
+				"flux-system",
+				"--timeout",
+				"5m0s",
+				"--author-name",
+				"Flux",
+				"--branch",
+				"main",
+				"--cluster-domain",
+				"cluster.local",
+				"--components",
+				"source-controller,kustomize-controller,helm-controller,notification-controller",
+				"--log-level",
+				"info",
+				"--network-policy",
+				"--registry",
+				"ghcr.io/fluxcd",
+				"--secret-name",
+				"flux-system",
+				"--ssh-ecdsa-curve",
+				"p384",
+				"--ssh-key-algorithm",
+				"ecdsa",
+				"--ssh-rsa-bits",
+				"2048",
+				"--watch-all-namespaces",
+				"--hostname",
+				"gitlab.com",
+				"--interval",
+				"1m0s",
+				"--private",
+			}))
+		})
+
+	})
+})

--- a/pkg/fluxexec/global.go
+++ b/pkg/fluxexec/global.go
@@ -1,0 +1,239 @@
+package fluxexec
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+)
+
+type globalConfig struct {
+	as                    string
+	asGroup               []string
+	asUid                 string
+	cacheDir              string
+	certificateAuthority  string
+	clientCertificate     string
+	clientKey             string
+	cluster               string
+	context               string
+	insecureSkipTlsVerify bool
+	kubeApiBurst          int
+	kubeApiQps            float32
+	kubeconfig            string
+	namespace             string
+	server                string
+	timeout               string
+	tlsServerName         string
+	token                 string
+	user                  string
+	verbose               bool
+}
+
+func defaultCacheDir() string {
+	homedir, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+
+	return filepath.Join(homedir, ".kube", "cache")
+}
+
+var defaultGlobalOptions = globalConfig{
+	cacheDir:     defaultCacheDir(),
+	kubeApiBurst: 100,
+	kubeApiQps:   50,
+	namespace:    "flux-system",
+	timeout:      "5m0s",
+}
+
+// GlobalOption represents options used in the Global* methods.
+type GlobalOption interface {
+	configureGlobal(*globalConfig)
+}
+
+func (opt *AsOption) configureGlobal(conf *globalConfig) {
+	conf.as = opt.as
+}
+
+func (opt *AsGroupOption) configureGlobal(conf *globalConfig) {
+	conf.asGroup = opt.asGroup
+}
+
+func (opt *AsUidOption) configureGlobal(conf *globalConfig) {
+	conf.asUid = opt.asUid
+}
+
+func (opt *CacheDirOption) configureGlobal(conf *globalConfig) {
+	conf.cacheDir = opt.cacheDir
+}
+
+func (opt *CertificateAuthorityOption) configureGlobal(conf *globalConfig) {
+	conf.certificateAuthority = opt.certificateAuthority
+}
+
+func (opt *ClientCertificateOption) configureGlobal(conf *globalConfig) {
+	conf.clientCertificate = opt.clientCertificate
+}
+
+func (opt *ClientKeyOption) configureGlobal(conf *globalConfig) {
+	conf.clientKey = opt.clientKey
+}
+
+func (opt *ClusterOption) configureGlobal(conf *globalConfig) {
+	conf.cluster = opt.cluster
+}
+
+func (opt *ContextOption) configureGlobal(conf *globalConfig) {
+	conf.context = opt.context
+}
+
+func (opt *InsecureSkipTlsVerifyOption) configureGlobal(conf *globalConfig) {
+	conf.insecureSkipTlsVerify = opt.insecureSkipTlsVerify
+}
+
+func (opt *KubeApiBurstOption) configureGlobal(conf *globalConfig) {
+	conf.kubeApiBurst = opt.kubeApiBurst
+}
+
+func (opt *KubeApiQpsOption) configureGlobal(conf *globalConfig) {
+	conf.kubeApiQps = opt.kubeApiQps
+}
+
+func (opt *KubeconfigOption) configureGlobal(conf *globalConfig) {
+	conf.kubeconfig = opt.kubeconfig
+}
+
+func (opt *NamespaceOption) configureGlobal(conf *globalConfig) {
+	conf.namespace = opt.namespace
+}
+
+func (opt *ServerOption) configureGlobal(conf *globalConfig) {
+	conf.server = opt.server
+}
+
+func (opt *TimeoutOption) configureGlobal(conf *globalConfig) {
+	conf.timeout = opt.timeout
+}
+
+func (opt *TLSServerNameOption) configureGlobal(conf *globalConfig) {
+	conf.tlsServerName = opt.tlsServerName
+}
+
+func (opt *TokenOption) configureGlobal(conf *globalConfig) {
+	conf.token = opt.token
+}
+
+func (opt *UserOption) configureGlobal(conf *globalConfig) {
+	conf.user = opt.user
+}
+
+func (opt *VerboseOption) configureGlobal(conf *globalConfig) {
+	conf.verbose = opt.verbose
+}
+
+// GlobalOptions is a special set of options for the (parent) global command.
+type GlobalOptions struct {
+	globalOptions []GlobalOption
+}
+
+func (opt *GlobalOptions) configureBootstrapGitHub(conf *bootstrapGitHubConfig) {
+	conf.globalOptions = opt.globalOptions
+}
+
+func WithGlobalOptions(opts ...GlobalOption) *GlobalOptions {
+	return &GlobalOptions{opts}
+}
+
+func (flux *Flux) globalArgs(opts ...GlobalOption) []string {
+	c := defaultGlobalOptions
+	for _, o := range opts {
+		o.configureGlobal(&c)
+	}
+
+	args := []string{}
+
+	if c.as != "" {
+		args = append(args, "--as", c.as)
+	}
+
+	if len(c.asGroup) > 0 {
+		// this flag can be repeated to add multiple groups
+		for _, g := range c.asGroup {
+			args = append(args, "--as-group", g)
+		}
+	}
+
+	if c.asUid != "" {
+		args = append(args, "--as-uid", c.asUid)
+	}
+
+	if c.cacheDir != "" {
+		args = append(args, "--cache-dir", c.cacheDir)
+	}
+
+	if c.certificateAuthority != "" {
+		args = append(args, "--certificate-authority", c.certificateAuthority)
+	}
+
+	if c.clientCertificate != "" {
+		args = append(args, "--client-certificate", c.clientCertificate)
+	}
+
+	if c.clientKey != "" {
+		args = append(args, "--client-key", c.clientKey)
+	}
+
+	if c.cluster != "" {
+		args = append(args, "--cluster", c.cluster)
+	}
+
+	if c.context != "" {
+		args = append(args, "--context", c.context)
+	}
+
+	if c.insecureSkipTlsVerify {
+		args = append(args, "--insecure-skip-tls-verify")
+	}
+
+	if c.kubeApiBurst != 0 {
+		args = append(args, "--kube-api-burst", strconv.Itoa(c.kubeApiBurst))
+	}
+
+	if c.kubeApiQps != 0 {
+		args = append(args, "--kube-api-qps", strconv.FormatFloat(float64(c.kubeApiQps), 'f', -1, 32))
+	}
+
+	if c.kubeconfig != "" {
+		args = append(args, "--kubeconfig", c.kubeconfig)
+	}
+
+	if c.namespace != "" {
+		args = append(args, "--namespace", c.namespace)
+	}
+
+	if c.server != "" {
+		args = append(args, "--server", c.server)
+	}
+
+	if c.timeout != "" {
+		args = append(args, "--timeout", c.timeout)
+	}
+
+	if c.tlsServerName != "" {
+		args = append(args, "--tls-server-name", c.tlsServerName)
+	}
+
+	if c.token != "" {
+		args = append(args, "--token", c.token)
+	}
+
+	if c.user != "" {
+		args = append(args, "--user", c.user)
+	}
+
+	if c.verbose {
+		args = append(args, "--verbose")
+	}
+
+	return args
+}

--- a/pkg/fluxexec/options_for_global.go
+++ b/pkg/fluxexec/options_for_global.go
@@ -1,0 +1,181 @@
+package fluxexec
+
+type AsOption struct {
+	as string
+}
+
+// As represents the --as flag.
+func As(as string) *AsOption {
+	return &AsOption{as}
+}
+
+type AsGroupOption struct {
+	asGroup []string
+}
+
+// AsGroup represents the --as-group flag.
+func AsGroup(asGroup ...string) *AsGroupOption {
+	return &AsGroupOption{asGroup}
+}
+
+type AsUidOption struct {
+	asUid string
+}
+
+// AsUid represents the --as-uid flag.
+func AsUid(asUid string) *AsUidOption {
+	return &AsUidOption{asUid}
+}
+
+type CacheDirOption struct {
+	cacheDir string
+}
+
+// CacheDir represents the --cache-dir flag.
+func CacheDir(cacheDir string) *CacheDirOption {
+	return &CacheDirOption{cacheDir}
+}
+
+type CertificateAuthorityOption struct {
+	certificateAuthority string
+}
+
+// CertificateAuthority represents the --certificate-authority flag.
+func CertificateAuthority(certificateAuthority string) *CertificateAuthorityOption {
+	return &CertificateAuthorityOption{certificateAuthority}
+}
+
+type ClientCertificateOption struct {
+	clientCertificate string
+}
+
+// ClientCertificate represents the --client-certificate flag.
+func ClientCertificate(clientCertificate string) *ClientCertificateOption {
+	return &ClientCertificateOption{clientCertificate}
+}
+
+type ClientKeyOption struct {
+	clientKey string
+}
+
+// ClientKey represents the --client-key flag.
+func ClientKey(clientKey string) *ClientKeyOption {
+	return &ClientKeyOption{clientKey}
+}
+
+type ClusterOption struct {
+	cluster string
+}
+
+// Cluster represents the --cluster flag.
+func Cluster(cluster string) *ClusterOption {
+	return &ClusterOption{cluster}
+}
+
+type ContextOption struct {
+	context string
+}
+
+// KubeContext represents the --context flag.
+func KubeContext(context string) *ContextOption {
+	return &ContextOption{context}
+}
+
+type InsecureSkipTlsVerifyOption struct {
+	insecureSkipTlsVerify bool
+}
+
+// InsecureSkipTlsVerify represents the --insecure-skip-tls-verify flag.
+func InsecureSkipTlsVerify(insecureSkipTlsVerify bool) *InsecureSkipTlsVerifyOption {
+	return &InsecureSkipTlsVerifyOption{insecureSkipTlsVerify}
+}
+
+type KubeApiBurstOption struct {
+	kubeApiBurst int
+}
+
+// KubeApiBurst represents the --kube-api-burst flag.
+func KubeApiBurst(kubeApiBurst int) *KubeApiBurstOption {
+	return &KubeApiBurstOption{kubeApiBurst}
+}
+
+type KubeApiQpsOption struct {
+	kubeApiQps float32
+}
+
+// KubeApiQps represents the --kube-api-qps flag.
+func KubeApiQps(kubeApiQps float32) *KubeApiQpsOption {
+	return &KubeApiQpsOption{kubeApiQps}
+}
+
+type KubeconfigOption struct {
+	kubeconfig string
+}
+
+// Kubeconfig represents the --kubeconfig flag.
+func Kubeconfig(kubeconfig string) *KubeconfigOption {
+	return &KubeconfigOption{kubeconfig}
+}
+
+type NamespaceOption struct {
+	namespace string
+}
+
+// Namespace represents the --namespace flag.
+func Namespace(namespace string) *NamespaceOption {
+	return &NamespaceOption{namespace}
+}
+
+type ServerOption struct {
+	server string
+}
+
+// Server represents the --server flag.
+func Server(server string) *ServerOption {
+	return &ServerOption{server}
+}
+
+type TimeoutOption struct {
+	timeout string
+}
+
+// Timeout represents the --timeout flag.
+func Timeout(timeout string) *TimeoutOption {
+	return &TimeoutOption{timeout}
+}
+
+type TLSServerNameOption struct {
+	tlsServerName string
+}
+
+// TLSServerName represents the --tls-server-name flag.
+func TLSServerName(tlsServerName string) *TLSServerNameOption {
+	return &TLSServerNameOption{tlsServerName}
+}
+
+type TokenOption struct {
+	token string
+}
+
+// Token represents the --token flag.
+func Token(token string) *TokenOption {
+	return &TokenOption{token}
+}
+
+type UserOption struct {
+	user string
+}
+
+// User represents the --user flag.
+func User(user string) *UserOption {
+	return &UserOption{user}
+}
+
+type VerboseOption struct {
+	verbose bool
+}
+
+// Verbose represents the --verbose flag.
+func Verbose(verbose bool) *VerboseOption {
+	return &VerboseOption{verbose}
+}


### PR DESCRIPTION
This PR implements a wrapper of `bootstrap gitlab` command and also supports missing global flags in the flux-exec package.
Partially fix #2689 