### PR TITLE
add support for Azure OIDC

### DIFF
--- a/pkg/server/auth/jwt.go
+++ b/pkg/server/auth/jwt.go
@@ -93,13 +93,14 @@ func parseJWTToken(ctx context.Context, verifier *oidc.IDTokenVerifier, rawIDTok
 	var claims struct {
 		Email  string   `json:"email"`
 		Groups []string `json:"groups"`
+		Roles  []string `json:"roles"`
 	}
 
 	if err := token.Claims(&claims); err != nil {
 		return nil, fmt.Errorf("failed to parse claims from the JWT token: %w", err)
 	}
 
-	return &UserPrincipal{ID: claims.Email, Groups: claims.Groups}, nil
+	return &UserPrincipal{ID: claims.Email, Groups: append(claims.Groups, claims.Roles...)}, nil
 }
 
 type JWTAdminCookiePrincipalGetter struct {

--- a/pkg/server/auth/server.go
+++ b/pkg/server/auth/server.go
@@ -26,6 +26,7 @@ const (
 	FeatureFlagClusterUser     string = "CLUSTER_USER_AUTH"
 	FeatureFlagOIDCAuth        string = "OIDC_AUTH"
 	FeatureFlagOIDCPassthrough string = "WEAVE_GITOPS_FEATURE_OIDC_AUTH_PASSTHROUGH"
+	FeatureFlagOIDCGroupsScope string = "WEAVE_GITOPS_FEATURE_OIDC_GROUPS_SCOPE"
 	FeatureFlagSet             string = "true"
 )
 
@@ -165,6 +166,10 @@ func (s *AuthServer) oidcPassthroughEnabled() bool {
 	return featureflags.Get(FeatureFlagOIDCPassthrough) == FeatureFlagSet
 }
 
+func (s *AuthServer) oidcGroupsScopeEnabled() bool {
+	return featureflags.Get(FeatureFlagOIDCGroupsScope) != "false"
+}
+
 func (s *AuthServer) verifier() *oidc.IDTokenVerifier {
 	return s.provider.Verifier(&oidc.Config{ClientID: s.config.ClientID})
 }
@@ -181,7 +186,7 @@ func (s *AuthServer) oauth2Config(scopes []string) *oauth2.Config {
 	}
 
 	// Request "groups" scope to get user's groups.
-	if !contains(scopes, scopeGroups) {
+	if s.oidcGroupsScopeEnabled() && !contains(scopes, scopeGroups) {
 		scopes = append(scopes, scopeGroups)
 	}
 


### PR DESCRIPTION
Two things are needed to support Azure OIDC:
- allow disabling "groups" scope
- combine roles with groups

1. Azure does not support "groups" scope - we need a way to disable it. 
There are a number ways of indicating intent: env var, cmd option, based on issuer url. I will leave decision on what is the best approach to Weave Works team.
PR uses env var - helm chart config:
```
    envVars:
    - name: WEAVE_GITOPS_FEATURE_OIDC_GROUPS_SCOPE
      value: "false"
```

2. Azure registered application can be configured to send groups in jwt claim. Issues is that Azure sends group ids (which are uuids) and these are bad candidates for group names on k8s side. Better idea is to setup "App roles" in given Application on Azure side. These come as "roles" array in jwt token - hence update that merges Groups and Roles. 
Another idea for handling groups in Azure would be to map between group uuid and group on k8s side (this is how Argo team handled it).

Closes #2507, #2334

In case this is tested with `impersonationResources: ["groups"]` there is helm chart configuration issue: #2696 that warrants chart and documentation update.
