### PR TITLE
add empty table row prop so it can be configured from parent component

### DIFF
--- a/ui/components/DataTable.tsx
+++ b/ui/components/DataTable.tsx
@@ -59,6 +59,7 @@ export interface Props {
   dialogOpen?: boolean;
   hasCheckboxes?: boolean;
   hideSearchAndFilters?: boolean;
+  emptyMessagePlaceholder?: string | React.ReactNode;
 }
 //styled components
 const EmptyRow = styled(TableRow)<{ colSpan: number }>`
@@ -331,6 +332,7 @@ function UnstyledDataTable({
   hasCheckboxes: checkboxes,
   dialogOpen,
   hideSearchAndFilters,
+  emptyMessagePlaceholder,
 }: Props) {
   //URL info
   const history = useHistory();
@@ -561,7 +563,9 @@ function UnstyledDataTable({
                         size="base"
                       />
                       <Spacer padding="xxs" />
-                      <Text color="neutral30">No data</Text>
+                      <Text color="neutral30">
+                        {emptyMessagePlaceholder || "No data"}
+                      </Text>
                     </Flex>
                   </TableCell>
                 </EmptyRow>


### PR DESCRIPTION
-Resolve [Issue-1566](https://github.com/weaveworks/weave-gitops-enterprise/issues/1566)

What are the changes ?
- add new prop to DataTable "emptyMessagePlaceholder"

Why these changes are done ? 
- To be able to manipulate the "No Data" message with custom message being sent from parent component. 