### PR TITLE
Guard against undefined as argument for computeReady and computeMessage

### DIFF
--- a/ui/components/KubeStatusIndicator.tsx
+++ b/ui/components/KubeStatusIndicator.tsx
@@ -19,7 +19,7 @@ export enum ReadyType {
 }
 
 export function computeReady(conditions: Condition[]): ReadyType {
-  if (!conditions.length) return undefined;
+  if (!conditions || !conditions[0]) return undefined;
   const readyCondition =
     _.find(conditions, (c) => c.type === "Ready") ||
     _.find(conditions, (c) => c.type === "Available");
@@ -39,7 +39,7 @@ export function computeReady(conditions: Condition[]): ReadyType {
 }
 
 export function computeMessage(conditions: Condition[]) {
-  if (!conditions.length) return undefined;
+  if (!conditions || !conditions[0]) return undefined;
   const readyCondition =
     _.find(conditions, (c) => c.type === "Ready") ||
     _.find(conditions, (c) => c.type === "Available");


### PR DESCRIPTION
In fixing the incorrect display of status from computeMessage, I needed to guard against an empty array as an argument - thus testing a property of the array. I didn't switch to the graph tab though - in the graph nodes we are throwing in undefined as an argument since some Nodes can be SourceRefs and not FluxObjectNodes (in FluxObjectNodes, undefined conditions become empty arrays, while SourceRefs won't even have the conditions field). 

This made it through testing since we were not anticipating for undefined to be a possible argument for these functions. I added a simple guard against undefined and the graph is now rendering locally on all objects.
