### PR TITLE
Upgrade go-git-providers to v0.9.0 for EE compatibility

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/cheshir/ttlcache v1.0.1-0.20220504185148-8ceeff21b789
 	github.com/coreos/go-oidc/v3 v3.1.0
 	github.com/fluxcd/flux2 v0.34.0
-	github.com/fluxcd/go-git-providers v0.8.0
+	github.com/fluxcd/go-git-providers v0.9.0
 	github.com/fluxcd/helm-controller/api v0.24.0
 	github.com/fluxcd/kustomize-controller/api v0.28.0
 	github.com/fluxcd/notification-controller/api v0.26.0
@@ -220,7 +220,7 @@ require (
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/subosito/gotenv v1.2.0 // indirect
-	github.com/xanzy/go-gitlab v0.69.0 // indirect
+	github.com/xanzy/go-gitlab v0.73.1 // indirect
 	github.com/xanzy/ssh-agent v0.3.1 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
@@ -233,9 +233,9 @@ require (
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.8.0 // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
-	golang.org/x/net v0.0.0-20220722155237-a158d28d115b
+	golang.org/x/net v0.0.0-20220805013720-a33c5aa5df48
 	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4 // indirect
-	golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f // indirect
+	golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10 // indirect
 	golang.org/x/term v0.0.0-20220722155259-a9ba230a4035
 	golang.org/x/text v0.3.7
 	golang.org/x/time v0.0.0-20220722155302-e5dcc9cfc0b9 // indirect

--- a/go.mod
+++ b/go.mod
@@ -82,7 +82,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
 	github.com/google/gnostic v0.6.9 // indirect
-	github.com/google/go-github/v45 v45.2.0 // indirect
+	github.com/google/go-github/v47 v47.0.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/iancoleman/strcase v0.1.2 // indirect
 	github.com/klauspost/cpuid v1.3.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -349,6 +349,8 @@ github.com/fluxcd/flux2 v0.34.0 h1:EMcLjQBGYyDcN1YCbcGsoC3CaqJwNcvuodO639gQ/30=
 github.com/fluxcd/flux2 v0.34.0/go.mod h1:X69vpRvdCMoLOb+D4R70o8HaF2ExHqH/Rk/4RJEKQd8=
 github.com/fluxcd/go-git-providers v0.8.0 h1:80UMu7yvRoEVfEIg0eGb9bJ0bSceizNJrEVvwLo+0YI=
 github.com/fluxcd/go-git-providers v0.8.0/go.mod h1:krF+f3UFciy5QmFaYfaORCVxaEj7u2qD7R/WrfKCLWk=
+github.com/fluxcd/go-git-providers v0.9.0 h1:iiiKe3dzRCgVkjEi8rfpvaWTZwuGRfb3RJFhjSNz+Uc=
+github.com/fluxcd/go-git-providers v0.9.0/go.mod h1:GcaDVP9RlamLKJp25Nwi7X5t0MyZV3FY+qy1GiRdbtk=
 github.com/fluxcd/helm-controller/api v0.24.0 h1:JYE34zzPMfd/QTyCaeafFEnCu0mvnG6zayGLIC0W6D0=
 github.com/fluxcd/helm-controller/api v0.24.0/go.mod h1:OhrOXaxwBBvW1R0OiV49caa3YszWiwmPViQkm67HW4M=
 github.com/fluxcd/kustomize-controller/api v0.28.0 h1:BEidxWgemuVacqAGKQnG/UXkWkpRyuWryaPSIFba6kw=
@@ -1221,6 +1223,7 @@ github.com/weaveworks/go-checkpoint v0.0.0-20170503165305-ebbb8b0518ab h1:mW+hgc
 github.com/weaveworks/go-checkpoint v0.0.0-20170503165305-ebbb8b0518ab/go.mod h1:qkbvw5GPibQ/Nf7IZJL0UoLwmJ6858b4S/hUWRd+cH4=
 github.com/xanzy/go-gitlab v0.69.0 h1:sPci9xHzlX+lcJvPqNu3y3BQpePuR2R694Bal4AeyB8=
 github.com/xanzy/go-gitlab v0.69.0/go.mod h1:o4yExCtdaqlM8YGdDJWuZoBmfxBsmA9TPEjs9mx1UO4=
+github.com/xanzy/go-gitlab v0.73.1/go.mod h1:d/a0vswScO7Agg1CZNz15Ic6SSvBG9vfw8egL99t4kA=
 github.com/xanzy/ssh-agent v0.3.0/go.mod h1:3s9xbODqPuuhK9JV1R321M/FlMZSBvE5aY6eAcqrDh0=
 github.com/xanzy/ssh-agent v0.3.1 h1:AmzO1SSWxw73zxFZPRwaMN1MohDw8UyHnmuxyceTEGo=
 github.com/xanzy/ssh-agent v0.3.1/go.mod h1:QIE4lCeL7nkC25x+yA3LBIYfwCc1TFziCtG7cBAac6w=
@@ -1443,6 +1446,7 @@ golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4/go.mod h1:CfG3xpIq0wQ8r1q4Su
 golang.org/x/net v0.0.0-20220607020251-c690dde0001d/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b h1:PxfKdU9lEEDYjdIzOtC4qFWgkU2rGHdKlKowJSMN9h0=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
+golang.org/x/net v0.0.0-20220805013720-a33c5aa5df48/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -1591,6 +1595,7 @@ golang.org/x/sys v0.0.0-20220610221304-9f5ed59c137d/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f h1:v4INt8xihDGvnrfjMDVXGxw9wrfxYyCjk0KbXjhR55s=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=

--- a/go.sum
+++ b/go.sum
@@ -347,8 +347,6 @@ github.com/felixge/httpsnoop v1.0.1 h1:lvB5Jl89CsZtGIWuTcDM1E/vkVs49/Ml7JJe07l8S
 github.com/flowstack/go-jsonschema v0.1.1/go.mod h1:yL7fNggx1o8rm9RlgXv7hTBWxdBM0rVwpMwimd3F3N0=
 github.com/fluxcd/flux2 v0.34.0 h1:EMcLjQBGYyDcN1YCbcGsoC3CaqJwNcvuodO639gQ/30=
 github.com/fluxcd/flux2 v0.34.0/go.mod h1:X69vpRvdCMoLOb+D4R70o8HaF2ExHqH/Rk/4RJEKQd8=
-github.com/fluxcd/go-git-providers v0.8.0 h1:80UMu7yvRoEVfEIg0eGb9bJ0bSceizNJrEVvwLo+0YI=
-github.com/fluxcd/go-git-providers v0.8.0/go.mod h1:krF+f3UFciy5QmFaYfaORCVxaEj7u2qD7R/WrfKCLWk=
 github.com/fluxcd/go-git-providers v0.9.0 h1:iiiKe3dzRCgVkjEi8rfpvaWTZwuGRfb3RJFhjSNz+Uc=
 github.com/fluxcd/go-git-providers v0.9.0/go.mod h1:GcaDVP9RlamLKJp25Nwi7X5t0MyZV3FY+qy1GiRdbtk=
 github.com/fluxcd/helm-controller/api v0.24.0 h1:JYE34zzPMfd/QTyCaeafFEnCu0mvnG6zayGLIC0W6D0=
@@ -585,8 +583,8 @@ github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/google/go-github/v45 v45.2.0 h1:5oRLszbrkvxDDqBCNj2hjDZMKmvexaZ1xw/FCD+K3FI=
-github.com/google/go-github/v45 v45.2.0/go.mod h1:FObaZJEDSTa/WGCzZ2Z3eoCDXWJKMenWWTrd8jrta28=
+github.com/google/go-github/v47 v47.0.0 h1:eQap5bIRZibukP0VhngWgpuM0zhY4xntqOzn6DhdkE4=
+github.com/google/go-github/v47 v47.0.0/go.mod h1:DRjdvizXE876j0YOZwInB1ESpOcU/xFBClNiQLSdorE=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
@@ -1221,8 +1219,7 @@ github.com/valyala/tcplisten v1.0.0/go.mod h1:T0xQ8SeCZGxckz9qRXTfG43PvQ/mcWh7Fw
 github.com/viki-org/dnscache v0.0.0-20130720023526-c70c1f23c5d8/go.mod h1:dniwbG03GafCjFohMDmz6Zc6oCuiqgH6tGNyXTkHzXE=
 github.com/weaveworks/go-checkpoint v0.0.0-20170503165305-ebbb8b0518ab h1:mW+hgchD9qUUBqnuaDBj7BkcpFPk/FxeFcUFI5lvvUw=
 github.com/weaveworks/go-checkpoint v0.0.0-20170503165305-ebbb8b0518ab/go.mod h1:qkbvw5GPibQ/Nf7IZJL0UoLwmJ6858b4S/hUWRd+cH4=
-github.com/xanzy/go-gitlab v0.69.0 h1:sPci9xHzlX+lcJvPqNu3y3BQpePuR2R694Bal4AeyB8=
-github.com/xanzy/go-gitlab v0.69.0/go.mod h1:o4yExCtdaqlM8YGdDJWuZoBmfxBsmA9TPEjs9mx1UO4=
+github.com/xanzy/go-gitlab v0.73.1 h1:UMagqUZLJdjss1SovIC+kJCH4k2AZWXl58gJd38Y/hI=
 github.com/xanzy/go-gitlab v0.73.1/go.mod h1:d/a0vswScO7Agg1CZNz15Ic6SSvBG9vfw8egL99t4kA=
 github.com/xanzy/ssh-agent v0.3.0/go.mod h1:3s9xbODqPuuhK9JV1R321M/FlMZSBvE5aY6eAcqrDh0=
 github.com/xanzy/ssh-agent v0.3.1 h1:AmzO1SSWxw73zxFZPRwaMN1MohDw8UyHnmuxyceTEGo=
@@ -1444,8 +1441,7 @@ golang.org/x/net v0.0.0-20220325170049-de3da57026de/go.mod h1:CfG3xpIq0wQ8r1q4Su
 golang.org/x/net v0.0.0-20220412020605-290c469a71a5/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220607020251-c690dde0001d/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
-golang.org/x/net v0.0.0-20220722155237-a158d28d115b h1:PxfKdU9lEEDYjdIzOtC4qFWgkU2rGHdKlKowJSMN9h0=
-golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
+golang.org/x/net v0.0.0-20220805013720-a33c5aa5df48 h1:N9Vc/rorQUDes6B9CNdIxAn5jODGj2wzfrei2x4wNj4=
 golang.org/x/net v0.0.0-20220805013720-a33c5aa5df48/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -1593,8 +1589,7 @@ golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220610221304-9f5ed59c137d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f h1:v4INt8xihDGvnrfjMDVXGxw9wrfxYyCjk0KbXjhR55s=
-golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10 h1:WIoqL4EROvwiPdUtaip4VcDdpZ4kha7wBWZrbVKCIZg=
 golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/pkg/gitproviders/provider_org_test.go
+++ b/pkg/gitproviders/provider_org_test.go
@@ -326,7 +326,7 @@ var _ = Describe("Org Provider", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(c).To(Equal([]*gitprovider.CommitFile{file}))
 			Expect(fileClient.GetCallCount()).To(Equal(1))
-			_, dirPath, targetBranch := fileClient.GetArgsForCall(0)
+			_, dirPath, targetBranch, _ := fileClient.GetArgsForCall(0)
 			Expect(dirPath).To(Equal("path"))
 			Expect(targetBranch).To(Equal("main"))
 		})

--- a/pkg/gitproviders/provider_user_test.go
+++ b/pkg/gitproviders/provider_user_test.go
@@ -321,7 +321,7 @@ var _ = Describe("User Provider", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(c).To(Equal([]*gitprovider.CommitFile{file}))
 			Expect(fileClient.GetCallCount()).To(Equal(1))
-			_, dirPath, targetBranch := fileClient.GetArgsForCall(0)
+			_, dirPath, targetBranch, _ := fileClient.GetArgsForCall(0)
 			Expect(dirPath).To(Equal("path"))
 			Expect(targetBranch).To(Equal("main"))
 		})

--- a/pkg/vendorfakes/fakegitprovider/file_client.go
+++ b/pkg/vendorfakes/fakegitprovider/file_client.go
@@ -9,12 +9,13 @@ import (
 )
 
 type FileClient struct {
-	GetStub        func(context.Context, string, string) ([]*gitprovider.CommitFile, error)
+	GetStub        func(context.Context, string, string, ...gitprovider.FilesGetOption) ([]*gitprovider.CommitFile, error)
 	getMutex       sync.RWMutex
 	getArgsForCall []struct {
 		arg1 context.Context
 		arg2 string
 		arg3 string
+		arg4 []gitprovider.FilesGetOption
 	}
 	getReturns struct {
 		result1 []*gitprovider.CommitFile
@@ -28,20 +29,21 @@ type FileClient struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FileClient) Get(arg1 context.Context, arg2 string, arg3 string) ([]*gitprovider.CommitFile, error) {
+func (fake *FileClient) Get(arg1 context.Context, arg2 string, arg3 string, arg4 ...gitprovider.FilesGetOption) ([]*gitprovider.CommitFile, error) {
 	fake.getMutex.Lock()
 	ret, specificReturn := fake.getReturnsOnCall[len(fake.getArgsForCall)]
 	fake.getArgsForCall = append(fake.getArgsForCall, struct {
 		arg1 context.Context
 		arg2 string
 		arg3 string
-	}{arg1, arg2, arg3})
+		arg4 []gitprovider.FilesGetOption
+	}{arg1, arg2, arg3, arg4})
 	stub := fake.GetStub
 	fakeReturns := fake.getReturns
-	fake.recordInvocation("Get", []interface{}{arg1, arg2, arg3})
+	fake.recordInvocation("Get", []interface{}{arg1, arg2, arg3, arg4})
 	fake.getMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3)
+		return stub(arg1, arg2, arg3, arg4...)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -55,17 +57,17 @@ func (fake *FileClient) GetCallCount() int {
 	return len(fake.getArgsForCall)
 }
 
-func (fake *FileClient) GetCalls(stub func(context.Context, string, string) ([]*gitprovider.CommitFile, error)) {
+func (fake *FileClient) GetCalls(stub func(context.Context, string, string, ...gitprovider.FilesGetOption) ([]*gitprovider.CommitFile, error)) {
 	fake.getMutex.Lock()
 	defer fake.getMutex.Unlock()
 	fake.GetStub = stub
 }
 
-func (fake *FileClient) GetArgsForCall(i int) (context.Context, string, string) {
+func (fake *FileClient) GetArgsForCall(i int) (context.Context, string, string, []gitprovider.FilesGetOption) {
 	fake.getMutex.RLock()
 	defer fake.getMutex.RUnlock()
 	argsForCall := fake.getArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
 }
 
 func (fake *FileClient) GetReturns(result1 []*gitprovider.CommitFile, result2 error) {

--- a/pkg/vendorfakes/fakegitprovider/org_repository.go
+++ b/pkg/vendorfakes/fakegitprovider/org_repository.go
@@ -134,6 +134,16 @@ type OrgRepository struct {
 	teamAccessReturnsOnCall map[int]struct {
 		result1 gitprovider.TeamAccessClient
 	}
+	TreesStub        func() gitprovider.TreeClient
+	treesMutex       sync.RWMutex
+	treesArgsForCall []struct {
+	}
+	treesReturns struct {
+		result1 gitprovider.TreeClient
+	}
+	treesReturnsOnCall map[int]struct {
+		result1 gitprovider.TreeClient
+	}
 	UpdateStub        func(context.Context) error
 	updateMutex       sync.RWMutex
 	updateArgsForCall []struct {
@@ -812,6 +822,59 @@ func (fake *OrgRepository) TeamAccessReturnsOnCall(i int, result1 gitprovider.Te
 	}{result1}
 }
 
+func (fake *OrgRepository) Trees() gitprovider.TreeClient {
+	fake.treesMutex.Lock()
+	ret, specificReturn := fake.treesReturnsOnCall[len(fake.treesArgsForCall)]
+	fake.treesArgsForCall = append(fake.treesArgsForCall, struct {
+	}{})
+	stub := fake.TreesStub
+	fakeReturns := fake.treesReturns
+	fake.recordInvocation("Trees", []interface{}{})
+	fake.treesMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *OrgRepository) TreesCallCount() int {
+	fake.treesMutex.RLock()
+	defer fake.treesMutex.RUnlock()
+	return len(fake.treesArgsForCall)
+}
+
+func (fake *OrgRepository) TreesCalls(stub func() gitprovider.TreeClient) {
+	fake.treesMutex.Lock()
+	defer fake.treesMutex.Unlock()
+	fake.TreesStub = stub
+}
+
+func (fake *OrgRepository) TreesReturns(result1 gitprovider.TreeClient) {
+	fake.treesMutex.Lock()
+	defer fake.treesMutex.Unlock()
+	fake.TreesStub = nil
+	fake.treesReturns = struct {
+		result1 gitprovider.TreeClient
+	}{result1}
+}
+
+func (fake *OrgRepository) TreesReturnsOnCall(i int, result1 gitprovider.TreeClient) {
+	fake.treesMutex.Lock()
+	defer fake.treesMutex.Unlock()
+	fake.TreesStub = nil
+	if fake.treesReturnsOnCall == nil {
+		fake.treesReturnsOnCall = make(map[int]struct {
+			result1 gitprovider.TreeClient
+		})
+	}
+	fake.treesReturnsOnCall[i] = struct {
+		result1 gitprovider.TreeClient
+	}{result1}
+}
+
 func (fake *OrgRepository) Update(arg1 context.Context) error {
 	fake.updateMutex.Lock()
 	ret, specificReturn := fake.updateReturnsOnCall[len(fake.updateArgsForCall)]
@@ -900,6 +963,8 @@ func (fake *OrgRepository) Invocations() map[string][][]interface{} {
 	defer fake.setMutex.RUnlock()
 	fake.teamAccessMutex.RLock()
 	defer fake.teamAccessMutex.RUnlock()
+	fake.treesMutex.RLock()
+	defer fake.treesMutex.RUnlock()
 	fake.updateMutex.RLock()
 	defer fake.updateMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/pkg/vendorfakes/fakegitprovider/user_repository.go
+++ b/pkg/vendorfakes/fakegitprovider/user_repository.go
@@ -124,6 +124,16 @@ type UserRepository struct {
 	setReturnsOnCall map[int]struct {
 		result1 error
 	}
+	TreesStub        func() gitprovider.TreeClient
+	treesMutex       sync.RWMutex
+	treesArgsForCall []struct {
+	}
+	treesReturns struct {
+		result1 gitprovider.TreeClient
+	}
+	treesReturnsOnCall map[int]struct {
+		result1 gitprovider.TreeClient
+	}
 	UpdateStub        func(context.Context) error
 	updateMutex       sync.RWMutex
 	updateArgsForCall []struct {
@@ -749,6 +759,59 @@ func (fake *UserRepository) SetReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
+func (fake *UserRepository) Trees() gitprovider.TreeClient {
+	fake.treesMutex.Lock()
+	ret, specificReturn := fake.treesReturnsOnCall[len(fake.treesArgsForCall)]
+	fake.treesArgsForCall = append(fake.treesArgsForCall, struct {
+	}{})
+	stub := fake.TreesStub
+	fakeReturns := fake.treesReturns
+	fake.recordInvocation("Trees", []interface{}{})
+	fake.treesMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *UserRepository) TreesCallCount() int {
+	fake.treesMutex.RLock()
+	defer fake.treesMutex.RUnlock()
+	return len(fake.treesArgsForCall)
+}
+
+func (fake *UserRepository) TreesCalls(stub func() gitprovider.TreeClient) {
+	fake.treesMutex.Lock()
+	defer fake.treesMutex.Unlock()
+	fake.TreesStub = stub
+}
+
+func (fake *UserRepository) TreesReturns(result1 gitprovider.TreeClient) {
+	fake.treesMutex.Lock()
+	defer fake.treesMutex.Unlock()
+	fake.TreesStub = nil
+	fake.treesReturns = struct {
+		result1 gitprovider.TreeClient
+	}{result1}
+}
+
+func (fake *UserRepository) TreesReturnsOnCall(i int, result1 gitprovider.TreeClient) {
+	fake.treesMutex.Lock()
+	defer fake.treesMutex.Unlock()
+	fake.TreesStub = nil
+	if fake.treesReturnsOnCall == nil {
+		fake.treesReturnsOnCall = make(map[int]struct {
+			result1 gitprovider.TreeClient
+		})
+	}
+	fake.treesReturnsOnCall[i] = struct {
+		result1 gitprovider.TreeClient
+	}{result1}
+}
+
 func (fake *UserRepository) Update(arg1 context.Context) error {
 	fake.updateMutex.Lock()
 	ret, specificReturn := fake.updateReturnsOnCall[len(fake.updateArgsForCall)]
@@ -835,6 +898,8 @@ func (fake *UserRepository) Invocations() map[string][][]interface{} {
 	defer fake.repositoryMutex.RUnlock()
 	fake.setMutex.RLock()
 	defer fake.setMutex.RUnlock()
+	fake.treesMutex.RLock()
+	defer fake.treesMutex.RUnlock()
 	fake.updateMutex.RLock()
 	defer fake.updateMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}


### PR DESCRIPTION
This gets EE and Core on the same version of `go-git-providers` (v0.9.0). This came out of trying to get both Core and EE to work in a single `go` workspace. 