### PR TITLE
Add flag to hide search and filters menu in DataTable

### DIFF
--- a/ui/components/DataTable.tsx
+++ b/ui/components/DataTable.tsx
@@ -58,6 +58,7 @@ export interface Props {
   filters?: FilterConfig;
   dialogOpen?: boolean;
   hasCheckboxes?: boolean;
+  hideSearchAndFilters?: boolean;
 }
 //styled components
 const EmptyRow = styled(TableRow)<{ colSpan: number }>`
@@ -329,6 +330,7 @@ function UnstyledDataTable({
   filters,
   hasCheckboxes: checkboxes,
   dialogOpen,
+  hideSearchAndFilters,
 }: Props) {
   //URL info
   const history = useHistory();
@@ -483,7 +485,7 @@ function UnstyledDataTable({
         start={filters ? false : true}
       >
         {checkboxes && <CheckboxActions checked={checked} rows={filtered} />}
-        {filters && (
+        {filters && !hideSearchAndFilters && (
           <Flex wide align end>
             <ChipGroup
               chips={chips}


### PR DESCRIPTION
Follow up from the discussion on https://github.com/weaveworks/weave-gitops-enterprise/pull/1400 

We need the flag to hide the Search and Filters menu in Data Table as we're using this in EE in some contexts where it doesn't make sense having the options 