### PR TITLE
Make it possible to set env vars for flux exec & bootstrap

### DIFF
--- a/pkg/fluxexec/bootstrap_bitbucket.go
+++ b/pkg/fluxexec/bootstrap_bitbucket.go
@@ -152,5 +152,5 @@ func (flux *Flux) bootstrapBitbucketServerCmd(ctx context.Context, opts ...Boots
 		args = append(args, "--username", c.username)
 	}
 
-	return flux.buildFluxCmd(ctx, nil, args...), nil
+	return flux.buildFluxCmd(ctx, flux.env, args...), nil
 }

--- a/pkg/fluxexec/bootstrap_github.go
+++ b/pkg/fluxexec/bootstrap_github.go
@@ -145,5 +145,5 @@ func (flux *Flux) bootstrapGitHubCmd(ctx context.Context, opts ...BootstrapGitHu
 		args = append(args, "--team", strings.Join(c.team, ","))
 	}
 
-	return flux.buildFluxCmd(ctx, nil, args...), nil
+	return flux.buildFluxCmd(ctx, flux.env, args...), nil
 }

--- a/pkg/fluxexec/bootstrap_gitlab.go
+++ b/pkg/fluxexec/bootstrap_gitlab.go
@@ -130,7 +130,7 @@ func (flux *Flux) bootstrapGitLabCmd(ctx context.Context, opts ...BootstrapGitLa
 		args = append(args, "--team", strings.Join(c.team, ","))
 	}
 
-	return flux.buildFluxCmd(ctx, nil, args...), nil
+	return flux.buildFluxCmd(ctx, flux.env, args...), nil
 }
 
 func (flux *Flux) BootstrapGitlab(ctx context.Context, opts ...BootstrapGitLabOption) error {

--- a/pkg/fluxexec/fluxexec.go
+++ b/pkg/fluxexec/fluxexec.go
@@ -40,7 +40,7 @@ func NewFlux(workingDir string, execPath string) (*Flux, error) {
 	flux := Flux{
 		execPath:   execPath,
 		workingDir: workingDir,
-		env:        nil, // explicit nil means copy os.Environ
+		env:        make(map[string]string),
 		logger:     nil,
 	}
 
@@ -76,4 +76,8 @@ func (flux *Flux) SetStdout(w io.Writer) {
 // flow. Any parsing necessary should be added as functionality to this package.
 func (flux *Flux) SetStderr(w io.Writer) {
 	flux.stderr = w
+}
+
+func (flux *Flux) SetEnvVar(key, value string) {
+	flux.env[key] = value
 }


### PR DESCRIPTION
I want the wizard to ask you for your PAT, instead of flux, so I need to set the env var before running flux-exec

This makes the bootstrap flags pass on the flux env vars. It also initializes them to an empty map instead of nil - either way, we always merge the env vars.