### PR TITLE
Improve gitops run context handling

### DIFF
--- a/cmd/gitops/beta/run/cmd.go
+++ b/cmd/gitops/beta/run/cmd.go
@@ -3,7 +3,6 @@ package run
 import (
 	"context"
 	"fmt"
-	"github.com/weaveworks/weave-gitops/pkg/kube"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -11,6 +10,8 @@ import (
 	"sync/atomic"
 	"syscall"
 	"time"
+
+	"github.com/weaveworks/weave-gitops/pkg/kube"
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/manifoldco/promptui"
@@ -268,7 +269,7 @@ func runCommandWithoutSession(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("to run against a remote cluster, use --allow-k8s-context=%s", contextName)
 	}
 
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
 
 	log.Actionf("Checking if Flux is already installed ...")
 
@@ -285,17 +286,20 @@ func runCommandWithoutSession(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			execPath, err = installer.Install(ctx, product)
 			if err != nil {
+				cancel()
 				return err
 			}
 		}
 
 		wd, err := os.Getwd()
 		if err != nil {
+			cancel()
 			return err
 		}
 
 		flux, err := fluxexec.NewFlux(wd, execPath)
 		if err != nil {
+			cancel()
 			return err
 		}
 
@@ -320,6 +324,7 @@ func runCommandWithoutSession(cmd *cobra.Command, args []string) error {
 				fluxexec.Timeout(flags.Timeout),
 			),
 		); err != nil {
+			cancel()
 			return err
 		}
 	} else {
@@ -343,27 +348,32 @@ func runCommandWithoutSession(cmd *cobra.Command, args []string) error {
 		if err == nil && strings.ToUpper(result) == "Y" {
 			password, err := install.ReadPassword(log)
 			if err != nil {
+				cancel()
 				return err
 			}
 
 			passwordHash, err := install.GeneratePasswordHash(log, password)
 			if err != nil {
+				cancel()
 				return err
 			}
 
 			man, err := install.NewManager(log, ctx, kubeClient, kubeConfigArgs)
 			if err != nil {
 				log.Failuref("Error creating resource manager")
+				cancel()
 				return err
 			}
 
 			manifests, err := install.CreateDashboardObjects(log, dashboardName, flags.Namespace, adminUsername, passwordHash, HelmChartVersion)
 			if err != nil {
+				cancel()
 				return fmt.Errorf("error creating dashboard objects: %w", err)
 			}
 
 			err = install.InstallDashboard(log, ctx, man, manifests)
 			if err != nil {
+				cancel()
 				return fmt.Errorf("gitops dashboard installation failed: %w", err)
 			} else {
 				dashboardInstalled = true
@@ -376,32 +386,36 @@ func runCommandWithoutSession(cmd *cobra.Command, args []string) error {
 	if dashboardInstalled {
 		log.Actionf("Request reconciliation of dashboard (timeout %v) ...", flags.Timeout)
 
-		if err := install.ReconcileDashboard(kubeClient, dashboardName, flags.Namespace, dashboardPodName, flags.Timeout); err != nil {
+		if err := install.ReconcileDashboard(ctx, kubeClient, dashboardName, flags.Namespace, dashboardPodName, flags.Timeout); err != nil {
 			log.Failuref("Error requesting reconciliation of dashboard: %v", err.Error())
 		} else {
 			log.Successf("Dashboard reconciliation is done.")
 		}
 	}
 
-	cancelDevBucketPortForwarding, err := watch.InstallDevBucketServer(log, kubeClient, cfg)
+	cancelDevBucketPortForwarding, err := watch.InstallDevBucketServer(ctx, log, kubeClient, cfg)
 	if err != nil {
+		cancel()
 		return err
 	}
 
 	var cancelDashboardPortForwarding func() = nil
 
 	if dashboardInstalled {
-		cancelDashboardPortForwarding, err = watch.EnablePortForwardingForDashboard(log, kubeClient, cfg, flags.Namespace, dashboardPodName, flags.DashboardPort)
+		cancelDashboardPortForwarding, err = watch.EnablePortForwardingForDashboard(ctx, log, kubeClient, cfg, flags.Namespace, dashboardPodName, flags.DashboardPort)
 		if err != nil {
+			cancel()
 			return err
 		}
 	}
 
 	if err := watch.InitializeTargetDir(targetPath); err != nil {
+		cancel()
 		return fmt.Errorf("couldn't set up against target %s: %w", targetPath, err)
 	}
 
-	if err := watch.SetupBucketSourceAndKS(log, kubeClient, flags.Namespace, relativePath, flags.Timeout); err != nil {
+	if err := watch.SetupBucketSourceAndKS(ctx, log, kubeClient, flags.Namespace, relativePath, flags.Timeout); err != nil {
+		cancel()
 		return err
 	}
 
@@ -416,17 +430,20 @@ func runCommandWithoutSession(cmd *cobra.Command, args []string) error {
 		},
 	)
 	if err != nil {
+		cancel()
 		return err
 	}
 
 	// watch for file changes in dir gitRepoRoot
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
+		cancel()
 		return err
 	}
 
 	err = filepath.Walk(rootDir, watch.WatchDirsForFileWalker(watcher, ignorer))
 	if err != nil {
+		cancel()
 		return err
 	}
 
@@ -477,7 +494,7 @@ func runCommandWithoutSession(cmd *cobra.Command, args []string) error {
 					// reset counter
 					atomic.StoreUint64(&counter, 0)
 
-					if err := watch.SyncDir(log, rootDir, "dev-bucket", minioClient, ignorer); err != nil {
+					if err := watch.SyncDir(ctx, log, rootDir, "dev-bucket", minioClient, ignorer); err != nil {
 						log.Failuref("Error syncing dir: %v", err)
 					}
 
@@ -502,7 +519,7 @@ func runCommandWithoutSession(cmd *cobra.Command, args []string) error {
 
 					log.Actionf("Request reconciliation of dev-bucket, and dev-ks (timeout %v) ... ", flags.Timeout)
 
-					if err := watch.ReconcileDevBucketSourceAndKS(log, kubeClient, flags.Namespace, flags.Timeout); err != nil {
+					if err := watch.ReconcileDevBucketSourceAndKS(ctx, log, kubeClient, flags.Namespace, flags.Timeout); err != nil {
 						log.Failuref("Error requesting reconciliation: %v", err)
 					}
 
@@ -517,7 +534,7 @@ func runCommandWithoutSession(cmd *cobra.Command, args []string) error {
 						// get pod from specMap
 						namespacedName := types.NamespacedName{Namespace: specMap.Namespace, Name: specMap.Name}
 
-						pod, err := run.GetPodFromResourceDescription(namespacedName, specMap.Kind, kubeClient)
+						pod, err := run.GetPodFromResourceDescription(ctx, namespacedName, specMap.Kind, kubeClient)
 						if err != nil {
 							log.Failuref("Error getting pod from specMap: %v", err)
 						}
@@ -553,6 +570,10 @@ func runCommandWithoutSession(cmd *cobra.Command, args []string) error {
 	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM, syscall.SIGUSR1)
 	sig := <-sigs
 
+	cancel()
+	// create new context that isn't cancelled, for bootstrapping
+	ctx = context.Background()
+
 	if err := watcher.Close(); err != nil {
 		log.Warningf("Error closing watcher: %v", err.Error())
 	}
@@ -567,12 +588,12 @@ func runCommandWithoutSession(cmd *cobra.Command, args []string) error {
 
 	ticker.Stop()
 
-	if err := watch.CleanupBucketSourceAndKS(log, kubeClient, flags.Namespace); err != nil {
+	if err := watch.CleanupBucketSourceAndKS(ctx, log, kubeClient, flags.Namespace); err != nil {
 		return err
 	}
 
 	// uninstall dev-bucket server
-	if err := watch.UninstallDevBucketServer(log, kubeClient); err != nil {
+	if err := watch.UninstallDevBucketServer(ctx, log, kubeClient); err != nil {
 		return err
 	}
 

--- a/cmd/gitops/create/dashboard/cmd.go
+++ b/cmd/gitops/create/dashboard/cmd.go
@@ -231,7 +231,7 @@ func createDashboardCommandRunE(opts *config.Options) func(*cobra.Command, []str
 
 		dashboardPodName := dashboardName + "-" + helmChartName
 
-		if err := install.ReconcileDashboard(kubeClient, dashboardName, flags.Namespace, dashboardPodName, flags.Timeout); err != nil {
+		if err := install.ReconcileDashboard(ctx, kubeClient, dashboardName, flags.Namespace, dashboardPodName, flags.Timeout); err != nil {
 			log.Failuref("Error requesting reconciliation of dashboard: %v", err.Error())
 		} else {
 			log.Successf("GitOps Dashboard %s is ready", dashboardName)

--- a/pkg/run/install/install_dashboard.go
+++ b/pkg/run/install/install_dashboard.go
@@ -111,7 +111,7 @@ func getDashboardHelmChart(log logger.Logger, ctx context.Context, kubeClient cl
 }
 
 // ReconcileDashboard reconciles the dashboard.
-func ReconcileDashboard(kubeClient client.Client, name string, namespace string, podName string, timeout time.Duration) error {
+func ReconcileDashboard(ctx context.Context, kubeClient client.Client, name string, namespace string, podName string, timeout time.Duration) error {
 	const interval = 3 * time.Second / 2
 
 	helmChartName := namespace + "-" + name
@@ -131,7 +131,7 @@ func ReconcileDashboard(kubeClient client.Client, name string, namespace string,
 
 	if err := wait.Poll(interval, timeout, func() (bool, error) {
 		var err error
-		sourceRequestedAt, err = run.RequestReconciliation(context.Background(), kubeClient,
+		sourceRequestedAt, err = run.RequestReconciliation(ctx, kubeClient,
 			namespacedName, gvk)
 
 		return err == nil, nil
@@ -142,7 +142,7 @@ func ReconcileDashboard(kubeClient client.Client, name string, namespace string,
 	// wait for the reconciliation of dashboard to be done
 	if err := wait.Poll(interval, timeout, func() (bool, error) {
 		dashboard := &sourcev1.HelmChart{}
-		if err := kubeClient.Get(context.Background(), types.NamespacedName{
+		if err := kubeClient.Get(ctx, types.NamespacedName{
 			Namespace: namespace,
 			Name:      helmChartName,
 		}, dashboard); err != nil {
@@ -158,7 +158,7 @@ func ReconcileDashboard(kubeClient client.Client, name string, namespace string,
 	if err := wait.Poll(interval, timeout, func() (bool, error) {
 		namespacedName := types.NamespacedName{Namespace: namespace, Name: podName}
 
-		dashboard, _ := run.GetPodFromResourceDescription(namespacedName, "deployment", kubeClient)
+		dashboard, _ := run.GetPodFromResourceDescription(ctx, namespacedName, "deployment", kubeClient)
 		if dashboard == nil {
 			return false, nil
 		}

--- a/pkg/run/utils.go
+++ b/pkg/run/utils.go
@@ -68,24 +68,24 @@ func IsLocalCluster(kubeClient *kube.KubeHTTP) bool {
 	}
 }
 
-func GetPodFromResourceDescription(namespacedName types.NamespacedName, kind string, kubeClient client.Client) (*corev1.Pod, error) {
+func GetPodFromResourceDescription(ctx context.Context, namespacedName types.NamespacedName, kind string, kubeClient client.Client) (*corev1.Pod, error) {
 	switch kind {
 	case "pod":
 		pod := &corev1.Pod{}
-		if err := kubeClient.Get(context.Background(), namespacedName, pod); err != nil {
+		if err := kubeClient.Get(ctx, namespacedName, pod); err != nil {
 			return nil, err
 		}
 
 		return pod, nil
 	case "service":
 		svc := &corev1.Service{}
-		if err := kubeClient.Get(context.Background(), namespacedName, svc); err != nil {
+		if err := kubeClient.Get(ctx, namespacedName, svc); err != nil {
 			return nil, fmt.Errorf("error getting service: %s, namespaced Name: %v", err, namespacedName)
 		}
 
 		// list pods of the service "svc" by selector in a specific namespace using the controller-runtime client
 		podList := &corev1.PodList{}
-		if err := kubeClient.List(context.Background(), podList,
+		if err := kubeClient.List(ctx, podList,
 			client.MatchingLabelsSelector{
 				Selector: labels.Set(svc.Spec.Selector).AsSelector(),
 			},
@@ -107,13 +107,13 @@ func GetPodFromResourceDescription(namespacedName types.NamespacedName, kind str
 		return nil, ErrNoRunningPodsForService
 	case "deployment":
 		deployment := &appsv1.Deployment{}
-		if err := kubeClient.Get(context.Background(), namespacedName, deployment); err != nil {
+		if err := kubeClient.Get(ctx, namespacedName, deployment); err != nil {
 			return nil, fmt.Errorf("error getting deployment: %s, namespaced Name: %v", err, namespacedName)
 		}
 
 		// list pods of the deployment "deployment" by selector in a specific namespace using the controller-runtime client
 		podList := &corev1.PodList{}
-		if err := kubeClient.List(context.Background(), podList,
+		if err := kubeClient.List(ctx, podList,
 			client.MatchingLabelsSelector{
 				Selector: labels.Set(deployment.Spec.Selector.MatchLabels).AsSelector(),
 			},

--- a/pkg/run/utils_test.go
+++ b/pkg/run/utils_test.go
@@ -224,7 +224,7 @@ var _ = Describe("GetPodFromResourceDescription", func() {
 	It("should return an error if the pod spec is not correct", func() {
 		namespacedName := types.NamespacedName{Namespace: "", Name: ""}
 
-		_, err := GetPodFromResourceDescription(namespacedName, "something", &mockClientForGetPodFromResourceDescription{})
+		_, err := GetPodFromResourceDescription(context.Background(), namespacedName, "something", &mockClientForGetPodFromResourceDescription{})
 
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("unsupported spec kind"))
@@ -233,7 +233,7 @@ var _ = Describe("GetPodFromResourceDescription", func() {
 	It("should return an error if the client returns an error", func() {
 		namespacedName := types.NamespacedName{Namespace: "ns", Name: "name"}
 
-		_, err := GetPodFromResourceDescription(namespacedName, "pod", &mockClientForGetPodFromResourceDescription{state: stateGetReturnErr})
+		_, err := GetPodFromResourceDescription(context.Background(), namespacedName, "pod", &mockClientForGetPodFromResourceDescription{state: stateGetReturnErr})
 
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("fake error"))
@@ -242,7 +242,7 @@ var _ = Describe("GetPodFromResourceDescription", func() {
 	It("returns a pod according to the pod spec", func() {
 		namespacedName := types.NamespacedName{Namespace: "ns", Name: "name"}
 
-		pod, err := GetPodFromResourceDescription(namespacedName, "pod", &mockClientForGetPodFromResourceDescription{})
+		pod, err := GetPodFromResourceDescription(context.Background(), namespacedName, "pod", &mockClientForGetPodFromResourceDescription{})
 
 		Expect(err).To(BeNil())
 		Expect(pod.Name).To(Equal("name"))
@@ -254,7 +254,7 @@ var _ = Describe("GetPodFromResourceDescription", func() {
 	It("should return an error if the client returns an error", func() {
 		namespacedName := types.NamespacedName{Namespace: "ns", Name: "name"}
 
-		_, err := GetPodFromResourceDescription(namespacedName, "service", &mockClientForGetPodFromResourceDescription{state: stateGetReturnErr})
+		_, err := GetPodFromResourceDescription(context.Background(), namespacedName, "service", &mockClientForGetPodFromResourceDescription{state: stateGetReturnErr})
 
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(Equal("error getting service: fake error, namespaced Name: ns/name"))
@@ -263,7 +263,7 @@ var _ = Describe("GetPodFromResourceDescription", func() {
 	It("should return an error if the client returns an error", func() {
 		namespacedName := types.NamespacedName{Namespace: "ns", Name: "name"}
 
-		_, err := GetPodFromResourceDescription(namespacedName, "service", &mockClientForGetPodFromResourceDescription{state: stateListReturnErr})
+		_, err := GetPodFromResourceDescription(context.Background(), namespacedName, "service", &mockClientForGetPodFromResourceDescription{state: stateListReturnErr})
 
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("fake error"))
@@ -272,7 +272,7 @@ var _ = Describe("GetPodFromResourceDescription", func() {
 	It("returns a pod according to the service spec", func() {
 		namespacedName := types.NamespacedName{Namespace: "ns", Name: "name"}
 
-		pod, err := GetPodFromResourceDescription(namespacedName, "service", &mockClientForGetPodFromResourceDescription{state: stateListHasPod})
+		pod, err := GetPodFromResourceDescription(context.Background(), namespacedName, "service", &mockClientForGetPodFromResourceDescription{state: stateListHasPod})
 
 		Expect(err).To(BeNil())
 		Expect(pod.Name).To(Equal("pod-1"))
@@ -282,7 +282,7 @@ var _ = Describe("GetPodFromResourceDescription", func() {
 	It("returns a pod according to the service spec", func() {
 		namespacedName := types.NamespacedName{Namespace: "ns", Name: "name"}
 
-		pod, err := GetPodFromResourceDescription(namespacedName, "service", &mockClientForGetPodFromResourceDescription{state: stateListZeroPod})
+		pod, err := GetPodFromResourceDescription(context.Background(), namespacedName, "service", &mockClientForGetPodFromResourceDescription{state: stateListZeroPod})
 
 		Expect(err).To(HaveOccurred())
 		Expect(pod).To(BeNil())
@@ -292,7 +292,7 @@ var _ = Describe("GetPodFromResourceDescription", func() {
 	It("returns a pod according to the service spec", func() {
 		namespacedName := types.NamespacedName{Namespace: "ns", Name: "name"}
 
-		pod, err := GetPodFromResourceDescription(namespacedName, "service", &mockClientForGetPodFromResourceDescription{state: stateListNoRunningPod})
+		pod, err := GetPodFromResourceDescription(context.Background(), namespacedName, "service", &mockClientForGetPodFromResourceDescription{state: stateListNoRunningPod})
 
 		Expect(err).To(HaveOccurred())
 		Expect(pod).To(BeNil())
@@ -304,7 +304,7 @@ var _ = Describe("GetPodFromResourceDescription", func() {
 	It("should return an error if the client returns an error", func() {
 		namespacedName := types.NamespacedName{Namespace: "ns", Name: "name"}
 
-		_, err := GetPodFromResourceDescription(namespacedName, "deployment", &mockClientForGetPodFromResourceDescription{state: stateGetReturnErr})
+		_, err := GetPodFromResourceDescription(context.Background(), namespacedName, "deployment", &mockClientForGetPodFromResourceDescription{state: stateGetReturnErr})
 
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(Equal("error getting deployment: fake error, namespaced Name: ns/name"))
@@ -313,7 +313,7 @@ var _ = Describe("GetPodFromResourceDescription", func() {
 	It("should return an error if the client returns an error", func() {
 		namespacedName := types.NamespacedName{Namespace: "ns", Name: "name"}
 
-		_, err := GetPodFromResourceDescription(namespacedName, "deployment", &mockClientForGetPodFromResourceDescription{state: stateListReturnErr})
+		_, err := GetPodFromResourceDescription(context.Background(), namespacedName, "deployment", &mockClientForGetPodFromResourceDescription{state: stateListReturnErr})
 
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("fake error"))
@@ -322,7 +322,7 @@ var _ = Describe("GetPodFromResourceDescription", func() {
 	It("returns a pod according to the deployment spec", func() {
 		namespacedName := types.NamespacedName{Namespace: "ns", Name: "name"}
 
-		pod, err := GetPodFromResourceDescription(namespacedName, "deployment", &mockClientForGetPodFromResourceDescription{state: stateListHasPod})
+		pod, err := GetPodFromResourceDescription(context.Background(), namespacedName, "deployment", &mockClientForGetPodFromResourceDescription{state: stateListHasPod})
 
 		Expect(err).To(BeNil())
 		Expect(pod.Name).To(Equal("pod-1"))
@@ -332,7 +332,7 @@ var _ = Describe("GetPodFromResourceDescription", func() {
 	It("returns a pod according to the deployment spec", func() {
 		namespacedName := types.NamespacedName{Namespace: "ns", Name: "name"}
 
-		pod, err := GetPodFromResourceDescription(namespacedName, "deployment", &mockClientForGetPodFromResourceDescription{state: stateListZeroPod})
+		pod, err := GetPodFromResourceDescription(context.Background(), namespacedName, "deployment", &mockClientForGetPodFromResourceDescription{state: stateListZeroPod})
 
 		Expect(err).To(HaveOccurred())
 		Expect(pod).To(BeNil())
@@ -341,7 +341,7 @@ var _ = Describe("GetPodFromResourceDescription", func() {
 
 	It("returns a pod according to the deployment spec", func() {
 		namespacedName := types.NamespacedName{Namespace: "ns", Name: "name"}
-		pod, err := GetPodFromResourceDescription(namespacedName, "deployment", &mockClientForGetPodFromResourceDescription{state: stateListNoRunningPod})
+		pod, err := GetPodFromResourceDescription(context.Background(), namespacedName, "deployment", &mockClientForGetPodFromResourceDescription{state: stateListNoRunningPod})
 
 		Expect(err).To(HaveOccurred())
 		Expect(pod).To(BeNil())

--- a/pkg/run/watch/dashboard.go
+++ b/pkg/run/watch/dashboard.go
@@ -1,6 +1,8 @@
 package watch
 
 import (
+	"context"
+
 	"github.com/weaveworks/weave-gitops/pkg/logger"
 	"github.com/weaveworks/weave-gitops/pkg/run"
 	"github.com/weaveworks/weave-gitops/pkg/server"
@@ -10,7 +12,7 @@ import (
 )
 
 // EnablePortForwardingForDashboard enables port forwarding for the GitOps Dashboard.
-func EnablePortForwardingForDashboard(log logger.Logger, kubeClient client.Client, config *rest.Config, namespace string, podName string, dashboardPort string) (func(), error) {
+func EnablePortForwardingForDashboard(ctx context.Context, log logger.Logger, kubeClient client.Client, config *rest.Config, namespace string, podName string, dashboardPort string) (func(), error) {
 	specMap := &PortForwardSpec{
 		Namespace:     namespace,
 		Name:          podName,
@@ -21,7 +23,7 @@ func EnablePortForwardingForDashboard(log logger.Logger, kubeClient client.Clien
 	// get pod from specMap
 	namespacedName := types.NamespacedName{Namespace: specMap.Namespace, Name: specMap.Name}
 
-	pod, err := run.GetPodFromResourceDescription(namespacedName, specMap.Kind, kubeClient)
+	pod, err := run.GetPodFromResourceDescription(ctx, namespacedName, specMap.Kind, kubeClient)
 	if err != nil {
 		log.Failuref("Error getting pod from specMap: %v", err)
 	}

--- a/pkg/run/watch/install_bucket_source_and_ks_test.go
+++ b/pkg/run/watch/install_bucket_source_and_ks_test.go
@@ -122,7 +122,7 @@ var _ = Describe("findConditionMessages", func() {
 				},
 			},
 		}
-		messages, err := findConditionMessages(client, ks)
+		messages, err := findConditionMessages(context.Background(), client, ks)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(messages).To(Equal([]string{
 			"Deployment default/deployment: This is message",


### PR DESCRIPTION
This contains 2 changes:

 * It makes all of pkg/run take a context, rather than make up its own.
 
 This allows us to do proper context handling. This PR doesn't do very good context handling, but it does sufficient context handling so that file uploads stop when hitting ctrl+c.

In other words, once you hit ctrl+c, the watcher's context will immediately abort, and thus no more transfers will happen. We might still print a warning or two about the closed context which can be improved with follow-up patches, but this means I no longer need to wait a long time for the watcher to finish before I can use the bootstrap UI.

 * It moves the signal handler as early as possible. If I hit ctrl+c before everything is booted up we would before just exit, which when I'm impatient would leave me with a left-behind bucket. Now we will always run through the cleanup routines.