### PR TITLE
flux-exec: add wrapper for bootstrap git

### DIFF
--- a/pkg/fluxexec/bootstrap_git.go
+++ b/pkg/fluxexec/bootstrap_git.go
@@ -1,0 +1,117 @@
+package fluxexec
+
+import (
+	"context"
+	"os/exec"
+)
+
+type bootstrapGitConfig struct {
+	globalOptions    []GlobalOption
+	bootstrapOptions []BootstrapOption
+
+	allowInsecureHTTP bool
+	interval          string
+	password          string
+	path              string
+	silent            bool
+	url               string
+	username          string
+}
+
+var defaultBootstrapGitOptions = bootstrapGitConfig{
+	interval: "1m0s",
+	username: "git",
+}
+
+// BootstrapGitOption represents options used in the BootstrapGit method.
+type BootstrapGitOption interface {
+	configureBootstrapGit(*bootstrapGitConfig)
+}
+
+func (opt *AllowInsecureHTTPOption) configureBootstrapGit(conf *bootstrapGitConfig) {
+	conf.allowInsecureHTTP = opt.allowInsecureHTTP
+}
+
+func (opt *IntervalOption) configureBootstrapGit(conf *bootstrapGitConfig) {
+	conf.interval = opt.interval
+}
+
+func (opt *PasswordOption) configureBootstrapGit(conf *bootstrapGitConfig) {
+	conf.password = opt.password
+}
+
+func (opt *PathOption) configureBootstrapGit(conf *bootstrapGitConfig) {
+	conf.path = opt.path
+}
+
+func (opt *SilentOption) configureBootstrapGit(conf *bootstrapGitConfig) {
+	conf.silent = opt.silent
+}
+
+func (opt *URLOption) configureBootstrapGit(conf *bootstrapGitConfig) {
+	conf.url = opt.url
+}
+
+func (opt *UsernameOption) configureBootstrapGit(conf *bootstrapGitConfig) {
+	conf.username = opt.username
+}
+
+func (flux *Flux) BootstrapGit(ctx context.Context, opts ...BootstrapGitOption) error {
+	bootstrapGitCmd, err := flux.bootstrapGitCmd(ctx, opts...)
+	if err != nil {
+		return err
+	}
+
+	if err := flux.runFluxCmd(ctx, bootstrapGitCmd); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (flux *Flux) bootstrapGitCmd(ctx context.Context, opts ...BootstrapGitOption) (*exec.Cmd, error) {
+	c := defaultBootstrapGitOptions
+	for _, o := range opts {
+		o.configureBootstrapGit(&c)
+	}
+
+	args := []string{"bootstrap", "git"}
+
+	// Add the global args first.
+	globalArgs := flux.globalArgs(c.globalOptions...)
+	args = append(args, globalArgs...)
+
+	// The add the bootstrap args.
+	bootstrapArgs := flux.bootstrapArgs(c.bootstrapOptions...)
+	args = append(args, bootstrapArgs...)
+
+	if c.allowInsecureHTTP {
+		args = append(args, "--allow-insecure-http")
+	}
+
+	if c.interval != "" {
+		args = append(args, "--interval", c.interval)
+	}
+
+	if c.password != "" {
+		args = append(args, "--password", c.password)
+	}
+
+	if c.path != "" {
+		args = append(args, "--path", c.path)
+	}
+
+	if c.silent {
+		args = append(args, "--silent")
+	}
+
+	if c.url != "" {
+		args = append(args, "--url", c.url)
+	}
+
+	if c.username != "" {
+		args = append(args, "--username", c.username)
+	}
+
+	return flux.buildFluxCmd(ctx, nil, args...), nil
+}

--- a/pkg/fluxexec/bootstrap_git_test.go
+++ b/pkg/fluxexec/bootstrap_git_test.go
@@ -1,0 +1,130 @@
+package fluxexec
+
+import (
+	"context"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"os"
+	"path/filepath"
+)
+
+var _ = Describe("bootstrapGitCmd", func() {
+	It("should be able to generate correct install commands", func() {
+		By("generating the default command", func() {
+			flux, err := NewFlux(".", "/path/to/flux")
+			Expect(err).To(BeNil())
+
+			homedir, err := os.UserHomeDir()
+			Expect(err).To(BeNil())
+
+			initCmd, err := flux.bootstrapGitCmd(context.TODO())
+			Expect(err).To(BeNil())
+			Expect(initCmd.Args[1:]).To(Equal([]string{
+				"bootstrap",
+				"git",
+				"--cache-dir",
+				filepath.Join(homedir, ".kube", "cache"),
+				"--kube-api-burst",
+				"100",
+				"--kube-api-qps",
+				"50",
+				"--namespace",
+				"flux-system",
+				"--timeout",
+				"5m0s",
+				"--author-name",
+				"Flux",
+				"--branch",
+				"main",
+				"--cluster-domain",
+				"cluster.local",
+				"--components",
+				"source-controller,kustomize-controller,helm-controller,notification-controller",
+				"--log-level",
+				"info",
+				"--network-policy",
+				"--registry",
+				"ghcr.io/fluxcd",
+				"--secret-name",
+				"flux-system",
+				"--ssh-ecdsa-curve",
+				"p384",
+				"--ssh-key-algorithm",
+				"ecdsa",
+				"--ssh-rsa-bits",
+				"2048",
+				"--watch-all-namespaces",
+				"--interval",
+				"1m0s",
+				"--username",
+				"git",
+			}))
+		})
+
+		By("generating the command with all options", func() {
+			flux, err := NewFlux(".", "/path/to/flux")
+			Expect(err).To(BeNil())
+
+			homedir, err := os.UserHomeDir()
+			Expect(err).To(BeNil())
+
+			initCmd, err := flux.bootstrapGitCmd(context.TODO(),
+				AllowInsecureHTTP(true),
+				Interval("2m"),
+				Password("password"),
+				Path("./"),
+				Silent(true),
+				URL("git@git.example.com"),
+				Username("username"))
+			Expect(err).To(BeNil())
+			Expect(initCmd.Args[1:]).To(Equal([]string{
+				"bootstrap",
+				"git",
+				"--cache-dir",
+				filepath.Join(homedir, ".kube", "cache"),
+				"--kube-api-burst",
+				"100",
+				"--kube-api-qps",
+				"50",
+				"--namespace",
+				"flux-system",
+				"--timeout",
+				"5m0s",
+				"--author-name",
+				"Flux",
+				"--branch",
+				"main",
+				"--cluster-domain",
+				"cluster.local",
+				"--components",
+				"source-controller,kustomize-controller,helm-controller,notification-controller",
+				"--log-level",
+				"info",
+				"--network-policy",
+				"--registry",
+				"ghcr.io/fluxcd",
+				"--secret-name",
+				"flux-system",
+				"--ssh-ecdsa-curve",
+				"p384",
+				"--ssh-key-algorithm",
+				"ecdsa",
+				"--ssh-rsa-bits",
+				"2048",
+				"--watch-all-namespaces",
+				"--allow-insecure-http",
+				"--interval",
+				"2m",
+				"--password",
+				"password",
+				"--path",
+				"./",
+				"--silent",
+				"--url",
+				"git@git.example.com",
+				"--username",
+				"username",
+			}))
+		})
+	})
+})

--- a/pkg/fluxexec/options.go
+++ b/pkg/fluxexec/options.go
@@ -374,3 +374,39 @@ type UsernameOption struct {
 func Username(username string) *UsernameOption {
 	return &UsernameOption{username}
 }
+
+type PasswordOption struct {
+	password string
+}
+
+// Password represents the --password flag.
+func Password(password string) *PasswordOption {
+	return &PasswordOption{password}
+}
+
+type AllowInsecureHTTPOption struct {
+	allowInsecureHTTP bool
+}
+
+// AllowInsecureHTTP represents the --allow-insecure-http flag.
+func AllowInsecureHTTP(allowInsecureHTTP bool) *AllowInsecureHTTPOption {
+	return &AllowInsecureHTTPOption{allowInsecureHTTP: allowInsecureHTTP}
+}
+
+type SilentOption struct {
+	silent bool
+}
+
+// Silent represents the --silent flag.
+func Silent(silent bool) *SilentOption {
+	return &SilentOption{silent: silent}
+}
+
+type URLOption struct {
+	url string
+}
+
+// URL represents the --url flag.
+func URL(url string) *URLOption {
+	return &URLOption{url: url}
+}


### PR DESCRIPTION
This PR implements a wrapper for `flux bootstrap git` command.

Partially resolves #2689 

It is blocked by #2709 to merge.