### PR TITLE
Use the correct labels to get reconciled objects

### DIFF
--- a/core/server/fluxruntime.go
+++ b/core/server/fluxruntime.go
@@ -166,11 +166,13 @@ func (cs *coreServer) GetReconciledObjects(ctx context.Context, msg *pb.GetRecon
 	switch msg.AutomationKind {
 	case pb.FluxObjectKind_KindKustomization:
 		opts = client.MatchingLabels{
-			KustomizeNameKey: msg.AutomationName,
+			KustomizeNameKey:      msg.AutomationName,
+			KustomizeNamespaceKey: msg.Namespace,
 		}
 	case pb.FluxObjectKind_KindHelmRelease:
 		opts = client.MatchingLabels{
-			HelmNameKey: msg.AutomationName,
+			HelmNameKey:      msg.AutomationName,
+			HelmNamespaceKey: msg.Namespace,
 		}
 	default:
 		return nil, fmt.Errorf("unsupported application kind: %s", msg.AutomationKind.String())


### PR DESCRIPTION
We didn't filter by namespace at all. This meant that we display all automations in all namespaces that have been created by an automation that matches this automation's name - e.g., the details page for the helm release `weave-gitops` in namespace `prod` will show the resources created by the helm release `weave-gitops` in namespace `staging`. That's incorrect.

This was introduced in e8c89fb - before that we did filter by namespace. That commit claims that it's done to make sure `targetNamespace` works properly - I've created both kustomizations and helm releases with targetNamespace set, and both of them work fine.

The reason is that e8c89fb contained 2 different changes - it also stopped restricting the query to the namespace the automation was installed into, which is what actually fixes the bug with targetNamespace.

This fixes #2761.