### PR TITLE
Add `.DS_Store` files to `.gitignore`.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ gha-creds-*.json
 
 # .vscode
 .vscode
+
+# macOS
+.DS_Store


### PR DESCRIPTION
Since `.DS_Store` are temporary files which keep folder configs on macOS, they sometimes get created for me in the project if I examine a project folder with Finder. So, I've finally got to add `.DS_Store` to gitignore.