### PR TITLE
Enable stylecheck lint rule

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -5,5 +5,6 @@ run:
 linters:
   enable:
     - wsl
+    - stylecheck
 
 linters-settings: {}

--- a/cmd/gitops-server/cmd/cmd.go
+++ b/cmd/gitops-server/cmd/cmd.go
@@ -156,7 +156,7 @@ func runCmd(cmd *cobra.Command, args []string) error {
 
 	namespace, _, err := kubeConfig.Namespace()
 	if err != nil {
-		return fmt.Errorf("Couldn't get current namespace")
+		return fmt.Errorf("couldn't get current namespace")
 	}
 
 	authServer, err := auth.InitAuthServer(cmd.Context(), log, rawClient, options.OIDC, options.OIDCSecret, namespace, options.AuthMethods)
@@ -269,12 +269,12 @@ func runCmd(cmd *cobra.Command, args []string) error {
 	}()
 
 	if err := srv.Shutdown(ctx); err != nil {
-		return fmt.Errorf("Server shutdown failed: %w", err)
+		return fmt.Errorf("server shutdown failed: %w", err)
 	}
 
 	if options.EnableMetrics {
 		if err := metricsServer.Shutdown(ctx); err != nil {
-			return fmt.Errorf("Metrics server shutdown failed: %w", err)
+			return fmt.Errorf("metrics server shutdown failed: %w", err)
 		}
 	}
 

--- a/cmd/gitops/version/cmd.go
+++ b/cmd/gitops/version/cmd.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// The current wego version
+// Version is the current wego version
 var Version = "v0.0.0"
 var GitCommit = ""
 var Branch = ""

--- a/core/clustersmngr/client_test.go
+++ b/core/clustersmngr/client_test.go
@@ -12,7 +12,6 @@ import (
 	sourcev1 "github.com/fluxcd/source-controller/api/v1beta2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
 
@@ -42,7 +41,7 @@ func TestClientGet(t *testing.T) {
 	clustersClient := clustersmngr.NewClient(clientsPool, nsMap)
 
 	kust := &kustomizev1.Kustomization{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      appName,
 			Namespace: ns.Name,
 		},
@@ -78,7 +77,7 @@ func TestClientClusteredList(t *testing.T) {
 	clustersClient := clustersmngr.NewClient(clientsPool, nsMap)
 
 	kust := &kustomizev1.Kustomization{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      appName,
 			Namespace: ns.Name,
 		},
@@ -103,7 +102,7 @@ func TestClientClusteredList(t *testing.T) {
 	g.Expect(klist.Items[0].Name).To(Equal(appName))
 
 	gitRepo := &sourcev1.GitRepository{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      appName,
 			Namespace: ns.Name,
 		},
@@ -139,7 +138,7 @@ func TestClientClusteredListPagination(t *testing.T) {
 
 	createKust := func(name string, nsName string) {
 		kust := &kustomizev1.Kustomization{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: nsName,
 			},
@@ -215,7 +214,7 @@ func TestClientClusteredListClusterScoped(t *testing.T) {
 
 	clustersClient := clustersmngr.NewClient(clientsPool, nsMap)
 	clusterRole := rbacv1.ClusterRole{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name: appName,
 		},
 		Rules: []rbacv1.PolicyRule{
@@ -289,7 +288,7 @@ func TestClientList(t *testing.T) {
 	clustersClient := clustersmngr.NewClient(clientsPool, nsMap)
 
 	kust := &kustomizev1.Kustomization{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      appName,
 			Namespace: ns.Name,
 		},
@@ -326,7 +325,7 @@ func TestClientCreate(t *testing.T) {
 	clustersClient := clustersmngr.NewClient(clientsPool, nsMap)
 
 	kust := &kustomizev1.Kustomization{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      appName,
 			Namespace: ns.Name,
 		},
@@ -361,7 +360,7 @@ func TestClientDelete(t *testing.T) {
 	clustersClient := clustersmngr.NewClient(clientsPool, nsMap)
 
 	kust := &kustomizev1.Kustomization{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      appName,
 			Namespace: ns.Name,
 		},
@@ -394,7 +393,7 @@ func TestClientUpdate(t *testing.T) {
 	clustersClient := clustersmngr.NewClient(clientsPool, nsMap)
 
 	kust := &kustomizev1.Kustomization{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      appName,
 			Namespace: ns.Name,
 		},
@@ -436,7 +435,7 @@ func TestClientPatch(t *testing.T) {
 			Kind:       kustomizev1.KustomizationKind,
 			APIVersion: kustomizev1.GroupVersion.String(),
 		},
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      appName,
 			Namespace: ns.Name,
 		},

--- a/core/clustersmngr/clustersmngr_test.go
+++ b/core/clustersmngr/clustersmngr_test.go
@@ -40,7 +40,7 @@ func TestClientConfigWithUser(t *testing.T) {
 		{
 			name:                  "No token or user Id should error",
 			principal:             &auth.UserPrincipal{},
-			expectedErr:           fmt.Errorf("No user ID or Token found in UserPrincipal."),
+			expectedErr:           fmt.Errorf("no user ID or Token found in UserPrincipal"),
 			expectedToken:         "",
 			expectedImpersonation: nil,
 		},

--- a/core/clustersmngr/factory.go
+++ b/core/clustersmngr/factory.go
@@ -521,7 +521,7 @@ func ClientConfigWithUser(user *auth.UserPrincipal, options ...KubeConfigOption)
 		config := restConfigFromCluster(cluster)
 
 		if !user.Valid() {
-			return nil, fmt.Errorf("No user ID or Token found in UserPrincipal.")
+			return nil, fmt.Errorf("no user ID or Token found in UserPrincipal")
 		} else if tok := user.Token(); tok != "" {
 			config.BearerToken = tok
 		} else {

--- a/core/clustersmngr/factory_caches.go
+++ b/core/clustersmngr/factory_caches.go
@@ -145,6 +145,6 @@ func (un *UsersNamespaces) Clear() {
 	un.Cache.Clear()
 }
 
-func (u UsersNamespaces) cacheKey(user *auth.UserPrincipal, cluster string) uint64 {
+func (un UsersNamespaces) cacheKey(user *auth.UserPrincipal, cluster string) uint64 {
 	return ttlcache.StringKey(fmt.Sprintf("%s:%s", user.ID, cluster))
 }

--- a/core/server/fluxruntime_test.go
+++ b/core/server/fluxruntime_test.go
@@ -8,13 +8,11 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/weaveworks/weave-gitops/core/clustersmngr"
 	"github.com/weaveworks/weave-gitops/core/server"
-	coretypes "github.com/weaveworks/weave-gitops/core/server/types"
 	stypes "github.com/weaveworks/weave-gitops/core/server/types"
 	pb "github.com/weaveworks/weave-gitops/pkg/api/core"
 	"github.com/weaveworks/weave-gitops/pkg/kube"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -182,7 +180,7 @@ func TestListFluxRuntimeObjects(t *testing.T) {
 	k, err := kube.NewKubeHTTPClientWithConfig(k8sEnv.Rest, "")
 	g.Expect(err).NotTo(HaveOccurred())
 
-	nss := &v1.Namespace{}
+	nss := &corev1.Namespace{}
 	nss.Name = "ns1"
 	g.Expect(k.Create(ctx, nss)).To(Succeed())
 
@@ -193,7 +191,7 @@ func TestListFluxRuntimeObjects(t *testing.T) {
 	g.Expect(res.Errors[0].Namespace).To(BeEmpty())
 	g.Expect(res.Errors[0].ClusterName).To(Equal(clustersmngr.DefaultCluster))
 
-	fluxNs := &v1.Namespace{}
+	fluxNs := &corev1.Namespace{}
 	fluxNs.Name = "flux-ns"
 	fluxNs.Labels = map[string]string{
 		stypes.PartOfLabel: server.FluxNamespacePartOf,
@@ -256,7 +254,7 @@ func TestListFluxCrds(t *testing.T) {
 
 	crd1 := &apiextensions.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{
 		Name:   "crd1",
-		Labels: map[string]string{coretypes.PartOfLabel: "flux"},
+		Labels: map[string]string{stypes.PartOfLabel: "flux"},
 	}, Spec: apiextensions.CustomResourceDefinitionSpec{
 		Group:    "group",
 		Names:    apiextensions.CustomResourceDefinitionNames{Plural: "plural", Kind: "kind"},
@@ -264,7 +262,7 @@ func TestListFluxCrds(t *testing.T) {
 	}}
 	crd2 := &apiextensions.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{
 		Name:   "crd2",
-		Labels: map[string]string{coretypes.PartOfLabel: "flux"},
+		Labels: map[string]string{stypes.PartOfLabel: "flux"},
 	}, Spec: apiextensions.CustomResourceDefinitionSpec{
 		Group:    "group",
 		Versions: []apiextensions.CustomResourceDefinitionVersion{{Name: "0"}},

--- a/core/server/helm_release.go
+++ b/core/server/helm_release.go
@@ -10,7 +10,6 @@ import (
 	"io"
 	"strings"
 
-	"github.com/fluxcd/helm-controller/api/v2beta1"
 	helmv2 "github.com/fluxcd/helm-controller/api/v2beta1"
 	"github.com/fluxcd/pkg/ssa"
 	"github.com/hashicorp/go-multierror"
@@ -110,7 +109,7 @@ func (cs *coreServer) GetHelmRelease(ctx context.Context, msg *pb.GetHelmRelease
 	}, err
 }
 
-func getHelmReleaseInventory(ctx context.Context, helmRelease v2beta1.HelmRelease, c clustersmngr.Client, cluster string) ([]*pb.GroupVersionKind, error) {
+func getHelmReleaseInventory(ctx context.Context, helmRelease helmv2.HelmRelease, c clustersmngr.Client, cluster string) ([]*pb.GroupVersionKind, error) {
 	storageNamespace := helmRelease.GetStorageNamespace()
 
 	storageName := helmRelease.GetReleaseName()

--- a/core/server/internal/adapters.go
+++ b/core/server/internal/adapters.go
@@ -62,24 +62,24 @@ type GitRepositoryAdapter struct {
 	*sourcev1.GitRepository
 }
 
-func (o GitRepositoryAdapter) GetLastHandledReconcileRequest() string {
-	return o.Status.GetLastHandledReconcileRequest()
+func (obj GitRepositoryAdapter) GetLastHandledReconcileRequest() string {
+	return obj.Status.GetLastHandledReconcileRequest()
 }
 
-func (o GitRepositoryAdapter) AsClientObject() client.Object {
-	return o.GitRepository
+func (obj GitRepositoryAdapter) AsClientObject() client.Object {
+	return obj.GitRepository
 }
 
-func (o GitRepositoryAdapter) GroupVersionKind() schema.GroupVersionKind {
+func (obj GitRepositoryAdapter) GroupVersionKind() schema.GroupVersionKind {
 	return sourcev1.GroupVersion.WithKind(sourcev1.GitRepositoryKind)
 }
 
-func (o GitRepositoryAdapter) SetSuspended(suspend bool) {
-	o.Spec.Suspend = suspend
+func (obj GitRepositoryAdapter) SetSuspended(suspend bool) {
+	obj.Spec.Suspend = suspend
 }
 
-func (o GitRepositoryAdapter) DeepCopyClientObject() client.Object {
-	return o.DeepCopy()
+func (obj GitRepositoryAdapter) DeepCopyClientObject() client.Object {
+	return obj.DeepCopy()
 }
 
 type BucketAdapter struct {
@@ -94,16 +94,16 @@ func (obj BucketAdapter) AsClientObject() client.Object {
 	return obj.Bucket
 }
 
-func (o BucketAdapter) GroupVersionKind() schema.GroupVersionKind {
+func (obj BucketAdapter) GroupVersionKind() schema.GroupVersionKind {
 	return sourcev1.GroupVersion.WithKind(sourcev1.BucketKind)
 }
 
-func (o BucketAdapter) SetSuspended(suspend bool) {
-	o.Spec.Suspend = suspend
+func (obj BucketAdapter) SetSuspended(suspend bool) {
+	obj.Spec.Suspend = suspend
 }
 
-func (o BucketAdapter) DeepCopyClientObject() client.Object {
-	return o.DeepCopy()
+func (obj BucketAdapter) DeepCopyClientObject() client.Object {
+	return obj.DeepCopy()
 }
 
 type HelmChartAdapter struct {
@@ -118,16 +118,16 @@ func (obj HelmChartAdapter) AsClientObject() client.Object {
 	return obj.HelmChart
 }
 
-func (o HelmChartAdapter) GroupVersionKind() schema.GroupVersionKind {
+func (obj HelmChartAdapter) GroupVersionKind() schema.GroupVersionKind {
 	return sourcev1.GroupVersion.WithKind(sourcev1.HelmChartKind)
 }
 
-func (o HelmChartAdapter) SetSuspended(suspend bool) {
-	o.Spec.Suspend = suspend
+func (obj HelmChartAdapter) SetSuspended(suspend bool) {
+	obj.Spec.Suspend = suspend
 }
 
-func (o HelmChartAdapter) DeepCopyClientObject() client.Object {
-	return o.DeepCopy()
+func (obj HelmChartAdapter) DeepCopyClientObject() client.Object {
+	return obj.DeepCopy()
 }
 
 type HelmRepositoryAdapter struct {
@@ -142,16 +142,16 @@ func (obj HelmRepositoryAdapter) AsClientObject() client.Object {
 	return obj.HelmRepository
 }
 
-func (o HelmRepositoryAdapter) GroupVersionKind() schema.GroupVersionKind {
+func (obj HelmRepositoryAdapter) GroupVersionKind() schema.GroupVersionKind {
 	return sourcev1.GroupVersion.WithKind(sourcev1.HelmRepositoryKind)
 }
 
-func (o HelmRepositoryAdapter) SetSuspended(suspend bool) {
-	o.Spec.Suspend = suspend
+func (obj HelmRepositoryAdapter) SetSuspended(suspend bool) {
+	obj.Spec.Suspend = suspend
 }
 
-func (o HelmRepositoryAdapter) DeepCopyClientObject() client.Object {
-	return o.DeepCopy()
+func (obj HelmRepositoryAdapter) DeepCopyClientObject() client.Object {
+	return obj.DeepCopy()
 }
 
 type OCIRepositoryAdapter struct {
@@ -166,16 +166,16 @@ func (obj OCIRepositoryAdapter) AsClientObject() client.Object {
 	return obj.OCIRepository
 }
 
-func (o OCIRepositoryAdapter) GroupVersionKind() schema.GroupVersionKind {
+func (obj OCIRepositoryAdapter) GroupVersionKind() schema.GroupVersionKind {
 	return sourcev1.GroupVersion.WithKind(sourcev1.OCIRepositoryKind)
 }
 
-func (o OCIRepositoryAdapter) SetSuspended(suspend bool) {
-	o.Spec.Suspend = suspend
+func (obj OCIRepositoryAdapter) SetSuspended(suspend bool) {
+	obj.Spec.Suspend = suspend
 }
 
-func (o OCIRepositoryAdapter) DeepCopyClientObject() client.Object {
-	return o.DeepCopy()
+func (obj OCIRepositoryAdapter) DeepCopyClientObject() client.Object {
+	return obj.DeepCopy()
 }
 
 type HelmReleaseAdapter struct {
@@ -190,8 +190,8 @@ func (obj HelmReleaseAdapter) AsClientObject() client.Object {
 	return obj.HelmRelease
 }
 
-func (o HelmReleaseAdapter) SourceRef() SourceRef {
-	sr := o.Spec.Chart.Spec.SourceRef
+func (obj HelmReleaseAdapter) SourceRef() SourceRef {
+	sr := obj.Spec.Chart.Spec.SourceRef
 
 	return sRef{
 		apiVersion: sr.APIVersion,
@@ -201,49 +201,49 @@ func (o HelmReleaseAdapter) SourceRef() SourceRef {
 	}
 }
 
-func (o HelmReleaseAdapter) GroupVersionKind() schema.GroupVersionKind {
+func (obj HelmReleaseAdapter) GroupVersionKind() schema.GroupVersionKind {
 	return helmv2.GroupVersion.WithKind(helmv2.HelmReleaseKind)
 }
 
-func (o HelmReleaseAdapter) SetSuspended(suspend bool) {
-	o.Spec.Suspend = suspend
+func (obj HelmReleaseAdapter) SetSuspended(suspend bool) {
+	obj.Spec.Suspend = suspend
 }
 
-func (o HelmReleaseAdapter) DeepCopyClientObject() client.Object {
-	return o.DeepCopy()
+func (obj HelmReleaseAdapter) DeepCopyClientObject() client.Object {
+	return obj.DeepCopy()
 }
 
 type KustomizationAdapter struct {
 	*kustomizev1.Kustomization
 }
 
-func (o KustomizationAdapter) GetLastHandledReconcileRequest() string {
-	return o.Status.GetLastHandledReconcileRequest()
+func (obj KustomizationAdapter) GetLastHandledReconcileRequest() string {
+	return obj.Status.GetLastHandledReconcileRequest()
 }
 
-func (o KustomizationAdapter) AsClientObject() client.Object {
-	return o.Kustomization
+func (obj KustomizationAdapter) AsClientObject() client.Object {
+	return obj.Kustomization
 }
 
-func (o KustomizationAdapter) SourceRef() SourceRef {
+func (obj KustomizationAdapter) SourceRef() SourceRef {
 	return sRef{
-		apiVersion: o.Spec.SourceRef.APIVersion,
-		name:       o.Spec.SourceRef.Name,
-		namespace:  o.Spec.SourceRef.Namespace,
-		kind:       o.Spec.SourceRef.Kind,
+		apiVersion: obj.Spec.SourceRef.APIVersion,
+		name:       obj.Spec.SourceRef.Name,
+		namespace:  obj.Spec.SourceRef.Namespace,
+		kind:       obj.Spec.SourceRef.Kind,
 	}
 }
 
-func (o KustomizationAdapter) GroupVersionKind() schema.GroupVersionKind {
+func (obj KustomizationAdapter) GroupVersionKind() schema.GroupVersionKind {
 	return kustomizev1.GroupVersion.WithKind(kustomizev1.KustomizationKind)
 }
 
-func (o KustomizationAdapter) SetSuspended(suspend bool) {
-	o.Spec.Suspend = suspend
+func (obj KustomizationAdapter) SetSuspended(suspend bool) {
+	obj.Spec.Suspend = suspend
 }
 
-func (o KustomizationAdapter) DeepCopyClientObject() client.Object {
-	return o.DeepCopy()
+func (obj KustomizationAdapter) DeepCopyClientObject() client.Object {
+	return obj.DeepCopy()
 }
 
 type sRef struct {

--- a/core/server/primarykinds.go
+++ b/core/server/primarykinds.go
@@ -42,7 +42,7 @@ func DefaultPrimaryKinds() *PrimaryKinds {
 func (pk *PrimaryKinds) Add(kind string, gvk schema.GroupVersionKind) error {
 	_, ok := pk.kinds[kind]
 	if ok {
-		return fmt.Errorf("Couldn't add kind %v - already added", kind)
+		return fmt.Errorf("couldn't add kind %v - already added", kind)
 	}
 
 	pk.kinds[kind] = gvk
@@ -55,7 +55,7 @@ func (pk *PrimaryKinds) Add(kind string, gvk schema.GroupVersionKind) error {
 func (pk *PrimaryKinds) Lookup(kind string) (*schema.GroupVersionKind, error) {
 	gvk, ok := pk.kinds[kind]
 	if !ok {
-		return nil, fmt.Errorf("Looking up objects of kind %v not supported", kind)
+		return nil, fmt.Errorf("looking up objects of kind %v not supported", kind)
 	}
 
 	return &gvk, nil

--- a/core/server/sync.go
+++ b/core/server/sync.go
@@ -207,7 +207,7 @@ func waitForSync(ctx context.Context, c client.Client, key client.ObjectKey, obj
 		checkResourceSync(ctx, c, key, obj, obj.GetLastHandledReconcileRequest()),
 	); err != nil {
 		if errors.Is(err, wait.ErrWaitTimeout) {
-			return errors.New("Sync request timed out. The sync operation may still be in progress.")
+			return errors.New("sync request timed out - the sync operation may still be in progress")
 		}
 
 		return fmt.Errorf("syncing resource: %w", err)

--- a/core/server/types/kustomization.go
+++ b/core/server/types/kustomization.go
@@ -85,10 +85,10 @@ func getKustomizeInventory(kustomization *kustomizev1.Kustomization) ([]*pb.Grou
 			return gvk, fmt.Errorf("invalid inventory item '%s', error: %w", entry.ID, err)
 		}
 
-		gvkId := strings.Join([]string{objMeta.GroupKind.Group, entry.Version, objMeta.GroupKind.Kind}, "_")
+		gvkID := strings.Join([]string{objMeta.GroupKind.Group, entry.Version, objMeta.GroupKind.Kind}, "_")
 
-		if !found[gvkId] {
-			found[gvkId] = true
+		if !found[gvkID] {
+			found[gvkID] = true
 
 			gvk = append(gvk, &pb.GroupVersionKind{
 				Group:   objMeta.GroupKind.Group,

--- a/pkg/flux/flux.go
+++ b/pkg/flux/flux.go
@@ -11,7 +11,7 @@ import (
 
 //counterfeiter:generate . Flux
 type Flux interface {
-	CreateSecretGit(name string, repoUrl gitproviders.RepoURL, namespace string) ([]byte, error)
+	CreateSecretGit(name string, repoURL gitproviders.RepoURL, namespace string) ([]byte, error)
 }
 
 const (
@@ -33,10 +33,10 @@ func New(cliRunner runner.Runner) *FluxClient {
 var _ Flux = &FluxClient{}
 
 // CreatSecretGit Creates a Git secret returns the deploy key
-func (f *FluxClient) CreateSecretGit(name string, repoUrl gitproviders.RepoURL, namespace string) ([]byte, error) {
+func (f *FluxClient) CreateSecretGit(name string, repoURL gitproviders.RepoURL, namespace string) ([]byte, error) {
 	args := []string{
 		"create", "secret", "git", name,
-		"--url", repoUrl.String(),
+		"--url", repoURL.String(),
 		"--namespace", namespace,
 		"--export",
 	}

--- a/pkg/flux/flux_test.go
+++ b/pkg/flux/flux_test.go
@@ -28,9 +28,9 @@ var _ = Describe("CreateSecretGit", func() {
 			return []byte(`ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCh...`), nil
 		}
 
-		repoUrl, err := gitproviders.NewRepoURL("ssh://git@github.com/foo/bar.git")
+		repoURL, err := gitproviders.NewRepoURL("ssh://git@github.com/foo/bar.git")
 		Expect(err).ShouldNot(HaveOccurred())
-		out, err := fluxClient.CreateSecretGit("my-secret", repoUrl, "flux-system")
+		out, err := fluxClient.CreateSecretGit("my-secret", repoURL, "flux-system")
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(out).To(Equal([]byte("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCh...")))
 

--- a/pkg/fluxexec/bootstrap.go
+++ b/pkg/fluxexec/bootstrap.go
@@ -24,10 +24,10 @@ type bootstrapConfig struct {
 	recurseSubmodules     bool
 	registry              string
 	secretName            string
-	sshEcdsaCurve         EcdsaCurve
+	sshECDSACurve         ECDSACurve
 	sshHostname           string
 	sshKeyAlgorithm       KeyAlgorithm
-	sshRsaBits            int
+	sshRSABits            int
 	tokenAuth             bool
 	tolerationKeys        []string
 	watchAllNamespaces    bool
@@ -44,9 +44,9 @@ var defaultBootstrapOptions = bootstrapConfig{
 	recurseSubmodules:  false,
 	registry:           "ghcr.io/fluxcd",
 	secretName:         "flux-system",
-	sshEcdsaCurve:      EcdsaCurveP384,
+	sshECDSACurve:      ECDSACurveP384,
 	sshKeyAlgorithm:    KeyAlgorithmECDSA,
-	sshRsaBits:         2048,
+	sshRSABits:         2048,
 	tokenAuth:          false,
 	tolerationKeys:     []string{},
 	watchAllNamespaces: true,
@@ -90,15 +90,15 @@ func (opt *ComponentsExtraOption) configureBootstrap(conf *bootstrapConfig) {
 	conf.componentsExtra = opt.componentsExtra
 }
 
-func (opt *GpgKeyIdOption) configureBootstrap(conf *bootstrapConfig) {
-	conf.gpgKeyID = opt.gpgKeyId
+func (opt *GPGKeyIDOption) configureBootstrap(conf *bootstrapConfig) {
+	conf.gpgKeyID = opt.gpgKeyID
 }
 
-func (opt *GpgKeyRingOption) configureBootstrap(conf *bootstrapConfig) {
+func (opt *GPGKeyRingOption) configureBootstrap(conf *bootstrapConfig) {
 	conf.gpgKeyRing = opt.gpgKeyRing
 }
 
-func (opt *GpgPassphraseOption) configureBootstrap(conf *bootstrapConfig) {
+func (opt *GPGPassphraseOption) configureBootstrap(conf *bootstrapConfig) {
 	conf.gpgPassphrase = opt.gpgPassphrase
 }
 
@@ -130,20 +130,20 @@ func (opt *SecretNameOption) configureBootstrap(conf *bootstrapConfig) {
 	conf.secretName = opt.secretName
 }
 
-func (opt *SshEcdsaCurveOption) configureBootstrap(conf *bootstrapConfig) {
-	conf.sshEcdsaCurve = opt.sshEcdsaCurve
+func (opt *SSHECDSACurveOption) configureBootstrap(conf *bootstrapConfig) {
+	conf.sshECDSACurve = opt.sshECDSACurve
 }
 
-func (opt *SshHostnameOption) configureBootstrap(conf *bootstrapConfig) {
+func (opt *SSHHostnameOption) configureBootstrap(conf *bootstrapConfig) {
 	conf.sshHostname = opt.sshHostname
 }
 
-func (opt *SshKeyAlgorithmOption) configureBootstrap(conf *bootstrapConfig) {
+func (opt *SSHKeyAlgorithmOption) configureBootstrap(conf *bootstrapConfig) {
 	conf.sshKeyAlgorithm = opt.sshKeyAlgorithm
 }
 
-func (opt *SshRsaBitsOption) configureBootstrap(conf *bootstrapConfig) {
-	conf.sshRsaBits = opt.sshRsaBits
+func (opt *SSHRSABitsOption) configureBootstrap(conf *bootstrapConfig) {
+	conf.sshRSABits = opt.sshRSABits
 }
 
 func (opt *TokenAuthOption) configureBootstrap(conf *bootstrapConfig) {
@@ -262,8 +262,8 @@ func (flux *Flux) bootstrapArgs(opts ...BootstrapOption) []string {
 		args = append(args, "--secret-name", c.secretName)
 	}
 
-	if c.sshEcdsaCurve != "" {
-		args = append(args, "--ssh-ecdsa-curve", string(c.sshEcdsaCurve))
+	if c.sshECDSACurve != "" {
+		args = append(args, "--ssh-ecdsa-curve", string(c.sshECDSACurve))
 	}
 
 	if c.sshHostname != "" {
@@ -274,8 +274,8 @@ func (flux *Flux) bootstrapArgs(opts ...BootstrapOption) []string {
 		args = append(args, "--ssh-key-algorithm", string(c.sshKeyAlgorithm))
 	}
 
-	if c.sshRsaBits != 0 {
-		args = append(args, "--ssh-rsa-bits", strconv.Itoa(c.sshRsaBits))
+	if c.sshRSABits != 0 {
+		args = append(args, "--ssh-rsa-bits", strconv.Itoa(c.sshRSABits))
 	}
 
 	if c.tokenAuth {

--- a/pkg/fluxexec/global.go
+++ b/pkg/fluxexec/global.go
@@ -9,16 +9,16 @@ import (
 type globalConfig struct {
 	as                    string
 	asGroup               []string
-	asUid                 string
+	asUID                 string
 	cacheDir              string
 	certificateAuthority  string
 	clientCertificate     string
 	clientKey             string
 	cluster               string
 	context               string
-	insecureSkipTlsVerify bool
-	kubeApiBurst          int
-	kubeApiQps            float32
+	insecureSkipTLSVerify bool
+	kubeAPIBurst          int
+	kubeAPIQPS            float32
 	kubeconfig            string
 	namespace             string
 	server                string
@@ -40,8 +40,8 @@ func defaultCacheDir() string {
 
 var defaultGlobalOptions = globalConfig{
 	cacheDir:     defaultCacheDir(),
-	kubeApiBurst: 100,
-	kubeApiQps:   50,
+	kubeAPIBurst: 100,
+	kubeAPIQPS:   50,
 	namespace:    "flux-system",
 	timeout:      "5m0s",
 }
@@ -59,8 +59,8 @@ func (opt *AsGroupOption) configureGlobal(conf *globalConfig) {
 	conf.asGroup = opt.asGroup
 }
 
-func (opt *AsUidOption) configureGlobal(conf *globalConfig) {
-	conf.asUid = opt.asUid
+func (opt *AsUIDOption) configureGlobal(conf *globalConfig) {
+	conf.asUID = opt.asUID
 }
 
 func (opt *CacheDirOption) configureGlobal(conf *globalConfig) {
@@ -87,16 +87,16 @@ func (opt *ContextOption) configureGlobal(conf *globalConfig) {
 	conf.context = opt.context
 }
 
-func (opt *InsecureSkipTlsVerifyOption) configureGlobal(conf *globalConfig) {
-	conf.insecureSkipTlsVerify = opt.insecureSkipTlsVerify
+func (opt *InsecureSkipTLSVerifyOption) configureGlobal(conf *globalConfig) {
+	conf.insecureSkipTLSVerify = opt.insecureSkipTLSVerify
 }
 
-func (opt *KubeApiBurstOption) configureGlobal(conf *globalConfig) {
-	conf.kubeApiBurst = opt.kubeApiBurst
+func (opt *KubeAPIBurstOption) configureGlobal(conf *globalConfig) {
+	conf.kubeAPIBurst = opt.kubeAPIBurst
 }
 
-func (opt *KubeApiQpsOption) configureGlobal(conf *globalConfig) {
-	conf.kubeApiQps = opt.kubeApiQps
+func (opt *KubeAPIQPSOption) configureGlobal(conf *globalConfig) {
+	conf.kubeAPIQPS = opt.kubeAPIQPS
 }
 
 func (opt *KubeconfigOption) configureGlobal(conf *globalConfig) {
@@ -163,8 +163,8 @@ func (flux *Flux) globalArgs(opts ...GlobalOption) []string {
 		}
 	}
 
-	if c.asUid != "" {
-		args = append(args, "--as-uid", c.asUid)
+	if c.asUID != "" {
+		args = append(args, "--as-uid", c.asUID)
 	}
 
 	if c.cacheDir != "" {
@@ -191,16 +191,16 @@ func (flux *Flux) globalArgs(opts ...GlobalOption) []string {
 		args = append(args, "--context", c.context)
 	}
 
-	if c.insecureSkipTlsVerify {
+	if c.insecureSkipTLSVerify {
 		args = append(args, "--insecure-skip-tls-verify")
 	}
 
-	if c.kubeApiBurst != 0 {
-		args = append(args, "--kube-api-burst", strconv.Itoa(c.kubeApiBurst))
+	if c.kubeAPIBurst != 0 {
+		args = append(args, "--kube-api-burst", strconv.Itoa(c.kubeAPIBurst))
 	}
 
-	if c.kubeApiQps != 0 {
-		args = append(args, "--kube-api-qps", strconv.FormatFloat(float64(c.kubeApiQps), 'f', -1, 32))
+	if c.kubeAPIQPS != 0 {
+		args = append(args, "--kube-api-qps", strconv.FormatFloat(float64(c.kubeAPIQPS), 'f', -1, 32))
 	}
 
 	if c.kubeconfig != "" {

--- a/pkg/fluxexec/option_consts.go
+++ b/pkg/fluxexec/option_consts.go
@@ -8,12 +8,12 @@ const (
 	KeyAlgorithmED25519 KeyAlgorithm = "ed25519"
 )
 
-type EcdsaCurve string
+type ECDSACurve string
 
 const (
-	EcdsaCurveP256 EcdsaCurve = "p256"
-	EcdsaCurveP384 EcdsaCurve = "p384"
-	EcdsaCurveP521 EcdsaCurve = "p521"
+	ECDSACurveP256 ECDSACurve = "p256"
+	ECDSACurveP384 ECDSACurve = "p384"
+	ECDSACurveP521 ECDSACurve = "p521"
 )
 
 type Component string

--- a/pkg/fluxexec/options.go
+++ b/pkg/fluxexec/options.go
@@ -267,31 +267,31 @@ func Group(group ...string) *GroupOption {
 	return &GroupOption{group}
 }
 
-type GpgKeyIdOption struct {
-	gpgKeyId string
+type GPGKeyIDOption struct {
+	gpgKeyID string
 }
 
-// GpgKeyId represents the --gpg-key-id flag.
-func GpgKeyId(gpgKeyId string) *GpgKeyIdOption {
-	return &GpgKeyIdOption{gpgKeyId}
+// GPGKeyID represents the --gpg-key-id flag.
+func GPGKeyID(gpgKeyID string) *GPGKeyIDOption {
+	return &GPGKeyIDOption{gpgKeyID}
 }
 
-type GpgKeyRingOption struct {
+type GPGKeyRingOption struct {
 	gpgKeyRing string
 }
 
-// GpgKeyRing represents the --gpg-key-ring flag.
-func GpgKeyRing(gpgKeyRing string) *GpgKeyRingOption {
-	return &GpgKeyRingOption{gpgKeyRing}
+// GPGKeyRing represents the --gpg-key-ring flag.
+func GPGKeyRing(gpgKeyRing string) *GPGKeyRingOption {
+	return &GPGKeyRingOption{gpgKeyRing}
 }
 
-type GpgPassphraseOption struct {
+type GPGPassphraseOption struct {
 	gpgPassphrase string
 }
 
-// GpgPassphrase represents the --gpg-passphrase flag.
-func GpgPassphrase(gpgPassphrase string) *GpgPassphraseOption {
-	return &GpgPassphraseOption{gpgPassphrase}
+// GPGPassphrase represents the --gpg-passphrase flag.
+func GPGPassphrase(gpgPassphrase string) *GPGPassphraseOption {
+	return &GPGPassphraseOption{gpgPassphrase}
 }
 
 type PrivateKeyFileOption struct {
@@ -321,40 +321,40 @@ func SecretName(secretName string) *SecretNameOption {
 	return &SecretNameOption{secretName}
 }
 
-type SshEcdsaCurveOption struct {
-	sshEcdsaCurve EcdsaCurve
+type SSHECDSACurveOption struct {
+	sshECDSACurve ECDSACurve
 }
 
-// SshEcdsaCurve represents the --ssh-ecdsa-curve flag.
-func SshEcdsaCurve(ecdsaCurve EcdsaCurve) *SshEcdsaCurveOption {
-	return &SshEcdsaCurveOption{ecdsaCurve}
+// SSHECDSACurve represents the --ssh-ecdsa-curve flag.
+func SSHECDSACurve(ecdsaCurve ECDSACurve) *SSHECDSACurveOption {
+	return &SSHECDSACurveOption{ecdsaCurve}
 }
 
-type SshHostnameOption struct {
+type SSHHostnameOption struct {
 	sshHostname string
 }
 
-// SshHostname represents the --ssh-hostname flag.
-func SshHostname(sshHostname string) *SshHostnameOption {
-	return &SshHostnameOption{sshHostname}
+// SSHHostname represents the --ssh-hostname flag.
+func SSHHostname(sshHostname string) *SSHHostnameOption {
+	return &SSHHostnameOption{sshHostname}
 }
 
-type SshKeyAlgorithmOption struct {
+type SSHKeyAlgorithmOption struct {
 	sshKeyAlgorithm KeyAlgorithm
 }
 
-// SshKeyAlgorithm represents the --ssh-key-algorithm flag.
-func SshKeyAlgorithm(sshKeyAlgorithm KeyAlgorithm) *SshKeyAlgorithmOption {
-	return &SshKeyAlgorithmOption{sshKeyAlgorithm}
+// SSHKeyAlgorithm represents the --ssh-key-algorithm flag.
+func SSHKeyAlgorithm(sshKeyAlgorithm KeyAlgorithm) *SSHKeyAlgorithmOption {
+	return &SSHKeyAlgorithmOption{sshKeyAlgorithm}
 }
 
-type SshRsaBitsOption struct {
-	sshRsaBits int
+type SSHRSABitsOption struct {
+	sshRSABits int
 }
 
-// SshRsaBits represents the --ssh-rsa-bits flag.
-func SshRsaBits(sshRsaBits int) *SshRsaBitsOption {
-	return &SshRsaBitsOption{sshRsaBits}
+// SSHRSABits represents the --ssh-rsa-bits flag.
+func SSHRSABits(sshRSABits int) *SSHRSABitsOption {
+	return &SSHRSABitsOption{sshRSABits}
 }
 
 type TokenAuthOption struct {

--- a/pkg/fluxexec/options_for_global.go
+++ b/pkg/fluxexec/options_for_global.go
@@ -18,13 +18,13 @@ func AsGroup(asGroup ...string) *AsGroupOption {
 	return &AsGroupOption{asGroup}
 }
 
-type AsUidOption struct {
-	asUid string
+type AsUIDOption struct {
+	asUID string
 }
 
-// AsUid represents the --as-uid flag.
-func AsUid(asUid string) *AsUidOption {
-	return &AsUidOption{asUid}
+// AsUID represents the --as-uid flag.
+func AsUID(asUID string) *AsUIDOption {
+	return &AsUIDOption{asUID}
 }
 
 type CacheDirOption struct {
@@ -81,31 +81,31 @@ func KubeContext(context string) *ContextOption {
 	return &ContextOption{context}
 }
 
-type InsecureSkipTlsVerifyOption struct {
-	insecureSkipTlsVerify bool
+type InsecureSkipTLSVerifyOption struct {
+	insecureSkipTLSVerify bool
 }
 
-// InsecureSkipTlsVerify represents the --insecure-skip-tls-verify flag.
-func InsecureSkipTlsVerify(insecureSkipTlsVerify bool) *InsecureSkipTlsVerifyOption {
-	return &InsecureSkipTlsVerifyOption{insecureSkipTlsVerify}
+// InsecureSkipTLSVerify represents the --insecure-skip-tls-verify flag.
+func InsecureSkipTLSVerify(insecureSkipTLSVerify bool) *InsecureSkipTLSVerifyOption {
+	return &InsecureSkipTLSVerifyOption{insecureSkipTLSVerify}
 }
 
-type KubeApiBurstOption struct {
-	kubeApiBurst int
+type KubeAPIBurstOption struct {
+	kubeAPIBurst int
 }
 
-// KubeApiBurst represents the --kube-api-burst flag.
-func KubeApiBurst(kubeApiBurst int) *KubeApiBurstOption {
-	return &KubeApiBurstOption{kubeApiBurst}
+// KubeAPIBurst represents the --kube-api-burst flag.
+func KubeAPIBurst(kubeAPIBurst int) *KubeAPIBurstOption {
+	return &KubeAPIBurstOption{kubeAPIBurst}
 }
 
-type KubeApiQpsOption struct {
-	kubeApiQps float32
+type KubeAPIQPSOption struct {
+	kubeAPIQPS float32
 }
 
-// KubeApiQps represents the --kube-api-qps flag.
-func KubeApiQps(kubeApiQps float32) *KubeApiQpsOption {
-	return &KubeApiQpsOption{kubeApiQps}
+// KubeAPIQPS represents the --kube-api-qps flag.
+func KubeAPIQPS(kubeAPIQPS float32) *KubeAPIQPSOption {
+	return &KubeAPIQPSOption{kubeAPIQPS}
 }
 
 type KubeconfigOption struct {

--- a/pkg/fluxinstall/installer_test.go
+++ b/pkg/fluxinstall/installer_test.go
@@ -2,10 +2,11 @@ package fluxinstall
 
 import (
 	"context"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 	"os"
 	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	"github.com/weaveworks/weave-gitops/pkg/fluxinstall/src"
 )
@@ -21,7 +22,7 @@ var _ = Describe("Install Flux CLI", func() {
 
 			product := &Product{
 				Version: "0.32.0",
-				cli:     &MockProductHttpClient{},
+				cli:     &MockProductHTTPClient{},
 			}
 
 			installer := NewInstaller()
@@ -35,7 +36,7 @@ var _ = Describe("Install Flux CLI", func() {
 
 			product := &Product{
 				Version: "0.32.0",
-				cli:     &MockProductHttpClient{},
+				cli:     &MockProductHTTPClient{},
 			}
 
 			installer := NewInstaller()

--- a/pkg/fluxinstall/product.go
+++ b/pkg/fluxinstall/product.go
@@ -19,13 +19,13 @@ import (
 	isrc "github.com/weaveworks/weave-gitops/pkg/fluxinstall/internal/src"
 )
 
-type HttpGetter interface {
+type HTTPGetter interface {
 	Get(url string) (resp *http.Response, err error)
 }
 
 type Product struct {
 	Version string
-	cli     HttpGetter
+	cli     HTTPGetter
 }
 
 func NewProduct(version string) *Product {
@@ -35,7 +35,7 @@ func NewProduct(version string) *Product {
 	}
 }
 
-func NewProductWithHttpClient(version string, cli HttpGetter) *Product {
+func NewProductWithHTTPClient(version string, cli HTTPGetter) *Product {
 	return &Product{
 		Version: version,
 		cli:     cli,
@@ -61,9 +61,9 @@ func (p *Product) Install(ctx context.Context) (string, error) {
 
 	// TODO enable windows support
 	extension := "tar.gz"
-	binaryUrl := fmt.Sprintf("https://github.com/fluxcd/flux2/releases/download/v%s/flux_%s_%s_%s.%s", p.Version, p.Version, runtime.GOOS, runtime.GOARCH, extension)
+	binaryURL := fmt.Sprintf("https://github.com/fluxcd/flux2/releases/download/v%s/flux_%s_%s_%s.%s", p.Version, p.Version, runtime.GOOS, runtime.GOARCH, extension)
 	client := p.cli
-	resp, err := client.Get(binaryUrl)
+	resp, err := client.Get(binaryURL)
 
 	if err != nil {
 		return "", err
@@ -116,9 +116,9 @@ func (p *Product) Find(ctx context.Context) (string, error) {
 }
 
 func (p *Product) verifyChecksum(filename string, sum string) error {
-	checkSumUrl := fmt.Sprintf("https://github.com/fluxcd/flux2/releases/download/v%s/flux_%s_checksums.txt", p.Version, p.Version)
+	checkSumURL := fmt.Sprintf("https://github.com/fluxcd/flux2/releases/download/v%s/flux_%s_checksums.txt", p.Version, p.Version)
 	client := p.cli
-	resp, err := client.Get(checkSumUrl)
+	resp, err := client.Get(checkSumURL)
 
 	if err != nil {
 		return err

--- a/pkg/fluxinstall/product_test.go
+++ b/pkg/fluxinstall/product_test.go
@@ -82,10 +82,10 @@ func addToArchive(tw *tar.Writer, filename string, data []byte) error {
 	return nil
 }
 
-type MockProductHttpClient struct {
+type MockProductHTTPClient struct {
 }
 
-func (m *MockProductHttpClient) Get(url string) (resp *http.Response, err error) {
+func (m *MockProductHTTPClient) Get(url string) (resp *http.Response, err error) {
 	var archivePattern = regexp.MustCompile(`https://github.com/fluxcd/flux2/releases/download/v0.32.0/flux_0.32.0_(linux|darwin)_(amd64|arm64).tar.gz`)
 	if archivePattern.MatchString(url) {
 		body, err := createMockFluxArchive([]byte("flux"))
@@ -119,7 +119,7 @@ var _ = Describe("Product", func() {
 		By("creating product, and verify checksum", func() {
 			product = &Product{
 				Version: "0.32.0",
-				cli:     &MockProductHttpClient{},
+				cli:     &MockProductHTTPClient{},
 			}
 			_, err := product.Install(context.Background())
 			Expect(err).To(BeNil())

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -95,6 +95,6 @@ type Git interface {
 	Push(ctx context.Context) error
 	Status() (bool, error)
 	Head() (string, error)
-	GetRemoteUrl(dir string, remoteName string) (string, error)
+	GetRemoteURL(dir string, remoteName string) (string, error)
 	ValidateAccess(ctx context.Context, url string, branch string) error
 }

--- a/pkg/git/gitfakes/fake_git.go
+++ b/pkg/git/gitfakes/fake_git.go
@@ -51,17 +51,17 @@ type FakeGit struct {
 		result1 string
 		result2 error
 	}
-	GetRemoteUrlStub        func(string, string) (string, error)
-	getRemoteUrlMutex       sync.RWMutex
-	getRemoteUrlArgsForCall []struct {
+	GetRemoteURLStub        func(string, string) (string, error)
+	getRemoteURLMutex       sync.RWMutex
+	getRemoteURLArgsForCall []struct {
 		arg1 string
 		arg2 string
 	}
-	getRemoteUrlReturns struct {
+	getRemoteURLReturns struct {
 		result1 string
 		result2 error
 	}
-	getRemoteUrlReturnsOnCall map[int]struct {
+	getRemoteURLReturnsOnCall map[int]struct {
 		result1 string
 		result2 error
 	}
@@ -374,17 +374,17 @@ func (fake *FakeGit) CommitReturnsOnCall(i int, result1 string, result2 error) {
 	}{result1, result2}
 }
 
-func (fake *FakeGit) GetRemoteUrl(arg1 string, arg2 string) (string, error) {
-	fake.getRemoteUrlMutex.Lock()
-	ret, specificReturn := fake.getRemoteUrlReturnsOnCall[len(fake.getRemoteUrlArgsForCall)]
-	fake.getRemoteUrlArgsForCall = append(fake.getRemoteUrlArgsForCall, struct {
+func (fake *FakeGit) GetRemoteURL(arg1 string, arg2 string) (string, error) {
+	fake.getRemoteURLMutex.Lock()
+	ret, specificReturn := fake.getRemoteURLReturnsOnCall[len(fake.getRemoteURLArgsForCall)]
+	fake.getRemoteURLArgsForCall = append(fake.getRemoteURLArgsForCall, struct {
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
-	stub := fake.GetRemoteUrlStub
-	fakeReturns := fake.getRemoteUrlReturns
-	fake.recordInvocation("GetRemoteUrl", []interface{}{arg1, arg2})
-	fake.getRemoteUrlMutex.Unlock()
+	stub := fake.GetRemoteURLStub
+	fakeReturns := fake.getRemoteURLReturns
+	fake.recordInvocation("GetRemoteURL", []interface{}{arg1, arg2})
+	fake.getRemoteURLMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2)
 	}
@@ -394,46 +394,46 @@ func (fake *FakeGit) GetRemoteUrl(arg1 string, arg2 string) (string, error) {
 	return fakeReturns.result1, fakeReturns.result2
 }
 
-func (fake *FakeGit) GetRemoteUrlCallCount() int {
-	fake.getRemoteUrlMutex.RLock()
-	defer fake.getRemoteUrlMutex.RUnlock()
-	return len(fake.getRemoteUrlArgsForCall)
+func (fake *FakeGit) GetRemoteURLCallCount() int {
+	fake.getRemoteURLMutex.RLock()
+	defer fake.getRemoteURLMutex.RUnlock()
+	return len(fake.getRemoteURLArgsForCall)
 }
 
-func (fake *FakeGit) GetRemoteUrlCalls(stub func(string, string) (string, error)) {
-	fake.getRemoteUrlMutex.Lock()
-	defer fake.getRemoteUrlMutex.Unlock()
-	fake.GetRemoteUrlStub = stub
+func (fake *FakeGit) GetRemoteURLCalls(stub func(string, string) (string, error)) {
+	fake.getRemoteURLMutex.Lock()
+	defer fake.getRemoteURLMutex.Unlock()
+	fake.GetRemoteURLStub = stub
 }
 
-func (fake *FakeGit) GetRemoteUrlArgsForCall(i int) (string, string) {
-	fake.getRemoteUrlMutex.RLock()
-	defer fake.getRemoteUrlMutex.RUnlock()
-	argsForCall := fake.getRemoteUrlArgsForCall[i]
+func (fake *FakeGit) GetRemoteURLArgsForCall(i int) (string, string) {
+	fake.getRemoteURLMutex.RLock()
+	defer fake.getRemoteURLMutex.RUnlock()
+	argsForCall := fake.getRemoteURLArgsForCall[i]
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *FakeGit) GetRemoteUrlReturns(result1 string, result2 error) {
-	fake.getRemoteUrlMutex.Lock()
-	defer fake.getRemoteUrlMutex.Unlock()
-	fake.GetRemoteUrlStub = nil
-	fake.getRemoteUrlReturns = struct {
+func (fake *FakeGit) GetRemoteURLReturns(result1 string, result2 error) {
+	fake.getRemoteURLMutex.Lock()
+	defer fake.getRemoteURLMutex.Unlock()
+	fake.GetRemoteURLStub = nil
+	fake.getRemoteURLReturns = struct {
 		result1 string
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeGit) GetRemoteUrlReturnsOnCall(i int, result1 string, result2 error) {
-	fake.getRemoteUrlMutex.Lock()
-	defer fake.getRemoteUrlMutex.Unlock()
-	fake.GetRemoteUrlStub = nil
-	if fake.getRemoteUrlReturnsOnCall == nil {
-		fake.getRemoteUrlReturnsOnCall = make(map[int]struct {
+func (fake *FakeGit) GetRemoteURLReturnsOnCall(i int, result1 string, result2 error) {
+	fake.getRemoteURLMutex.Lock()
+	defer fake.getRemoteURLMutex.Unlock()
+	fake.GetRemoteURLStub = nil
+	if fake.getRemoteURLReturnsOnCall == nil {
+		fake.getRemoteURLReturnsOnCall = make(map[int]struct {
 			result1 string
 			result2 error
 		})
 	}
-	fake.getRemoteUrlReturnsOnCall[i] = struct {
+	fake.getRemoteURLReturnsOnCall[i] = struct {
 		result1 string
 		result2 error
 	}{result1, result2}
@@ -1006,8 +1006,8 @@ func (fake *FakeGit) Invocations() map[string][][]interface{} {
 	defer fake.cloneMutex.RUnlock()
 	fake.commitMutex.RLock()
 	defer fake.commitMutex.RUnlock()
-	fake.getRemoteUrlMutex.RLock()
-	defer fake.getRemoteUrlMutex.RUnlock()
+	fake.getRemoteURLMutex.RLock()
+	defer fake.getRemoteURLMutex.RUnlock()
 	fake.headMutex.RLock()
 	defer fake.headMutex.RUnlock()
 	fake.initMutex.RLock()

--- a/pkg/git/gogit.go
+++ b/pkg/git/gogit.go
@@ -343,8 +343,8 @@ func (g *GoGit) Head() (string, error) {
 	return head.Hash().String(), nil
 }
 
-// GetRemoteUrl returns the url of the first listed remote server
-func (g *GoGit) GetRemoteUrl(dir string, remoteName string) (string, error) {
+// GetRemoteURL returns the url of the first listed remote server
+func (g *GoGit) GetRemoteURL(dir string, remoteName string) (string, error) {
 	repo, err := g.Open(dir)
 	if err != nil {
 		return "", fmt.Errorf("failed to open repository: %s: %w", dir, err)

--- a/pkg/gitproviders/client.go
+++ b/pkg/gitproviders/client.go
@@ -3,5 +3,5 @@ package gitproviders
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
 //counterfeiter:generate . Client
 type Client interface {
-	GetProvider(repoUrl RepoURL, getAccountType AccountTypeGetter) (GitProvider, error)
+	GetProvider(repoURL RepoURL, getAccountType AccountTypeGetter) (GitProvider, error)
 }

--- a/pkg/gitproviders/dryrun.go
+++ b/pkg/gitproviders/dryrun.go
@@ -26,31 +26,31 @@ func NewDryRun() (GitProvider, error) {
 	}, nil
 }
 
-func (p *dryrunProvider) RepositoryExists(_ context.Context, repoUrl RepoURL) (bool, error) {
+func (p *dryrunProvider) RepositoryExists(_ context.Context, repoURL RepoURL) (bool, error) {
 	return true, nil
 }
 
-func (p *dryrunProvider) DeployKeyExists(_ context.Context, repoUrl RepoURL) (bool, error) {
+func (p *dryrunProvider) DeployKeyExists(_ context.Context, repoURL RepoURL) (bool, error) {
 	return true, nil
 }
 
-func (p *dryrunProvider) GetDefaultBranch(_ context.Context, repoUrl RepoURL) (string, error) {
+func (p *dryrunProvider) GetDefaultBranch(_ context.Context, repoURL RepoURL) (string, error) {
 	return "<default-branch>", nil
 }
 
-func (p *dryrunProvider) GetRepoVisibility(_ context.Context, repoUrl RepoURL) (*gitprovider.RepositoryVisibility, error) {
+func (p *dryrunProvider) GetRepoVisibility(_ context.Context, repoURL RepoURL) (*gitprovider.RepositoryVisibility, error) {
 	return gitprovider.RepositoryVisibilityVar(gitprovider.RepositoryVisibilityPrivate), nil
 }
 
-func (p *dryrunProvider) UploadDeployKey(_ context.Context, repoUrl RepoURL, deployKey []byte) error {
+func (p *dryrunProvider) UploadDeployKey(_ context.Context, repoURL RepoURL, deployKey []byte) error {
 	return nil
 }
 
-func (p *dryrunProvider) CreatePullRequest(_ context.Context, repoUrl RepoURL, prInfo PullRequestInfo) (gitprovider.PullRequest, error) {
+func (p *dryrunProvider) CreatePullRequest(_ context.Context, repoURL RepoURL, prInfo PullRequestInfo) (gitprovider.PullRequest, error) {
 	return nil, nil
 }
 
-func (p *dryrunProvider) GetCommits(_ context.Context, repoUrl RepoURL, targetBranch string, pageSize int, pageToken int) ([]gitprovider.Commit, error) {
+func (p *dryrunProvider) GetCommits(_ context.Context, repoURL RepoURL, targetBranch string, pageSize int, pageToken int) ([]gitprovider.Commit, error) {
 	return []gitprovider.Commit{}, nil
 }
 
@@ -58,10 +58,10 @@ func (p *dryrunProvider) GetProviderDomain() string {
 	return p.provider.GetProviderDomain()
 }
 
-func (p *dryrunProvider) GetRepoDirFiles(_ context.Context, repoUrl RepoURL, dirPath, targetBranch string) ([]*gitprovider.CommitFile, error) {
+func (p *dryrunProvider) GetRepoDirFiles(_ context.Context, repoURL RepoURL, dirPath, targetBranch string) ([]*gitprovider.CommitFile, error) {
 	return nil, nil
 }
 
-func (p *dryrunProvider) MergePullRequest(ctx context.Context, repoUrl RepoURL, pullRequestNumber int, commitMesage string) error {
+func (p *dryrunProvider) MergePullRequest(ctx context.Context, repoURL RepoURL, pullRequestNumber int, commitMesage string) error {
 	return nil
 }

--- a/pkg/gitproviders/dryrun_test.go
+++ b/pkg/gitproviders/dryrun_test.go
@@ -12,7 +12,7 @@ import (
 var (
 	dryRunProvider GitProvider
 	ctx            context.Context
-	repoUrl        RepoURL
+	repoURL        RepoURL
 )
 
 var _ = Describe("DryRun", func() {
@@ -32,12 +32,12 @@ var _ = Describe("DryRun", func() {
 			provider: orgProvider,
 		}
 
-		repoUrl = RepoURL{}
+		repoURL = RepoURL{}
 	})
 
 	Describe("RepositoryExists", func() {
 		It("returns true", func() {
-			res, err := dryRunProvider.RepositoryExists(ctx, repoUrl)
+			res, err := dryRunProvider.RepositoryExists(ctx, repoURL)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(res).To(BeTrue())
 		})
@@ -45,7 +45,7 @@ var _ = Describe("DryRun", func() {
 
 	Describe("DeployKeyExists", func() {
 		It("returns true", func() {
-			res, err := dryRunProvider.DeployKeyExists(ctx, repoUrl)
+			res, err := dryRunProvider.DeployKeyExists(ctx, repoURL)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(res).To(BeTrue())
 		})
@@ -53,7 +53,7 @@ var _ = Describe("DryRun", func() {
 
 	Describe("GetDefaultBranch", func() {
 		It("returns branch placeholder", func() {
-			res, err := dryRunProvider.GetDefaultBranch(ctx, repoUrl)
+			res, err := dryRunProvider.GetDefaultBranch(ctx, repoURL)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(res).To(Equal("<default-branch>"))
 		})
@@ -61,7 +61,7 @@ var _ = Describe("DryRun", func() {
 
 	Describe("GetRepoVisibility", func() {
 		It("returns private", func() {
-			res, err := dryRunProvider.GetRepoVisibility(ctx, repoUrl)
+			res, err := dryRunProvider.GetRepoVisibility(ctx, repoURL)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(res).To(Equal(gitprovider.RepositoryVisibilityVar(gitprovider.RepositoryVisibilityPrivate)))
 		})
@@ -69,13 +69,13 @@ var _ = Describe("DryRun", func() {
 
 	Describe("UploadDeployKey", func() {
 		It("returns nil", func() {
-			Expect(dryRunProvider.UploadDeployKey(ctx, repoUrl, []byte{})).To(Succeed())
+			Expect(dryRunProvider.UploadDeployKey(ctx, repoURL, []byte{})).To(Succeed())
 		})
 	})
 
 	Describe("CreatePullRequest", func() {
 		It("returns nil", func() {
-			res, err := dryRunProvider.CreatePullRequest(ctx, repoUrl, PullRequestInfo{})
+			res, err := dryRunProvider.CreatePullRequest(ctx, repoURL, PullRequestInfo{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(res).To(BeNil())
 		})
@@ -83,7 +83,7 @@ var _ = Describe("DryRun", func() {
 
 	Describe("GetCommits", func() {
 		It("returns emtpy", func() {
-			res, err := dryRunProvider.GetCommits(ctx, repoUrl, "", 1, 1)
+			res, err := dryRunProvider.GetCommits(ctx, repoURL, "", 1, 1)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(res).To(Equal([]gitprovider.Commit{}))
 		})

--- a/pkg/gitproviders/provider.go
+++ b/pkg/gitproviders/provider.go
@@ -30,16 +30,16 @@ var ErrRepositoryNoPermissionsOrDoesNotExist = errors.New("no permissions to acc
 // GitProvider Handler
 //counterfeiter:generate . GitProvider
 type GitProvider interface {
-	RepositoryExists(ctx context.Context, repoUrl RepoURL) (bool, error)
-	DeployKeyExists(ctx context.Context, repoUrl RepoURL) (bool, error)
-	GetDefaultBranch(ctx context.Context, repoUrl RepoURL) (string, error)
-	GetRepoVisibility(ctx context.Context, repoUrl RepoURL) (*gitprovider.RepositoryVisibility, error)
-	UploadDeployKey(ctx context.Context, repoUrl RepoURL, deployKey []byte) error
-	CreatePullRequest(ctx context.Context, repoUrl RepoURL, prInfo PullRequestInfo) (gitprovider.PullRequest, error)
-	GetCommits(ctx context.Context, repoUrl RepoURL, targetBranch string, pageSize int, pageToken int) ([]gitprovider.Commit, error)
+	RepositoryExists(ctx context.Context, repoURL RepoURL) (bool, error)
+	DeployKeyExists(ctx context.Context, repoURL RepoURL) (bool, error)
+	GetDefaultBranch(ctx context.Context, repoURL RepoURL) (string, error)
+	GetRepoVisibility(ctx context.Context, repoURL RepoURL) (*gitprovider.RepositoryVisibility, error)
+	UploadDeployKey(ctx context.Context, repoURL RepoURL, deployKey []byte) error
+	CreatePullRequest(ctx context.Context, repoURL RepoURL, prInfo PullRequestInfo) (gitprovider.PullRequest, error)
+	GetCommits(ctx context.Context, repoURL RepoURL, targetBranch string, pageSize int, pageToken int) ([]gitprovider.Commit, error)
 	GetProviderDomain() string
-	GetRepoDirFiles(ctx context.Context, repoUrl RepoURL, dirPath, targetBranch string) ([]*gitprovider.CommitFile, error)
-	MergePullRequest(ctx context.Context, repoUrl RepoURL, pullRequestNumber int, commitMesage string) error
+	GetRepoDirFiles(ctx context.Context, repoURL RepoURL, dirPath, targetBranch string) ([]*gitprovider.CommitFile, error)
+	MergePullRequest(ctx context.Context, repoURL RepoURL, pullRequestNumber int, commitMesage string) error
 }
 
 type PullRequestInfo struct {

--- a/pkg/gitproviders/provider_org.go
+++ b/pkg/gitproviders/provider_org.go
@@ -15,10 +15,10 @@ type orgGitProvider struct {
 
 var _ GitProvider = orgGitProvider{}
 
-func (p orgGitProvider) RepositoryExists(ctx context.Context, repoUrl RepoURL) (bool, error) {
+func (p orgGitProvider) RepositoryExists(ctx context.Context, repoURL RepoURL) (bool, error) {
 	orgRef := gitprovider.OrgRepositoryRef{
-		OrganizationRef: gitprovider.OrganizationRef{Domain: p.domain, Organization: repoUrl.Owner()},
-		RepositoryName:  repoUrl.RepositoryName(),
+		OrganizationRef: gitprovider.OrganizationRef{Domain: p.domain, Organization: repoURL.Owner()},
+		RepositoryName:  repoURL.RepositoryName(),
 	}
 	if _, err := p.provider.OrgRepositories().Get(ctx, orgRef); err != nil {
 		if errors.Is(err, gitprovider.ErrNotFound) {
@@ -31,19 +31,19 @@ func (p orgGitProvider) RepositoryExists(ctx context.Context, repoUrl RepoURL) (
 	return true, nil
 }
 
-func (p orgGitProvider) DeployKeyExists(ctx context.Context, repoUrl RepoURL) (bool, error) {
-	orgRepo, err := p.getOrgRepo(ctx, repoUrl)
+func (p orgGitProvider) DeployKeyExists(ctx context.Context, repoURL RepoURL) (bool, error) {
+	orgRepo, err := p.getOrgRepo(ctx, repoURL)
 	if err != nil {
-		return false, fmt.Errorf("error getting org repo reference for owner %s, repo %s, %s", repoUrl.Owner(), repoUrl.RepositoryName(), err)
+		return false, fmt.Errorf("error getting org repo reference for owner %s, repo %s, %s", repoURL.Owner(), repoURL.RepositoryName(), err)
 	}
 
 	return deployKeyExists(ctx, orgRepo)
 }
 
-func (p orgGitProvider) UploadDeployKey(ctx context.Context, repoUrl RepoURL, deployKey []byte) error {
-	orgRepo, err := p.getOrgRepo(ctx, repoUrl)
+func (p orgGitProvider) UploadDeployKey(ctx context.Context, repoURL RepoURL, deployKey []byte) error {
+	orgRepo, err := p.getOrgRepo(ctx, repoURL)
 	if err != nil {
-		return fmt.Errorf("error getting org repo reference for owner %s, repo %s, %w", repoUrl.Owner(), repoUrl.RepositoryName(), err)
+		return fmt.Errorf("error getting org repo reference for owner %s, repo %s, %w", repoURL.Owner(), repoURL.RepositoryName(), err)
 	}
 
 	deployKeyInfo := gitprovider.DeployKeyInfo{
@@ -55,8 +55,8 @@ func (p orgGitProvider) UploadDeployKey(ctx context.Context, repoUrl RepoURL, de
 	return uploadDeployKey(ctx, orgRepo, deployKeyInfo)
 }
 
-func (p orgGitProvider) GetDefaultBranch(ctx context.Context, repoUrl RepoURL) (string, error) {
-	repoInfoRef, err := p.getRepoInfoFromUrl(ctx, repoUrl)
+func (p orgGitProvider) GetDefaultBranch(ctx context.Context, repoURL RepoURL) (string, error) {
+	repoInfoRef, err := p.getRepoInfoFromURL(ctx, repoURL)
 	if err != nil {
 		return "main", err
 	}
@@ -64,8 +64,8 @@ func (p orgGitProvider) GetDefaultBranch(ctx context.Context, repoUrl RepoURL) (
 	return *repoInfoRef.DefaultBranch, nil
 }
 
-func (p orgGitProvider) GetRepoVisibility(ctx context.Context, repoUrl RepoURL) (*gitprovider.RepositoryVisibility, error) {
-	repoInfoRef, err := p.getRepoInfoFromUrl(ctx, repoUrl)
+func (p orgGitProvider) GetRepoVisibility(ctx context.Context, repoURL RepoURL) (*gitprovider.RepositoryVisibility, error) {
+	repoInfoRef, err := p.getRepoInfoFromURL(ctx, repoURL)
 	if err != nil {
 		return nil, err
 	}
@@ -73,8 +73,8 @@ func (p orgGitProvider) GetRepoVisibility(ctx context.Context, repoUrl RepoURL) 
 	return repoInfoRef.Visibility, nil
 }
 
-func (p orgGitProvider) getRepoInfoFromUrl(ctx context.Context, repoUrl RepoURL) (*gitprovider.RepositoryInfo, error) {
-	repoInfo, err := p.getRepoInfo(ctx, repoUrl)
+func (p orgGitProvider) getRepoInfoFromURL(ctx context.Context, repoURL RepoURL) (*gitprovider.RepositoryInfo, error) {
+	repoInfo, err := p.getRepoInfo(ctx, repoURL)
 	if err != nil {
 		return nil, err
 	}
@@ -82,8 +82,8 @@ func (p orgGitProvider) getRepoInfoFromUrl(ctx context.Context, repoUrl RepoURL)
 	return repoInfo, nil
 }
 
-func (p orgGitProvider) getRepoInfo(ctx context.Context, repoUrl RepoURL) (*gitprovider.RepositoryInfo, error) {
-	repo, err := p.getOrgRepo(ctx, repoUrl)
+func (p orgGitProvider) getRepoInfo(ctx context.Context, repoURL RepoURL) (*gitprovider.RepositoryInfo, error) {
+	repo, err := p.getOrgRepo(ctx, repoURL)
 	if err != nil {
 		return nil, err
 	}
@@ -93,8 +93,8 @@ func (p orgGitProvider) getRepoInfo(ctx context.Context, repoUrl RepoURL) (*gitp
 	return &info, nil
 }
 
-func (p orgGitProvider) getOrgRepo(ctx context.Context, repoUrl RepoURL) (gitprovider.OrgRepository, error) {
-	orgRepoRef := NewOrgRepositoryRef(p.domain, repoUrl.Owner(), repoUrl.RepositoryName())
+func (p orgGitProvider) getOrgRepo(ctx context.Context, repoURL RepoURL) (gitprovider.OrgRepository, error) {
+	orgRepoRef := NewOrgRepositoryRef(p.domain, repoURL.Owner(), repoURL.RepositoryName())
 
 	repo, err := p.provider.OrgRepositories().Get(context.Background(), orgRepoRef)
 	if err != nil {
@@ -104,19 +104,19 @@ func (p orgGitProvider) getOrgRepo(ctx context.Context, repoUrl RepoURL) (gitpro
 	return repo, nil
 }
 
-func (p orgGitProvider) CreatePullRequest(ctx context.Context, repoUrl RepoURL, prInfo PullRequestInfo) (gitprovider.PullRequest, error) {
-	orgRepo, err := p.getOrgRepo(ctx, repoUrl)
+func (p orgGitProvider) CreatePullRequest(ctx context.Context, repoURL RepoURL, prInfo PullRequestInfo) (gitprovider.PullRequest, error) {
+	orgRepo, err := p.getOrgRepo(ctx, repoURL)
 	if err != nil {
-		return nil, fmt.Errorf("error getting org repo for owner %s, repo %s, %w", repoUrl.Owner(), repoUrl.RepositoryName(), err)
+		return nil, fmt.Errorf("error getting org repo for owner %s, repo %s, %w", repoURL.Owner(), repoURL.RepositoryName(), err)
 	}
 
 	return createPullRequest(ctx, orgRepo, prInfo)
 }
 
-func (p orgGitProvider) GetCommits(ctx context.Context, repoUrl RepoURL, targetBranch string, pageSize int, pageToken int) ([]gitprovider.Commit, error) {
-	orgRepo, err := p.getOrgRepo(ctx, repoUrl)
+func (p orgGitProvider) GetCommits(ctx context.Context, repoURL RepoURL, targetBranch string, pageSize int, pageToken int) ([]gitprovider.Commit, error) {
+	orgRepo, err := p.getOrgRepo(ctx, repoURL)
 	if err != nil {
-		return nil, fmt.Errorf("error getting repo for owner %s, repo %s, %w", repoUrl.Owner(), repoUrl.RepositoryName(), err)
+		return nil, fmt.Errorf("error getting repo for owner %s, repo %s, %w", repoURL.Owner(), repoURL.RepositoryName(), err)
 	}
 
 	return getCommits(ctx, orgRepo, targetBranch, pageSize, pageToken)
@@ -128,8 +128,8 @@ func (p orgGitProvider) GetProviderDomain() string {
 
 // GetRepoDirFiles returns the files found in the subdirectory of a repository.
 // Note that the current implementation only gets an end subdirectory. It does not get multiple directories recursively. See https://github.com/fluxcd/go-git-providers/issues/143.
-func (p orgGitProvider) GetRepoDirFiles(ctx context.Context, repoUrl RepoURL, dirPath, targetBranch string) ([]*gitprovider.CommitFile, error) {
-	repo, err := p.getOrgRepo(ctx, repoUrl)
+func (p orgGitProvider) GetRepoDirFiles(ctx context.Context, repoURL RepoURL, dirPath, targetBranch string) ([]*gitprovider.CommitFile, error) {
+	repo, err := p.getOrgRepo(ctx, repoURL)
 	if err != nil {
 		return nil, err
 	}
@@ -143,8 +143,8 @@ func (p orgGitProvider) GetRepoDirFiles(ctx context.Context, repoUrl RepoURL, di
 }
 
 // MergePullRequest merges a pull request given the repository's URL and the PR's number with a commit message.
-func (p orgGitProvider) MergePullRequest(ctx context.Context, repoUrl RepoURL, pullRequestNumber int, commitMesage string) error {
-	repo, err := p.getOrgRepo(ctx, repoUrl)
+func (p orgGitProvider) MergePullRequest(ctx context.Context, repoURL RepoURL, pullRequestNumber int, commitMesage string) error {
+	repo, err := p.getOrgRepo(ctx, repoURL)
 	if err != nil {
 		return err
 	}

--- a/pkg/gitproviders/provider_org_test.go
+++ b/pkg/gitproviders/provider_org_test.go
@@ -25,7 +25,7 @@ var _ = Describe("Org Provider", func() {
 		pullRequestsClient *fakegitprovider.PullRequestClient
 		fileClient         *fakegitprovider.FileClient
 
-		repoUrl RepoURL
+		repoURL RepoURL
 	)
 
 	var _ = BeforeEach(func() {
@@ -52,7 +52,7 @@ var _ = Describe("Org Provider", func() {
 		}
 
 		var err error
-		repoUrl, err = NewRepoURL("http://github.com/owner/repo-name")
+		repoURL, err = NewRepoURL("http://github.com/owner/repo-name")
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -60,7 +60,7 @@ var _ = Describe("Org Provider", func() {
 		It("returns false when repo not found", func() {
 			orgRepoClient.GetReturns(nil, gitprovider.ErrNotFound)
 
-			res, err := orgProvider.RepositoryExists(ctx, repoUrl)
+			res, err := orgProvider.RepositoryExists(ctx, repoURL)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(res).To(BeFalse())
 		})
@@ -68,13 +68,13 @@ var _ = Describe("Org Provider", func() {
 		It("returns error when can't verify", func() {
 			orgRepoClient.GetReturns(nil, errors.New("random error"))
 
-			res, err := orgProvider.RepositoryExists(ctx, repoUrl)
+			res, err := orgProvider.RepositoryExists(ctx, repoURL)
 			Expect(err).To(HaveOccurred())
 			Expect(res).To(BeFalse())
 		})
 
 		It("returns true when repo exists", func() {
-			res, err := orgProvider.RepositoryExists(ctx, repoUrl)
+			res, err := orgProvider.RepositoryExists(ctx, repoURL)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(res).To(BeTrue())
 		})
@@ -91,7 +91,7 @@ var _ = Describe("Org Provider", func() {
 		It("return error when repo doest exist", func() {
 			orgRepoClient.GetReturns(nil, gitprovider.ErrNotFound)
 
-			res, err := orgProvider.DeployKeyExists(ctx, repoUrl)
+			res, err := orgProvider.DeployKeyExists(ctx, repoURL)
 			Expect(err.Error()).Should(ContainSubstring("error getting org repo reference for owner"))
 			Expect(res).To(BeFalse())
 		})
@@ -99,7 +99,7 @@ var _ = Describe("Org Provider", func() {
 		It("returns false when key not found", func() {
 			deployKeyClient.GetReturns(nil, gitprovider.ErrNotFound)
 
-			res, err := orgProvider.DeployKeyExists(ctx, repoUrl)
+			res, err := orgProvider.DeployKeyExists(ctx, repoURL)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(res).To(BeFalse())
 		})
@@ -107,13 +107,13 @@ var _ = Describe("Org Provider", func() {
 		It("returns error when can't verify", func() {
 			deployKeyClient.GetReturns(nil, errors.New("random error"))
 
-			res, err := orgProvider.DeployKeyExists(ctx, repoUrl)
+			res, err := orgProvider.DeployKeyExists(ctx, repoURL)
 			Expect(err.Error()).Should(ContainSubstring("error getting deploy key"))
 			Expect(res).To(BeFalse())
 		})
 
 		It("returns true when repo exists", func() {
-			res, err := orgProvider.DeployKeyExists(ctx, repoUrl)
+			res, err := orgProvider.DeployKeyExists(ctx, repoURL)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(res).To(BeTrue())
 		})
@@ -130,21 +130,21 @@ var _ = Describe("Org Provider", func() {
 		It("return error when repo doesn't exist", func() {
 			orgRepoClient.GetReturns(nil, gitprovider.ErrNotFound)
 
-			err := orgProvider.UploadDeployKey(ctx, repoUrl, []byte("my-key"))
+			err := orgProvider.UploadDeployKey(ctx, repoURL, []byte("my-key"))
 			Expect(err.Error()).Should(ContainSubstring("error getting org repo reference for owner"))
 		})
 
 		It("returns error when can't create the key", func() {
 			deployKeyClient.CreateReturns(nil, errors.New("random error"))
 
-			err := orgProvider.UploadDeployKey(ctx, repoUrl, []byte("my-key"))
+			err := orgProvider.UploadDeployKey(ctx, repoURL, []byte("my-key"))
 			Expect(err.Error()).Should(ContainSubstring("error uploading deploy key"))
 		})
 
 		It("return error when it fails to upload a deploy key", func() {
 			deployKeyClient.CreateReturns(nil, gitprovider.ErrNotFound)
 
-			err := orgProvider.UploadDeployKey(ctx, repoUrl, []byte("my-key"))
+			err := orgProvider.UploadDeployKey(ctx, repoURL, []byte("my-key"))
 			Expect(err).Should(Equal(ErrRepositoryNoPermissionsOrDoesNotExist))
 		})
 
@@ -152,7 +152,7 @@ var _ = Describe("Org Provider", func() {
 			deployKeyClient.CreateReturns(nil, nil)
 			deployKeyClient.GetReturns(nil, nil)
 
-			err := orgProvider.UploadDeployKey(ctx, repoUrl, []byte("my-key"))
+			err := orgProvider.UploadDeployKey(ctx, repoURL, []byte("my-key"))
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})
@@ -161,14 +161,14 @@ var _ = Describe("Org Provider", func() {
 		It("returns error when can't get branch", func() {
 			orgRepoClient.GetReturns(nil, gitprovider.ErrNotFound)
 
-			_, err := orgProvider.GetDefaultBranch(ctx, repoUrl)
+			_, err := orgProvider.GetDefaultBranch(ctx, repoURL)
 			Expect(err.Error()).Should(ContainSubstring("error getting org repository"))
 		})
 
 		It("returns repo default branch", func() {
 			orgRepo.GetReturns(gitprovider.RepositoryInfo{DefaultBranch: gitprovider.StringVar("my-branch")})
 
-			branch, err := orgProvider.GetDefaultBranch(ctx, repoUrl)
+			branch, err := orgProvider.GetDefaultBranch(ctx, repoURL)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(branch).To(Equal("my-branch"))
 		})
@@ -178,7 +178,7 @@ var _ = Describe("Org Provider", func() {
 		It("returns error when can't get branch", func() {
 			orgRepoClient.GetReturns(nil, gitprovider.ErrNotFound)
 
-			_, err := orgProvider.GetRepoVisibility(ctx, repoUrl)
+			_, err := orgProvider.GetRepoVisibility(ctx, repoURL)
 			Expect(err.Error()).Should(ContainSubstring("error getting org repository"))
 		})
 
@@ -186,7 +186,7 @@ var _ = Describe("Org Provider", func() {
 			visibility := gitprovider.RepositoryVisibilityVar(gitprovider.RepositoryVisibilityPrivate)
 			orgRepo.GetReturns(gitprovider.RepositoryInfo{Visibility: visibility})
 
-			vis, err := orgProvider.GetRepoVisibility(ctx, repoUrl)
+			vis, err := orgProvider.GetRepoVisibility(ctx, repoURL)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(vis).To(Equal(visibility))
 		})
@@ -216,13 +216,13 @@ var _ = Describe("Org Provider", func() {
 		It("returns error when can't get repo", func() {
 			orgRepoClient.GetReturns(nil, errors.New("random error"))
 
-			_, err := orgProvider.CreatePullRequest(ctx, repoUrl, prInfo)
+			_, err := orgProvider.CreatePullRequest(ctx, repoURL, prInfo)
 			Expect(err.Error()).To(ContainSubstring("error getting org repo for owner"))
 		})
 
 		It("sets default branch", func() {
 			prInfo.TargetBranch = ""
-			_, err := orgProvider.CreatePullRequest(ctx, repoUrl, prInfo)
+			_, err := orgProvider.CreatePullRequest(ctx, repoURL, prInfo)
 			Expect(err).ToNot(HaveOccurred())
 
 			_, _, _, targetBranch, _ := pullRequestsClient.CreateArgsForCall(0)
@@ -232,19 +232,19 @@ var _ = Describe("Org Provider", func() {
 		It("returns error when unable to list commits", func() {
 			commitClient.ListPageReturns(nil, errors.New("error"))
 
-			_, err := orgProvider.CreatePullRequest(ctx, repoUrl, prInfo)
+			_, err := orgProvider.CreatePullRequest(ctx, repoURL, prInfo)
 			Expect(err.Error()).To(ContainSubstring("error getting commits"))
 		})
 
 		It("returns error if no commits listed on target repo", func() {
 			commitClient.ListPageReturns([]gitprovider.Commit{}, nil)
 
-			_, err := orgProvider.CreatePullRequest(ctx, repoUrl, prInfo)
+			_, err := orgProvider.CreatePullRequest(ctx, repoURL, prInfo)
 			Expect(err.Error()).To(ContainSubstring("no commits on the target branch"))
 		})
 
 		It("creates a branch", func() {
-			_, err := orgProvider.CreatePullRequest(ctx, repoUrl, prInfo)
+			_, err := orgProvider.CreatePullRequest(ctx, repoURL, prInfo)
 			Expect(err).ToNot(HaveOccurred())
 
 			_, newBranch, sha := branchesClient.CreateArgsForCall(0)
@@ -254,7 +254,7 @@ var _ = Describe("Org Provider", func() {
 
 		It("creates a commit", func() {
 			prInfo.Files = []gitprovider.CommitFile{{}}
-			_, err := orgProvider.CreatePullRequest(ctx, repoUrl, prInfo)
+			_, err := orgProvider.CreatePullRequest(ctx, repoURL, prInfo)
 			Expect(err).ToNot(HaveOccurred())
 
 			_, newBranch, commitMsg, files := commitClient.CreateArgsForCall(0)
@@ -264,7 +264,7 @@ var _ = Describe("Org Provider", func() {
 		})
 
 		It("creates a pull requests", func() {
-			_, err := orgProvider.CreatePullRequest(ctx, repoUrl, prInfo)
+			_, err := orgProvider.CreatePullRequest(ctx, repoURL, prInfo)
 			Expect(err).ToNot(HaveOccurred())
 
 			_, prTitle, newBranch, targetBranch, prDescription := pullRequestsClient.CreateArgsForCall(0)
@@ -279,14 +279,14 @@ var _ = Describe("Org Provider", func() {
 		It("return error when repo doest exist", func() {
 			orgRepoClient.GetReturns(nil, gitprovider.ErrNotFound)
 
-			_, err := orgProvider.GetCommits(ctx, repoUrl, "target-branch", 1, 1)
+			_, err := orgProvider.GetCommits(ctx, repoURL, "target-branch", 1, 1)
 			Expect(err.Error()).Should(ContainSubstring("error getting repo"))
 		})
 
 		It("returns empty array when empty error", func() {
 			commitClient.ListPageReturns(nil, errors.New("409 Git Repository is empty"))
 
-			commits, err := orgProvider.GetCommits(ctx, repoUrl, "target-branch", 1, 1)
+			commits, err := orgProvider.GetCommits(ctx, repoURL, "target-branch", 1, 1)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(commits).To(HaveLen(0))
 		})
@@ -294,7 +294,7 @@ var _ = Describe("Org Provider", func() {
 		It("returns error when random error", func() {
 			commitClient.ListPageReturns(nil, errors.New("error"))
 
-			_, err := orgProvider.GetCommits(ctx, repoUrl, "target-branch", 1, 1)
+			_, err := orgProvider.GetCommits(ctx, repoURL, "target-branch", 1, 1)
 			Expect(err.Error()).Should(ContainSubstring("error getting commits"))
 		})
 
@@ -304,7 +304,7 @@ var _ = Describe("Org Provider", func() {
 
 			commitClient.ListPageReturns([]gitprovider.Commit{commit}, nil)
 
-			commits, err := orgProvider.GetCommits(ctx, repoUrl, "target-branch", 1, 1)
+			commits, err := orgProvider.GetCommits(ctx, repoURL, "target-branch", 1, 1)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(commits[0].Get().Sha).To(Equal("commit-sha"))
 		})
@@ -322,7 +322,7 @@ var _ = Describe("Org Provider", func() {
 		It("returns a list of files", func() {
 			file := &gitprovider.CommitFile{}
 			fileClient.GetReturns([]*gitprovider.CommitFile{file}, nil)
-			c, err := orgProvider.GetRepoDirFiles(context.TODO(), repoUrl, "path", "main")
+			c, err := orgProvider.GetRepoDirFiles(context.TODO(), repoURL, "path", "main")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(c).To(Equal([]*gitprovider.CommitFile{file}))
 			Expect(fileClient.GetCallCount()).To(Equal(1))
@@ -335,7 +335,7 @@ var _ = Describe("Org Provider", func() {
 			It("returns an error", func() {
 				file := &gitprovider.CommitFile{}
 				fileClient.GetReturns([]*gitprovider.CommitFile{file}, fmt.Errorf("err"))
-				_, err := orgProvider.GetRepoDirFiles(context.TODO(), repoUrl, "path", "main")
+				_, err := orgProvider.GetRepoDirFiles(context.TODO(), repoURL, "path", "main")
 				Expect(err).To(MatchError("err"))
 				Expect(fileClient.GetCallCount()).To(Equal(1))
 			})
@@ -345,7 +345,7 @@ var _ = Describe("Org Provider", func() {
 	Describe("MergePullRequest", func() {
 		It("merges a given pull request", func() {
 			pullRequestsClient.MergeReturns(nil)
-			err := orgProvider.MergePullRequest(context.TODO(), repoUrl, 1, "message")
+			err := orgProvider.MergePullRequest(context.TODO(), repoURL, 1, "message")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(pullRequestsClient.MergeCallCount()).To(Equal(1))
 			_, prNumber, mergeMethod, message := pullRequestsClient.MergeArgsForCall(0)
@@ -357,7 +357,7 @@ var _ = Describe("Org Provider", func() {
 		When("merge the PR fails", func() {
 			It("returns an error", func() {
 				pullRequestsClient.MergeReturns(fmt.Errorf("err"))
-				err := orgProvider.MergePullRequest(context.TODO(), repoUrl, 1, "message")
+				err := orgProvider.MergePullRequest(context.TODO(), repoURL, 1, "message")
 				Expect(err).To(MatchError("err"))
 				Expect(pullRequestsClient.MergeCallCount()).To(Equal(1))
 			})

--- a/pkg/gitproviders/provider_user.go
+++ b/pkg/gitproviders/provider_user.go
@@ -15,10 +15,10 @@ type userGitProvider struct {
 
 var _ GitProvider = userGitProvider{}
 
-func (p userGitProvider) RepositoryExists(ctx context.Context, repoUrl RepoURL) (bool, error) {
+func (p userGitProvider) RepositoryExists(ctx context.Context, repoURL RepoURL) (bool, error) {
 	userRepoRef := gitprovider.UserRepositoryRef{
-		UserRef:        gitprovider.UserRef{Domain: p.domain, UserLogin: repoUrl.Owner()},
-		RepositoryName: repoUrl.RepositoryName(),
+		UserRef:        gitprovider.UserRef{Domain: p.domain, UserLogin: repoURL.Owner()},
+		RepositoryName: repoURL.RepositoryName(),
 	}
 	if _, err := p.provider.UserRepositories().Get(ctx, userRepoRef); err != nil {
 		if errors.Is(err, gitprovider.ErrNotFound) {
@@ -31,19 +31,19 @@ func (p userGitProvider) RepositoryExists(ctx context.Context, repoUrl RepoURL) 
 	return true, nil
 }
 
-func (p userGitProvider) DeployKeyExists(ctx context.Context, repoUrl RepoURL) (bool, error) {
-	userRepo, err := p.getUserRepo(ctx, repoUrl)
+func (p userGitProvider) DeployKeyExists(ctx context.Context, repoURL RepoURL) (bool, error) {
+	userRepo, err := p.getUserRepo(ctx, repoURL)
 	if err != nil {
-		return false, fmt.Errorf("error getting user repo reference for owner %s, repo %s, %w", repoUrl.Owner(), repoUrl.RepositoryName(), err)
+		return false, fmt.Errorf("error getting user repo reference for owner %s, repo %s, %w", repoURL.Owner(), repoURL.RepositoryName(), err)
 	}
 
 	return deployKeyExists(ctx, userRepo)
 }
 
-func (p userGitProvider) UploadDeployKey(ctx context.Context, repoUrl RepoURL, deployKey []byte) error {
-	userRepo, err := p.getUserRepo(ctx, repoUrl)
+func (p userGitProvider) UploadDeployKey(ctx context.Context, repoURL RepoURL, deployKey []byte) error {
+	userRepo, err := p.getUserRepo(ctx, repoURL)
 	if err != nil {
-		return fmt.Errorf("error getting user repo reference for owner %s, repo %s, %w", repoUrl.Owner(), repoUrl.RepositoryName(), err)
+		return fmt.Errorf("error getting user repo reference for owner %s, repo %s, %w", repoURL.Owner(), repoURL.RepositoryName(), err)
 	}
 
 	deployKeyInfo := gitprovider.DeployKeyInfo{
@@ -55,8 +55,8 @@ func (p userGitProvider) UploadDeployKey(ctx context.Context, repoUrl RepoURL, d
 	return uploadDeployKey(ctx, userRepo, deployKeyInfo)
 }
 
-func (p userGitProvider) GetDefaultBranch(ctx context.Context, repoUrl RepoURL) (string, error) {
-	repoInfoRef, err := p.getRepoInfoFromUrl(ctx, repoUrl)
+func (p userGitProvider) GetDefaultBranch(ctx context.Context, repoURL RepoURL) (string, error) {
+	repoInfoRef, err := p.getRepoInfoFromURL(ctx, repoURL)
 	if err != nil {
 		return "main", err
 	}
@@ -64,8 +64,8 @@ func (p userGitProvider) GetDefaultBranch(ctx context.Context, repoUrl RepoURL) 
 	return *repoInfoRef.DefaultBranch, nil
 }
 
-func (p userGitProvider) GetRepoVisibility(ctx context.Context, repoUrl RepoURL) (*gitprovider.RepositoryVisibility, error) {
-	repoInfoRef, err := p.getRepoInfoFromUrl(ctx, repoUrl)
+func (p userGitProvider) GetRepoVisibility(ctx context.Context, repoURL RepoURL) (*gitprovider.RepositoryVisibility, error) {
+	repoInfoRef, err := p.getRepoInfoFromURL(ctx, repoURL)
 	if err != nil {
 		return nil, err
 	}
@@ -73,8 +73,8 @@ func (p userGitProvider) GetRepoVisibility(ctx context.Context, repoUrl RepoURL)
 	return repoInfoRef.Visibility, nil
 }
 
-func (p userGitProvider) getRepoInfoFromUrl(ctx context.Context, repoUrl RepoURL) (*gitprovider.RepositoryInfo, error) {
-	repo, err := p.getUserRepo(ctx, repoUrl)
+func (p userGitProvider) getRepoInfoFromURL(ctx context.Context, repoURL RepoURL) (*gitprovider.RepositoryInfo, error) {
+	repo, err := p.getUserRepo(ctx, repoURL)
 	if err != nil {
 		return nil, err
 	}
@@ -84,8 +84,8 @@ func (p userGitProvider) getRepoInfoFromUrl(ctx context.Context, repoUrl RepoURL
 	return &repoInfo, nil
 }
 
-func (p userGitProvider) getUserRepo(ctx context.Context, repoUrl RepoURL) (gitprovider.UserRepository, error) {
-	repo, err := p.provider.UserRepositories().Get(ctx, newUserRepositoryRef(p.domain, repoUrl.Owner(), repoUrl.RepositoryName()))
+func (p userGitProvider) getUserRepo(ctx context.Context, repoURL RepoURL) (gitprovider.UserRepository, error) {
+	repo, err := p.provider.UserRepositories().Get(ctx, newUserRepositoryRef(p.domain, repoURL.Owner(), repoURL.RepositoryName()))
 	if err != nil {
 		return nil, fmt.Errorf("error getting user repository %w", err)
 	}
@@ -93,19 +93,19 @@ func (p userGitProvider) getUserRepo(ctx context.Context, repoUrl RepoURL) (gitp
 	return repo, nil
 }
 
-func (p userGitProvider) CreatePullRequest(ctx context.Context, repoUrl RepoURL, prInfo PullRequestInfo) (gitprovider.PullRequest, error) {
-	userRepo, err := p.getUserRepo(ctx, repoUrl)
+func (p userGitProvider) CreatePullRequest(ctx context.Context, repoURL RepoURL, prInfo PullRequestInfo) (gitprovider.PullRequest, error) {
+	userRepo, err := p.getUserRepo(ctx, repoURL)
 	if err != nil {
-		return nil, fmt.Errorf("error getting user repo for owner %s, repo %s, %w", repoUrl.Owner(), repoUrl.RepositoryName(), err)
+		return nil, fmt.Errorf("error getting user repo for owner %s, repo %s, %w", repoURL.Owner(), repoURL.RepositoryName(), err)
 	}
 
 	return createPullRequest(ctx, userRepo, prInfo)
 }
 
-func (p userGitProvider) GetCommits(ctx context.Context, repoUrl RepoURL, targetBranch string, pageSize int, pageToken int) ([]gitprovider.Commit, error) {
-	userRepo, err := p.getUserRepo(ctx, repoUrl)
+func (p userGitProvider) GetCommits(ctx context.Context, repoURL RepoURL, targetBranch string, pageSize int, pageToken int) ([]gitprovider.Commit, error) {
+	userRepo, err := p.getUserRepo(ctx, repoURL)
 	if err != nil {
-		return nil, fmt.Errorf("error getting repo for owner %s, repo %s, %w", repoUrl.Owner(), repoUrl.RepositoryName(), err)
+		return nil, fmt.Errorf("error getting repo for owner %s, repo %s, %w", repoURL.Owner(), repoURL.RepositoryName(), err)
 	}
 
 	return getCommits(ctx, userRepo, targetBranch, pageSize, pageToken)
@@ -117,8 +117,8 @@ func (p userGitProvider) GetProviderDomain() string {
 
 // GetRepoDirFiles returns the files found in a directory. The dirPath must point to a directory, not a file.
 // Note that the current implementation only gets an end subdirectory. It does not get multiple directories recursively. See https://github.com/fluxcd/go-git-providers/issues/143.
-func (p userGitProvider) GetRepoDirFiles(ctx context.Context, repoUrl RepoURL, dirPath, targetBranch string) ([]*gitprovider.CommitFile, error) {
-	repo, err := p.getUserRepo(ctx, repoUrl)
+func (p userGitProvider) GetRepoDirFiles(ctx context.Context, repoURL RepoURL, dirPath, targetBranch string) ([]*gitprovider.CommitFile, error) {
+	repo, err := p.getUserRepo(ctx, repoURL)
 	if err != nil {
 		return nil, err
 	}
@@ -132,8 +132,8 @@ func (p userGitProvider) GetRepoDirFiles(ctx context.Context, repoUrl RepoURL, d
 }
 
 // MergePullRequest merges a pull request given the repository's URL and the PR's number with a commit message.
-func (p userGitProvider) MergePullRequest(ctx context.Context, repoUrl RepoURL, pullRequestNumber int, commitMesage string) error {
-	repo, err := p.getUserRepo(ctx, repoUrl)
+func (p userGitProvider) MergePullRequest(ctx context.Context, repoURL RepoURL, pullRequestNumber int, commitMesage string) error {
+	repo, err := p.getUserRepo(ctx, repoURL)
 	if err != nil {
 		return err
 	}

--- a/pkg/gitproviders/provider_user_test.go
+++ b/pkg/gitproviders/provider_user_test.go
@@ -24,7 +24,7 @@ var _ = Describe("User Provider", func() {
 		pullRequestsClient *fakegitprovider.PullRequestClient
 		fileClient         *fakegitprovider.FileClient
 
-		repoUrl RepoURL
+		repoURL RepoURL
 	)
 
 	var _ = BeforeEach(func() {
@@ -51,7 +51,7 @@ var _ = Describe("User Provider", func() {
 		}
 
 		var err error
-		repoUrl, err = NewRepoURL("http://github.com/owner/repo-name")
+		repoURL, err = NewRepoURL("http://github.com/owner/repo-name")
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -59,7 +59,7 @@ var _ = Describe("User Provider", func() {
 		It("returns false when repo not found", func() {
 			userRepoClient.GetReturns(nil, gitprovider.ErrNotFound)
 
-			res, err := userProvider.RepositoryExists(ctx, repoUrl)
+			res, err := userProvider.RepositoryExists(ctx, repoURL)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(res).To(BeFalse())
 		})
@@ -67,13 +67,13 @@ var _ = Describe("User Provider", func() {
 		It("returns error when can't verify", func() {
 			userRepoClient.GetReturns(nil, errors.New("random error"))
 
-			res, err := userProvider.RepositoryExists(ctx, repoUrl)
+			res, err := userProvider.RepositoryExists(ctx, repoURL)
 			Expect(err).To(HaveOccurred())
 			Expect(res).To(BeFalse())
 		})
 
 		It("returns true when repo exists", func() {
-			res, err := userProvider.RepositoryExists(ctx, repoUrl)
+			res, err := userProvider.RepositoryExists(ctx, repoURL)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(res).To(BeTrue())
 		})
@@ -90,7 +90,7 @@ var _ = Describe("User Provider", func() {
 		It("return error when repo doest exist", func() {
 			userRepoClient.GetReturns(nil, gitprovider.ErrNotFound)
 
-			res, err := userProvider.DeployKeyExists(ctx, repoUrl)
+			res, err := userProvider.DeployKeyExists(ctx, repoURL)
 			Expect(err.Error()).Should(ContainSubstring("error getting user repo reference for owner"))
 			Expect(res).To(BeFalse())
 		})
@@ -98,7 +98,7 @@ var _ = Describe("User Provider", func() {
 		It("returns false when key not found", func() {
 			deployKeyClient.GetReturns(nil, gitprovider.ErrNotFound)
 
-			res, err := userProvider.DeployKeyExists(ctx, repoUrl)
+			res, err := userProvider.DeployKeyExists(ctx, repoURL)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(res).To(BeFalse())
 		})
@@ -106,13 +106,13 @@ var _ = Describe("User Provider", func() {
 		It("returns error when can't verify", func() {
 			deployKeyClient.GetReturns(nil, errors.New("random error"))
 
-			res, err := userProvider.DeployKeyExists(ctx, repoUrl)
+			res, err := userProvider.DeployKeyExists(ctx, repoURL)
 			Expect(err.Error()).Should(ContainSubstring("error getting deploy key"))
 			Expect(res).To(BeFalse())
 		})
 
 		It("returns true when repo exists", func() {
-			res, err := userProvider.DeployKeyExists(ctx, repoUrl)
+			res, err := userProvider.DeployKeyExists(ctx, repoURL)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(res).To(BeTrue())
 		})
@@ -129,14 +129,14 @@ var _ = Describe("User Provider", func() {
 		It("return error when repo doest exist", func() {
 			userRepoClient.GetReturns(nil, gitprovider.ErrNotFound)
 
-			err := userProvider.UploadDeployKey(ctx, repoUrl, []byte("my-key"))
+			err := userProvider.UploadDeployKey(ctx, repoURL, []byte("my-key"))
 			Expect(err.Error()).Should(ContainSubstring("error getting user repo reference for owner"))
 		})
 
 		It("returns error when can't create the key", func() {
 			deployKeyClient.CreateReturns(nil, errors.New("random error"))
 
-			err := userProvider.UploadDeployKey(ctx, repoUrl, []byte("my-key"))
+			err := userProvider.UploadDeployKey(ctx, repoURL, []byte("my-key"))
 			Expect(err.Error()).Should(ContainSubstring("error uploading deploy key"))
 		})
 
@@ -144,7 +144,7 @@ var _ = Describe("User Provider", func() {
 			deployKeyClient.CreateReturns(nil, nil)
 			deployKeyClient.GetReturns(nil, nil)
 
-			err := userProvider.UploadDeployKey(ctx, repoUrl, []byte("my-key"))
+			err := userProvider.UploadDeployKey(ctx, repoURL, []byte("my-key"))
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})
@@ -153,14 +153,14 @@ var _ = Describe("User Provider", func() {
 		It("returns error when can't get branch", func() {
 			userRepoClient.GetReturns(nil, gitprovider.ErrNotFound)
 
-			_, err := userProvider.GetDefaultBranch(ctx, repoUrl)
+			_, err := userProvider.GetDefaultBranch(ctx, repoURL)
 			Expect(err.Error()).Should(ContainSubstring("error getting user repository"))
 		})
 
 		It("returns repo default branch", func() {
 			userRepo.GetReturns(gitprovider.RepositoryInfo{DefaultBranch: gitprovider.StringVar("my-branch")})
 
-			branch, err := userProvider.GetDefaultBranch(ctx, repoUrl)
+			branch, err := userProvider.GetDefaultBranch(ctx, repoURL)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(branch).To(Equal("my-branch"))
 		})
@@ -170,7 +170,7 @@ var _ = Describe("User Provider", func() {
 		It("returns error when can't get branch", func() {
 			userRepoClient.GetReturns(nil, gitprovider.ErrNotFound)
 
-			_, err := userProvider.GetRepoVisibility(ctx, repoUrl)
+			_, err := userProvider.GetRepoVisibility(ctx, repoURL)
 			Expect(err.Error()).Should(ContainSubstring("error getting user repository"))
 		})
 
@@ -178,7 +178,7 @@ var _ = Describe("User Provider", func() {
 			visibility := gitprovider.RepositoryVisibilityVar(gitprovider.RepositoryVisibilityPrivate)
 			userRepo.GetReturns(gitprovider.RepositoryInfo{Visibility: visibility})
 
-			vis, err := userProvider.GetRepoVisibility(ctx, repoUrl)
+			vis, err := userProvider.GetRepoVisibility(ctx, repoURL)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(vis).To(Equal(visibility))
 		})
@@ -208,13 +208,13 @@ var _ = Describe("User Provider", func() {
 		It("returns error when can't get repo", func() {
 			userRepoClient.GetReturns(nil, errors.New("random error"))
 
-			_, err := userProvider.CreatePullRequest(ctx, repoUrl, prInfo)
+			_, err := userProvider.CreatePullRequest(ctx, repoURL, prInfo)
 			Expect(err.Error()).To(ContainSubstring("error getting user repo for"))
 		})
 
 		It("sets default branch", func() {
 			prInfo.TargetBranch = ""
-			_, err := userProvider.CreatePullRequest(ctx, repoUrl, prInfo)
+			_, err := userProvider.CreatePullRequest(ctx, repoURL, prInfo)
 			Expect(err).ToNot(HaveOccurred())
 
 			_, _, _, targetBranch, _ := pullRequestsClient.CreateArgsForCall(0)
@@ -224,19 +224,19 @@ var _ = Describe("User Provider", func() {
 		It("returns error when unable to list commits", func() {
 			commitClient.ListPageReturns(nil, errors.New("error"))
 
-			_, err := userProvider.CreatePullRequest(ctx, repoUrl, prInfo)
+			_, err := userProvider.CreatePullRequest(ctx, repoURL, prInfo)
 			Expect(err.Error()).To(ContainSubstring("error getting commits"))
 		})
 
 		It("returns error if no commits listed on target repo", func() {
 			commitClient.ListPageReturns([]gitprovider.Commit{}, nil)
 
-			_, err := userProvider.CreatePullRequest(ctx, repoUrl, prInfo)
+			_, err := userProvider.CreatePullRequest(ctx, repoURL, prInfo)
 			Expect(err.Error()).To(ContainSubstring("no commits on the target branch"))
 		})
 
 		It("creates a branch", func() {
-			_, err := userProvider.CreatePullRequest(ctx, repoUrl, prInfo)
+			_, err := userProvider.CreatePullRequest(ctx, repoURL, prInfo)
 			Expect(err).ToNot(HaveOccurred())
 
 			_, newBranch, sha := branchesClient.CreateArgsForCall(0)
@@ -247,7 +247,7 @@ var _ = Describe("User Provider", func() {
 		It("creates a commit", func() {
 			prInfo.Files = []gitprovider.CommitFile{{}}
 
-			_, err := userProvider.CreatePullRequest(ctx, repoUrl, prInfo)
+			_, err := userProvider.CreatePullRequest(ctx, repoURL, prInfo)
 			Expect(err).ToNot(HaveOccurred())
 
 			_, newBranch, commitMsg, files := commitClient.CreateArgsForCall(0)
@@ -259,7 +259,7 @@ var _ = Describe("User Provider", func() {
 		It("creates a pull requests", func() {
 			prInfo.Files = []gitprovider.CommitFile{{}}
 
-			_, err := userProvider.CreatePullRequest(ctx, repoUrl, prInfo)
+			_, err := userProvider.CreatePullRequest(ctx, repoURL, prInfo)
 			Expect(err).ToNot(HaveOccurred())
 
 			_, prTitle, newBranch, targetBranch, prDescription := pullRequestsClient.CreateArgsForCall(0)
@@ -274,14 +274,14 @@ var _ = Describe("User Provider", func() {
 		It("return error when repo doest exist", func() {
 			userRepoClient.GetReturns(nil, gitprovider.ErrNotFound)
 
-			_, err := userProvider.GetCommits(ctx, repoUrl, "target-branch", 1, 1)
+			_, err := userProvider.GetCommits(ctx, repoURL, "target-branch", 1, 1)
 			Expect(err.Error()).Should(ContainSubstring("error getting repo"))
 		})
 
 		It("returns empty array when empty error", func() {
 			commitClient.ListPageReturns(nil, errors.New("409 Git Repository is empty"))
 
-			commits, err := userProvider.GetCommits(ctx, repoUrl, "target-branch", 1, 1)
+			commits, err := userProvider.GetCommits(ctx, repoURL, "target-branch", 1, 1)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(commits).To(HaveLen(0))
 		})
@@ -289,7 +289,7 @@ var _ = Describe("User Provider", func() {
 		It("returns error when random error", func() {
 			commitClient.ListPageReturns(nil, errors.New("error"))
 
-			_, err := userProvider.GetCommits(ctx, repoUrl, "target-branch", 1, 1)
+			_, err := userProvider.GetCommits(ctx, repoURL, "target-branch", 1, 1)
 			Expect(err.Error()).Should(ContainSubstring("error getting commits"))
 		})
 
@@ -299,7 +299,7 @@ var _ = Describe("User Provider", func() {
 
 			commitClient.ListPageReturns([]gitprovider.Commit{commit}, nil)
 
-			commits, err := userProvider.GetCommits(ctx, repoUrl, "target-branch", 1, 1)
+			commits, err := userProvider.GetCommits(ctx, repoURL, "target-branch", 1, 1)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(commits[0].Get().Sha).To(Equal("commit-sha"))
 		})
@@ -317,7 +317,7 @@ var _ = Describe("User Provider", func() {
 		It("returns a list of files", func() {
 			file := &gitprovider.CommitFile{}
 			fileClient.GetReturns([]*gitprovider.CommitFile{file}, nil)
-			c, err := userProvider.GetRepoDirFiles(context.TODO(), repoUrl, "path", "main")
+			c, err := userProvider.GetRepoDirFiles(context.TODO(), repoURL, "path", "main")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(c).To(Equal([]*gitprovider.CommitFile{file}))
 			Expect(fileClient.GetCallCount()).To(Equal(1))
@@ -330,7 +330,7 @@ var _ = Describe("User Provider", func() {
 			It("returns an error", func() {
 				file := &gitprovider.CommitFile{}
 				fileClient.GetReturns([]*gitprovider.CommitFile{file}, fmt.Errorf("err"))
-				_, err := userProvider.GetRepoDirFiles(context.TODO(), repoUrl, "path", "main")
+				_, err := userProvider.GetRepoDirFiles(context.TODO(), repoURL, "path", "main")
 				Expect(err).To(MatchError("err"))
 				Expect(fileClient.GetCallCount()).To(Equal(1))
 			})
@@ -340,7 +340,7 @@ var _ = Describe("User Provider", func() {
 	Describe("MergePullRequest", func() {
 		It("merges a given pull request", func() {
 			pullRequestsClient.MergeReturns(nil)
-			err := userProvider.MergePullRequest(context.TODO(), repoUrl, 1, "message")
+			err := userProvider.MergePullRequest(context.TODO(), repoURL, 1, "message")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(pullRequestsClient.MergeCallCount()).To(Equal(1))
 			_, prNumber, mergeMethod, message := pullRequestsClient.MergeArgsForCall(0)
@@ -352,7 +352,7 @@ var _ = Describe("User Provider", func() {
 		When("merge the PR fails", func() {
 			It("returns an error", func() {
 				pullRequestsClient.MergeReturns(fmt.Errorf("err"))
-				err := userProvider.MergePullRequest(context.TODO(), repoUrl, 1, "message")
+				err := userProvider.MergePullRequest(context.TODO(), repoURL, 1, "message")
 				Expect(err).To(MatchError("err"))
 				Expect(pullRequestsClient.MergeCallCount()).To(Equal(1))
 			})

--- a/pkg/gitproviders/repo_url.go
+++ b/pkg/gitproviders/repo_url.go
@@ -26,7 +26,7 @@ type RepoURL struct {
 }
 
 func NewRepoURL(uri string) (RepoURL, error) {
-	providerName, err := detectGitProviderFromUrl(uri, ViperGetStringMapString("git-host-types"))
+	providerName, err := detectGitProviderFromURL(uri, ViperGetStringMapString("git-host-types"))
 	if err != nil {
 		return RepoURL{}, fmt.Errorf("could not get provider name from URL %s: %w", uri, err)
 	}
@@ -41,7 +41,7 @@ func NewRepoURL(uri string) (RepoURL, error) {
 		return RepoURL{}, fmt.Errorf("could not create normalized repo URL %s: %w", uri, err)
 	}
 
-	owner, err := getOwnerFromUrl(*u, providerName)
+	owner, err := getOwnerFromURL(*u, providerName)
 	if err != nil {
 		return RepoURL{}, fmt.Errorf("could not get owner name from URL %s: %w", uri, err)
 	}
@@ -52,7 +52,7 @@ func NewRepoURL(uri string) (RepoURL, error) {
 	}
 
 	return RepoURL{
-		repoName:   utils.UrlToRepoName(uri),
+		repoName:   utils.URLToRepoName(uri),
 		owner:      owner,
 		url:        u,
 		normalized: normalized,
@@ -85,7 +85,7 @@ func (n RepoURL) Protocol() RepositoryURLProtocol {
 	return n.protocol
 }
 
-func getOwnerFromUrl(url url.URL, providerName GitProviderName) (string, error) {
+func getOwnerFromURL(url url.URL, providerName GitProviderName) (string, error) {
 	url.Path = strings.TrimPrefix(url.Path, "/")
 
 	parts := strings.Split(url.Path, "/")
@@ -106,9 +106,9 @@ func getOwnerFromUrl(url url.URL, providerName GitProviderName) (string, error) 
 	return parts[0], nil
 }
 
-// detectGitProviderFromUrl accepts a url related to a git repo and
+// detectGitProviderFromURL accepts a url related to a git repo and
 // returns the name of the provider associated.
-func detectGitProviderFromUrl(raw string, gitHostTypes map[string]string) (GitProviderName, error) {
+func detectGitProviderFromURL(raw string, gitHostTypes map[string]string) (GitProviderName, error) {
 	u, err := parseGitURL(raw)
 	if err != nil {
 		return "", fmt.Errorf("could not parse git repo url %q: %w", raw, err)

--- a/pkg/gitproviders/repo_url_test.go
+++ b/pkg/gitproviders/repo_url_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/spf13/viper"
 )
 
-var _ = DescribeTable("detectGitProviderFromUrl", func(input string, expected GitProviderName) {
-	result, err := detectGitProviderFromUrl(input, map[string]string{})
+var _ = DescribeTable("detectGitProviderFromURL", func(input string, expected GitProviderName) {
+	result, err := detectGitProviderFromURL(input, map[string]string{})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(result).To(Equal(expected))
 },
@@ -18,10 +18,10 @@ var _ = DescribeTable("detectGitProviderFromUrl", func(input string, expected Gi
 )
 
 var _ = Describe("get owner from url", func() {
-	DescribeTable("getOwnerFromUrl", func(normalizedUrl string, providerName GitProviderName, expected string) {
-		u, err := url.Parse(normalizedUrl)
+	DescribeTable("getOwnerFromURL", func(normalizedURL string, providerName GitProviderName, expected string) {
+		u, err := url.Parse(normalizedURL)
 		Expect(err).NotTo(HaveOccurred())
-		result, err := getOwnerFromUrl(*u, providerName)
+		result, err := getOwnerFromURL(*u, providerName)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result).To(Equal(expected))
 	},
@@ -31,28 +31,28 @@ var _ = Describe("get owner from url", func() {
 	)
 
 	It("missing owner", func() {
-		normalizedUrl := "ssh://git@gitlab.com/weave-gitops.git"
-		u, err := url.Parse(normalizedUrl)
+		normalizedURL := "ssh://git@gitlab.com/weave-gitops.git"
+		u, err := url.Parse(normalizedURL)
 		Expect(err).NotTo(HaveOccurred())
-		_, err = getOwnerFromUrl(*u, GitProviderGitLab)
+		_, err = getOwnerFromURL(*u, GitProviderGitLab)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(Equal("could not get owner from url ssh://git@gitlab.com/weave-gitops.git"))
 	})
 
 	It("empty url", func() {
-		normalizedUrl := ""
-		u, err := url.Parse(normalizedUrl)
+		normalizedURL := ""
+		u, err := url.Parse(normalizedURL)
 		Expect(err).NotTo(HaveOccurred())
-		_, err = getOwnerFromUrl(*u, GitProviderGitLab)
+		_, err = getOwnerFromURL(*u, GitProviderGitLab)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(Equal("could not get owner from url "))
 	})
 
 	It("subgroup in a subgroup", func() {
-		normalizedUrl := "ssh://git@gitlab.com/weaveworks/sub_group/another_sub_group/weave-gitops.git"
-		u, err := url.Parse(normalizedUrl)
+		normalizedURL := "ssh://git@gitlab.com/weaveworks/sub_group/another_sub_group/weave-gitops.git"
+		u, err := url.Parse(normalizedURL)
 		Expect(err).NotTo(HaveOccurred())
-		_, err = getOwnerFromUrl(*u, GitProviderGitLab)
+		_, err = getOwnerFromURL(*u, GitProviderGitLab)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(Equal("a subgroup in a subgroup is not currently supported"))
 	})

--- a/pkg/helm/charts_test.go
+++ b/pkg/helm/charts_test.go
@@ -8,7 +8,6 @@ import (
 	"sort"
 	"time"
 
-	"github.com/fluxcd/pkg/apis/meta"
 	fluxmeta "github.com/fluxcd/pkg/apis/meta"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1beta2"
 	. "github.com/onsi/ginkgo/v2"
@@ -209,7 +208,7 @@ var _ = Describe("RepoManager", func() {
 		When("the entry fails to be built", func() {
 			It("errors", func() {
 				helmRepo := makeTestHelmRepository("http://[::1]:namedport/index.yaml")
-				helmRepo.Spec.SecretRef = &meta.LocalObjectReference{
+				helmRepo.Spec.SecretRef = &fluxmeta.LocalObjectReference{
 					Name: "name",
 				}
 				chartReference := &helm.ChartReference{Chart: "demo-profile", Version: "0.0.1"}

--- a/pkg/helm/releases.go
+++ b/pkg/helm/releases.go
@@ -12,7 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
-	kyaml "sigs.k8s.io/yaml"
+	"sigs.k8s.io/yaml"
 )
 
 const DefaultBufferSize = 2048
@@ -54,7 +54,7 @@ func AppendHelmReleaseToString(content string, newRelease *helmv2.HelmRelease) (
 		sb.WriteString(content + "\n")
 	}
 
-	helmReleaseManifest, err := kyaml.Marshal(newRelease)
+	helmReleaseManifest, err := yaml.Marshal(newRelease)
 	if err != nil {
 		return "", fmt.Errorf("failed to marshal HelmRelease: %w", err)
 	}
@@ -91,7 +91,7 @@ func MarshalHelmReleases(existingReleases []*helmv2.HelmRelease) (string, error)
 	var sb strings.Builder
 
 	for _, r := range existingReleases {
-		b, err := kyaml.Marshal(r)
+		b, err := yaml.Marshal(r)
 		if err != nil {
 			return "", fmt.Errorf("failed to marshal: %w", err)
 		}

--- a/pkg/helm/releases_test.go
+++ b/pkg/helm/releases_test.go
@@ -13,7 +13,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/yaml"
-	kyaml "sigs.k8s.io/yaml"
 )
 
 var _ = Describe("MakeHelmRelease", func() {
@@ -86,7 +85,7 @@ var _ = Describe("AppendHelmReleaseToString", func() {
 
 	When("the given string is not empty", func() {
 		It("appends a HelmRelease to it", func() {
-			b, _ := kyaml.Marshal(helm.MakeHelmRelease(
+			b, _ := yaml.Marshal(helm.MakeHelmRelease(
 				"another-profile", "7.0.0", "prod", "test-namespace",
 				types.NamespacedName{Name: "helm-repo-name", Namespace: "helm-repo-namespace"},
 			))
@@ -105,13 +104,13 @@ var _ = Describe("MarshalHelmRelease", func() {
 			"random-profile", "7.0.0", "prod", "weave-system",
 			types.NamespacedName{Name: "helm-repo-name", Namespace: "helm-repo-namespace"},
 		)
-		releaseBytes1, _ := kyaml.Marshal(release1)
+		releaseBytes1, _ := yaml.Marshal(release1)
 
 		release2 := helm.MakeHelmRelease(
 			"podinfo", "6.0.0", "prod", "weave-system",
 			types.NamespacedName{Name: "helm-repo-name", Namespace: "helm-repo-namespace"},
 		)
-		releaseBytes2, _ := kyaml.Marshal(release2)
+		releaseBytes2, _ := yaml.Marshal(release2)
 
 		patchedContent, err := helm.MarshalHelmReleases([]*helmv2.HelmRelease{release1, release2})
 		Expect(err).NotTo(HaveOccurred())
@@ -130,9 +129,9 @@ var _ = Describe("SplitHelmReleaseYAML", func() {
 				"profile", "6.0.1", "prod", "test-namespace",
 				types.NamespacedName{Name: "helm-repo-name", Namespace: "test-namespace"},
 			)
-			b1, _ := kyaml.Marshal(r1)
+			b1, _ := yaml.Marshal(r1)
 			bytes := append(b1, []byte("\n---\n")...)
-			b2, _ := kyaml.Marshal(r2)
+			b2, _ := yaml.Marshal(r2)
 			list, err := helm.SplitHelmReleaseYAML(append(bytes, b2...))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(list).To(ContainElements(r1, r2))
@@ -141,7 +140,7 @@ var _ = Describe("SplitHelmReleaseYAML", func() {
 
 	When("the resource contains any resource other than a HelmRelease", func() {
 		It("returns an error", func() {
-			b, _ := kyaml.Marshal("content")
+			b, _ := yaml.Marshal("content")
 			_, err := helm.SplitHelmReleaseYAML(b)
 			Expect(err).To(MatchError(ContainSubstring("error unmarshaling JSON")))
 		})

--- a/pkg/kube/kubehttp_test.go
+++ b/pkg/kube/kubehttp_test.go
@@ -12,7 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/rest"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api/v1"
-	kyaml "sigs.k8s.io/yaml"
+	"sigs.k8s.io/yaml"
 )
 
 var _ = Describe("KubeHTTP", func() {
@@ -134,7 +134,7 @@ func createKubeconfig(name, clusterName, dir string, setCurContext bool) {
 	c.Contexts = append(c.Contexts, clientcmdapi.NamedContext{Name: name, Context: clientcmdapi.Context{Cluster: clusterName}})
 	c.Clusters = append(c.Clusters, clientcmdapi.NamedCluster{Name: clusterName, Cluster: clientcmdapi.Cluster{Server: "127.0.0.1"}})
 
-	kubeconfig, err := kyaml.Marshal(&c)
+	kubeconfig, err := yaml.Marshal(&c)
 	Expect(err).ToNot(HaveOccurred())
 
 	_, err = f.Write(kubeconfig)

--- a/pkg/run/install_dashboard.go
+++ b/pkg/run/install_dashboard.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	helmChartName     = "weave-gitops"
-	helmRepositoryUrl = "https://helm.gitops.weave.works"
+	helmRepositoryURL = "https://helm.gitops.weave.works"
 )
 
 func ReadPassword(log logger.Logger) (string, error) {
@@ -271,7 +271,7 @@ func makeHelmRepository(name string, namespace string) *sourcev1.HelmRepository 
 			},
 		},
 		Spec: sourcev1.HelmRepositorySpec{
-			URL: helmRepositoryUrl,
+			URL: helmRepositoryURL,
 			Interval: metav1.Duration{
 				Duration: time.Minute * 60,
 			},

--- a/pkg/run/install_dashboard_test.go
+++ b/pkg/run/install_dashboard_test.go
@@ -218,7 +218,7 @@ var _ = Describe("makeHelmRepository", func() {
 		annotations := actual.Annotations
 		Expect(annotations["metadata.weave.works/description"]).NotTo(BeEmpty())
 
-		Expect(actual.Spec.URL).To(Equal(helmRepositoryUrl))
+		Expect(actual.Spec.URL).To(Equal(helmRepositoryURL))
 		Expect(actual.Spec.Interval.Duration).To(Equal(60 * time.Minute))
 	})
 })

--- a/pkg/server/auth/auth_method_type.go
+++ b/pkg/server/auth/auth_method_type.go
@@ -71,7 +71,7 @@ func (am *AuthMethod) UnmarshalText(text []byte) error {
 	case "token-passthrough":
 		*am = TokenPassthrough
 	default:
-		return fmt.Errorf("Unknown auth method '%q'", text)
+		return fmt.Errorf("unknown auth method '%q'", text)
 	}
 
 	return nil

--- a/pkg/server/auth/auth_method_type_test.go
+++ b/pkg/server/auth/auth_method_type_test.go
@@ -28,7 +28,7 @@ func TestInvariant(t *testing.T) {
 
 func TestBadAuthMethod(t *testing.T) {
 	method, err := auth.ParseAuthMethod("badMethod")
-	if !strings.HasPrefix(err.Error(), "Unknown auth method") {
+	if !strings.HasPrefix(err.Error(), "unknown auth method") {
 		t.Fatalf("Expected ParseAuthMethod to produce 'Unknown auth method' error, instead got (method='%d', err='%s')", method, err)
 	}
 }

--- a/pkg/server/auth/auth_test.go
+++ b/pkg/server/auth/auth_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/go-logr/logr"
 	"github.com/oauth2-proxy/mockoidc"
-	"github.com/onsi/gomega"
 	. "github.com/onsi/gomega"
 	"github.com/weaveworks/weave-gitops/pkg/server/auth"
 	"golang.org/x/crypto/bcrypt"
@@ -26,7 +25,7 @@ import (
 const testNamespace = "flux-system"
 
 func TestWithAPIAuthReturns401ForUnauthenticatedRequests(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
+	g := NewGomegaWithT(t)
 
 	m, err := mockoidc.Run()
 	g.Expect(err).NotTo(HaveOccurred())
@@ -84,7 +83,7 @@ func TestWithAPIAuthReturns401ForUnauthenticatedRequests(t *testing.T) {
 func TestWithAPIAuthOnlyUsesValidMethods(t *testing.T) {
 	// In theory all attempts to login in this should fail as, despite
 	// the auth server having access to
-	g := gomega.NewGomegaWithT(t)
+	g := NewGomegaWithT(t)
 
 	m, err := mockoidc.Run()
 	g.Expect(err).NotTo(HaveOccurred())
@@ -162,7 +161,7 @@ func TestWithAPIAuthOnlyUsesValidMethods(t *testing.T) {
 }
 
 func TestOauth2FlowRedirectsToOIDCIssuerForUnauthenticatedRequests(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
+	g := NewGomegaWithT(t)
 
 	m, err := mockoidc.Run()
 	g.Expect(err).NotTo(HaveOccurred())
@@ -215,7 +214,7 @@ func TestOauth2FlowRedirectsToOIDCIssuerForUnauthenticatedRequests(t *testing.T)
 }
 
 func TestIsPublicRoute(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
+	g := NewGomegaWithT(t)
 
 	g.Expect(auth.IsPublicRoute(&url.URL{Path: "/foo"}, []string{"/foo"})).To(BeTrue())
 	g.Expect(auth.IsPublicRoute(&url.URL{Path: "foo"}, []string{"/foo"})).To(BeFalse())
@@ -223,7 +222,7 @@ func TestIsPublicRoute(t *testing.T) {
 }
 
 func TestRateLimit(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
+	g := NewGomegaWithT(t)
 
 	mux := http.NewServeMux()
 	tokenSignerVerifier, err := auth.NewHMACTokenSignerVerifier(5 * time.Minute)
@@ -284,7 +283,7 @@ func TestRateLimit(t *testing.T) {
 }
 
 func TestUserPrincipalValid(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
+	g := NewGomegaWithT(t)
 
 	tests := []struct {
 		name    string

--- a/pkg/server/auth/init.go
+++ b/pkg/server/auth/init.go
@@ -8,7 +8,6 @@ import (
 	"github.com/weaveworks/weave-gitops/core/logger"
 	"github.com/weaveworks/weave-gitops/pkg/featureflags"
 	corev1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -21,7 +20,7 @@ func InitAuthServer(ctx context.Context, log logr.Logger, rawKubernetesClient ct
 	}
 
 	if len(authMethods) == 0 {
-		return nil, fmt.Errorf("No authentication methods set")
+		return nil, fmt.Errorf("no authentication methods set")
 	}
 
 	if authMethods[OIDC] {
@@ -31,7 +30,7 @@ func InitAuthServer(ctx context.Context, log logr.Logger, rawKubernetesClient ct
 
 		// If OIDC auth secret is found prefer that over CLI parameters
 		var secret corev1.Secret
-		if err := rawKubernetesClient.Get(ctx, client.ObjectKey{
+		if err := rawKubernetesClient.Get(ctx, ctrlclient.ObjectKey{
 			Namespace: namespace,
 			Name:      oidcSecret,
 		}, &secret); err == nil {

--- a/pkg/server/auth/jwt.go
+++ b/pkg/server/auth/jwt.go
@@ -158,5 +158,5 @@ func (m MultiAuthPrincipal) Principal(r *http.Request) (*UserPrincipal, error) {
 		}
 	}
 
-	return nil, fmt.Errorf("Could not find valid principal")
+	return nil, fmt.Errorf("could not find valid principal")
 }

--- a/pkg/server/auth/jwt_test.go
+++ b/pkg/server/auth/jwt_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
-	"github.com/onsi/gomega"
 	. "github.com/onsi/gomega"
 	"github.com/weaveworks/weave-gitops/pkg/server/auth"
 	"github.com/weaveworks/weave-gitops/pkg/testutils"
@@ -96,10 +95,10 @@ func makeAuthenticatedRequest(token string) *http.Request {
 }
 
 func TestMultiAuth(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
+	g := NewGomegaWithT(t)
 
 	err := errors.New("oops")
-	noAuthError := errors.New("Could not find valid principal")
+	noAuthError := errors.New("could not find valid principal")
 
 	multiAuthTests := []struct {
 		name  string

--- a/pkg/server/auth/server_test.go
+++ b/pkg/server/auth/server_test.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/oauth2-proxy/mockoidc"
-	"github.com/onsi/gomega"
 	. "github.com/onsi/gomega"
 	"github.com/weaveworks/weave-gitops/pkg/featureflags"
 	"github.com/weaveworks/weave-gitops/pkg/server/auth"
@@ -34,7 +33,7 @@ var httpClient = &http.Client{
 }
 
 func TestCallbackAllowsGet(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
+	g := NewGomegaWithT(t)
 
 	methods := []string{
 		http.MethodPost,
@@ -59,7 +58,7 @@ func TestCallbackAllowsGet(t *testing.T) {
 }
 
 func TestCallbackErrorFromOIDC(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
+	g := NewGomegaWithT(t)
 
 	s, _ := makeAuthServer(t, nil, nil, []auth.AuthMethod{auth.OIDC})
 
@@ -71,7 +70,7 @@ func TestCallbackErrorFromOIDC(t *testing.T) {
 }
 
 func TestCallbackCodeIsEmpty(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
+	g := NewGomegaWithT(t)
 
 	s, _ := makeAuthServer(t, nil, nil, []auth.AuthMethod{auth.OIDC})
 
@@ -83,7 +82,7 @@ func TestCallbackCodeIsEmpty(t *testing.T) {
 }
 
 func TestCallbackStateCookieNotSet(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
+	g := NewGomegaWithT(t)
 
 	s, _ := makeAuthServer(t, nil, nil, []auth.AuthMethod{auth.OIDC})
 
@@ -95,7 +94,7 @@ func TestCallbackStateCookieNotSet(t *testing.T) {
 }
 
 func TestCallbackStateCookieNotValid(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
+	g := NewGomegaWithT(t)
 
 	s, _ := makeAuthServer(t, nil, nil, []auth.AuthMethod{auth.OIDC})
 
@@ -112,7 +111,7 @@ func TestCallbackStateCookieNotValid(t *testing.T) {
 }
 
 func TestCallbackStateCookieNotBase64Encoded(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
+	g := NewGomegaWithT(t)
 
 	s, _ := makeAuthServer(t, nil, nil, []auth.AuthMethod{auth.OIDC})
 
@@ -129,7 +128,7 @@ func TestCallbackStateCookieNotBase64Encoded(t *testing.T) {
 }
 
 func TestCallbackStateCookieNotJSONPayload(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
+	g := NewGomegaWithT(t)
 
 	s, _ := makeAuthServer(t, nil, nil, []auth.AuthMethod{auth.OIDC})
 
@@ -148,7 +147,7 @@ func TestCallbackStateCookieNotJSONPayload(t *testing.T) {
 }
 
 func TestCallbackCodeExchangeError(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
+	g := NewGomegaWithT(t)
 
 	s, _ := makeAuthServer(t, nil, nil, []auth.AuthMethod{auth.OIDC})
 
@@ -171,7 +170,7 @@ func TestCallbackCodeExchangeError(t *testing.T) {
 }
 
 func TestSignInAllowsPOST(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
+	g := NewGomegaWithT(t)
 
 	methods := []string{
 		http.MethodGet,
@@ -199,7 +198,7 @@ func TestSignInAllowsPOST(t *testing.T) {
 }
 
 func TestSignInNoPayloadReturnsBadRequest(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
+	g := NewGomegaWithT(t)
 
 	tokenSignerVerifier, err := auth.NewHMACTokenSignerVerifier(5 * time.Minute)
 	if err != nil {
@@ -222,7 +221,7 @@ func TestSignInNoPayloadReturnsBadRequest(t *testing.T) {
 }
 
 func TestSignInNoSecret(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
+	g := NewGomegaWithT(t)
 
 	tokenSignerVerifier, err := auth.NewHMACTokenSignerVerifier(5 * time.Minute)
 	g.Expect(err).NotTo(HaveOccurred())
@@ -242,7 +241,7 @@ func TestSignInNoSecret(t *testing.T) {
 }
 
 func TestSignInWrongUsernameReturnsUnauthorized(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
+	g := NewGomegaWithT(t)
 
 	username := "admin"
 	password := "my-secret-password"
@@ -286,7 +285,7 @@ func TestSignInWrongUsernameReturnsUnauthorized(t *testing.T) {
 }
 
 func TestSignInWrongPasswordReturnsUnauthorized(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
+	g := NewGomegaWithT(t)
 
 	password := "my-secret-password"
 
@@ -327,7 +326,7 @@ func TestSignInWrongPasswordReturnsUnauthorized(t *testing.T) {
 }
 
 func TestSingInCorrectPassword(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
+	g := NewGomegaWithT(t)
 
 	password := "my-secret-password"
 
@@ -382,7 +381,7 @@ func TestSingInCorrectPassword(t *testing.T) {
 }
 
 func TestUserInfoAllowsGET(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
+	g := NewGomegaWithT(t)
 
 	methods := []string{
 		http.MethodPost,
@@ -407,7 +406,7 @@ func TestUserInfoAllowsGET(t *testing.T) {
 }
 
 func TestUserInfoIDTokenCookieNotSet(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
+	g := NewGomegaWithT(t)
 
 	s, _ := makeAuthServer(t, nil, nil, []auth.AuthMethod{auth.OIDC})
 
@@ -419,7 +418,7 @@ func TestUserInfoIDTokenCookieNotSet(t *testing.T) {
 }
 
 func TestUserInfoAdminFlow(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
+	g := NewGomegaWithT(t)
 
 	tokenSignerVerifier, err := auth.NewHMACTokenSignerVerifier(5 * time.Minute)
 	g.Expect(err).NotTo(HaveOccurred())
@@ -459,7 +458,7 @@ func TestUserInfoAdminFlow(t *testing.T) {
 }
 
 func TestUserInfoAdminFlow_differentUsername(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
+	g := NewGomegaWithT(t)
 
 	tokenSignerVerifier, err := auth.NewHMACTokenSignerVerifier(5 * time.Minute)
 	g.Expect(err).NotTo(HaveOccurred())
@@ -500,7 +499,7 @@ func TestUserInfoAdminFlow_differentUsername(t *testing.T) {
 }
 
 func TestUserInfoAdminFlowBadCookie(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
+	g := NewGomegaWithT(t)
 
 	tokenSignerVerifier, err := auth.NewHMACTokenSignerVerifier(5 * time.Minute)
 	g.Expect(err).NotTo(HaveOccurred())
@@ -544,7 +543,7 @@ func TestUserInfoOIDCFlow(t *testing.T) {
 		code  = "mnopqr"
 	)
 
-	g := gomega.NewGomegaWithT(t)
+	g := NewGomegaWithT(t)
 
 	tokenSignerVerifier, err := auth.NewHMACTokenSignerVerifier(5 * time.Minute)
 	g.Expect(err).NotTo(HaveOccurred())
@@ -626,7 +625,7 @@ func TestUserInfoOIDCFlow(t *testing.T) {
 }
 
 func TestLogoutSuccess(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
+	g := NewGomegaWithT(t)
 
 	hashedSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -668,7 +667,7 @@ func TestLogoutSuccess(t *testing.T) {
 }
 
 func TestLogoutWithWrongMethod(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
+	g := NewGomegaWithT(t)
 
 	hashedSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -694,7 +693,7 @@ func TestLogoutWithWrongMethod(t *testing.T) {
 
 func makeAuthServer(t *testing.T, client ctrlclient.Client, tsv auth.TokenSignerVerifier, authMethods []auth.AuthMethod) (*auth.AuthServer, *mockoidc.MockOIDC) {
 	t.Helper()
-	g := gomega.NewGomegaWithT(t)
+	g := NewGomegaWithT(t)
 
 	featureflags.Set("OIDC_AUTH", "") // Reset this
 
@@ -732,7 +731,7 @@ func makeAuthServer(t *testing.T, client ctrlclient.Client, tsv auth.TokenSigner
 }
 
 func TestAuthMethods(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
+	g := NewGomegaWithT(t)
 
 	featureflags.Set("OIDC_AUTH", "")
 	featureflags.Set("CLUSTER_USER_AUTH", "")

--- a/pkg/server/auth/token_signer_verifier.go
+++ b/pkg/server/auth/token_signer_verifier.go
@@ -77,7 +77,7 @@ func (sv *HMACTokenSignerVerifier) Verify(tokenString string) (*AdminClaims, err
 	token, err := jwt.ParseWithClaims(tokenString, &AdminClaims{},
 		func(token *jwt.Token) (interface{}, error) {
 			if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
-				return nil, fmt.Errorf("Unexpected signing method: %v", token.Header["alg"])
+				return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
 			}
 
 			return sv.hmacSecret, nil

--- a/pkg/server/profiles.go
+++ b/pkg/server/profiles.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	OctetStreamType = "application/octet-stream"
-	JsonType        = "application/json"
+	JSONType        = "application/json"
 )
 
 type ProfilesConfig struct {
@@ -193,7 +193,7 @@ func (s *ProfilesServer) GetProfileValues(ctx context.Context, msg *pb.GetProfil
 	}
 
 	return &httpbody.HttpBody{
-		ContentType: JsonType,
+		ContentType: JSONType,
 		Data:        res,
 	}, nil
 }

--- a/pkg/server/profiles_test.go
+++ b/pkg/server/profiles_test.go
@@ -136,7 +136,7 @@ var _ = Describe("ProfilesServer", func() {
 					resp, err := s.GetProfileValues(context.TODO(), &pb.GetProfileValuesRequest{ProfileName: profileName,
 						ProfileVersion: profileVersion, HelmRepoName: "test-name", HelmRepoNamespace: "test-namespace"})
 					Expect(err).NotTo(HaveOccurred())
-					Expect(resp.ContentType).To(Equal(server.JsonType))
+					Expect(resp.ContentType).To(Equal(server.JSONType))
 					valuesResp := &pb.GetProfileValuesResponse{}
 					err = json.Unmarshal(resp.Data, valuesResp)
 					Expect(err).NotTo(HaveOccurred())
@@ -159,7 +159,7 @@ var _ = Describe("ProfilesServer", func() {
 							ProfileVersion: profileVersion,
 						})
 						Expect(err).NotTo(HaveOccurred())
-						Expect(resp.ContentType).To(Equal(server.JsonType))
+						Expect(resp.ContentType).To(Equal(server.JSONType))
 						valuesResp := &pb.GetProfileValuesResponse{}
 						err = json.Unmarshal(resp.Data, valuesResp)
 						Expect(err).NotTo(HaveOccurred())

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -190,7 +190,7 @@ func (s *applicationServer) AuthorizeGitlab(ctx context.Context, msg *pb.Authori
 		return nil, fmt.Errorf("could not exchange code: %w", err)
 	}
 
-	token, err := s.jwtClient.GenerateJWT(tokenState.ExpiresInSeconds, gitproviders.GitProviderGitLab, tokenState.AccessToken)
+	token, err := s.jwtClient.GenerateJWT(tokenState.ExpiresIn, gitproviders.GitProviderGitLab, tokenState.AccessToken)
 	if err != nil {
 		return nil, fmt.Errorf("could not generate token: %w", err)
 	}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -207,10 +207,10 @@ var _ = Describe("ApplicationsServer", func() {
 	Describe("GetGitlabAuthURL", func() {
 		It("returns the gitlab url", func() {
 			urlString := "http://gitlab.com/oauth/authorize"
-			authUrl, err := url.Parse(urlString)
+			authURL, err := url.Parse(urlString)
 			Expect(err).NotTo(HaveOccurred())
 
-			glAuthClient.AuthURLReturns(*authUrl, nil)
+			glAuthClient.AuthURLReturns(*authURL, nil)
 
 			res, err := appsClient.GetGitlabAuthURL(context.Background(), &pb.GetGitlabAuthURLRequest{
 				RedirectUri: "http://example.com/oauth/fake",

--- a/pkg/services/auth/auth.go
+++ b/pkg/services/auth/auth.go
@@ -45,7 +45,7 @@ func (sn SecretName) NamespacedName() types.NamespacedName {
 }
 
 type AuthService interface {
-	CreateGitClient(ctx context.Context, repoUrl gitproviders.RepoURL, namespace string, dryRun bool) (git.Git, error)
+	CreateGitClient(ctx context.Context, repoURL gitproviders.RepoURL, namespace string, dryRun bool) (git.Git, error)
 	GetGitProvider() gitproviders.GitProvider
 	SetupDeployKey(ctx context.Context, namespace string, repo gitproviders.RepoURL) (*ssh.PublicKeys, error)
 }
@@ -76,13 +76,13 @@ func (a *authSvc) GetGitProvider() gitproviders.GitProvider {
 
 // CreateGitClient creates a git.Git client instrumented with existing or generated deploy keys.
 // This ensures that git operations are done with stored deploy keys instead of a user's local ssh-agent or equivalent.
-func (a *authSvc) CreateGitClient(ctx context.Context, repoUrl gitproviders.RepoURL, namespace string, dryRun bool) (git.Git, error) {
+func (a *authSvc) CreateGitClient(ctx context.Context, repoURL gitproviders.RepoURL, namespace string, dryRun bool) (git.Git, error) {
 	if dryRun {
 		d, _ := makePublicKey([]byte(""))
 		return git.New(d, wrapper.NewGoGit()), nil
 	}
 
-	pubKey, keyErr := a.SetupDeployKey(ctx, namespace, repoUrl)
+	pubKey, keyErr := a.SetupDeployKey(ctx, namespace, repoURL)
 	if keyErr != nil {
 		return nil, fmt.Errorf("error setting up deploy keys: %w", keyErr)
 	}

--- a/pkg/services/auth/auth_test.go
+++ b/pkg/services/auth/auth_test.go
@@ -20,7 +20,7 @@ import (
 
 var _ = Describe("auth", func() {
 	var (
-		configRepoUrl gitproviders.RepoURL
+		configRepoURL gitproviders.RepoURL
 		namespace     *corev1.Namespace
 		ctx           context.Context
 		secretName    names.GeneratedSecretName
@@ -30,10 +30,10 @@ var _ = Describe("auth", func() {
 	)
 
 	BeforeEach(func() {
-		repoUrlString := "ssh://git@github.com/my-org/my-repo.git"
+		repoURLString := "ssh://git@github.com/my-org/my-repo.git"
 
 		var err error
-		configRepoUrl, err = gitproviders.NewRepoURL(repoUrlString)
+		configRepoURL, err = gitproviders.NewRepoURL(repoURLString)
 		Expect(err).NotTo(HaveOccurred())
 
 		namespace = &corev1.Namespace{}
@@ -41,7 +41,7 @@ var _ = Describe("auth", func() {
 		Expect(k8sClient.Create(context.Background(), namespace)).To(Succeed())
 
 		ctx = context.Background()
-		secretName = names.CreateRepoSecretName(configRepoUrl)
+		secretName = names.CreateRepoSecretName(configRepoURL)
 		Expect(err).NotTo(HaveOccurred())
 		gp = gitprovidersfakes.FakeGitProvider{}
 		gp.GetRepoVisibilityReturns(gitprovider.RepositoryVisibilityVar(gitprovider.RepositoryVisibilityPrivate), nil)
@@ -55,7 +55,7 @@ var _ = Describe("auth", func() {
 	})
 
 	It("create and stores a deploy key if none exists", func() {
-		_, err := as.CreateGitClient(ctx, configRepoUrl, namespace.Name, false)
+		_, err := as.CreateGitClient(ctx, configRepoURL, namespace.Name, false)
 		Expect(err).NotTo(HaveOccurred())
 		sn := auth.SecretName{Name: secretName, Namespace: namespace.Name}
 		secret := &corev1.Secret{}
@@ -66,7 +66,7 @@ var _ = Describe("auth", func() {
 	})
 
 	It("doesn't create a deploy key when dry-run is true", func() {
-		_, err := as.CreateGitClient(ctx, configRepoUrl, namespace.Name, true)
+		_, err := as.CreateGitClient(ctx, configRepoURL, namespace.Name, true)
 		Expect(err).NotTo(HaveOccurred())
 		sn := auth.SecretName{Name: secretName, Namespace: namespace.Name}
 		secret := &corev1.Secret{}
@@ -77,7 +77,7 @@ var _ = Describe("auth", func() {
 		var original int
 
 		BeforeEach(func() {
-			_, err := as.CreateGitClient(ctx, configRepoUrl, namespace.Name, false)
+			_, err := as.CreateGitClient(ctx, configRepoURL, namespace.Name, false)
 			Expect(err).NotTo(HaveOccurred())
 
 			original = gp.UploadDeployKeyCallCount()
@@ -89,7 +89,7 @@ var _ = Describe("auth", func() {
 
 			gp.DeployKeyExistsReturns(true, nil)
 
-			_, err := as.CreateGitClient(ctx, configRepoUrl, namespace.Name, false)
+			_, err := as.CreateGitClient(ctx, configRepoURL, namespace.Name, false)
 			Expect(err).NotTo(HaveOccurred())
 
 			// We should NOT have uploaded anything since the key already exists
@@ -101,7 +101,7 @@ var _ = Describe("auth", func() {
 		gp.DeployKeyExistsReturns(true, nil)
 		sn := auth.SecretName{Name: secretName, Namespace: namespace.Name}
 
-		_, err := as.CreateGitClient(ctx, configRepoUrl, namespace.Name, false)
+		_, err := as.CreateGitClient(ctx, configRepoURL, namespace.Name, false)
 		Expect(err).NotTo(HaveOccurred())
 
 		newSecret := &corev1.Secret{}

--- a/pkg/services/auth/github.go
+++ b/pkg/services/auth/github.go
@@ -115,7 +115,7 @@ func doGithubCodeRequest(client *http.Client, scope string) (*GithubDeviceCodeRe
 var ErrAuthPending = errors.New("auth pending")
 var ErrSlowDown = errors.New("slow down")
 
-const accessTokenUrl = "https://github.com/login/oauth/access_token?%s"
+const accessTokenURL = "https://github.com/login/oauth/access_token?%s"
 const githubRequiredGrantType = "urn:ietf:params:oauth:grant-type:device_code"
 
 // It appears we need `repo` scope, which is VERY permissive.
@@ -135,7 +135,7 @@ func doGithubDeviceAuthRequest(client *http.Client, deviceCode string) (string, 
 		"device_code": {deviceCode},
 		"grant_type":  {githubRequiredGrantType},
 	})
-	url := fmt.Sprintf(accessTokenUrl, query)
+	url := fmt.Sprintf(accessTokenURL, query)
 
 	req, err := http.NewRequest("POST", url, nil)
 	if err != nil {

--- a/pkg/services/auth/gitlab.go
+++ b/pkg/services/auth/gitlab.go
@@ -17,8 +17,8 @@ var gitlabScopes = []string{"api", "read_user", "profile"}
 
 //counterfeiter:generate . GitlabAuthClient
 type GitlabAuthClient interface {
-	AuthURL(ctx context.Context, redirectUri string) (url.URL, error)
-	ExchangeCode(ctx context.Context, redirectUri, code string) (*types.TokenResponseState, error)
+	AuthURL(ctx context.Context, redirectURI string) (url.URL, error)
+	ExchangeCode(ctx context.Context, redirectURI, code string) (*types.TokenResponseState, error)
 	ValidateToken(ctx context.Context, token string) error
 }
 
@@ -39,18 +39,18 @@ func NewGitlabAuthClient(client *http.Client) GitlabAuthClient {
 	}
 }
 
-func (g glAuth) AuthURL(ctx context.Context, redirectUri string) (url.URL, error) {
-	return internal.GitlabAuthorizeUrl(redirectUri, gitlabScopes, g.verifier)
+func (g glAuth) AuthURL(ctx context.Context, redirectURI string) (url.URL, error) {
+	return internal.GitlabAuthorizeURL(redirectURI, gitlabScopes, g.verifier)
 }
 
-func (g glAuth) ExchangeCode(ctx context.Context, redirectUri, code string) (*types.TokenResponseState, error) {
-	tUrl := internal.GitlabTokenUrl(redirectUri, code, g.verifier)
+func (g glAuth) ExchangeCode(ctx context.Context, redirectURI, code string) (*types.TokenResponseState, error) {
+	tURL := internal.GitlabTokenURL(redirectURI, code, g.verifier)
 
-	return doCodeExchangeRequest(ctx, tUrl, g.http)
+	return doCodeExchangeRequest(ctx, tURL, g.http)
 }
 
 func (g glAuth) ValidateToken(ctx context.Context, token string) error {
-	u := internal.GitlabUserUrl()
+	u := internal.GitlabUserURL()
 
 	req, err := http.NewRequestWithContext(ctx, "GET", u.String(), nil)
 	if err != nil {
@@ -69,8 +69,8 @@ func (g glAuth) ValidateToken(ctx context.Context, token string) error {
 	return nil
 }
 
-func doCodeExchangeRequest(ctx context.Context, tUrl url.URL, c *http.Client) (*types.TokenResponseState, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, tUrl.String(), strings.NewReader(""))
+func doCodeExchangeRequest(ctx context.Context, tURL url.URL, c *http.Client) (*types.TokenResponseState, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, tURL.String(), strings.NewReader(""))
 	if err != nil {
 		return nil, fmt.Errorf("could not create gitlab code request: %w", err)
 	}

--- a/pkg/services/auth/gitlab_test.go
+++ b/pkg/services/auth/gitlab_test.go
@@ -52,7 +52,7 @@ var _ = Describe("GitlabAuthClient", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(tokenState.AccessToken).To(Equal(rs.AccessToken))
-		Expect(tokenState.ExpiresInSeconds).To(Equal(time.Duration(rs.ExpiresIn) * time.Second))
+		Expect(tokenState.ExpiresIn).To(Equal(time.Duration(rs.ExpiresIn) * time.Second))
 	})
 
 	Describe("ValidateToken", func() {

--- a/pkg/services/auth/internal/gitlab.go
+++ b/pkg/services/auth/internal/gitlab.go
@@ -11,11 +11,11 @@ const (
 	gitlabScheme = "https"
 	gitlabHost   = "gitlab.com"
 	// Default values that can be used for OAuth with the `wego-dev` GitLab Application
-	gitlabClientId       = "451df5d954a3ebb371bba5e6b7d1468ead1a0ee6d88b0791b001566b7bbc10cd"
+	gitlabClientID       = "451df5d954a3ebb371bba5e6b7d1468ead1a0ee6d88b0791b001566b7bbc10cd"
 	gitlabClientSecret   = "b402c7601b71904fffec85d3cc8aa7e953405680aa9b1fc4fb8603e9bb7e208a"
 	GitlabVerifierMin    = 43
 	GitlabVerifierMax    = 128
-	GitlabRedirectUriCLI = "http://127.0.0.1:9999/oauth/gitlab/callback"
+	GitlabRedirectURICLI = "http://127.0.0.1:9999/oauth/gitlab/callback"
 	GitlabCallbackPath   = "/oauth/gitlab/callback"
 	GitlabTempServerPort = ":9999"
 )
@@ -42,22 +42,22 @@ func getGitlabHost() string {
 	return getEnvDefault("GITLAB_HOSTNAME", gitlabHost)
 }
 
-func getGitlabClientId() string {
-	return getEnvDefault("GITLAB_CLIENT_ID", gitlabClientId)
+func getGitlabClientID() string {
+	return getEnvDefault("GITLAB_CLIENT_ID", gitlabClientID)
 }
 
 func getGitlabClientSecret() string {
 	return getEnvDefault("GITLAB_CLIENT_SECRET", gitlabClientSecret)
 }
 
-// GitlabAuthorizeUrl returns a URL that can be used for a Gitlab OAuth authorize request
-func GitlabAuthorizeUrl(redirectUri string, scopes []string, verifier CodeVerifier) (url.URL, error) {
-	u := buildGitlabUrl()
+// GitlabAuthorizeURL returns a URL that can be used for a Gitlab OAuth authorize request
+func GitlabAuthorizeURL(redirectURI string, scopes []string, verifier CodeVerifier) (url.URL, error) {
+	u := buildGitlabURL()
 	u.Path = "/oauth/authorize"
 
 	params := u.Query()
-	params.Set("client_id", getGitlabClientId())
-	params.Set("redirect_uri", redirectUri)
+	params.Set("client_id", getGitlabClientID())
+	params.Set("redirect_uri", redirectURI)
 	params.Set("response_type", "code")
 
 	codeChallenge, err := verifier.CodeChallenge()
@@ -73,14 +73,14 @@ func GitlabAuthorizeUrl(redirectUri string, scopes []string, verifier CodeVerifi
 	return u, nil
 }
 
-// GitlabTokenUrl returns a URL that can be used for a Gitlab OAuth token request
-func GitlabTokenUrl(redirectUri, authorizationCode string, verifier CodeVerifier) url.URL {
-	u := buildGitlabUrl()
+// GitlabTokenURL returns a URL that can be used for a Gitlab OAuth token request
+func GitlabTokenURL(redirectURI, authorizationCode string, verifier CodeVerifier) url.URL {
+	u := buildGitlabURL()
 	u.Path = "/oauth/token"
 
 	params := u.Query()
-	params.Set("client_id", getGitlabClientId())
-	params.Set("redirect_uri", redirectUri)
+	params.Set("client_id", getGitlabClientID())
+	params.Set("redirect_uri", redirectURI)
 	params.Set("code", authorizationCode)
 	params.Set("grant_type", "authorization_code")
 	params.Set("code_verifier", verifier.RawValue())
@@ -90,15 +90,15 @@ func GitlabTokenUrl(redirectUri, authorizationCode string, verifier CodeVerifier
 	return u
 }
 
-// GitlabUserUrl returns the url to request data about the currently logged in user
-func GitlabUserUrl() url.URL {
-	u := buildGitlabUrl()
+// GitlabUserURL returns the url to request data about the currently logged in user
+func GitlabUserURL() url.URL {
+	u := buildGitlabURL()
 	u.Path = "/user"
 
 	return u
 }
 
-func buildGitlabUrl() url.URL {
+func buildGitlabURL() url.URL {
 	u := url.URL{}
 	u.Scheme = gitlabScheme
 	u.Host = getGitlabHost()

--- a/pkg/services/auth/internal/gitlab_test.go
+++ b/pkg/services/auth/internal/gitlab_test.go
@@ -11,7 +11,7 @@ var _ = Describe("Gitlab authorize url", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		scopes := []string{"api", "read_user", "profile"}
-		u, err := GitlabAuthorizeUrl("https://weave.works/test", scopes, codeVerifier)
+		u, err := GitlabAuthorizeURL("https://weave.works/test", scopes, codeVerifier)
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(u.Scheme).To(Equal("https"))
@@ -20,7 +20,7 @@ var _ = Describe("Gitlab authorize url", func() {
 
 		params := u.Query()
 		Expect(len(params)).To(Equal(6))
-		Expect(params.Get("client_id")).To(Equal(gitlabClientId))
+		Expect(params.Get("client_id")).To(Equal(gitlabClientID))
 		Expect(params.Get("response_type")).To(Equal("code"))
 		Expect(params.Get("scope")).To(Equal("api read_user profile"))
 
@@ -38,14 +38,14 @@ var _ = Describe("Gitlab token", func() {
 		codeVerifier, err := NewCodeVerifier(5, 10)
 		Expect(err).NotTo(HaveOccurred())
 
-		u := GitlabTokenUrl("https://weave.works/test", "12345", codeVerifier)
+		u := GitlabTokenURL("https://weave.works/test", "12345", codeVerifier)
 		Expect(u.Scheme).To(Equal("https"))
 		Expect(u.Host).To(Equal("gitlab.com"))
 		Expect(u.Path).To(Equal("/oauth/token"))
 
 		params := u.Query()
 		Expect(len(params)).To(Equal(6))
-		Expect(params.Get("client_id")).To(Equal(gitlabClientId))
+		Expect(params.Get("client_id")).To(Equal(gitlabClientID))
 		Expect(params.Get("redirect_uri")).To(Equal("https://weave.works/test"))
 		Expect(params.Get("grant_type")).To(Equal("authorization_code"))
 		Expect(params.Get("code_verifier")).To(Equal(codeVerifier.RawValue()))

--- a/pkg/services/auth/types/token.go
+++ b/pkg/services/auth/types/token.go
@@ -8,13 +8,13 @@ import (
 
 // TokenResponseState is used for passing state through HTTP middleware
 type TokenResponseState struct {
-	AccessToken      string
-	TokenType        string
-	ExpiresInSeconds time.Duration
-	RefreshToken     string
-	CreatedAt        int64
-	HttpStatusCode   int
-	Err              error
+	AccessToken    string
+	TokenType      string
+	ExpiresIn      time.Duration
+	RefreshToken   string
+	CreatedAt      int64
+	HTTPStatusCode int
+	Err            error
 }
 
 // SetGitlabTokenResponse will modify the TokenResponseState and populate the relevant fields from
@@ -22,7 +22,7 @@ type TokenResponseState struct {
 func (t *TokenResponseState) SetGitlabTokenResponse(token internal.GitlabTokenResponse) {
 	t.AccessToken = token.AccessToken
 	t.RefreshToken = token.RefreshToken
-	t.ExpiresInSeconds = time.Duration(token.ExpiresIn) * time.Second
+	t.ExpiresIn = time.Duration(token.ExpiresIn) * time.Second
 	t.CreatedAt = token.CreatedAt
 	t.TokenType = token.TokenType
 }

--- a/pkg/services/auth/types/token_test.go
+++ b/pkg/services/auth/types/token_test.go
@@ -35,7 +35,7 @@ var _ = Describe("TokenResponseState", func() {
 
 		Expect(token.AccessToken).To(Equal(accessToken))
 		Expect(token.TokenType).To(Equal(tokenType))
-		Expect(token.ExpiresInSeconds).To(Equal(time.Duration(seconds) * time.Second))
+		Expect(token.ExpiresIn).To(Equal(time.Duration(seconds) * time.Second))
 		Expect(token.RefreshToken).To(Equal(refreshToken))
 		Expect(token.CreatedAt).To(Equal(createdAt))
 

--- a/pkg/services/factory.go
+++ b/pkg/services/factory.go
@@ -41,17 +41,17 @@ func NewFactory(fluxClient flux.Flux, log logr.Logger) Factory {
 }
 
 func (f *defaultFactory) GetGitClients(ctx context.Context, kubeClient *kube.KubeHTTP, gpClient gitproviders.Client, params GitConfigParams) (git.Git, gitproviders.GitProvider, error) {
-	configNormalizedUrl, err := gitproviders.NewRepoURL(params.ConfigRepo)
+	configNormalizedURL, err := gitproviders.NewRepoURL(params.ConfigRepo)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error normalizing config url: %w", err)
 	}
 
-	authSvc, err := f.getAuthService(kubeClient, configNormalizedUrl, gpClient, params.DryRun)
+	authSvc, err := f.getAuthService(kubeClient, configNormalizedURL, gpClient, params.DryRun)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error getting auth service: %w", err)
 	}
 
-	client, err := authSvc.CreateGitClient(ctx, configNormalizedUrl, params.Namespace, params.DryRun)
+	client, err := authSvc.CreateGitClient(ctx, configNormalizedURL, params.Namespace, params.DryRun)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -59,7 +59,7 @@ func (f *defaultFactory) GetGitClients(ctx context.Context, kubeClient *kube.Kub
 	return client, authSvc.GetGitProvider(), nil
 }
 
-func (f *defaultFactory) getAuthService(kubeClient *kube.KubeHTTP, normalizedUrl gitproviders.RepoURL, gpClient gitproviders.Client, dryRun bool) (auth.AuthService, error) {
+func (f *defaultFactory) getAuthService(kubeClient *kube.KubeHTTP, normalizedURL gitproviders.RepoURL, gpClient gitproviders.Client, dryRun bool) (auth.AuthService, error) {
 	var (
 		gitProvider gitproviders.GitProvider
 		err         error
@@ -70,7 +70,7 @@ func (f *defaultFactory) getAuthService(kubeClient *kube.KubeHTTP, normalizedUrl
 			return nil, fmt.Errorf("error creating git provider client: %w", err)
 		}
 	} else {
-		if gitProvider, err = gpClient.GetProvider(normalizedUrl, gitproviders.GetAccountType); err != nil {
+		if gitProvider, err = gpClient.GetProvider(normalizedURL, gitproviders.GetAccountType); err != nil {
 			return nil, fmt.Errorf("error obtaining git provider token: %w", err)
 		}
 	}

--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -51,7 +51,7 @@ func timedRepeat(out io.Writer, start time.Time, poll, timeout time.Duration, up
 	return currentTime, fmt.Errorf("timeout reached %s", timeout.String())
 }
 
-func UrlToRepoName(url string) string {
+func URLToRepoName(url string) string {
 	return strings.TrimSuffix(filepath.Base(url), ".git")
 }
 


### PR DESCRIPTION
This lint rule has some pretty good checks - for example the "error strings shouldn't be capitalized", so we can always log errors properly, or "duplicate imports" that make the code look more complex than it is.

However, to enable it required me to search replace all sorts of things to capitalize them: Url with URL, Uri with URI, Http with HTTP, Json with JSON, etc.