### PR TITLE
Rename places that call the password hash "secret"

### DIFF
--- a/cmd/gitops/beta/run/cmd.go
+++ b/cmd/gitops/beta/run/cmd.go
@@ -346,7 +346,7 @@ func runCommandWithoutSession(cmd *cobra.Command, args []string) error {
 				return err
 			}
 
-			secret, err := install.GenerateSecret(log, password)
+			passwordHash, err := install.GeneratePasswordHash(log, password)
 			if err != nil {
 				return err
 			}
@@ -357,7 +357,7 @@ func runCommandWithoutSession(cmd *cobra.Command, args []string) error {
 				return err
 			}
 
-			manifests, err := install.CreateDashboardObjects(log, dashboardName, flags.Namespace, adminUsername, secret, HelmChartVersion)
+			manifests, err := install.CreateDashboardObjects(log, dashboardName, flags.Namespace, adminUsername, passwordHash, HelmChartVersion)
 			if err != nil {
 				return fmt.Errorf("error creating dashboard objects: %w", err)
 			}

--- a/cmd/gitops/create/dashboard/cmd.go
+++ b/cmd/gitops/create/dashboard/cmd.go
@@ -131,10 +131,10 @@ func createDashboardCommandRunE(opts *config.Options) func(*cobra.Command, []str
 
 		log.Generatef("Generating GitOps Dashboard manifests ...")
 
-		var secret string
+		var passwordHash string
 
 		if flags.Password != "" {
-			secret, err = install.GenerateSecret(log, flags.Password)
+			passwordHash, err = install.GeneratePasswordHash(log, flags.Password)
 			if err != nil {
 				return err
 			}
@@ -148,7 +148,7 @@ func createDashboardCommandRunE(opts *config.Options) func(*cobra.Command, []str
 			adminUsername = defaultAdminUsername
 		}
 
-		manifests, err := install.CreateDashboardObjects(log, dashboardName, flags.Namespace, adminUsername, secret, "")
+		manifests, err := install.CreateDashboardObjects(log, dashboardName, flags.Namespace, adminUsername, passwordHash, "")
 		if err != nil {
 			return fmt.Errorf("error creating dashboard objects: %w", err)
 		}


### PR DESCRIPTION
A password hash is not a secret in the k8s sense, and it's a less descriptive name for a password hash than "passwordHash".

This was triggered by me seeing `GenerateSecret` and being surprised that we create k8s secrets directly.  Five times in a row.