### PR TITLE
ui: Don't flatten children for the graph

### DIFF
--- a/ui/components/ReconciliationGraph.tsx
+++ b/ui/components/ReconciliationGraph.tsx
@@ -2,7 +2,7 @@ import { Slider } from "@material-ui/core";
 import * as d3 from "d3";
 import * as React from "react";
 import styled from "styled-components";
-import { useGetReconciledObjects } from "../hooks/flux";
+import { useGetReconciledTree } from "../hooks/flux";
 import { ObjectRef } from "../lib/api/core/types.pb";
 import { Automation } from "../lib/objects";
 import DirectedGraph from "./DirectedGraph";
@@ -49,7 +49,7 @@ function ReconciliationGraph({
     error,
     isLoading,
   } = parentObject
-    ? useGetReconciledObjects(
+    ? useGetReconciledTree(
         parentObject?.name,
         parentObject?.namespace,
         automationKind,

--- a/ui/hooks/flux.ts
+++ b/ui/hooks/flux.ts
@@ -64,21 +64,36 @@ export function useGetReconciledObjects(
     refetchInterval: 5000,
   }
 ) {
+  const result = useGetReconciledTree(
+    name,
+    namespace,
+    type,
+    kinds,
+    clusterName,
+    opts
+  );
+  if (result.data) {
+    result.data = flattenChildren(result.data);
+  }
+  return result;
+}
+
+export function useGetReconciledTree(
+  name: string,
+  namespace: string,
+  type: Kind,
+  kinds: GroupVersionKind[],
+  clusterName = DefaultCluster,
+  opts: ReactQueryOptions<UnstructuredObject[], RequestError> = {
+    retry: false,
+    refetchInterval: 5000,
+  }
+) {
   const { api } = useContext(CoreClientContext);
 
   return useQuery<UnstructuredObject[], RequestError>(
     ["reconciled_objects", { name, namespace, type, kinds }],
-    async () => {
-      const childrenTrees = await getChildren(
-        api,
-        name,
-        namespace,
-        type,
-        kinds,
-        clusterName
-      );
-      return flattenChildren(childrenTrees);
-    },
+    () => getChildren(api, name, namespace, type, kinds, clusterName),
     opts
   );
 }


### PR DESCRIPTION
I added the flattenChildren in da33a4b, where I assumed that ReconciliationGraph used getChildren directly. Which it doesn't.

flattenChildren thus did it's thing of copying the children out to the top layer so they show up in the top level of the array so they show up in the Details view. But that also created copies at the wrong depth in the graph.

This fixes it by introducing two different ways to get reconciled objects - one that is flat and one that isn't.

I'm hoping we'll change from the tree structure to the d3-dag structure one of these days, at which point it won't need to be nested and this code can be removed.

This fixes #2808