### PR TITLE
Link to filtered tables from alert event sources

### DIFF
--- a/ui/components/AlertsTable.tsx
+++ b/ui/components/AlertsTable.tsx
@@ -66,22 +66,19 @@ function AlertsTable({ className, rows = [] }: Props) {
         return (
           <ul className="event-sources">
             {a?.eventSources?.map((obj: CrossNamespaceObjectRef, index) => {
-              if (obj.name && obj.namespace && obj.kind)
-                return (
-                  <Link
-                    className="event-sources"
-                    key={index}
-                    to={makeEventSourceLink(obj)}
-                  >
-                    {obj.kind}: {obj.namespace}/{obj.name}
-                  </Link>
-                );
-              else
-                return (
-                  <li className="event-sources" key={index}>
-                    {obj.kind}: {obj.namespace}/{obj.name}
-                  </li>
-                );
+              obj.name && obj.namespace && obj.kind ? (
+                <Link
+                  className="event-sources"
+                  key={index}
+                  to={makeEventSourceLink(obj)}
+                >
+                  {obj.kind}: {obj.namespace}/{obj.name}
+                </Link>
+              ) : (
+                <li className="event-sources" key={index}>
+                  {obj.kind}: {obj.namespace}/{obj.name}
+                </li>
+              );
             })}
           </ul>
         );

--- a/ui/components/AlertsTable.tsx
+++ b/ui/components/AlertsTable.tsx
@@ -18,14 +18,13 @@ type Props = {
   rows?: Alert[];
 };
 
-const makeEventSourceLink = (obj: CrossNamespaceObjectRef) => {
+export const makeEventSourceLink = (obj: CrossNamespaceObjectRef) => {
   const url =
     obj.kind === Kind.Kustomization || obj.kind === Kind.HelmRelease
       ? V2Routes.Automations
       : V2Routes.Sources;
   let filters = "";
   if (obj.name !== "*") filters += `name${filterSeparator}${obj.name}_`;
-  if (obj.kind !== "*") filters += `type${filterSeparator}${obj.kind}_`;
   if (obj.namespace !== "*")
     filters += `namespace${filterSeparator}${obj.namespace}_`;
   if (filters) return url + `?${qs.stringify({ filters: filters })}`;
@@ -67,15 +66,24 @@ function AlertsTable({ className, rows = [] }: Props) {
       value: (a) => {
         return (
           <ul className="event-sources">
-            {a?.eventSources?.map((obj: CrossNamespaceObjectRef, index) => (
-              <Link
-                className="event-sources"
-                key={index}
-                to={makeEventSourceLink(obj)}
-              >
-                {obj.kind}: {obj.namespace}/{obj.name}
-              </Link>
-            ))}
+            {a?.eventSources?.map((obj: CrossNamespaceObjectRef, index) => {
+              if (obj.name && obj.namespace && obj.kind)
+                return (
+                  <Link
+                    className="event-sources"
+                    key={index}
+                    to={makeEventSourceLink(obj)}
+                  >
+                    {obj.kind}: {obj.namespace}/{obj.name}
+                  </Link>
+                );
+              else
+                return (
+                  <li className="event-sources" key={index}>
+                    {obj.kind}: {obj.namespace}/{obj.name}
+                  </li>
+                );
+            })}
           </ul>
         );
       },
@@ -120,7 +128,7 @@ export default styled(AlertsTable).attrs({ className: AlertsTable.name })`
       padding-left: ${(props) => props.theme.spacing.small};
     }
   }
-  ${Link} {
+  ${Link}, li {
     &.event-sources {
       display: block;
     }

--- a/ui/components/AlertsTable.tsx
+++ b/ui/components/AlertsTable.tsx
@@ -23,13 +23,11 @@ export const makeEventSourceLink = (obj: CrossNamespaceObjectRef) => {
     obj.kind === Kind.Kustomization || obj.kind === Kind.HelmRelease
       ? V2Routes.Automations
       : V2Routes.Sources;
-  let filters = "";
+  let filters = `type${filterSeparator}${obj.kind}_`;
   if (obj.name !== "*") filters += `name${filterSeparator}${obj.name}_`;
   if (obj.namespace !== "*")
     filters += `namespace${filterSeparator}${obj.namespace}_`;
-  filters += `type${filterSeparator}${obj.kind}_`;
-  if (filters) return url + `?${qs.stringify({ filters: filters })}`;
-  return url;
+  return url + `?${qs.stringify({ filters: filters })}`;
 };
 
 function AlertsTable({ className, rows = [] }: Props) {

--- a/ui/components/AlertsTable.tsx
+++ b/ui/components/AlertsTable.tsx
@@ -27,6 +27,7 @@ export const makeEventSourceLink = (obj: CrossNamespaceObjectRef) => {
   if (obj.name !== "*") filters += `name${filterSeparator}${obj.name}_`;
   if (obj.namespace !== "*")
     filters += `namespace${filterSeparator}${obj.namespace}_`;
+  filters += `type${filterSeparator}${obj.kind}_`;
   if (filters) return url + `?${qs.stringify({ filters: filters })}`;
   return url;
 };

--- a/ui/components/__tests__/AlertsTable.test.tsx
+++ b/ui/components/__tests__/AlertsTable.test.tsx
@@ -1,0 +1,35 @@
+import { makeEventSourceLink } from "../AlertsTable";
+
+describe("AlertsTable", () => {
+  describe("makeEventSourceLink", () => {
+    it("should convert CrossNamespaceRef objects to urls with filters", () => {
+      const allNames = {
+        apiVersion: "v1",
+        name: "*",
+        namespace: "space",
+        kind: "GitRepository",
+        matchLabels: [],
+      };
+      const sourceLink = makeEventSourceLink(allNames);
+      expect(sourceLink.includes("/sources")).toEqual(true);
+      expect(
+        sourceLink.includes("type") && sourceLink.includes("GitRepository")
+      ).toEqual(true);
+      console.log(sourceLink);
+      expect(sourceLink.includes("*")).toEqual(false);
+      const allNamespaces = {
+        apiVersion: "v1",
+        name: "goose",
+        namespace: "*",
+        kind: "HelmRelease",
+        matchLabels: [],
+      };
+      const automationLink = makeEventSourceLink(allNamespaces);
+      expect(automationLink.includes("/applications")).toEqual(true);
+      expect(
+        automationLink.includes("name") && automationLink.includes("goose")
+      ).toEqual(true);
+      expect(automationLink.includes("namespace")).toEqual(false);
+    });
+  });
+});

--- a/ui/components/__tests__/AlertsTable.test.tsx
+++ b/ui/components/__tests__/AlertsTable.test.tsx
@@ -15,7 +15,6 @@ describe("AlertsTable", () => {
       expect(
         sourceLink.includes("type") && sourceLink.includes("GitRepository")
       ).toEqual(true);
-      console.log(sourceLink);
       expect(sourceLink.includes("*")).toEqual(false);
       const allNamespaces = {
         apiVersion: "v1",


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes #2734 

<!-- Describe what has changed in this PR -->
**What changed?**
- Event sources are now links to either the automations or sources table depending on the `kind`
- If any field values are falsy, a `li` is shown rather than a `Link`
- The asterisk wildcard character means no filters are added for that key (name and namespace are implemented, although it's unclear to me whether namespace should be in there or not based on https://github.com/fluxcd/notification-controller/issues/71 - it seems like it's not implemented but I figured I'd future proof things.) 
