### PR TITLE
Adds 'null' to undefined values in chips

### DIFF
--- a/ui/components/ChipGroup.tsx
+++ b/ui/components/ChipGroup.tsx
@@ -22,7 +22,7 @@ function ChipGroup({ className, chips = [], onChipRemove, onClearAll }: Props) {
           //javascript search finds first occurance of substring, returning index
           chip.search(filterSeparator) ===
           //if first occurance of filterSeparator is the end of the chip string, it's an undefined value
-          chip.length - 1 - filterSeparator.length;
+          chip.length - filterSeparator.length;
         return (
           <Flex key={index}>
             <Chip

--- a/ui/components/ChipGroup.tsx
+++ b/ui/components/ChipGroup.tsx
@@ -2,6 +2,7 @@ import { Chip } from "@material-ui/core";
 import _ from "lodash";
 import * as React from "react";
 import styled from "styled-components";
+import { filterSeparator } from "./FilterDialog";
 import Flex from "./Flex";
 
 export interface Props {
@@ -17,9 +18,17 @@ function ChipGroup({ className, chips = [], onChipRemove, onClearAll }: Props) {
   return (
     <Flex className={className} wide align start>
       {_.map(chips, (chip, index) => {
+        const isUndefined =
+          //javascript search finds first occurance of substring, returning index
+          chip.search(filterSeparator) ===
+          //if first occurance of filterSeparator is the end of the chip string, it's an undefined value
+          chip.length - 1 - filterSeparator.length;
         return (
           <Flex key={index}>
-            <Chip label={chip} onDelete={() => onChipRemove([chip])} />
+            <Chip
+              label={isUndefined ? chip + "null" : chip}
+              onDelete={() => onChipRemove([chip])}
+            />
           </Flex>
         );
       })}

--- a/ui/components/ChipGroup.tsx
+++ b/ui/components/ChipGroup.tsx
@@ -19,9 +19,9 @@ function ChipGroup({ className, chips = [], onChipRemove, onClearAll }: Props) {
     <Flex className={className} wide align start>
       {_.map(chips, (chip, index) => {
         const isUndefined =
-          //javascript search finds first occurance of substring, returning index
+          //javascript search finds first occurence of substring, returning index
           chip.search(filterSeparator) ===
-          //if first occurance of filterSeparator is the end of the chip string, it's an undefined value
+          //if first occurence of filterSeparator is the end of the chip string, it's an undefined value
           chip.length - filterSeparator.length;
         return (
           <Flex key={index}>

--- a/ui/components/__tests__/ChipGroup.test.tsx
+++ b/ui/components/__tests__/ChipGroup.test.tsx
@@ -3,10 +3,17 @@ import "jest-styled-components";
 import React from "react";
 import { withTheme } from "../../lib/test-utils";
 import ChipGroup from "../ChipGroup";
+import { filterSeparator } from "../FilterDialog";
 
 describe("ChipGroup", () => {
   const setActiveChips = jest.fn();
-  const chipList = ["app", "app2", "app3", `appappapp`];
+  const chipList = [
+    "app",
+    "app2",
+    "app3",
+    `appapp${filterSeparator}`,
+    `app${filterSeparator}app`,
+  ];
 
   it("should render chips", () => {
     render(
@@ -21,5 +28,18 @@ describe("ChipGroup", () => {
     expect(screen.queryByText("app")).toBeTruthy();
     expect(screen.queryByText("app3")).toBeTruthy();
     expect(screen.queryByText("Clear All")).toBeTruthy();
+  });
+  it("adds 'null' to undefined values", () => {
+    render(
+      withTheme(
+        <ChipGroup
+          chips={chipList}
+          onChipRemove={setActiveChips}
+          onClearAll={() => jest.fn()}
+        />
+      )
+    );
+    expect(screen.queryByText(`appapp${filterSeparator}null`)).toBeTruthy();
+    expect(screen.queryByText(`app${filterSeparator}app`)).toBeTruthy();
   });
 });


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes #2725 

a new boolean value for each chip searches for the first occurrence of the `filterSeparator` to see if it is the end of the chip string. If it is, it adds the string 'null' to the end without altering the original chip value
`const isUndefined = chip.search(filterSeparator) === chip.length - filterSeparator.length;`

<img width="1469" alt="image" src="https://user-images.githubusercontent.com/65822698/191782228-b08b5e46-2d0c-431e-86c7-4843f59a4e90.png">

