### PR TITLE
gitops run: Add silly little struct for paths

### DIFF
--- a/pkg/run/install/install.go
+++ b/pkg/run/install/install.go
@@ -1,42 +1,8 @@
 package install
 
 import (
-	"errors"
-	"os"
-	"path/filepath"
-
 	corev1 "k8s.io/api/core/v1"
 )
-
-// FindGitRepoDir finds git repo root directory
-func FindGitRepoDir() (string, error) {
-	gitDir := "."
-
-	for {
-		if _, err := os.Stat(filepath.Join(gitDir, ".git")); err == nil {
-			break
-		}
-
-		gitDir = filepath.Join(gitDir, "..")
-
-		if gitDir == "/" {
-			return "", errors.New("not in a git repo")
-		}
-	}
-
-	return filepath.Abs(gitDir)
-}
-
-// GetRelativePathToRootDir gets relative path to a directory from the git root. It returns an error if there's no git repo.
-func GetRelativePathToRootDir(rootDir string, path string) (string, error) {
-	absGitDir, err := filepath.Abs(rootDir)
-
-	if err != nil { // not in a git repo
-		return "", err
-	}
-
-	return filepath.Rel(absGitDir, path)
-}
 
 // isPodStatusConditionPresentAndEqual returns true when conditionType is present and equal to status.
 func isPodStatusConditionPresentAndEqual(conditions []corev1.PodCondition, conditionType corev1.PodConditionType, status corev1.ConditionStatus) bool {

--- a/pkg/run/paths.go
+++ b/pkg/run/paths.go
@@ -1,0 +1,98 @@
+package run
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+type Paths struct {
+	RootDir    string // Absolute path to the git repository
+	CurrentDir string // Path to the current working directory, relative to rootDir
+	ClusterDir string // Path to the cluster dir, relative to rootDir - currentDir / "clusters" / "my-cluster"
+	TargetDir  string // Path to the target workload dir, relative to rootDir. Must not contain clusterDir, may or may not be inside currentDir
+}
+
+func (p *Paths) GetAbsoluteTargetDir() string {
+	// this should have been sufficiently validated as to be un-failable
+	targetDir, _ := filepath.Abs(filepath.Join(p.RootDir, p.TargetDir))
+	return targetDir
+}
+
+func findGitRepoDir() (string, error) {
+	gitDir := "."
+
+	for {
+		if _, err := os.Stat(filepath.Join(gitDir, ".git")); err == nil {
+			break
+		}
+
+		gitDir = filepath.Join(gitDir, "..")
+
+		if gitDir == "/" {
+			return "", errors.New("not in a git repo")
+		}
+	}
+
+	return filepath.Abs(gitDir)
+}
+
+func getRelativePathToRootDir(rootDir string, path string) (string, error) {
+	absGitDir, err := filepath.Abs(rootDir)
+
+	if err != nil { // not in a git repo
+		return "", err
+	}
+
+	return filepath.Rel(absGitDir, path)
+}
+
+func NewPaths(specifiedTargetDir string, specifiedRootDir string) (*Paths, error) {
+	paths := Paths{}
+
+	gitRepoRoot, err := findGitRepoDir()
+	if err != nil {
+		return nil, err
+	}
+
+	rootDir := specifiedRootDir
+	if rootDir == "" {
+		rootDir = gitRepoRoot
+	}
+
+	// check if rootDir is valid
+	if _, err := os.Stat(rootDir); err != nil {
+		return nil, fmt.Errorf("root directory %s does not exist", paths.RootDir)
+	}
+
+	// find absolute path of the root Dir
+	paths.RootDir, err = filepath.Abs(rootDir)
+	if err != nil {
+		return nil, err
+	}
+
+	currentDir, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+
+	paths.CurrentDir, err = getRelativePathToRootDir(rootDir, currentDir)
+	if err != nil {
+		return nil, err
+	}
+
+	targetPath, err := filepath.Abs(filepath.Join(currentDir, specifiedTargetDir))
+	if err != nil {
+		return nil, err
+	}
+
+	paths.TargetDir, err = getRelativePathToRootDir(rootDir, targetPath)
+	if err != nil {
+		return nil, err
+	}
+
+	paths.ClusterDir = filepath.Join(paths.CurrentDir, "clusters", "my-cluster")
+
+	return &paths, nil
+}


### PR DESCRIPTION
I'm not sure how much of a good idea this actually is - it's definitely under-developed. However, I had a small breakdown while trying to get paths right and had to try something to sort some paths out.

Basically, we expect the git repo to be "somewhere". Inside that git repository, there's a manifests directory, which is the same as the current working directory. Inside that directory, there's a clusters directory. Somewhere, probably but not necessarily inside the manifests directory but definitely inside the git directory, there's a workload directory. All of these paths can be refered to as relative paths, absolute paths, and some of them (in flux) should be prefixed with `./`.

This bans all somethingPath variables, and puts a paths variable instead. That variable is a struct that has documented members so we can remember which path is which. There's no variable called `relativePath`.

Inside this struct, we should check those invariants described above, but for the moment I mainly just copy-pasted the code we already had.
