### PR TITLE
gitops run: Use .gitignore automatically

### DIFF
--- a/cmd/gitops/beta/run/cmd.go
+++ b/cmd/gitops/beta/run/cmd.go
@@ -336,6 +336,8 @@ func betaRunCommandRunE(opts *config.Options) func(*cobra.Command, []string) err
 			return err
 		}
 
+		ignorer := run.CreateIgnorer(rootDir)
+
 		minioClient, err := minio.New(
 			"localhost:9000",
 			&minio.Options{
@@ -354,7 +356,7 @@ func betaRunCommandRunE(opts *config.Options) func(*cobra.Command, []string) err
 			return err
 		}
 
-		err = filepath.Walk(rootDir, run.WatchDirsForFileWalker(watcher))
+		err = filepath.Walk(rootDir, run.WatchDirsForFileWalker(watcher, ignorer))
 		if err != nil {
 			return err
 		}
@@ -406,7 +408,7 @@ func betaRunCommandRunE(opts *config.Options) func(*cobra.Command, []string) err
 						// reset counter
 						atomic.StoreUint64(&counter, 0)
 
-						if err := run.SyncDir(log, rootDir, "dev-bucket", minioClient); err != nil {
+						if err := run.SyncDir(log, rootDir, "dev-bucket", minioClient, ignorer); err != nil {
 							log.Failuref("Error syncing dir: %v", err)
 						}
 
@@ -421,7 +423,7 @@ func betaRunCommandRunE(opts *config.Options) func(*cobra.Command, []string) err
 								log.Failuref("Error creating new watcher: %v", err)
 							}
 
-							err = filepath.Walk(rootDir, run.WatchDirsForFileWalker(watcher))
+							err = filepath.Walk(rootDir, run.WatchDirsForFileWalker(watcher, ignorer))
 							if err != nil {
 								log.Failuref("Error re-walking dir: %v", err)
 							}

--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.1.4
 	github.com/onsi/gomega v1.20.1
 	github.com/pkg/errors v0.9.1
+	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06
 	github.com/slok/go-http-metrics v0.10.0
 	github.com/spf13/cobra v1.5.0
 	github.com/spf13/viper v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -1102,6 +1102,8 @@ github.com/ryanrolds/sqlclosecheck v0.3.0/go.mod h1:1gREqxyTGR3lVtpngyFo3hZAgk0K
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/ryszard/goskiplist v0.0.0-20150312221310-2dfbae5fcf46 h1:GHRpF1pTW19a8tTFrMLUcfWwyC0pnifVo2ClaLq+hP8=
 github.com/ryszard/goskiplist v0.0.0-20150312221310-2dfbae5fcf46/go.mod h1:uAQ5PCi+MFsC7HjREoAz1BU+Mq60+05gifQSsHSDG/8=
+github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 h1:OkMGxebDjyw0ULyrTYWeN0UNCCkmCWfjPnIA2W6oviI=
+github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06/go.mod h1:+ePHsJ1keEjQtpvf9HHw0f4ZeJ0TLRsxhunSI2hYJSs=
 github.com/sagikazarmark/crypt v0.1.0/go.mod h1:B/mN0msZuINBtQ1zZLEQcegFJJf9vnYIR88KRMEuODE=
 github.com/sanposhiho/wastedassign/v2 v2.0.6/go.mod h1:KyZ0MWTwxxBmfwn33zh3k1dmsbF2ud9pAAGfoLfjhtI=
 github.com/sclevine/spec v1.4.0 h1:z/Q9idDcay5m5irkZ28M7PtQM4aOISzOpj4bUPkDee8=

--- a/pkg/run/install_bucket_source_and_ks_test.go
+++ b/pkg/run/install_bucket_source_and_ks_test.go
@@ -2,6 +2,7 @@ package run
 
 import (
 	"context"
+	"path/filepath"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -127,5 +128,22 @@ var _ = Describe("findConditionMessages", func() {
 			"Deployment default/app3: app 3 error",
 			"Deployment default/app3: time out",
 		}))
+	})
+})
+
+var _ = Describe("CreateIgnorer", func() {
+	It("finds and parses existing gitignore", func() {
+		str, err := filepath.Abs("../..")
+		Expect(err).ToNot(HaveOccurred())
+		ignorer := CreateIgnorer(str)
+		Expect(ignorer.MatchesPath("pkg/server")).To(Equal(false))
+		Expect(ignorer.MatchesPath("temp~")).To(Equal(true))
+		Expect(ignorer.MatchesPath("bin/gitops")).To(Equal(true))
+	})
+	It("doesn't mind no gitignore", func() {
+		str, err := filepath.Abs(".")
+		Expect(err).ToNot(HaveOccurred())
+		ignorer := CreateIgnorer(str)
+		Expect(ignorer.MatchesPath("bin/gitops")).To(Equal(false))
 	})
 })


### PR DESCRIPTION
Many modern tools pick up ignore files automatically - tilt for example automatically picks up your dockerignore files, and rg & fd uses your gitignore files. I chose gitignore, because we're doing gitops, not dockerops.

This is somewhat half-arsed: it doesn't pick up gitignore files in subdirectories, and it doesn't re-read the gitignore file properly.

I assume we'll need to make this optional one day, and I assume we'll need a custom .gitopsignore one day.

However until that day, this lets me run `gitops run` in the weave-gitops repository. The reason I need something like this is that my whole checkout is several GB, which made the upload take forever, and made flux refuse to do anything with it. Just parsing `.gitignore` to remove all `node_modules` quickly makes it "kinda" work.