### PR TITLE
Add an optional choice of NodePort

### DIFF
--- a/charts/gitops-server/templates/service.yaml
+++ b/charts/gitops-server/templates/service.yaml
@@ -17,6 +17,9 @@ spec:
   ports:
     - port: {{ .Values.service.port }}
       targetPort: http
+      {{- if and (eq .Values.service.type "NodePort") .Values.service.nodePort }}
+      nodePort: {{ .Values.service.nodePort }}
+      {{- end }}
       protocol: TCP
       name: http
     {{- if .Values.metrics.enabled }}

--- a/charts/gitops-server/values.yaml
+++ b/charts/gitops-server/values.yaml
@@ -97,6 +97,7 @@ service:
   create: true
   type: ClusterIP
   port: 9001
+  # nodePort:
   annotations: {}
 ingress:
   enabled: false


### PR DESCRIPTION
add an option to explicitly specify the nodePort value when service's type is nodePort.