### PR TITLE
Add LinkResolver for customized routing when running as "embedded"

### DIFF
--- a/ui/contexts/AppContext.tsx
+++ b/ui/contexts/AppContext.tsx
@@ -22,12 +22,6 @@ type AppSettings = {
   renderFooter: boolean;
 };
 
-export type LinkResolver = (incoming: string) => string;
-
-export function defaultLinkResolver(incoming: string): string {
-  return incoming;
-}
-
 export type AppContextType = {
   applicationsClient: typeof Applications;
   userConfigRepoName: string;
@@ -36,7 +30,6 @@ export type AppContextType = {
   setNodeYaml: (obj: FluxObject | FluxObjectNode) => void;
   appState: AppState;
   settings: AppSettings;
-  linkResolver: LinkResolver;
   getProviderToken: typeof getProviderToken;
   storeProviderToken: typeof storeProviderToken;
   getCallbackState: typeof getCallbackState;
@@ -56,7 +49,6 @@ export const AppContext = React.createContext<AppContextType>(
 
 export interface AppProps {
   applicationsClient?: typeof Applications;
-  linkResolver?: LinkResolver;
   children?: any;
   renderFooter?: boolean;
   notifySuccess?: typeof notifySuccess;
@@ -104,7 +96,6 @@ export default function AppContextProvider({
     clearAsyncError,
     setNodeYaml,
     appState,
-    linkResolver: props.linkResolver || defaultLinkResolver,
     getProviderToken,
     storeProviderToken,
     storeCallbackState,

--- a/ui/contexts/LinkResolverContext.tsx
+++ b/ui/contexts/LinkResolverContext.tsx
@@ -1,0 +1,27 @@
+import * as React from "react";
+import { formatURL } from "../lib/nav";
+
+export type LinkResolver = (str: string, params?: any) => string;
+
+interface Props {
+  resolver: LinkResolver;
+  children: any;
+}
+
+function defaultResolver(str: string, params?: any) {
+  return formatURL(str, params);
+}
+
+const LinkResolverContext = React.createContext<LinkResolver>(defaultResolver);
+
+export function LinkResolverProvider({ resolver, children }: Props) {
+  return (
+    <LinkResolverContext.Provider value={resolver}>
+      {children}
+    </LinkResolverContext.Provider>
+  );
+}
+
+export function useLinkResolver() {
+  return React.useContext(LinkResolverContext);
+}

--- a/ui/contexts/__tests__/LinkResolverContext.test.tsx
+++ b/ui/contexts/__tests__/LinkResolverContext.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from "@testing-library/react";
+import * as React from "react";
+import { LinkResolverProvider, useLinkResolver } from "../LinkResolverContext";
+
+describe("LinkResolverProvider", () => {
+  it("sets a link address via context", () => {
+    const MyComponent = () => {
+      const linkResolver = useLinkResolver();
+
+      return (
+        <a data-testid="link" href={linkResolver("")}>
+          My Link
+        </a>
+      );
+    };
+
+    render(
+      <LinkResolverProvider
+        resolver={() => {
+          return "/some/path";
+        }}
+      >
+        <MyComponent />
+      </LinkResolverProvider>
+    );
+
+    const link = screen.getByTestId("link");
+
+    expect(link.getAttribute("href")).toEqual("/some/path");
+  });
+});

--- a/ui/index.ts
+++ b/ui/index.ts
@@ -45,6 +45,7 @@ import CallbackStateContextProvider from "./contexts/CallbackStateContext";
 import CoreClientContextProvider, {
   UnAuthorizedInterceptor,
 } from "./contexts/CoreClientContext";
+import { LinkResolverProvider } from "./contexts/LinkResolverContext";
 import { useListAutomations } from "./hooks/automations";
 import { useFeatureFlags } from "./hooks/featureflags";
 import { useListFluxCrds, useListFluxRuntimeObjects } from "./hooks/flux";
@@ -74,6 +75,7 @@ import { V2Routes } from "./lib/types";
 import { isAllowedLink, statusSortHelper } from "./lib/utils";
 import OAuthCallback from "./pages/OAuthCallback";
 import SignIn from "./pages/SignIn";
+
 export {
   AppContextProvider,
   applicationsClient,
@@ -119,6 +121,7 @@ export {
   KubeStatusIndicator,
   KustomizationDetail,
   Link,
+  LinkResolverProvider,
   LoadingPage,
   MessageBox,
   Metadata,

--- a/ui/pages/OAuthCallback.tsx
+++ b/ui/pages/OAuthCallback.tsx
@@ -6,6 +6,7 @@ import Alert from "../components/Alert";
 import Flex from "../components/Flex";
 import Page from "../components/Page";
 import { AppContext } from "../contexts/AppContext";
+import { useLinkResolver } from "../contexts/LinkResolverContext";
 import { useRequestState } from "../hooks/common";
 import {
   AuthorizeGitlabResponse,
@@ -21,13 +22,10 @@ type Props = {
 
 function OAuthCallback({ className, code, provider }: Props) {
   const history = useHistory();
-  const {
-    applicationsClient,
-    storeProviderToken,
-    getCallbackState,
-    linkResolver,
-  } = React.useContext(AppContext);
+  const { applicationsClient, storeProviderToken, getCallbackState } =
+    React.useContext(AppContext);
   const [res, loading, error, req] = useRequestState<AuthorizeGitlabResponse>();
+  const linkResolver = useLinkResolver();
 
   React.useEffect(() => {
     if (provider === GitProvider.GitLab) {


### PR DESCRIPTION
Part of https://github.com/weaveworks/weave-gitops-enterprise/issues/1661

Allows us to override links in specific instances from "outside" the component tree:

```jsx
    const MyComponent = () => {
      const linkResolver = useLinkResolver();

      return (
        <a data-testid="link" href={linkResolver("")}>
          My Link
        </a>
      );
    };

//...

      <LinkResolverProvider
        resolver={() => {
          return "/some/path";
        }}
      >
        <MyComponent />
      </LinkResolverProvider>

// ^^ This will result in `a href="/some/path" />` allowing us to add custom routing in Enterprise
```