### PR TITLE
gitops run: Abort if dev-bucket resources couldn't be installed

### DIFF
--- a/pkg/run/install_bucket_source_and_ks.go
+++ b/pkg/run/install_bucket_source_and_ks.go
@@ -80,7 +80,7 @@ func SetupBucketSourceAndKS(log logger.Logger, kubeClient client.Client, namespa
 
 	if err := kubeClient.Get(context.Background(), client.ObjectKeyFromObject(&secret), &secret); err != nil && apierrors.IsNotFound(err) {
 		if err := kubeClient.Create(context.Background(), &secret); err != nil {
-			log.Failuref("Error creating secret %s: %v", secret.Name, err.Error())
+			return fmt.Errorf("couldn't create secret %s: %v", secret.Name, err.Error())
 		} else {
 			log.Successf("Created secret %s", secret.Name)
 		}
@@ -93,7 +93,7 @@ func SetupBucketSourceAndKS(log logger.Logger, kubeClient client.Client, namespa
 
 	if err := kubeClient.Get(context.Background(), client.ObjectKeyFromObject(&source), &source); err != nil && apierrors.IsNotFound(err) {
 		if err := kubeClient.Create(context.Background(), &source); err != nil {
-			log.Failuref("Error creating source %s: %v", source.Name, err.Error())
+			return fmt.Errorf("couldn't create source %s: %v", source.Name, err.Error())
 		} else {
 			log.Successf("Created source %s", source.Name)
 		}
@@ -106,7 +106,7 @@ func SetupBucketSourceAndKS(log logger.Logger, kubeClient client.Client, namespa
 
 	if err := kubeClient.Get(context.Background(), client.ObjectKeyFromObject(&ks), &ks); err != nil && apierrors.IsNotFound(err) {
 		if err := kubeClient.Create(context.Background(), &ks); err != nil {
-			log.Failuref("Error creating ks %s: %v", ks.Name, err.Error())
+			return fmt.Errorf("couldn't create kustomization %s: %v", ks.Name, err.Error())
 		} else {
 			log.Successf("Created ks %s", ks.Name)
 		}


### PR DESCRIPTION
When we can't create a bucket or kustomization, nothing will work. Before this, when you for example specify a namespace that doesn't exist, we didn't abort, instead the output was:

```
► Checking secret dev-bucket-credentials ...
✗ Error creating secret dev-bucket-credentials: namespaces "this-doesnt-exist" not found
► Checking bucket source dev-bucket ...
✗ Error creating source dev-bucket: namespaces "this-doesnt-exist" not found
► Checking Kustomization dev-ks ...
✗ Error creating ks dev-ks: namespaces "this-doesnt-exist" not found
✔ Setup Bucket Source and Kustomization successfully
◎ Press Ctrl+C to stop GitOps Run ...
► 1 change events detected
► Refreshing bucket dev-bucket ...
Handling connection for 9000
...............
► Uploaded 152 files
► Request reconciliation of dev-bucket, and dev-ks (timeout 30s) ... 
✗ Error requesting reconciliation: buckets.source.toolkit.fluxcd.io "dev-bucket" not found
✔ Reconciliation is done.
```
which is confusing - no resources are created, nothing works, and yet there's a tick that we're "done".

With this, it exits at the first error.