### PR TITLE
Fix displaying release version in footer + tiny other release fix

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -181,7 +181,6 @@ jobs:
   enterprise-pr:
     name: Make enterprise PR
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
     needs:
       - merge-pr
       - tag-release

--- a/ui/components/Footer.tsx
+++ b/ui/components/Footer.tsx
@@ -27,7 +27,7 @@ function Footer({ className }: Props) {
 
   const shouldDisplayApiVersion =
     !isLoading &&
-    versionData.semver !== p.version &&
+    (versionData.semver || "").replace(/^v+/, "") !== p.version &&
     versionData.branch &&
     versionData.commit;
 


### PR DESCRIPTION
Remove the event name filter for making an enterprise PR - I copy-pasted this line, but the release flow doesn't run on push, so it doesn't work.

Fix detecting in the footer whether the current release is stable - the git tag and thus the returned value from go has a leading `v`, but the npm version doesn't - just strip out 'v's and it works. I've tested this by installing the latest RC and doing `npm start` against that package.