### PR TITLE
gitops run bootstrapping

### DIFF
--- a/pkg/run/bootstrap/bootstrap.go
+++ b/pkg/run/bootstrap/bootstrap.go
@@ -1,0 +1,215 @@
+package bootstrap
+
+import (
+	"context"
+
+	"github.com/fluxcd/go-git-providers/github"
+	"github.com/fluxcd/go-git-providers/gitlab"
+	"github.com/fluxcd/go-git-providers/gitprovider"
+	"github.com/fluxcd/go-git-providers/stash"
+	"github.com/weaveworks/weave-gitops/pkg/fluxexec"
+	"github.com/weaveworks/weave-gitops/pkg/logger"
+)
+
+type Bootstrap interface {
+	RunBootstrapCmd(context.Context, *fluxexec.Flux) error
+	SyncResources(context.Context, logger.Logger, []gitprovider.CommitFile) error
+}
+
+type BootstrapCommon struct {
+	provider    GitProvider
+	clusterPath string
+	branch      string
+}
+
+// TODO: this needs to be implemented using plain go-git
+type BootstrapRaw struct {
+	BootstrapCommon
+	url            string
+	password       string
+	privateKeyFile string
+}
+
+type BootstrapForge struct {
+	BootstrapCommon
+	isPersonal bool
+	isPrivate  bool
+	host       string
+	owner      string
+	repository string
+	user       string
+	pat        string
+}
+
+func NewBootstrap(clusterPath string, options BootstrapCmdOptions, provider GitProvider) Bootstrap {
+	if provider == GitProviderGitHub || provider == GitProviderGitLab || provider == GitProviderBitbucketServer {
+		return &BootstrapForge{
+			BootstrapCommon: BootstrapCommon{
+				provider:    provider,
+				clusterPath: clusterPath,
+				branch:      options[BranchOptionKey],
+			},
+			isPersonal: options[PersonalOptionKey] == "true",
+			isPrivate:  options[PrivateOptionKey] == "true",
+			host:       options[HostnameOptionKey],
+			owner:      options[OwnerOptionKey],
+			repository: options[RepositoryOptionKey],
+			user:       options[UsernameOptionKey],
+			pat:        options[PATOptionKey],
+		}
+	} else if provider == GitProviderGit {
+		return &BootstrapRaw{
+			BootstrapCommon: BootstrapCommon{
+				provider:    provider,
+				clusterPath: clusterPath,
+				branch:      options[BranchOptionKey],
+			},
+			url:            options[URLOptionKey],
+			password:       options[PasswordOptionKey],
+			privateKeyFile: options[PrivateKeyFileOptionKey],
+		}
+	} else {
+		// TODO put additional manifests on disk
+		return nil
+	}
+}
+
+func (b *BootstrapForge) RunBootstrapCmd(ctx context.Context, flux *fluxexec.Flux) error {
+	globalOptions := fluxexec.WithBootstrapOptions(
+		fluxexec.Branch(b.branch),
+	)
+
+	switch b.provider {
+	case GitProviderGitHub:
+		flux.SetEnvVar("GITHUB_TOKEN", b.pat)
+
+		return flux.BootstrapGitHub(ctx,
+			fluxexec.Hostname(b.host),
+			fluxexec.Owner(b.owner),
+			fluxexec.Repository(b.repository),
+			fluxexec.Path(b.clusterPath),
+			fluxexec.Personal(b.isPersonal),
+			fluxexec.Private(b.isPrivate),
+			fluxexec.WithBootstrapOptions(fluxexec.Branch(b.branch)),
+			globalOptions,
+		)
+	case GitProviderGitLab:
+		flux.SetEnvVar("GITLAB_TOKEN", b.pat)
+
+		return flux.BootstrapGitlab(ctx,
+			fluxexec.Hostname(b.host),
+			fluxexec.Owner(b.owner),
+			fluxexec.Repository(b.repository),
+			fluxexec.Path(b.clusterPath),
+			fluxexec.Personal(b.isPersonal),
+			fluxexec.Private(b.isPrivate),
+			fluxexec.WithBootstrapOptions(fluxexec.Branch(b.branch)),
+			globalOptions,
+		)
+	case GitProviderBitbucketServer:
+		flux.SetEnvVar("BITBUCKET_TOKEN", b.pat)
+
+		return flux.BootstrapBitbucketServer(ctx,
+			fluxexec.Hostname(b.host),
+			fluxexec.Owner(b.owner),
+			fluxexec.Repository(b.repository),
+			fluxexec.Path(b.clusterPath),
+			fluxexec.Personal(b.isPersonal),
+			fluxexec.Private(b.isPrivate),
+			fluxexec.WithBootstrapOptions(fluxexec.Branch(b.branch)),
+			globalOptions,
+		)
+	}
+	// unreachable
+	return nil
+}
+
+func (b *BootstrapForge) SyncResources(ctx context.Context, log logger.Logger, commitFiles []gitprovider.CommitFile) error {
+	var (
+		commits gitprovider.CommitClient
+		client  gitprovider.Client
+		err     error
+	)
+
+	switch b.provider {
+	case GitProviderGitHub:
+		client, err = github.NewClient(
+			gitprovider.WithDomain(b.host),
+			gitprovider.WithOAuth2Token(b.pat),
+		)
+	case GitProviderGitLab:
+		client, err = gitlab.NewClient(b.pat, "",
+			gitprovider.WithDomain(b.host),
+			gitprovider.WithConditionalRequests(true),
+		)
+	case GitProviderBitbucketServer:
+		client, err = stash.NewStashClient(b.user, b.pat, gitprovider.WithDomain(b.host))
+	}
+
+	if err != nil || client == nil {
+		return err
+	}
+
+	var repoURL string
+
+	if b.isPersonal {
+		ref := gitprovider.UserRepositoryRef{
+			UserRef: gitprovider.UserRef{
+				Domain:    b.host,
+				UserLogin: b.owner,
+			},
+			RepositoryName: b.repository,
+		}
+
+		repo, err := client.UserRepositories().Get(ctx, ref)
+		if err != nil {
+			return err
+		}
+
+		commits = repo.Commits()
+		repoURL = ref.String()
+	} else {
+		ref := gitprovider.OrgRepositoryRef{
+			OrganizationRef: gitprovider.OrganizationRef{
+				Domain:       b.host,
+				Organization: b.owner,
+				// TODO: support suborganizations
+			},
+			RepositoryName: b.repository,
+		}
+		repo, err := client.OrgRepositories().Get(ctx, ref)
+		if err != nil {
+			return err
+		}
+		commits = repo.Commits()
+		repoURL = ref.String()
+	}
+
+	_, err = commits.Create(ctx, b.branch, "[gitops run] Additional manifests", commitFiles)
+	if err != nil {
+		return err
+	}
+
+	log.Successf("Your automations have been synced to %v", repoURL)
+
+	return nil
+}
+
+func (b *BootstrapRaw) RunBootstrapCmd(ctx context.Context, flux *fluxexec.Flux) error {
+	globalOptions := fluxexec.WithBootstrapOptions(
+		fluxexec.Branch(b.branch),
+		fluxexec.PrivateKeyFile(b.privateKeyFile),
+	)
+
+	return flux.BootstrapGit(ctx,
+		fluxexec.URL(b.url),
+		fluxexec.Password(b.password),
+		fluxexec.Path(b.clusterPath),
+		globalOptions,
+	)
+}
+
+func (b *BootstrapRaw) SyncResources(ctx context.Context, log logger.Logger, commitFiles []gitprovider.CommitFile) error {
+	// TODO this isn't implemented
+	return nil
+}

--- a/pkg/run/bootstrap/bootstrap_wizard.go
+++ b/pkg/run/bootstrap/bootstrap_wizard.go
@@ -319,7 +319,7 @@ var allGitProviderNames = []string{
 	gitProviderGitHubName,
 	gitProviderGitLabName,
 	gitProviderGitName,
-	gitProviderBitbucketServerName,
+	//gitProviderBitbucketServerName,
 }
 
 var allGitProviders = map[string]GitProvider{

--- a/pkg/run/install/install_dashboard.go
+++ b/pkg/run/install/install_dashboard.go
@@ -185,13 +185,13 @@ func generateManifestsForDashboard(log logger.Logger, helmRepository *sourcev1.H
 		return nil, err
 	}
 
-	sanitizedHelmRepositoryData, err := sanitizeResourceData(log, helmRepositoryData)
+	sanitizedHelmRepositoryData, err := SanitizeResourceData(log, helmRepositoryData)
 	if err != nil {
 		log.Failuref("Error sanitizing HelmRepository data")
 		return nil, err
 	}
 
-	sanitizedHelmReleaseData, err := sanitizeResourceData(log, helmReleaseData)
+	sanitizedHelmReleaseData, err := SanitizeResourceData(log, helmReleaseData)
 	if err != nil {
 		log.Failuref("Error sanitizing HelmRelease data")
 		return nil, err
@@ -300,7 +300,7 @@ func makeValues(username string, passwordHash string) ([]byte, error) {
 	return jsonRaw, nil
 }
 
-func sanitizeResourceData(log logger.Logger, resourceData []byte) ([]byte, error) {
+func SanitizeResourceData(log logger.Logger, resourceData []byte) ([]byte, error) {
 	// remove status
 	resNode, err := kyaml.Parse(string(resourceData))
 	if err != nil {

--- a/pkg/run/install/install_dashboard_test.go
+++ b/pkg/run/install/install_dashboard_test.go
@@ -239,7 +239,7 @@ var _ = Describe("makeValues", func() {
 	})
 })
 
-var _ = Describe("sanitizeResourceData", func() {
+var _ = Describe("SanitizeResourceData", func() {
 	var fakeLogger *loggerfakes.FakeLogger
 
 	BeforeEach(func() {
@@ -256,7 +256,7 @@ var _ = Describe("sanitizeResourceData", func() {
 		Expect(strings.Contains(resStr, "status")).To(BeTrue())
 		Expect(strings.Contains(resStr, "creationTimestamp")).To(BeTrue())
 
-		sanitizedResData, err := sanitizeResourceData(fakeLogger, resData)
+		sanitizedResData, err := SanitizeResourceData(fakeLogger, resData)
 		Expect(err).NotTo(HaveOccurred())
 
 		sanitizedResStr := string(sanitizedResData)
@@ -276,7 +276,7 @@ var _ = Describe("sanitizeResourceData", func() {
 		Expect(strings.Contains(resStr, "status")).To(BeTrue())
 		Expect(strings.Contains(resStr, "creationTimestamp")).To(BeTrue())
 
-		sanitizedResData, err := sanitizeResourceData(fakeLogger, resData)
+		sanitizedResData, err := SanitizeResourceData(fakeLogger, resData)
 		Expect(err).NotTo(HaveOccurred())
 
 		sanitizedResStr := string(sanitizedResData)

--- a/pkg/run/install/session.go
+++ b/pkg/run/install/session.go
@@ -1,10 +1,11 @@
 package install
 
 import (
-	"github.com/weaveworks/weave-gitops/pkg/logger"
 	"os"
 	"os/signal"
 	"syscall"
+
+	"github.com/weaveworks/weave-gitops/pkg/logger"
 
 	vcluster "github.com/loft-sh/vcluster/cmd/vclusterctl/cmd"
 	"github.com/loft-sh/vcluster/cmd/vclusterctl/flags"
@@ -32,6 +33,8 @@ func (s *Session) Connect() error {
 	subProcArgs := append(os.Args,
 		// we must run the sub-process without a session.
 		"--no-session",
+		// vclusters are always new clusters, that doesn't mean we haven't bootstrapped the outer cluster.
+		"--no-bootstrap",
 		// allow the sub-process to connect to the vcluster context.
 		"--allow-k8s-context="+s.name,
 		// we must skip resource cleanup in the sub-process because we are already deleting the vcluster.

--- a/pkg/run/paths.go
+++ b/pkg/run/paths.go
@@ -38,7 +38,7 @@ func findGitRepoDir() (string, error) {
 	return filepath.Abs(gitDir)
 }
 
-func getRelativePathToRootDir(rootDir string, path string) (string, error) {
+func GetRelativePathToRootDir(rootDir string, path string) (string, error) {
 	absGitDir, err := filepath.Abs(rootDir)
 
 	if err != nil { // not in a git repo
@@ -77,7 +77,7 @@ func NewPaths(specifiedTargetDir string, specifiedRootDir string) (*Paths, error
 		return nil, err
 	}
 
-	paths.CurrentDir, err = getRelativePathToRootDir(rootDir, currentDir)
+	paths.CurrentDir, err = GetRelativePathToRootDir(rootDir, currentDir)
 	if err != nil {
 		return nil, err
 	}
@@ -87,7 +87,7 @@ func NewPaths(specifiedTargetDir string, specifiedRootDir string) (*Paths, error
 		return nil, err
 	}
 
-	paths.TargetDir, err = getRelativePathToRootDir(rootDir, targetPath)
+	paths.TargetDir, err = GetRelativePathToRootDir(rootDir, targetPath)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This is a first version of gitops run bootstrap.

This only supports github, gitlab and bitbucket - I haven't implemented plain git, and I haven't implemented "write to disk instead".

This is poorly tested, with nothing automatic and little manual testing.

I added a question before bootstrapping, so that a user has a chance to understand that the shutdown finished and something else is starting. I also wrapped it in a loop, because I keep forgetting to put the correct values into place and then I have to delete my cluster and recreate it and if I'm annoyed I'm sure a user would be, too.

There is a limitation where this right now runs on _every_ run - this will be fixed by the fix for #2863.

This closes #2700.
This closes #2702.