### PR TITLE
Set security context that passes enforce:restricted pod security

### DIFF
--- a/charts/gitops-server/values.yaml
+++ b/charts/gitops-server/values.yaml
@@ -85,13 +85,16 @@ podAnnotations: {}
 podSecurityContext: {}
 # fsGroup: 2000
 
-securityContext: {}
-# capabilities:
-#   drop:
-#   - ALL
-# readOnlyRootFilesystem: true
-# runAsNonRoot: true
-# runAsUser: 1000
+securityContext:
+  runAsNonRoot: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+    - ALL
+  seccompProfile:
+    type: RuntimeDefault
+  runAsUser: 1000
+  readOnlyRootFilesystem: true
 
 service:
   create: true


### PR DESCRIPTION
I was browsing logs and came across warnings about pod security, which is new in 1.25. We clearly didn't pass the default `restricted` policy.

After putting the policy into place, I don't believe there's anything we do that isn't allowed by this policy, so let's run it with security turned on from now on.

To test that we pass this pod security policy, try setting `kubectl label namespace <namespace> pod-security.kubernetes.io/enforce=restricted` against the namespace where weave-gitops is running. Before this PR, that would make weave-gitops be rejected.

To test that these pod restrictions work, you shouldn't need to do anything - they're always enabled, so if it ever works, it should work both with and without pod security policy enforcement.