### PR TITLE
Change dashboard installation to use OCI

### DIFF
--- a/pkg/run/install_dashboard.go
+++ b/pkg/run/install_dashboard.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	helmChartName     = "weave-gitops"
-	helmRepositoryURL = "https://helm.gitops.weave.works"
+	helmRepositoryURL = "oci://ghcr.io/weaveworks/charts"
 )
 
 func ReadPassword(log logger.Logger) (string, error) {
@@ -271,7 +271,8 @@ func makeHelmRepository(name string, namespace string) *sourcev1.HelmRepository 
 			},
 		},
 		Spec: sourcev1.HelmRepositorySpec{
-			URL: helmRepositoryURL,
+			URL:  helmRepositoryURL,
+			Type: "oci",
 			Interval: metav1.Duration{
 				Duration: time.Minute * 60,
 			},


### PR DESCRIPTION
We changed the installation instructions to use the OCI repository instead in 0.9.2, however we were still using the HTTP repository in the source code, and that's what we ended up using for the rewritten installation instructions.

Change it to once again point at the OCI helm source.