### PR TITLE
Automate updating the helm chart in gitops run, remove mentions of flux 0.31

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -58,6 +58,7 @@ jobs:
           echo "GORELEASER_PREVIOUS_TAG=$(git describe --abbrev=0 --tags $(git rev-list --tags --skip=1 --max-count=1))" >> $GITHUB_ENV
           echo "GORELEASER_CURRENT_TAG=$(git describe --abbrev=0 --tags)" >> $GITHUB_ENV
           echo "FLUX_VERSION=$(make echo-flux-version)" >> $GITHUB_ENV
+          echo "CHART_VERSION=$(yq e '.version' charts/gitops-server/Chart.yaml) >> $GITHUB_ENV
       - name: "Make All"
         run: make all
       - name: Check Git State

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,6 +23,7 @@ builds:
         - -X github.com/weaveworks/weave-gitops/cmd/gitops/version.Branch={{ .Env.BRANCH}}
         - -X github.com/weaveworks/weave-gitops/cmd/gitops/version.GitCommit={{.Commit}}
         - -X github.com/weaveworks/weave-gitops/pkg/version.FluxVersion={{ .Env.FLUX_VERSION }}
+        - -X github.com/weaveworks/weave-gitops/cmd/gitops/beta/run.HelmChartVersion={{ .Env.CHART_VERSION }}
       env:
         - CGO_ENABLED=0
     id: linux-amd64

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ BRANCH?=$(shell which git > /dev/null && git rev-parse --abbrev-ref HEAD)
 GIT_COMMIT?=$(shell which git > /dev/null && git log -n1 --pretty='%h')
 VERSION?=$(shell which git > /dev/null && git describe --always --match "v*")
 FLUX_VERSION=0.34.0
+CHART_VERSION=$(shell which yq > /dev/null && yq e '.version' charts/gitops-server/Chart.yaml)
 DEV_BUCKET_CONTAINER_IMAGE=ghcr.io/weaveworks/gitops-bucket-server@sha256:b0446a6c645b5d39cf0db558958bf28363aca3ea80dc9d593983173613a4f290
 
 # Go build args
@@ -22,7 +23,8 @@ LDFLAGS?=-X github.com/weaveworks/weave-gitops/cmd/gitops/version.Branch=$(BRANC
 				 -X github.com/weaveworks/weave-gitops/core/server.Branch=$(BRANCH) \
 				 -X github.com/weaveworks/weave-gitops/core/server.Buildtime=$(BUILD_TIME) \
 				 -X github.com/weaveworks/weave-gitops/core/server.GitCommit=$(GIT_COMMIT) \
-				 -X github.com/weaveworks/weave-gitops/core/server.Version=$(VERSION)
+				 -X github.com/weaveworks/weave-gitops/core/server.Version=$(VERSION) \
+				 -X github.com/weaveworks/weave-gitops/cmd/gitops/beta/run.HelmChartVersion=$(CHART_VERSION)
 
 # Docker args
 # LDFLAGS is passed so we don't have to copy the entire .git directory into the image

--- a/charts/gitops-server/templates/deployment.yaml
+++ b/charts/gitops-server/templates/deployment.yaml
@@ -69,12 +69,6 @@ spec:
               path: /
               port: http
           env:
-            - name: WEAVE_GITOPS_AUTH_ENABLED
-              value: "true"
-          {{- if .Values.listOCIRepositories }}
-            - name: WEAVE_GITOPS_FEATURE_OCI_REPOSITORIES
-              value: "true"
-          {{- end }}
           {{- if .Values.envVars }}
           {{- with .Values.envVars }}
             {{- toYaml . | nindent 12 }}

--- a/charts/gitops-server/values.yaml
+++ b/charts/gitops-server/values.yaml
@@ -93,9 +93,6 @@ securityContext: {}
 # runAsNonRoot: true
 # runAsUser: 1000
 
-# -- If set to true, OCI repositories will be included in the source view.
-# This requires flux 0.32 or later.
-listOCIRepositories: false
 service:
   create: true
   type: ClusterIP

--- a/cmd/gitops/beta/run/cmd.go
+++ b/cmd/gitops/beta/run/cmd.go
@@ -30,8 +30,9 @@ const (
 	dashboardName    = "ww-gitops"
 	dashboardPodName = "ww-gitops-weave-gitops"
 	adminUsername    = "admin"
-	helmChartVersion = "3.0.0"
 )
+
+var HelmChartVersion = "3.0.0"
 
 type RunCommandFlags struct {
 	FluxVersion     string
@@ -292,7 +293,7 @@ func betaRunCommandRunE(opts *config.Options) func(*cobra.Command, []string) err
 					return err
 				}
 
-				manifests, err := run.CreateDashboardObjects(log, dashboardName, flags.Namespace, adminUsername, secret, helmChartVersion)
+				manifests, err := run.CreateDashboardObjects(log, dashboardName, flags.Namespace, adminUsername, secret, HelmChartVersion)
 				if err != nil {
 					return fmt.Errorf("error creating dashboard objects: %w", err)
 				}

--- a/website/docs/getting-started.mdx
+++ b/website/docs/getting-started.mdx
@@ -13,7 +13,7 @@ If you haven't already, be sure to check out our [introduction](./intro.md) to W
 ## Before you begin
 
 We will provide a complete walkthrough of getting Flux installed and Weave GitOps configured. However, if you have:
-- an existing cluster bootstrapped Flux version >= 0.31.0 🎉
+- an existing cluster bootstrapped Flux version >= 0.32.0 🎉
 - followed our [installation](./installation.mdx) doc to configure access to the Weave GitOps dashboard then install Weave GitOps 👏
 
 Then you can skip ahead to [Part 1](#part-1---weave-gitops-overview) 🏃
@@ -33,7 +33,7 @@ To follow along, you will need the following:
 
    For other installation methods, see the relevant [Flux documentation](https://fluxcd.io/docs/installation/#install-the-flux-cli).
 
-1. Make sure that the CLI version is at least 0.31.0
+1. Make sure that the CLI version is at least 0.32.0
 
    ```
    flux -v

--- a/website/docs/installation.mdx
+++ b/website/docs/installation.mdx
@@ -18,14 +18,14 @@ This version of Weave GitOps is tested against the following Kubernetes releases
 * 1.22
 * 1.23
 * 1.24
+* 1.25
 
 Note that the version of [Flux](https://fluxcd.io/docs/installation/#prerequisites) that you use might impose further minimum version requirements.
 
 #### Install Flux
-Weave GitOps is an extension to Flux and therefore requires that Flux 0.31 or later has already been installed on your Kubernetes cluster. Full documentation is avilable at: [https://fluxcd.io/docs/installation/](https://fluxcd.io/docs/installation/).
+Weave GitOps is an extension to Flux and therefore requires that Flux 0.32 or later has already been installed on your Kubernetes cluster. Full documentation is avilable at: [https://fluxcd.io/docs/installation/](https://fluxcd.io/docs/installation/).
 
 This version of Weave GitOps is tested against the following Flux releases:
-* 0.31
 * 0.32
 * 0.33
 * 0.34
@@ -53,7 +53,6 @@ spec:
       create: true
       username: <UPDATE>
       passwordHash: <UPDATE>
-    listOCIRepositories: true # Display OCI Repositories, requires flux 0.32
 ---
 apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmRepository


### PR DESCRIPTION
I broke the fallback flux 0.31 feature flag the last release. I'm not going to put it back, so I updated the manual instead.

I don't want to be updating the helm chart that gitops run installs all the time, so automate that.