### PR TITLE
Add help message when user has no notifications

### DIFF
--- a/ui/components/NotificationsTable.tsx
+++ b/ui/components/NotificationsTable.tsx
@@ -96,8 +96,6 @@ function NotificationsTable({ className, rows }: Props) {
       : []),
   ];
 
-  rows = [];
-
   if (!rows.length)
     return (
       <Flex wide tall column align>

--- a/ui/components/NotificationsTable.tsx
+++ b/ui/components/NotificationsTable.tsx
@@ -10,8 +10,11 @@ import DataTable, {
   filterByStatusCallback,
   filterConfig,
 } from "./DataTable";
+import Flex, { MessageFlex } from "./Flex";
 import KubeStatusIndicator from "./KubeStatusIndicator";
 import Link from "./Link";
+import Spacer from "./Spacer";
+import Text from "./Text";
 
 type Props = {
   className?: string;
@@ -92,6 +95,34 @@ function NotificationsTable({ className, rows }: Props) {
       ? [{ label: "Tenant", value: "tenant" }]
       : []),
   ];
+
+  rows = [];
+
+  if (!rows.length)
+    return (
+      <Flex wide tall column align>
+        <Spacer padding="xxl" />
+        <MessageFlex column align={false}>
+          <Text size="large" semiBold>
+            No notifications are currently configured
+          </Text>
+          <Spacer padding="medium" />
+          <Text>
+            Set up notifications to alert on changes via multiple different
+            platforms such as Slack, Azure Event Hub, Grafana, OpsGenie and many
+            more!
+          </Text>
+          <Spacer padding="xs" />
+          <Text>
+            To learn more about how to set up notifications,
+            <Link href="https://fluxcd.io/flux/guides/notifications/" newTab>
+              {" "}
+              visit our documentation
+            </Link>
+          </Text>
+        </MessageFlex>
+      </Flex>
+    );
 
   return (
     <DataTable

--- a/ui/components/NotificationsTable.tsx
+++ b/ui/components/NotificationsTable.tsx
@@ -112,9 +112,8 @@ function NotificationsTable({ className, rows }: Props) {
           </Text>
           <Spacer padding="xs" />
           <Text>
-            To learn more about how to set up notifications,
+            To learn more about how to set up notifications,&nbsp;
             <Link href="https://fluxcd.io/flux/guides/notifications/" newTab>
-              {" "}
               visit our documentation
             </Link>
           </Text>

--- a/ui/pages/v2/Notifications.tsx
+++ b/ui/pages/v2/Notifications.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import styled from "styled-components";
+import { MessageFlex } from "../../components/Flex";
 import NotificationsTable from "../../components/NotificationsTable";
 import Page from "../../components/Page";
 import { useListProviders } from "../../hooks/notifications";
@@ -17,7 +18,11 @@ function Notifications({ className }: Props) {
       loading={isLoading}
       error={data?.errors || error}
     >
-      <NotificationsTable rows={data?.objects} />
+      {data?.objects === [] ? (
+        <MessageFlex></MessageFlex>
+      ) : (
+        <NotificationsTable rows={data?.objects} />
+      )}
     </Page>
   );
 }

--- a/ui/pages/v2/Notifications.tsx
+++ b/ui/pages/v2/Notifications.tsx
@@ -1,28 +1,21 @@
 import * as React from "react";
 import styled from "styled-components";
-import { MessageFlex } from "../../components/Flex";
 import NotificationsTable from "../../components/NotificationsTable";
 import Page from "../../components/Page";
 import { useListProviders } from "../../hooks/notifications";
-
 type Props = {
   className?: string;
 };
 
 function Notifications({ className }: Props) {
   const { data, isLoading, error } = useListProviders();
-
   return (
     <Page
       className={className}
       loading={isLoading}
       error={data?.errors || error}
     >
-      {data?.objects === [] ? (
-        <MessageFlex></MessageFlex>
-      ) : (
-        <NotificationsTable rows={data?.objects} />
-      )}
+      <NotificationsTable rows={data?.objects} />
     </Page>
   );
 }


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes #2563 

<!-- Describe what has changed in this PR -->
If the ListNotifications request is a success but returns no notifications, a nice little helpful message will be displayed with a link to the flux docs:
<img width="1471" alt="image" src="https://user-images.githubusercontent.com/65822698/190212842-5ab20c86-9f71-46d9-aa92-3547be6a476f.png">
