### PR TITLE
Set more ldflags when making a release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -56,7 +56,8 @@ jobs:
         run: |
           echo "BRANCH=${{ github.event.pull_request.head.ref }}" >> $GITHUB_ENV
           echo "GORELEASER_PREVIOUS_TAG=$(git describe --abbrev=0 --tags $(git rev-list --tags --skip=1 --max-count=1))" >> $GITHUB_ENV
-          echo "GORELEASER_CURRENT_TAG=$(git describe --abbrev=0 --tags)" >> $GITHUB_ENV
+          echo "GORELEASER_CURRENT_TAG=${{ needs.tag-release.outputs.version }}" >> $GITHUB_ENV
+          echo "DEV_BUCKET_CONTAINER_IMAGE=$(make echo-dev-bucket-container)" >> $GITHUB_ENV
           echo "FLUX_VERSION=$(make echo-flux-version)" >> $GITHUB_ENV
           echo "CHART_VERSION=$(yq e '.version' charts/gitops-server/Chart.yaml)" >> $GITHUB_ENV
       - name: "Make All"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -18,11 +18,16 @@ builds:
       binary: "gitops"
       main: ./cmd/gitops
       ldflags:
-        - -X github.com/weaveworks/weave-gitops/cmd/gitops/version.Version={{.Version}}
-        - -X github.com/weaveworks/weave-gitops/cmd/gitops/version.BuildTime={{.Date}}
         - -X github.com/weaveworks/weave-gitops/cmd/gitops/version.Branch={{ .Env.BRANCH}}
+        - -X github.com/weaveworks/weave-gitops/cmd/gitops/version.BuildTime={{.Date}}
         - -X github.com/weaveworks/weave-gitops/cmd/gitops/version.GitCommit={{.Commit}}
+        - -X github.com/weaveworks/weave-gitops/cmd/gitops/version.Version={{.Version}}
         - -X github.com/weaveworks/weave-gitops/pkg/version.FluxVersion={{ .Env.FLUX_VERSION }}
+        - -X github.com/weaveworks/weave-gitops/pkg/run.DevBucketContainerImage={{ .Env.DEV_BUCKET_CONTAINER_IMAGE }}
+        - -X github.com/weaveworks/weave-gitops/core/server.Branch={{ .Env.BRANCH}}
+        - -X github.com/weaveworks/weave-gitops/core/server.BuildTime={{.Date}}
+        - -X github.com/weaveworks/weave-gitops/core/server.GitCommit={{.Commit}}
+        - -X github.com/weaveworks/weave-gitops/core/server.Version={{.Version}}
         - -X github.com/weaveworks/weave-gitops/cmd/gitops/beta/run.HelmChartVersion={{ .Env.CHART_VERSION }}
       env:
         - CGO_ENABLED=0

--- a/Makefile
+++ b/Makefile
@@ -212,6 +212,9 @@ echo-ldflags:
 echo-flux-version:
 	@echo $(FLUX_VERSION)
 
+echo-dev-bucket-container:
+	@echo $(DEV_BUCKET_CONTAINER_IMAGE)
+
 .PHONY: help
 # Thanks to https://www.thapaliya.com/en/writings/well-documented-makefiles/
 help:  ## Display this help.


### PR DESCRIPTION
This should also fix setting a proper tag for the current release.

This should be refactored, but I don't want to do that today. I just want releases to have a release number in the web UI.

To test, I plan to tag another RC with this in it, and check that it works.