### PR TITLE
Add version and revision info to Helm detail pages

### DIFF
--- a/ui/components/HelmChartDetail.tsx
+++ b/ui/components/HelmChartDetail.tsx
@@ -34,6 +34,8 @@ function HelmChartDetail({ className, helmChart }: Props) {
       info={[
         ["Type", Kind.HelmChart],
         ["Chart", helmChart.chart],
+        ["Version", helmChart.version],
+        ["Revision", helmChart.revision],
         ["Ref", helmChart.sourceRef?.name],
         ["Last Updated", <Timestamp time={helmChart.lastUpdatedAt} />],
         ["Interval", <Interval interval={helmChart.interval} />],

--- a/ui/components/HelmChartDetail.tsx
+++ b/ui/components/HelmChartDetail.tsx
@@ -35,7 +35,7 @@ function HelmChartDetail({ className, helmChart }: Props) {
         ["Type", Kind.HelmChart],
         ["Chart", helmChart.chart],
         ["Version", helmChart.version],
-        ["Revision", helmChart.revision],
+        ["Current Revision", helmChart.revision],
         ["Ref", helmChart.sourceRef?.name],
         ["Last Updated", <Timestamp time={helmChart.lastUpdatedAt} />],
         ["Interval", <Interval interval={helmChart.interval} />],

--- a/ui/components/HelmReleaseDetail.tsx
+++ b/ui/components/HelmReleaseDetail.tsx
@@ -62,8 +62,6 @@ function HelmReleaseDetail({ helmRelease, className, customTabs }: Props) {
       ? [["Cluster", helmRelease?.clusterName]]
       : [];
 
-  console.log(helmRelease);
-
   return (
     <AutomationDetail
       className={className}

--- a/ui/components/HelmReleaseDetail.tsx
+++ b/ui/components/HelmReleaseDetail.tsx
@@ -62,6 +62,8 @@ function HelmReleaseDetail({ helmRelease, className, customTabs }: Props) {
       ? [["Cluster", helmRelease?.clusterName]]
       : [];
 
+  console.log(helmRelease);
+
   return (
     <AutomationDetail
       className={className}
@@ -70,6 +72,9 @@ function HelmReleaseDetail({ helmRelease, className, customTabs }: Props) {
       info={[
         ["Source", helmChartLink(helmRelease)],
         ["Chart", helmRelease?.helmChart.chart],
+        ["Chart Version", helmRelease.helmChart.version],
+        ["Last Applied Revision", helmRelease.lastAppliedRevision],
+        ["Last Attempted Revision", helmRelease.lastAttemptedRevision],
         ...clusterInfo,
         ...tenancyInfo,
         ["Interval", <Interval interval={helmRelease?.interval} />],

--- a/ui/lib/objects.ts
+++ b/ui/lib/objects.ts
@@ -131,6 +131,14 @@ export class HelmChart extends FluxObject {
   get chart(): string {
     return this.obj.spec?.chart || "";
   }
+
+  get version(): string {
+    return this.obj.spec?.version || "";
+  }
+
+  get revision(): string {
+    return this.obj.status.artifact.revision;
+  }
 }
 
 export class Bucket extends FluxObject {
@@ -250,6 +258,14 @@ export class HelmRelease extends FluxObject {
 
   get sourceRef(): ObjectRef | undefined {
     return this.helmChart?.sourceRef;
+  }
+
+  get lastAppliedRevision(): string {
+    return this.obj.status.lastAppliedRevision || "";
+  }
+
+  get lastAttemptedRevision(): string {
+    return this.obj.status.lastAttemptedRevision || "";
   }
 }
 


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes #2706 

<!-- Describe what has changed in this PR -->
The HelmChart class has two new getters which are displayed in the details view - Version, and Revision (should this be artifact revision?)
The HelmRelease class has three - Version, Last Applied Revision, and Last Attempted Revision

Screenshots below - yes, there's a couple unfortunate bugs I found here with the overflow styling of chip group...and a chip will be created if you just press enter on the search input with no content...........issue incoming :(

<img width="1473" alt="image" src="https://user-images.githubusercontent.com/65822698/192037725-f2eb43a7-9dac-4deb-8c0f-ee641ef6262a.png">

<img width="782" alt="image" src="https://user-images.githubusercontent.com/65822698/192037181-97ad9dbc-60bd-418e-8fe5-e55bb8d95b65.png">
