### PR TITLE
Use go 1.19

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.18.X]
+        go-version: [1.19.X]
     steps:
       - uses: actions/checkout@v2
       - name: Go modules cache
@@ -79,7 +79,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.18.X]
+        go-version: [1.19.X]
         node-version: [16.X]
     steps:
       - uses: actions/checkout@v2
@@ -215,7 +215,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18.X
+        go-version: 1.19.X
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Clean

--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18.X
+          go-version: 1.19.X
       - name: Setup Node.js
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18.X
+          go-version: 1.19.X
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.X
+          go-version: 1.19.X
       - name: Run FOSSA scan and upload build data
         uses: fossa-contrib/fossa-action@v1
         with:

--- a/.github/workflows/upgrade-flux.yaml
+++ b/.github/workflows/upgrade-flux.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18.X
+          go-version: 1.19.X
       - name: Upgrade flux
         run: |
           sed -i 's/^FLUX_VERSION=.*/FLUX_VERSION=${{ needs.has-new-flux.outputs.version }}/' Makefile

--- a/cmd/gitops-server/cmd/cmd.go
+++ b/cmd/gitops-server/cmd/cmd.go
@@ -6,7 +6,6 @@ import (
 	"crypto/x509"
 	"fmt"
 	"io/fs"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -292,7 +291,7 @@ func listenAndServe(log logr.Logger, srv *http.Server, options Options) error {
 	}
 
 	if options.MTLS {
-		caCert, err := ioutil.ReadFile(options.TLSCertFile)
+		caCert, err := os.ReadFile(options.TLSCertFile)
 		if err != nil {
 			return fmt.Errorf("failed reading cert file %s. %s", options.TLSCertFile, err)
 		}

--- a/core/clustersmngr/clustersmngr.go
+++ b/core/clustersmngr/clustersmngr.go
@@ -50,13 +50,15 @@ func (e ClusterNotFoundError) Error() string {
 	return fmt.Sprintf("cluster=%s not found", e.Cluster)
 }
 
-//ClusterFetcher fetches all leaf clusters
+// ClusterFetcher fetches all leaf clusters
+//
 //counterfeiter:generate . ClusterFetcher
 type ClusterFetcher interface {
 	Fetch(ctx context.Context) ([]Cluster, error)
 }
 
 // ClientsPool stores all clients to the leaf clusters
+//
 //counterfeiter:generate . ClientsPool
 type ClientsPool interface {
 	Add(cfg ClusterClientConfigFunc, cluster Cluster) error

--- a/core/logger/logger_test.go
+++ b/core/logger/logger_test.go
@@ -2,7 +2,7 @@ package logger_test
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 	"testing"
@@ -184,7 +184,7 @@ func getLogs(t *testing.T, r, w *os.File) []byte {
 
 	w.Close()
 
-	out, err := ioutil.ReadAll(r)
+	out, err := io.ReadAll(r)
 	g.Expect(err).NotTo(HaveOccurred())
 
 	return out

--- a/doc/development-process.md
+++ b/doc/development-process.md
@@ -4,7 +4,7 @@ Depending on your area of focus we're providing guidance of each kind of develop
 
 Step one, you **must** have the following things installed:
 
-* [go](https://go.dev) v1.17 -- Primary development language.
+* [go](https://go.dev) v1.19 -- Primary development language.
 * [docker](https://www.docker.com/) -- Used for generating containers & testing kubernetes set-ups.
 * [helm](https://helm.sh/docs/intro/install/) v3. -- Package manager for kubernetes
 * [kind](https://kind.sigs.k8s.io/docs/user/quick-start#installation) -- Run kubernetes clusters in docker for testing.

--- a/pkg/api/applications/applications_grpc.pb.go
+++ b/pkg/api/applications/applications_grpc.pb.go
@@ -18,35 +18,28 @@ const _ = grpc.SupportPackageIsVersion7
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type ApplicationsClient interface {
-	//
 	// Authenticate generates jwt token using git provider name and git provider token arguments
 	Authenticate(ctx context.Context, in *AuthenticateRequest, opts ...grpc.CallOption) (*AuthenticateResponse, error)
-	//
 	// GetGithubDeviceCode retrieves a temporary device code for Github authentication.
 	// This code is used to start the Github device-flow.
 	GetGithubDeviceCode(ctx context.Context, in *GetGithubDeviceCodeRequest, opts ...grpc.CallOption) (*GetGithubDeviceCodeResponse, error)
-	//
 	// GetGithubAuthStatus gets the status of the Github device flow authentication requests.
 	// Once the user has completed the Github device flow, an access token will be returned.
 	// This token will expired in 15 minutes, after which the user will need to complete the flow again
 	// to do Git Provider operations.
 	GetGithubAuthStatus(ctx context.Context, in *GetGithubAuthStatusRequest, opts ...grpc.CallOption) (*GetGithubAuthStatusResponse, error)
-	//
 	// GetGitlabAuthURL returns the URL to initiate a GitLab OAuth PKCE flow.
 	// The user must browse to the returned URL to authorize the OAuth callback to the GitOps UI.
 	// See the GitLab OAuth docs for more more information:
 	// https://docs.gitlab.com/ee/api/oauth2.html#supported-oauth-20-flows
 	GetGitlabAuthURL(ctx context.Context, in *GetGitlabAuthURLRequest, opts ...grpc.CallOption) (*GetGitlabAuthURLResponse, error)
-	//
 	// AuthorizeGitlab exchanges a GitLab code obtained via OAuth callback.
 	// The returned token is useable for authentication with the GitOps server only.
 	// See the GitLab OAuth docs for more more information:
 	// https://docs.gitlab.com/ee/api/oauth2.html#supported-oauth-20-flows
 	AuthorizeGitlab(ctx context.Context, in *AuthorizeGitlabRequest, opts ...grpc.CallOption) (*AuthorizeGitlabResponse, error)
-	//
 	// ParseRepoURL returns structured data about a git repository URL
 	ParseRepoURL(ctx context.Context, in *ParseRepoURLRequest, opts ...grpc.CallOption) (*ParseRepoURLResponse, error)
-	//
 	// ValidateProviderToken check to see if the git provider token is still valid
 	ValidateProviderToken(ctx context.Context, in *ValidateProviderTokenRequest, opts ...grpc.CallOption) (*ValidateProviderTokenResponse, error)
 }
@@ -126,35 +119,28 @@ func (c *applicationsClient) ValidateProviderToken(ctx context.Context, in *Vali
 // All implementations must embed UnimplementedApplicationsServer
 // for forward compatibility
 type ApplicationsServer interface {
-	//
 	// Authenticate generates jwt token using git provider name and git provider token arguments
 	Authenticate(context.Context, *AuthenticateRequest) (*AuthenticateResponse, error)
-	//
 	// GetGithubDeviceCode retrieves a temporary device code for Github authentication.
 	// This code is used to start the Github device-flow.
 	GetGithubDeviceCode(context.Context, *GetGithubDeviceCodeRequest) (*GetGithubDeviceCodeResponse, error)
-	//
 	// GetGithubAuthStatus gets the status of the Github device flow authentication requests.
 	// Once the user has completed the Github device flow, an access token will be returned.
 	// This token will expired in 15 minutes, after which the user will need to complete the flow again
 	// to do Git Provider operations.
 	GetGithubAuthStatus(context.Context, *GetGithubAuthStatusRequest) (*GetGithubAuthStatusResponse, error)
-	//
 	// GetGitlabAuthURL returns the URL to initiate a GitLab OAuth PKCE flow.
 	// The user must browse to the returned URL to authorize the OAuth callback to the GitOps UI.
 	// See the GitLab OAuth docs for more more information:
 	// https://docs.gitlab.com/ee/api/oauth2.html#supported-oauth-20-flows
 	GetGitlabAuthURL(context.Context, *GetGitlabAuthURLRequest) (*GetGitlabAuthURLResponse, error)
-	//
 	// AuthorizeGitlab exchanges a GitLab code obtained via OAuth callback.
 	// The returned token is useable for authentication with the GitOps server only.
 	// See the GitLab OAuth docs for more more information:
 	// https://docs.gitlab.com/ee/api/oauth2.html#supported-oauth-20-flows
 	AuthorizeGitlab(context.Context, *AuthorizeGitlabRequest) (*AuthorizeGitlabResponse, error)
-	//
 	// ParseRepoURL returns structured data about a git repository URL
 	ParseRepoURL(context.Context, *ParseRepoURLRequest) (*ParseRepoURLResponse, error)
-	//
 	// ValidateProviderToken check to see if the git provider token is still valid
 	ValidateProviderToken(context.Context, *ValidateProviderTokenRequest) (*ValidateProviderTokenResponse, error)
 	mustEmbedUnimplementedApplicationsServer()

--- a/pkg/api/core/core_grpc.pb.go
+++ b/pkg/api/core/core_grpc.pb.go
@@ -18,55 +18,39 @@ const _ = grpc.SupportPackageIsVersion7
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type CoreClient interface {
-	//
 	// ListKustomization lists Kustomizations from a cluster via GitOps.
 	ListKustomizations(ctx context.Context, in *ListKustomizationsRequest, opts ...grpc.CallOption) (*ListKustomizationsResponse, error)
-	//
 	// GetKustomization gets data about a single Kustomization from a cluster.
 	GetKustomization(ctx context.Context, in *GetKustomizationRequest, opts ...grpc.CallOption) (*GetKustomizationResponse, error)
-	//
 	// ListHelmReleases lists helm releases from a cluster.
 	ListHelmReleases(ctx context.Context, in *ListHelmReleasesRequest, opts ...grpc.CallOption) (*ListHelmReleasesResponse, error)
-	//
 	// GetHelmRelease gets data about a single HelmRelease from the cluster.
 	GetHelmRelease(ctx context.Context, in *GetHelmReleaseRequest, opts ...grpc.CallOption) (*GetHelmReleaseResponse, error)
-	//
 	// GetObject gets data about a single primary object from a cluster.
 	GetObject(ctx context.Context, in *GetObjectRequest, opts ...grpc.CallOption) (*GetObjectResponse, error)
-	//
 	// ListObjects gets data about a primary objects.
 	ListObjects(ctx context.Context, in *ListObjectsRequest, opts ...grpc.CallOption) (*ListObjectsResponse, error)
-	//
 	// ListFluxRuntimeObjects lists the flux runtime deployments from a cluster.
 	ListFluxRuntimeObjects(ctx context.Context, in *ListFluxRuntimeObjectsRequest, opts ...grpc.CallOption) (*ListFluxRuntimeObjectsResponse, error)
 	ListFluxCrds(ctx context.Context, in *ListFluxCrdsRequest, opts ...grpc.CallOption) (*ListFluxCrdsResponse, error)
-	//
 	// GetReconciledObjects returns a list of objects that were created as a result a Flux automation.
 	// This list is derived by looking at the Kustomization or HelmRelease specified in the request body.
 	GetReconciledObjects(ctx context.Context, in *GetReconciledObjectsRequest, opts ...grpc.CallOption) (*GetReconciledObjectsResponse, error)
-	//
 	// GetChildObjects returns the children of a given object, specified by a GroupVersionKind.
 	// Not all Kubernets objects have children. For example, a Deployment has a child ReplicaSet, but a Service has no child objects.
 	GetChildObjects(ctx context.Context, in *GetChildObjectsRequest, opts ...grpc.CallOption) (*GetChildObjectsResponse, error)
-	//
 	// GetFluxNamespace returns with a namespace with a specific label.
 	GetFluxNamespace(ctx context.Context, in *GetFluxNamespaceRequest, opts ...grpc.CallOption) (*GetFluxNamespaceResponse, error)
-	//
 	// ListNamespaces returns with the list of available namespaces.
 	ListNamespaces(ctx context.Context, in *ListNamespacesRequest, opts ...grpc.CallOption) (*ListNamespacesResponse, error)
-	//
 	// ListEvents returns with a list of events
 	ListEvents(ctx context.Context, in *ListEventsRequest, opts ...grpc.CallOption) (*ListEventsResponse, error)
-	//
 	// SyncResource forces a reconciliation of a Flux resource
 	SyncFluxObject(ctx context.Context, in *SyncFluxObjectRequest, opts ...grpc.CallOption) (*SyncFluxObjectResponse, error)
-	//
 	// GetVersion returns version information about the server
 	GetVersion(ctx context.Context, in *GetVersionRequest, opts ...grpc.CallOption) (*GetVersionResponse, error)
-	//
 	// GetFeatureFlags returns configuration information about the server
 	GetFeatureFlags(ctx context.Context, in *GetFeatureFlagsRequest, opts ...grpc.CallOption) (*GetFeatureFlagsResponse, error)
-	//
 	// ToggleSuspendResource suspends or resumes a flux object.
 	ToggleSuspendResource(ctx context.Context, in *ToggleSuspendResourceRequest, opts ...grpc.CallOption) (*ToggleSuspendResourceResponse, error)
 }
@@ -236,55 +220,39 @@ func (c *coreClient) ToggleSuspendResource(ctx context.Context, in *ToggleSuspen
 // All implementations must embed UnimplementedCoreServer
 // for forward compatibility
 type CoreServer interface {
-	//
 	// ListKustomization lists Kustomizations from a cluster via GitOps.
 	ListKustomizations(context.Context, *ListKustomizationsRequest) (*ListKustomizationsResponse, error)
-	//
 	// GetKustomization gets data about a single Kustomization from a cluster.
 	GetKustomization(context.Context, *GetKustomizationRequest) (*GetKustomizationResponse, error)
-	//
 	// ListHelmReleases lists helm releases from a cluster.
 	ListHelmReleases(context.Context, *ListHelmReleasesRequest) (*ListHelmReleasesResponse, error)
-	//
 	// GetHelmRelease gets data about a single HelmRelease from the cluster.
 	GetHelmRelease(context.Context, *GetHelmReleaseRequest) (*GetHelmReleaseResponse, error)
-	//
 	// GetObject gets data about a single primary object from a cluster.
 	GetObject(context.Context, *GetObjectRequest) (*GetObjectResponse, error)
-	//
 	// ListObjects gets data about a primary objects.
 	ListObjects(context.Context, *ListObjectsRequest) (*ListObjectsResponse, error)
-	//
 	// ListFluxRuntimeObjects lists the flux runtime deployments from a cluster.
 	ListFluxRuntimeObjects(context.Context, *ListFluxRuntimeObjectsRequest) (*ListFluxRuntimeObjectsResponse, error)
 	ListFluxCrds(context.Context, *ListFluxCrdsRequest) (*ListFluxCrdsResponse, error)
-	//
 	// GetReconciledObjects returns a list of objects that were created as a result a Flux automation.
 	// This list is derived by looking at the Kustomization or HelmRelease specified in the request body.
 	GetReconciledObjects(context.Context, *GetReconciledObjectsRequest) (*GetReconciledObjectsResponse, error)
-	//
 	// GetChildObjects returns the children of a given object, specified by a GroupVersionKind.
 	// Not all Kubernets objects have children. For example, a Deployment has a child ReplicaSet, but a Service has no child objects.
 	GetChildObjects(context.Context, *GetChildObjectsRequest) (*GetChildObjectsResponse, error)
-	//
 	// GetFluxNamespace returns with a namespace with a specific label.
 	GetFluxNamespace(context.Context, *GetFluxNamespaceRequest) (*GetFluxNamespaceResponse, error)
-	//
 	// ListNamespaces returns with the list of available namespaces.
 	ListNamespaces(context.Context, *ListNamespacesRequest) (*ListNamespacesResponse, error)
-	//
 	// ListEvents returns with a list of events
 	ListEvents(context.Context, *ListEventsRequest) (*ListEventsResponse, error)
-	//
 	// SyncResource forces a reconciliation of a Flux resource
 	SyncFluxObject(context.Context, *SyncFluxObjectRequest) (*SyncFluxObjectResponse, error)
-	//
 	// GetVersion returns version information about the server
 	GetVersion(context.Context, *GetVersionRequest) (*GetVersionResponse, error)
-	//
 	// GetFeatureFlags returns configuration information about the server
 	GetFeatureFlags(context.Context, *GetFeatureFlagsRequest) (*GetFeatureFlagsResponse, error)
-	//
 	// ToggleSuspendResource suspends or resumes a flux object.
 	ToggleSuspendResource(context.Context, *ToggleSuspendResourceRequest) (*ToggleSuspendResourceResponse, error)
 	mustEmbedUnimplementedCoreServer()

--- a/pkg/fluxexec/cmd.go
+++ b/pkg/fluxexec/cmd.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 )
@@ -53,7 +52,7 @@ func mergeWriters(writers ...io.Writer) io.Writer {
 	}
 
 	if len(compact) == 0 {
-		return ioutil.Discard
+		return io.Discard
 	}
 
 	if len(compact) == 1 {

--- a/pkg/fluxinstall/product.go
+++ b/pkg/fluxinstall/product.go
@@ -8,7 +8,6 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -70,7 +69,7 @@ func (p *Product) Install(ctx context.Context) (string, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}
@@ -90,7 +89,7 @@ func (p *Product) Install(ctx context.Context) (string, error) {
 	}
 
 	binaryPath := filepath.Join(gitopsCacheFluxDir, "flux")
-	if err := ioutil.WriteFile(binaryPath, binary, 0744); err != nil {
+	if err := os.WriteFile(binaryPath, binary, 0744); err != nil {
 		return "", err
 	}
 
@@ -127,7 +126,7 @@ func (p *Product) verifyChecksum(filename string, sum string) error {
 	// read string from response body
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}

--- a/pkg/fluxinstall/product_test.go
+++ b/pkg/fluxinstall/product_test.go
@@ -6,7 +6,6 @@ import (
 	"compress/gzip"
 	"context"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"regexp"
 
@@ -95,7 +94,7 @@ func (m *MockProductHTTPClient) Get(url string) (resp *http.Response, err error)
 		}
 
 		return &http.Response{
-			Body: ioutil.NopCloser(bytes.NewReader(body)),
+			Body: io.NopCloser(bytes.NewReader(body)),
 		}, nil
 	} else if url == "https://github.com/fluxcd/flux2/releases/download/v0.32.0/flux_0.32.0_checksums.txt" {
 		body := []byte(`77622fd02dd5ad9377e17ecb59fa4f9598016bf0bf9761d09c9ed633840d7c7d  flux_0.32.0_linux_amd64.tar.gz
@@ -104,7 +103,7 @@ func (m *MockProductHTTPClient) Get(url string) (resp *http.Response, err error)
 `)
 
 		return &http.Response{
-			Body: ioutil.NopCloser(bytes.NewReader(body)),
+			Body: io.NopCloser(bytes.NewReader(body)),
 		}, nil
 	}
 

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -82,6 +82,7 @@ func GetProfilesPath(clusterName, profilesManifestPath string) string {
 
 // Git is an interface for basic Git operations on a single branch of a
 // remote repository.
+//
 //counterfeiter:generate . Git
 type Git interface {
 	Open(path string) (*gogit.Repository, error)

--- a/pkg/git/gogit_test.go
+++ b/pkg/git/gogit_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -36,7 +35,7 @@ var _ = BeforeEach(func() {
 	fakeGit = &wrapperfakes.FakeGit{}
 	fakeGitClient = git.New(nil, fakeGit)
 
-	dir, err = ioutil.TempDir("", "wego-git-test-")
+	dir, err = os.MkdirTemp("", "wego-git-test-")
 	Expect(err).ShouldNot(HaveOccurred())
 })
 
@@ -165,7 +164,7 @@ var _ = Describe("Read", func() {
 		_, err = gitClient.Init(dir, "https://github.com/github/gitignore", "master")
 		filePath := "/test.txt"
 		content := []byte("testing")
-		err := ioutil.WriteFile(dir+filePath, content, 0644)
+		err := os.WriteFile(dir+filePath, content, 0644)
 		Expect(err).ShouldNot(HaveOccurred())
 		fileContent, err := gitClient.Read(filePath)
 		Expect(err).ShouldNot(HaveOccurred())
@@ -207,7 +206,7 @@ var _ = Describe("Write", func() {
 		content := []byte("testing")
 		Expect(gitClient.Write(filePath, content)).To(Succeed())
 
-		fileContent, err := ioutil.ReadFile(dir + filePath)
+		fileContent, err := os.ReadFile(dir + filePath)
 		Expect(err).ShouldNot(HaveOccurred())
 
 		Expect(content).To(Equal(fileContent))

--- a/pkg/gitproviders/provider.go
+++ b/pkg/gitproviders/provider.go
@@ -28,6 +28,7 @@ const (
 var ErrRepositoryNoPermissionsOrDoesNotExist = errors.New("no permissions to access this repository or repository doesn't exists")
 
 // GitProvider Handler
+//
 //counterfeiter:generate . GitProvider
 type GitProvider interface {
 	RepositoryExists(ctx context.Context, repoURL RepoURL) (bool, error)

--- a/pkg/helm/watcher/cache/cache.go
+++ b/pkg/helm/watcher/cache/cache.go
@@ -33,6 +33,7 @@ type profileVersion = string
 type ValueMap map[profileName]map[profileVersion][]byte
 
 // Cache defines an interface to work with the profile data cacher.
+//
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
 //counterfeiter:generate . Cache
 type Cache interface {

--- a/pkg/helm/watcher/controller/helm_watcher.go
+++ b/pkg/helm/watcher/controller/helm_watcher.go
@@ -24,6 +24,7 @@ const (
 )
 
 // EventRecorder defines an external event recorder's function for creating events for the notification controller.
+//
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
 //counterfeiter:generate . eventRecorder
 type eventRecorder interface {

--- a/pkg/helm/watcher/server.go
+++ b/pkg/helm/watcher/server.go
@@ -1,7 +1,7 @@
 package watcher
 
 import (
-	"io/ioutil"
+	"os"
 
 	"github.com/fluxcd/pkg/runtime/events"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1beta2"
@@ -45,7 +45,7 @@ type Watcher struct {
 }
 
 func NewWatcher(opts Options) (*Watcher, error) {
-	tempDir, err := ioutil.TempDir("", "profile_cache")
+	tempDir, err := os.MkdirTemp("", "profile_cache")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kube/kubehttp_test.go
+++ b/pkg/kube/kubehttp_test.go
@@ -2,7 +2,6 @@ package kube_test
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -40,7 +39,7 @@ var _ = Describe("KubeHTTP", func() {
 			origkc = os.Getenv("KUBECONFIG")
 
 			var err error
-			dir, err = ioutil.TempDir("", "kube-http-test-")
+			dir, err = os.MkdirTemp("", "kube-http-test-")
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -76,7 +75,7 @@ var _ = Describe("KubeHTTP", func() {
 		})
 
 		It("errors when pointing at a missing kubeconfig file", func() {
-			t, err := ioutil.TempFile(dir, "not_a_kubeconfig")
+			t, err := os.CreateTemp(dir, "not_a_kubeconfig")
 			Expect(err).ToNot(HaveOccurred())
 
 			kube.InClusterConfig = func() (*rest.Config, error) { return nil, rest.ErrNotInCluster }
@@ -118,7 +117,7 @@ var _ = Describe("KubeHTTP", func() {
 })
 
 func createKubeconfig(name, clusterName, dir string, setCurContext bool) {
-	f, err := ioutil.TempFile(dir, "test.kubeconfig")
+	f, err := os.CreateTemp(dir, "test.kubeconfig")
 	Expect(err).ToNot(HaveOccurred())
 
 	defer f.Close()

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -7,6 +7,7 @@ import (
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
 
 // Runner is an entity which can execute commands with whatever backing medium behind it.
+//
 //counterfeiter:generate . Runner
 type Runner interface {
 	// Run takes a command name and some arguments and will apply it to the current environment.

--- a/pkg/server/auth/server_test.go
+++ b/pkg/server/auth/server_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -214,7 +214,7 @@ func TestSignInNoPayloadReturnsBadRequest(t *testing.T) {
 	resp := w.Result()
 	g.Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
 
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	g.Expect(err).NotTo(HaveOccurred())
 
 	g.Expect(string(b)).To(ContainSubstring("Failed to read request body."))
@@ -593,7 +593,7 @@ func TestUserInfoOIDCFlow(t *testing.T) {
 	g.Expect(tokenResp.StatusCode).To(Equal(http.StatusOK))
 
 	defer tokenResp.Body.Close()
-	body, err := ioutil.ReadAll(tokenResp.Body)
+	body, err := io.ReadAll(tokenResp.Body)
 	g.Expect(err).NotTo(HaveOccurred())
 
 	tokens := make(map[string]interface{})

--- a/pkg/services/auth/jwt.go
+++ b/pkg/services/auth/jwt.go
@@ -26,6 +26,7 @@ type Claims struct {
 }
 
 // JWTClient represents a type that has methods to generate and verify JWT tokens.
+//
 //counterfeiter:generate . JWTClient
 type JWTClient interface {
 	GenerateJWT(expirationTime time.Duration, providerName gitproviders.GitProviderName, providerToken string) (string, error)

--- a/pkg/services/auth/types/flow.go
+++ b/pkg/services/auth/types/flow.go
@@ -8,6 +8,7 @@ import (
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
 
 // AuthFlow is an interface for OAuth authorization flows
+//
 //counterfeiter:generate . AuthFlow
 type AuthFlow interface {
 	Authorize(ctx context.Context) (*http.Request, error)

--- a/pkg/utils/common_test.go
+++ b/pkg/utils/common_test.go
@@ -3,7 +3,6 @@ package utils
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -100,44 +99,44 @@ error occurred some error, retrying in 1s
 		})
 
 		It("fails to find core configuration in non-empty dir with no config file", func() {
-			configFile, err := ioutil.ReadFile("testdata/ingress.yaml")
+			configFile, err := os.ReadFile("testdata/ingress.yaml")
 			Expect(err).NotTo(HaveOccurred())
 
 			path := filepath.Join(dir, "ingress.yaml")
-			Expect(ioutil.WriteFile(path, configFile, 0666)).To(Succeed())
+			Expect(os.WriteFile(path, configFile, 0666)).To(Succeed())
 
 			Expect(FindCoreConfig(dir)).To(Equal(WalkResult{Status: Missing, Path: ""}))
 		})
 
 		It("finds embedded core configuration in dir containing file with wrong number of entries", func() {
-			configFile, err := ioutil.ReadFile("testdata/config.yaml")
+			configFile, err := os.ReadFile("testdata/config.yaml")
 			Expect(err).NotTo(HaveOccurred())
 
 			// Add an extraneous entry
 			configFile = append(configFile, []byte("---\napiVersion: v1\nkind: Namespace\nmetadata:\n  name: my-ns\n")...)
 			path := filepath.Join(dir, "config.yaml")
-			Expect(ioutil.WriteFile(path, configFile, 0666)).To(Succeed())
+			Expect(os.WriteFile(path, configFile, 0666)).To(Succeed())
 
 			Expect(FindCoreConfig(dir)).To(Equal(WalkResult{Status: Embedded, Path: path}))
 		})
 
 		It("finds partial core configuration in dir containing file with partial config", func() {
-			partialConfigFile, err := ioutil.ReadFile("testdata/partial-config.yaml")
+			partialConfigFile, err := os.ReadFile("testdata/partial-config.yaml")
 			Expect(err).NotTo(HaveOccurred())
 
 			path := filepath.Join(dir, "config.yaml")
-			Expect(ioutil.WriteFile(path, partialConfigFile, 0666)).To(Succeed())
+			Expect(os.WriteFile(path, partialConfigFile, 0666)).To(Succeed())
 
 			Expect(FindCoreConfig(dir)).To(Equal(WalkResult{Status: Embedded, Path: path}))
 		})
 
 		It("finds core configuration nested in dir containing one (regardless of name)", func() {
-			testConfigFile, err := ioutil.ReadFile("testdata/config.yaml")
+			testConfigFile, err := os.ReadFile("testdata/config.yaml")
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(os.MkdirAll(filepath.Join(dir, "nested"), 0700)).Should(Succeed())
 			renamedConfigFile := filepath.Join(dir, "nested", "sprug.yaml")
-			Expect(ioutil.WriteFile(renamedConfigFile, testConfigFile, 0666)).To(Succeed())
+			Expect(os.WriteFile(renamedConfigFile, testConfigFile, 0666)).To(Succeed())
 
 			Expect(FindCoreConfig(dir)).To(Equal(WalkResult{Status: Valid, Path: renamedConfigFile}))
 		})


### PR DESCRIPTION
The change mostly consists of a bunch of `//` having been inserted by
    the upgraded `go fmt`,  and remove ioutil all over.

For compatibility's sake, I've left go.mod still supporting 1.18, but
all lint rules and the like are now using 1.19.

This resolves #2681.