### PR TITLE
Stop creating resources in the hard-coded flux-system namespace

### DIFF
--- a/charts/gitops-server/Chart.yaml
+++ b/charts/gitops-server/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.0.3
+version: 4.0.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/gitops-server/templates/admin-user-creds.yaml
+++ b/charts/gitops-server/templates/admin-user-creds.yaml
@@ -12,19 +12,5 @@ data:
   username: {{ .username | b64enc | quote }}
   password: {{ .passwordHash | required "passwordHash must be set!" | b64enc | quote }}
   {{- end }}
-{{- if ne .Release.Namespace "flux-system" }}
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: cluster-user-auth
-  namespace: flux-system
-type: Opaque
-data:
-  {{- with .Values.adminUser }}
-  username: {{ .username | b64enc | quote }}
-  password: {{ .passwordHash | required "passwordHash must be set!" | b64enc | quote }}
-  {{- end }}
-{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/gitops-server/templates/admin-user-roles.yaml
+++ b/charts/gitops-server/templates/admin-user-roles.yaml
@@ -42,51 +42,6 @@ rules:
 {{- if gt (len $.Values.rbac.additionalRules) 0 -}}
 {{- toYaml $.Values.rbac.additionalRules | nindent 2 -}}
 {{- end }}
-{{- if ne .Release.Namespace "flux-system" }}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: wego-admin-role
-  namespace: flux-system
-rules:
-  - apiGroups: [""]
-    resources: ["configmaps", "secrets", "pods", "services", "namespaces", "persistentvolumes", "persistentvolumeclaims"]
-    verbs: [ "get", "list" ]
-  - apiGroups: ["apps"]
-    resources: [ "deployments", "replicasets", "statefulsets"]
-    verbs: [ "get", "list" ]
-  - apiGroups: ["batch"]
-    resources: [ "jobs", "cronjobs"]
-    verbs: [ "get", "list" ]
-  - apiGroups: ["autoscaling"]
-    resources: ["horizontalpodautoscalers"]
-    verbs: [ "get", "list" ]
-  - apiGroups: ["rbac.authorization.k8s.io"]
-    resources: ["roles", "clusterroles", "rolebindings", "clusterrolebindings"]
-    verbs: [ "get", "list" ]
-  - apiGroups: ["networking.k8s.io"]
-    resources: ["ingresses"]
-    verbs: [ "get", "list" ]
-  - apiGroups: [""]
-    resources: ["events"]
-    verbs: ["get", "watch", "list"]
-  - apiGroups: ["source.toolkit.fluxcd.io"]
-    resources: [ "buckets", "helmcharts", "gitrepositories", "helmrepositories", "ocirepositories" ]
-    verbs: [ "get", "list", "patch" ]
-  - apiGroups: ["kustomize.toolkit.fluxcd.io"]
-    resources: [ "kustomizations" ]
-    verbs: [ "get", "list", "patch" ]
-  - apiGroups: ["helm.toolkit.fluxcd.io"]
-    resources: [ "helmreleases" ]
-    verbs: [ "get", "list", "patch" ]
-  - apiGroups: ["infra.contrib.fluxcd.io"]
-    resources: ["terraforms"]
-    verbs: [ "get", "list", "patch" ]
-{{- if gt (len $.Values.rbac.additionalRules) 0 -}}
-{{- toYaml $.Values.rbac.additionalRules | nindent 2 -}}
-{{- end -}}
-{{- end -}}
 {{- if .Values.adminUser.createClusterRole }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/gitops-server/templates/admin-user.yaml
+++ b/charts/gitops-server/templates/admin-user.yaml
@@ -13,22 +13,6 @@ roleRef:
   kind: Role
   name: wego-admin-role
   apiGroup: rbac.authorization.k8s.io
-{{- if ne .Release.Namespace "flux-system" }}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: wego-test-user-read-resources
-  namespace: flux-system
-subjects:
-  - kind: User
-    name: {{ .Values.adminUser.username }}
-    namespace: {{ .Release.Namespace }}
-roleRef:
-  kind: Role
-  name: wego-admin-role
-  apiGroup: rbac.authorization.k8s.io
-{{- end -}}
 {{- if .Values.adminUser.createClusterRole }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/gitops-server/values.yaml
+++ b/charts/gitops-server/values.yaml
@@ -66,7 +66,7 @@ adminUser:
   create: false
   # -- Specifies whether the clusterRole & binding to the admin user should be created.
   # Will be created only if `adminUser.create` is enabled. Without this,
-  # the adminUser will only be able to see resources in the `flux-system` namespace.
+  # the adminUser will only be able to see resources in the target namespace.
   createClusterRole: true
   # -- Whether we should create the secret for the local
   # adminUser. Will be created only if `adminUser.create` is


### PR DESCRIPTION
There's been a few weeks of backwards compatibility. Let's remove
that - if you're upgrading the chart, upgrade the image.

This makes no difference to any user who installs weave-gitops into
flux-system. This makes a difference to anybody who installs it in a
different namespace - the new chart will not be compatible with images
0.9.1 or before, however it will install half the number of roles,
bindings and secrets for anybody running a newer version than that.

This closes #2415.