### PR TITLE
Fix including pods in details pages

### DIFF
--- a/ui/hooks/__tests__/flux.test.tsx
+++ b/ui/hooks/__tests__/flux.test.tsx
@@ -1,0 +1,45 @@
+import { flattenChildren } from "../flux";
+
+describe("flattenChildren", () => {
+  it("supports empty", () => {
+    const empty = [];
+    expect(flattenChildren(empty)).toEqual([]);
+  });
+
+  it("handles nested", () => {
+    const nested = [
+      {
+        name: "1",
+        children: [{ name: "2", children: [{ name: "3", children: [] }] }],
+      },
+    ];
+    const flattened = flattenChildren(nested);
+    expect(flattened[0]).toMatchObject({ name: "1" });
+    expect(flattened[1]).toMatchObject({ name: "2" });
+    expect(flattened[2]).toMatchObject({ name: "3" });
+  });
+
+  it("handles multiple", () => {
+    const multiple = [
+      { name: "1", children: [] },
+      {
+        name: "2",
+        children: [
+          { name: "3", children: [] },
+          { name: "4", children: [] },
+        ],
+      },
+    ];
+    const flattened = flattenChildren(multiple);
+    expect(flattened[0]).toMatchObject({ name: "1" });
+    expect(flattened[1]).toMatchObject({ name: "2" });
+    expect(flattened[2]).toMatchObject({ name: "3" });
+    expect(flattened[3]).toMatchObject({ name: "4" });
+  });
+
+  it("breaks if the format changes", () => {
+    // No children property suggests API has changed
+    const invalid = [{ name: "1" }];
+    expect(() => flattenChildren(invalid)).toThrow(TypeError);
+  });
+});


### PR DESCRIPTION
Since we made the graph a tree structure internally, we've not displayed e.g. pods and replicasets on the details page, because they weren't being returned as a flat list.

This changes it to work again.

I've tried to _not_ make the implementation handle unexpected input, to act as a booby trap if the API were to change again. The test won't catch it, but it should make the details page break so bad you can't avoid spotting it.