### PR TITLE
Fix styling bug on filter chips

### DIFF
--- a/ui/components/ChipGroup.tsx
+++ b/ui/components/ChipGroup.tsx
@@ -18,11 +18,13 @@ function ChipGroup({ className, chips = [], onChipRemove, onClearAll }: Props) {
   return (
     <Flex className={className} wide align start>
       {_.map(chips, (chip, index) => {
+        const hasSeparator = chip.search(filterSeparator);
         const isUndefined =
+          hasSeparator !== -1 &&
           //javascript search finds first occurence of substring, returning index
-          chip.search(filterSeparator) ===
-          //if first occurence of filterSeparator is the end of the chip string, it's an undefined value
-          chip.length - filterSeparator.length;
+          hasSeparator ===
+            //if first occurence of filterSeparator is the end of the chip string, it's an undefined value
+            chip.length - filterSeparator.length;
         return (
           <Flex key={index}>
             <Chip

--- a/ui/components/DataTable.tsx
+++ b/ui/components/DataTable.tsx
@@ -85,6 +85,11 @@ const TableButton = styled(Button)`
   }
 `;
 
+const TopBar = styled(Flex)`
+  max-width: 100%;
+  overflow: hidden;
+`;
+
 const IconFlex = styled(Flex)`
   position: relative;
   padding: 0 ${(props) => props.theme.spacing.small};
@@ -383,10 +388,11 @@ function UnstyledDataTable({
   };
 
   const handleTextSearchSubmit = (val: string) => {
-    setFilterState({
-      ...filterState,
-      textFilters: _.uniq(_.concat(filterState.textFilters, val)),
-    });
+    if (val)
+      setFilterState({
+        ...filterState,
+        textFilters: _.uniq(_.concat(filterState.textFilters, val)),
+      });
   };
 
   const handleClearAll = () => {
@@ -480,15 +486,10 @@ function UnstyledDataTable({
   });
   return (
     <Flex wide tall column className={className}>
-      <Flex
-        wide
-        align
-        between={filters ? true : false}
-        start={filters ? false : true}
-      >
+      <TopBar wide align end>
         {checkboxes && <CheckboxActions checked={checked} rows={filtered} />}
         {filters && !hideSearchAndFilters && (
-          <Flex wide align end>
+          <>
             <ChipGroup
               chips={chips}
               onChipRemove={handleChipRemove}
@@ -498,7 +499,6 @@ function UnstyledDataTable({
               <SearchField onSubmit={handleTextSearchSubmit} />
               <IconButton
                 onClick={() => setFilterDialogOpen(!filterDialogOpen)}
-                className={className}
                 variant={filterDialogOpen ? "contained" : "text"}
                 color="inherit"
               >
@@ -509,9 +509,9 @@ function UnstyledDataTable({
                 />
               </IconButton>
             </IconFlex>
-          </Flex>
+          </>
         )}
-      </Flex>
+      </TopBar>
       <Flex wide tall>
         <TableContainer>
           <Table aria-label="simple table">

--- a/ui/components/DataTable.tsx
+++ b/ui/components/DataTable.tsx
@@ -87,7 +87,6 @@ const TableButton = styled(Button)`
 
 const TopBar = styled(Flex)`
   max-width: 100%;
-  overflow: hidden;
 `;
 
 const IconFlex = styled(Flex)`

--- a/ui/components/__tests__/__snapshots__/DataTable.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/DataTable.test.tsx.snap
@@ -243,7 +243,6 @@ exports[`DataTable snapshots renders 1`] = `
 
 .c3 {
   max-width: 100%;
-  overflow: hidden;
 }
 
 .c1 {

--- a/ui/components/__tests__/__snapshots__/DataTable.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/DataTable.test.tsx.snap
@@ -30,13 +30,13 @@ exports[`DataTable snapshots renders 1`] = `
   -ms-flex-align: center;
   align-items: center;
   width: 100%;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
-  justify-content: flex-start;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
 }
 
-.c3 {
+.c4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -52,7 +52,7 @@ exports[`DataTable snapshots renders 1`] = `
   width: 100%;
 }
 
-.c4 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -70,7 +70,7 @@ exports[`DataTable snapshots renders 1`] = `
   justify-content: flex-start;
 }
 
-.c8 {
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -84,7 +84,7 @@ exports[`DataTable snapshots renders 1`] = `
   align-items: center;
 }
 
-.c14 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -102,7 +102,26 @@ exports[`DataTable snapshots renders 1`] = `
   justify-content: flex-start;
 }
 
-.c11 {
+.c17 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  width: 100%;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+}
+
+.c12 {
   font-family: 'proxima-nova',Helvetica,Arial,sans-serif;
   font-size: 14px;
   font-weight: 400;
@@ -110,7 +129,7 @@ exports[`DataTable snapshots renders 1`] = `
   font-style: normal;
 }
 
-.c16 {
+.c18 {
   font-family: 'proxima-nova',Helvetica,Arial,sans-serif;
   font-size: 20px;
   font-weight: 400;
@@ -119,29 +138,29 @@ exports[`DataTable snapshots renders 1`] = `
   color: #737373;
 }
 
-.c9 svg {
+.c10 svg {
   fill: !important;
   height: 16px;
   width: 16px;
 }
 
-.c9.downward {
+.c10.downward {
   -webkit-transform: rotate(180deg);
   -ms-transform: rotate(180deg);
   transform: rotate(180deg);
 }
 
-.c9.upward {
+.c10.upward {
   -webkit-transform: initial;
   -ms-transform: initial;
   transform: initial;
 }
 
-.c9 .c10 {
+.c10 .c11 {
   margin-left: 4px;
 }
 
-.c5.MuiButton-root {
+.c6.MuiButton-root {
   height: 32px;
   font-size: 12px;
   -webkit-letter-spacing: 1px;
@@ -153,16 +172,16 @@ exports[`DataTable snapshots renders 1`] = `
   font-weight: 600;
 }
 
-.c5.MuiButton-outlined {
+.c6.MuiButton-outlined {
   padding: 8px 12px;
   border-color: #d8d8d8;
 }
 
-.c7 {
+.c8 {
   padding: 4px;
 }
 
-.c12 {
+.c13 {
   position: relative;
   height: 100%;
   width: 0px;
@@ -175,12 +194,12 @@ exports[`DataTable snapshots renders 1`] = `
   transition-timing-function: ease-in-out;
 }
 
-.c12.open {
+.c13.open {
   left: 0px;
   width: 350px;
 }
 
-.c13 {
+.c14 {
   background: rbga(255,255,255,0.75);
   height: 100%;
   width: 100%;
@@ -189,19 +208,19 @@ exports[`DataTable snapshots renders 1`] = `
   padding-left: 32px;
 }
 
-.c15 .MuiListItem-gutters {
+.c16 .MuiListItem-gutters {
   padding-left: 0px;
 }
 
-.c15 .MuiCheckbox-root {
+.c16 .MuiCheckbox-root {
   padding: 0px;
 }
 
-.c15 .MuiCheckbox-colorSecondary.Mui-checked {
+.c16 .MuiCheckbox-colorSecondary.Mui-checked {
   color: #00b3ec;
 }
 
-.c6.MuiButton-root {
+.c7.MuiButton-root {
   margin: 0;
   text-transform: none;
   -webkit-letter-spacing: 0;
@@ -210,16 +229,21 @@ exports[`DataTable snapshots renders 1`] = `
   letter-spacing: 0;
 }
 
-.c6.MuiButton-text {
+.c7.MuiButton-text {
   min-width: 0px;
 }
 
-.c6.MuiButton-text .selected {
+.c7.MuiButton-text .selected {
   color: #1a1a1a;
 }
 
-.c6.arrow {
+.c7.arrow {
   min-width: 0px;
+}
+
+.c3 {
+  max-width: 100%;
+  overflow: hidden;
 }
 
 .c1 {
@@ -274,10 +298,10 @@ exports[`DataTable snapshots renders 1`] = `
   className="c0 c1"
 >
   <div
-    className="c2"
+    className="c2 c3"
   />
   <div
-    className="c3"
+    className="c4"
   >
     <div
       className="MuiTableContainer-root"
@@ -301,10 +325,10 @@ exports[`DataTable snapshots renders 1`] = `
               scope="col"
             >
               <div
-                className="c4"
+                className="c5"
               >
                 <button
-                  className="MuiButtonBase-root MuiButton-root MuiButton-text c5 c6 MuiButton-colorInherit MuiButton-disableElevation"
+                  className="MuiButtonBase-root MuiButton-root MuiButton-text c6 c7 MuiButton-colorInherit MuiButton-disableElevation"
                   disabled={false}
                   onBlur={[Function]}
                   onClick={[Function]}
@@ -332,10 +356,10 @@ exports[`DataTable snapshots renders 1`] = `
                   </span>
                 </button>
                 <div
-                  className="c7"
+                  className="c8"
                 />
                 <div
-                  className="c8 c9 downward"
+                  className="c9 c10 downward"
                 >
                   <svg
                     aria-hidden={true}
@@ -356,10 +380,10 @@ exports[`DataTable snapshots renders 1`] = `
               scope="col"
             >
               <div
-                className="c4"
+                className="c5"
               >
                 <button
-                  className="MuiButtonBase-root MuiButton-root MuiButton-text c5 c6 MuiButton-colorInherit MuiButton-disableElevation"
+                  className="MuiButtonBase-root MuiButton-root MuiButton-text c6 c7 MuiButton-colorInherit MuiButton-disableElevation"
                   disabled={false}
                   onBlur={[Function]}
                   onClick={[Function]}
@@ -387,7 +411,7 @@ exports[`DataTable snapshots renders 1`] = `
                   </span>
                 </button>
                 <div
-                  className="c7"
+                  className="c8"
                 />
                 <div
                   style={
@@ -404,10 +428,10 @@ exports[`DataTable snapshots renders 1`] = `
               scope="col"
             >
               <div
-                className="c4"
+                className="c5"
               >
                 <button
-                  className="MuiButtonBase-root MuiButton-root MuiButton-text c5 c6 MuiButton-colorInherit MuiButton-disableElevation"
+                  className="MuiButtonBase-root MuiButton-root MuiButton-text c6 c7 MuiButton-colorInherit MuiButton-disableElevation"
                   disabled={false}
                   onBlur={[Function]}
                   onClick={[Function]}
@@ -435,7 +459,7 @@ exports[`DataTable snapshots renders 1`] = `
                   </span>
                 </button>
                 <div
-                  className="c7"
+                  className="c8"
                 />
                 <div
                   style={
@@ -452,10 +476,10 @@ exports[`DataTable snapshots renders 1`] = `
               scope="col"
             >
               <div
-                className="c4"
+                className="c5"
               >
                 <button
-                  className="MuiButtonBase-root MuiButton-root MuiButton-text c5 c6 MuiButton-colorInherit MuiButton-disableElevation"
+                  className="MuiButtonBase-root MuiButton-root MuiButton-text c6 c7 MuiButton-colorInherit MuiButton-disableElevation"
                   disabled={false}
                   onBlur={[Function]}
                   onClick={[Function]}
@@ -483,7 +507,7 @@ exports[`DataTable snapshots renders 1`] = `
                   </span>
                 </button>
                 <div
-                  className="c7"
+                  className="c8"
                 />
                 <div
                   style={
@@ -509,7 +533,7 @@ exports[`DataTable snapshots renders 1`] = `
               className="MuiTableCell-root MuiTableCell-body"
             >
               <span
-                className="c10 c11"
+                className="c11 c12"
                 size="medium"
               >
                 <a
@@ -524,7 +548,7 @@ exports[`DataTable snapshots renders 1`] = `
               className="MuiTableCell-root MuiTableCell-body"
             >
               <span
-                className="c10 c11"
+                className="c11 c12"
                 size="medium"
               >
                 Ready
@@ -535,7 +559,7 @@ exports[`DataTable snapshots renders 1`] = `
               className="MuiTableCell-root MuiTableCell-body"
             >
               <span
-                className="c10 c11"
+                className="c11 c12"
                 size="medium"
               >
                 2004-01-02T15:04:05-0700
@@ -546,7 +570,7 @@ exports[`DataTable snapshots renders 1`] = `
               className="MuiTableCell-root MuiTableCell-body"
             >
               <span
-                className="c10 c11"
+                className="c11 c12"
                 size="medium"
               >
                 3000
@@ -562,7 +586,7 @@ exports[`DataTable snapshots renders 1`] = `
               className="MuiTableCell-root MuiTableCell-body"
             >
               <span
-                className="c10 c11"
+                className="c11 c12"
                 size="medium"
               >
                 <a
@@ -577,7 +601,7 @@ exports[`DataTable snapshots renders 1`] = `
               className="MuiTableCell-root MuiTableCell-body"
             >
               <span
-                className="c10 c11"
+                className="c11 c12"
                 size="medium"
               >
                 -
@@ -588,7 +612,7 @@ exports[`DataTable snapshots renders 1`] = `
               className="MuiTableCell-root MuiTableCell-body"
             >
               <span
-                className="c10 c11"
+                className="c11 c12"
                 size="medium"
               >
                 2006-01-02T15:04:05-0700
@@ -599,7 +623,7 @@ exports[`DataTable snapshots renders 1`] = `
               className="MuiTableCell-root MuiTableCell-body"
             >
               <span
-                className="c10 c11"
+                className="c11 c12"
                 size="medium"
               >
                 2000
@@ -615,7 +639,7 @@ exports[`DataTable snapshots renders 1`] = `
               className="MuiTableCell-root MuiTableCell-body"
             >
               <span
-                className="c10 c11"
+                className="c11 c12"
                 size="medium"
               >
                 <a
@@ -630,7 +654,7 @@ exports[`DataTable snapshots renders 1`] = `
               className="MuiTableCell-root MuiTableCell-body"
             >
               <span
-                className="c10 c11"
+                className="c11 c12"
                 size="medium"
               />
             </td>
@@ -639,7 +663,7 @@ exports[`DataTable snapshots renders 1`] = `
               className="MuiTableCell-root MuiTableCell-body"
             >
               <span
-                className="c10 c11"
+                className="c11 c12"
                 size="medium"
               >
                 2005-01-02T15:04:05-0700
@@ -650,7 +674,7 @@ exports[`DataTable snapshots renders 1`] = `
               className="MuiTableCell-root MuiTableCell-body"
             >
               <span
-                className="c10 c11"
+                className="c11 c12"
                 size="medium"
               >
                 1000
@@ -661,20 +685,20 @@ exports[`DataTable snapshots renders 1`] = `
       </table>
     </div>
     <div
-      className="c12"
+      className="c13"
       data-testid="container"
     >
       <div
-        className="c13"
+        className="c14"
       >
         <div
-          className="c14 c15"
+          className="c15 c16"
         >
           <div
-            className="c2"
+            className="c17"
           >
             <span
-              className="c10 c16"
+              className="c11 c18"
               color="neutral30"
               size="large"
             >


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes #2784

<!-- Describe what has changed in this PR -->
- ChipGroup properly overflows without pushing CheckboxActions or the icon buttons off the screen
- A bug where a one character text search could meet the requirements for an undefined filter has been fixed
- An empty text search is not able to be submitted as a valid filter

https://user-images.githubusercontent.com/65822698/194111349-33b058ba-0dbb-40e1-9748-973ac9aae02c.mov