### PR TITLE
update CLI ref link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Flags:
 Use "gitops [command] --help" for more information about a command.
 ```
 
-For more information please see the [docs](https://docs.gitops.weave.works/docs/cli-reference/gitops)
+For more information please see the [docs](https://docs.gitops.weave.works/docs/references/cli-reference/gitops/)
 
 ## FAQ
 


### PR DESCRIPTION
This fixes a weird quirk. 

The old link went to https://docs.gitops.weave.works/docs/cli-reference/gitops/index.html
<img width="1459" alt="Screenshot 2022-09-07 at 14 50 30" src="https://user-images.githubusercontent.com/19860021/188895231-1e188f63-1230-4bc4-ba33-111da1332e36.png">

Which then traps you in the past where `0.8.0` was latest.

Even navigating to a page which has the same positioning now, you're still trapped
<img width="1456" alt="Screenshot 2022-09-07 at 14 51 08" src="https://user-images.githubusercontent.com/19860021/188895374-0b83bcd3-ef5e-4f99-a3b6-faaefc1b51ae.png">
