### PR TITLE
gitops run: Create empty kustomization if target directory doesn't exist

### DIFF
--- a/cmd/gitops/beta/run/cmd.go
+++ b/cmd/gitops/beta/run/cmd.go
@@ -332,6 +332,10 @@ func betaRunCommandRunE(opts *config.Options) func(*cobra.Command, []string) err
 			}
 		}
 
+		if err := run.InitializeTargetDir(targetPath); err != nil {
+			return fmt.Errorf("couldn't set up against target %s: %w", targetPath, err)
+		}
+
 		if err := run.SetupBucketSourceAndKS(log, kubeClient, flags.Namespace, relativePathForKs, flags.Timeout); err != nil {
 			return err
 		}


### PR DESCRIPTION
If I run `gitops beta run ./this-is-a-new-directory`, I will now end up with a kustomization that turns green in flux. The same thing happens if I run `mkdir directory && gitops beta run ./directory`.

I chose to hard-code the kustomization as text instead of as an object to marshal, because I wanted to put comments in there.

This closes #2698