### PR TITLE
helm: Add network policy

### DIFF
--- a/charts/gitops-server/templates/network-policy.yaml
+++ b/charts/gitops-server/templates/network-policy.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.networkPolicy.create -}}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-dashboard-ingress
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "chart.selectorLabels" . | nindent 6 }}
+  ingress:
+  - ports:
+    - port: 9001
+      protocol: TCP
+  {{- if .Values.metrics.enabled }}
+    - port: {{ .Values.metrics.service.port }}
+      protocol: TCP
+  {{- end }}
+  policyTypes:
+  - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-dashboard-egress
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "chart.selectorLabels" . | nindent 6 }}
+  egress:
+    - {}
+  policyTypes:
+  - Egress
+{{- end -}}

--- a/charts/gitops-server/values.yaml
+++ b/charts/gitops-server/values.yaml
@@ -127,6 +127,10 @@ resources: {}
 #   cpu: 100m
 #   memory: 128Mi
 
+networkPolicy:
+  # -- Specifies whether default network policies should be created.
+  create: true
+
 nodeSelector: {}
 tolerations: []
 affinity: {}


### PR DESCRIPTION
Our default installation steps tells you to install weave-gitops in flux-system. Flux-system already contains network policies, and weave-gitops doesn't extend them to work, so if you enable network policies and follow our manual, gitops wouldn't work.

This creates enough network policies for weave gitops to work, even if your system default is to deny everything.

This creates network policies for
* Ingress access to the regular dashboard port, and optionally the metrics port - no other ingress should be required.
* Unrestricted egress access - when installed into flux-system this is redundant (flux already provides all pods in the namespace unrestricted egress), but in case it's installed into other namespaces this would make gitops work.

We could look into shrinking the egress permissions, but some of those can be configured (e.g. by configuring the cluster pool), so I'm not going to get into that today.

This resolves #2600.