### PR TITLE
Add `gitops set config` and `gitops get config` GitOps CLI commands.

### DIFF
--- a/cmd/gitops/cmderrors/errors.go
+++ b/cmd/gitops/cmderrors/errors.go
@@ -8,6 +8,7 @@ var (
 	ErrNoTLSCertOrKey         = errors.New("flags --tls-cert-file and --tls-private-key-file cannot be empty")
 	ErrNoFilePath             = errors.New("the filepath has not been set")
 	ErrMultipleFilePaths      = errors.New("only one filepath is allowed")
+	ErrInvalidArgs            = errors.New("invalid positional arguments")
 	ErrNoContextForKubeConfig = errors.New("no context provided for the kubeconfig")
 	ErrNoCluster              = errors.New("no cluster in the kube config")
 	ErrGetKubeClient          = errors.New("error getting Kube HTTP client")

--- a/cmd/gitops/get/bcrypt/cmd.go
+++ b/cmd/gitops/get/bcrypt/cmd.go
@@ -16,8 +16,8 @@ func HashCommand(opts *config.Options) *cobra.Command {
 		Use:   "bcrypt-hash",
 		Short: "Generates a hashed secret",
 		Example: `
-# PASSWORD="<your password>"
-# echo -n $PASSWORD | gitops get bcrypt-hash
+PASSWORD="<your password>"
+echo -n $PASSWORD | gitops get bcrypt-hash
 `,
 		SilenceUsage:  true,
 		SilenceErrors: true,

--- a/cmd/gitops/get/cmd.go
+++ b/cmd/gitops/get/cmd.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/weaveworks/weave-gitops/cmd/gitops/config"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/get/bcrypt"
+	configCmd "github.com/weaveworks/weave-gitops/cmd/gitops/get/config"
 )
 
 func GetCommand(opts *config.Options) *cobra.Command {
@@ -12,17 +13,16 @@ func GetCommand(opts *config.Options) *cobra.Command {
 		Use:   "get",
 		Short: "Display one or many Weave GitOps resources",
 		Example: `
-# Get all CAPI templates
-gitops get templates
+# Get the CLI configuration for Weave GitOps
+gitops get config
 
-# Get all CAPI credentials
-gitops get credentials
-
-# Get all CAPI clusters
-gitops get clusters`,
+# Generate a hashed secret
+PASSWORD="<your password>"
+echo -n $PASSWORD | gitops get bcrypt-hash`,
 	}
 
 	cmd.AddCommand(bcrypt.HashCommand(opts))
+	cmd.AddCommand(configCmd.ConfigCommand(opts))
 
 	return cmd
 }

--- a/cmd/gitops/get/config/cmd.go
+++ b/cmd/gitops/get/config/cmd.go
@@ -1,0 +1,53 @@
+package config
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/weaveworks/weave-gitops/cmd/gitops/config"
+	clilogger "github.com/weaveworks/weave-gitops/cmd/gitops/logger"
+
+	gitopsConfig "github.com/weaveworks/weave-gitops/pkg/config"
+)
+
+func ConfigCommand(opts *config.Options) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "config",
+		Short: "Prints out the CLI configuration for Weave GitOps",
+		Example: `
+# Prints out the CLI configuration for Weave GitOps
+gitops get config`,
+		SilenceUsage:      true,
+		SilenceErrors:     true,
+		RunE:              getConfigCommandRunE(opts),
+		DisableAutoGenTag: true,
+	}
+
+	return cmd
+}
+
+func getConfigCommandRunE(opts *config.Options) func(*cobra.Command, []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		var err error
+
+		log := clilogger.NewCLILogger(os.Stdout)
+
+		cfg, err := gitopsConfig.GetConfig(log, false)
+		if err != nil {
+			return err
+		}
+
+		log.Successf("Your CLI configuration for Weave GitOps:")
+
+		cfgStr, err := cfg.String()
+		if err != nil {
+			log.Failuref("Error printing config")
+			return err
+		}
+
+		fmt.Println(cfgStr)
+
+		return nil
+	}
+}

--- a/cmd/gitops/root/cmd.go
+++ b/cmd/gitops/root/cmd.go
@@ -14,6 +14,7 @@ import (
 	"github.com/weaveworks/weave-gitops/cmd/gitops/create"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/docs"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/get"
+	"github.com/weaveworks/weave-gitops/cmd/gitops/set"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/version"
 	"github.com/weaveworks/weave-gitops/pkg/kube"
 	"github.com/weaveworks/weave-gitops/pkg/utils"
@@ -100,6 +101,7 @@ func RootCmd() *cobra.Command {
 
 	rootCmd.AddCommand(version.Cmd)
 	rootCmd.AddCommand(get.GetCommand(options))
+	rootCmd.AddCommand(set.SetCommand(options))
 	rootCmd.AddCommand(docs.Cmd)
 	rootCmd.AddCommand(check.Cmd)
 	rootCmd.AddCommand(beta.GetCommand(options))

--- a/cmd/gitops/set/cmd.go
+++ b/cmd/gitops/set/cmd.go
@@ -1,0 +1,22 @@
+package set
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/weaveworks/weave-gitops/cmd/gitops/config"
+	configCmd "github.com/weaveworks/weave-gitops/cmd/gitops/set/config"
+)
+
+func SetCommand(opts *config.Options) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "set",
+		Short: "Sets one or many Weave GitOps CLI configs or resources",
+		Example: `
+# Enables analytics in the current user's CLI configuration for Weave GitOps
+gitops set config analytics true`,
+	}
+
+	cmd.AddCommand(configCmd.ConfigCommand(opts))
+
+	return cmd
+}

--- a/cmd/gitops/set/config/cmd.go
+++ b/cmd/gitops/set/config/cmd.go
@@ -1,0 +1,92 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/weaveworks/weave-gitops/cmd/gitops/cmderrors"
+	"github.com/weaveworks/weave-gitops/cmd/gitops/config"
+	clilogger "github.com/weaveworks/weave-gitops/cmd/gitops/logger"
+	gitopsConfig "github.com/weaveworks/weave-gitops/pkg/config"
+)
+
+const (
+	analyticsKey = "analytics"
+)
+
+var analyticsValue bool
+
+func ConfigCommand(opts *config.Options) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "config",
+		Short: "Set the CLI configuration for Weave GitOps",
+		Example: `
+# Enables analytics in the current user's CLI configuration for Weave GitOps
+gitops set config analytics true`,
+		SilenceUsage:      true,
+		SilenceErrors:     true,
+		PreRunE:           setConfigCommandPreRunE(&opts.Endpoint),
+		RunE:              setConfigCommandRunE(opts),
+		DisableAutoGenTag: true,
+	}
+
+	return cmd
+}
+
+func setConfigCommandPreRunE(endpoint *string) func(*cobra.Command, []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		if len(args) < 2 {
+			return fmt.Errorf("at least two positional arguments required")
+		}
+
+		if args[0] != analyticsKey {
+			return cmderrors.ErrInvalidArgs
+		}
+
+		var err error
+
+		analyticsValue, err = strconv.ParseBool(strings.TrimSpace(args[1]))
+		if err != nil {
+			return cmderrors.ErrInvalidArgs
+		}
+
+		return nil
+	}
+}
+
+func setConfigCommandRunE(opts *config.Options) func(*cobra.Command, []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		var err error
+
+		log := clilogger.NewCLILogger(os.Stdout)
+
+		if !analyticsValue {
+			log.Warningf("This will only turn off analytics for the GitOps CLI. Please refer to the documentation to turn off the analytics in the GitOps Dashboard.")
+		}
+
+		cfg, err := gitopsConfig.GetConfig(log, true)
+		if err != nil {
+			return err
+		}
+
+		cfg.Analytics = analyticsValue
+
+		if cfg.UserID == "" {
+			seed := time.Now().UnixNano()
+
+			cfg.UserID = gitopsConfig.GenerateUserID(10, seed)
+		}
+
+		if err = gitopsConfig.SaveConfig(log, cfg); err != nil {
+			log.Failuref("Error saving GitOps CLI config")
+			return err
+		}
+
+		return nil
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,0 +1,208 @@
+package config
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"math/rand"
+	"os"
+	"path/filepath"
+
+	"github.com/weaveworks/weave-gitops/pkg/logger"
+)
+
+const (
+	ConfigFileName       = "weave-gitops-config.json"
+	WrongConfigFormatMsg = `Your CLI configuration for Weave GitOps should represent a JSON object format:
+{
+	"analytics": true,
+	"userId": ""
+}
+Please set you configuration with: gitops set config`
+)
+
+var letters = []byte("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789+/")
+
+type GitopsCLIConfig struct {
+	Analytics bool   `json:"analytics"`
+	UserID    string `json:"userId"`
+}
+
+func (config *GitopsCLIConfig) String() (string, error) {
+	data, err := json.MarshalIndent(&config, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("error encoding config: %w", err)
+	}
+
+	return string(data), nil
+}
+
+// GetConfig reads the CLI configuration for Weave GitOps from the config file
+func GetConfig(log logger.Logger, shouldCreate bool) (*GitopsCLIConfig, error) {
+	log.Actionf("Reading GitOps CLI config ...")
+
+	configPath, err := getConfigPath(ConfigFileName)
+	if err != nil {
+		return nil, err
+	}
+
+	configFile, err := openConfigFile(configPath, shouldCreate)
+	if err != nil {
+		log.Failuref("Error opening config file at path: %s", configPath)
+		log.Warningf(WrongConfigFormatMsg)
+
+		return nil, err
+	}
+
+	defer configFile.Close()
+
+	config := &GitopsCLIConfig{}
+
+	data, err := readData(configFile)
+	if err != nil && !shouldCreate {
+		log.Failuref("Error reading config data from file at path: %s", configPath)
+		log.Warningf(WrongConfigFormatMsg)
+
+		return nil, err
+	}
+
+	if len(data) == 0 {
+		if !shouldCreate {
+			log.Warningf(WrongConfigFormatMsg)
+			return nil, fmt.Errorf("empty config file detected at path: %s", configPath)
+		}
+	} else if err = parseConfig(data, config); err != nil {
+		log.Failuref("Error reading GitOps CLI config from file")
+
+		if shouldCreate {
+			// just replace invalid config with default config
+			log.Actionf("Replacing invalid config ...")
+		} else {
+			log.Warningf(WrongConfigFormatMsg)
+			return nil, err
+		}
+	}
+
+	return config, nil
+}
+
+// SaveConfig saves the CLI configuration for Weave GitOps to the config file
+func SaveConfig(log logger.Logger, config *GitopsCLIConfig) error {
+	log.Actionf("Saving GitOps CLI config ...")
+
+	configPath, err := getConfigPath(ConfigFileName)
+	if err != nil {
+		return err
+	}
+
+	data, err := json.MarshalIndent(&config, "", "  ")
+	if err != nil {
+		return fmt.Errorf("error encoding config: %w", err)
+	}
+
+	configFile, err := openConfigFile(configPath, true)
+	if err != nil {
+		return fmt.Errorf("error opening config file: %w", err)
+	}
+
+	defer configFile.Close()
+
+	err = configFile.Truncate(0)
+	if err != nil {
+		return fmt.Errorf("error truncating config file: %w", err)
+	}
+
+	_, err = configFile.Seek(0, 0)
+	if err != nil {
+		return fmt.Errorf("error setting offset in config file: %w", err)
+	}
+
+	_, err = configFile.Write(data)
+	if err != nil {
+		return fmt.Errorf("error writing to config file: %w", err)
+	}
+
+	return nil
+}
+
+// getConfigPath composes the path of the config file for the GitOps CLI
+func getConfigPath(filename string) (string, error) {
+	var err error
+
+	userConfigDir, err := os.UserConfigDir()
+	if err != nil {
+		return "", fmt.Errorf("user config directory could not be determined: %w", err)
+	}
+
+	configPath := filepath.Join(userConfigDir, filename)
+
+	return configPath, nil
+}
+
+// openConfigFile opens existing config file or creates one if it does not exist
+func openConfigFile(configPath string, shouldCreate bool) (*os.File, error) {
+	_, err := os.Stat(configPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) && shouldCreate {
+			// we'll just create a new file
+		} else {
+			return nil, err
+		}
+	}
+
+	var configFile *os.File
+
+	var (
+		flag int
+		perm fs.FileMode
+	)
+
+	if shouldCreate {
+		flag = os.O_RDWR | os.O_CREATE
+		perm = 0666
+	} else {
+		flag = os.O_RDONLY
+		perm = 0444
+	}
+
+	configFile, err = os.OpenFile(configPath, flag, perm)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open config file: %w", err)
+	}
+
+	return configFile, nil
+}
+
+// readData reads the data from the config file
+func readData(configFile *os.File) ([]byte, error) {
+	data, err := io.ReadAll(configFile)
+	if err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}
+
+// parseConfig unmarshals the CLI configuration for Weave GitOps from the JSON blob
+func parseConfig(data []byte, config *GitopsCLIConfig) error {
+	err := json.Unmarshal(data, &config)
+	if err != nil {
+		return fmt.Errorf("error parsing config JSON: %w", err)
+	}
+
+	return nil
+}
+
+// GenerateUserID generates a string of specified length made of random characters and encodes it in base64 format
+func GenerateUserID(numChars int, seed int64) string {
+	rand.Seed(seed)
+
+	b := make([]byte, numChars)
+	for i := range b {
+		b[i] = letters[rand.Intn(len(letters))]
+	}
+
+	return string(b)
+}

--- a/pkg/config/config_suite_test.go
+++ b/pkg/config/config_suite_test.go
@@ -1,0 +1,13 @@
+package config
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Config Suite")
+}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,30 @@
+package config
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("parseConfig", func() {
+	It("parses config from data", func() {
+		data := []byte(`{
+	"analytics": true,
+	"userId": "Hph7bg5SiK"
+}`)
+		config := &GitopsCLIConfig{}
+
+		err := parseConfig(data, config)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(config.Analytics).To(BeTrue())
+		Expect(config.UserID).To(Equal("Hph7bg5SiK"))
+	})
+})
+
+var _ = Describe("GenerateUserID", func() {
+	It("generates user ID", func() {
+		userID := GenerateUserID(10, 1024)
+
+		Expect(userID).To(Equal("2Q2MsgBDSV"))
+	})
+})


### PR DESCRIPTION
Part of #2772
Part of #2811

- Added the `gitops set`, `gitops set config`, and `gitops get config` GitOps CLI commands.

- Added the `pkg/config` package with functions to read and write the CLI configuration for Weave GitOps and generate a user ID for analytics.

- Added tests for selected (where it makes sense) functions from the `pkg/config` package.

- Tested that new commands work with WG Enterprise. Will raise a PR in the enterprise repo with the `add-gitops-set-config-and-get-config-commands` branch when I get the write access.

- Removed enterprise examples from the `gitops get` command.

Notes and questions:

- The existing options type at `github.com/weaveworks/weave-gitops/cmd/gitops/config` can be mixed up with the new `github.com/weaveworks/weave-gitops/pkg/config` package containing config utility functions.

Maybe the name of the `github.com/weaveworks/weave-gitops/pkg/config` package should be changed?

- Do we need to provide example user ID here?

```
{
    "analytics": true,
    "userId": ""
}
```
In acceptance criteria it's 12345, but we changed it to a base64 encrypted string.