### PR TITLE
gitops run: Stop the wizard accepting missing values

### DIFF
--- a/pkg/run/bootstrap/bootstrap_wizard.go
+++ b/pkg/run/bootstrap/bootstrap_wizard.go
@@ -18,20 +18,17 @@ type BootstrapWizardTask struct {
 	isBoolean        bool
 }
 
-type BootstrapCmdOption struct {
-	FlagName  string
-	FlagValue string
-}
+type BootstrapCmdOptions map[string]string
 
 type BootstrapWizardCmd struct {
 	Provider GitProvider
-	Options  []*BootstrapCmdOption
+	Options  BootstrapCmdOptions
 }
 
 type BootstrapWizard struct {
 	gitProvider GitProvider
 	tasks       []*BootstrapWizardTask
-	cmdOptions  []*BootstrapCmdOption
+	cmdOptions  BootstrapCmdOptions
 }
 
 const (
@@ -488,7 +485,7 @@ func SelectGitProvider(log logger.Logger) (GitProvider, error) {
 func (wizard *BootstrapWizard) Run(log logger.Logger) error {
 	log.Actionf("Please enter or edit command values...")
 
-	m := initialWizardModel(wizard.tasks, make(chan []*BootstrapCmdOption))
+	m := initialWizardModel(wizard.tasks, make(chan BootstrapCmdOptions))
 
 	err := tea.NewProgram(m).Start()
 	if err != nil {

--- a/pkg/run/bootstrap/bootstrap_wizard_ui.go
+++ b/pkg/run/bootstrap/bootstrap_wizard_ui.go
@@ -159,7 +159,7 @@ func (m preWizardModel) View() string {
 type wizardModel struct {
 	textInputs []textinput.Model
 	prompts    []string
-	msgChan    chan []*BootstrapCmdOption
+	msgChan    chan BootstrapCmdOptions
 	cursorMode textinput.CursorMode
 	focusIndex int
 	errorMsg   string
@@ -182,7 +182,7 @@ func makeTextInput(value string, placeholder string, isFocused bool) textinput.M
 	return ti
 }
 
-func initialWizardModel(tasks []*BootstrapWizardTask, msgChan chan []*BootstrapCmdOption) wizardModel {
+func initialWizardModel(tasks []*BootstrapWizardTask, msgChan chan BootstrapCmdOptions) wizardModel {
 	numInputs := len(tasks)
 
 	inputs := make([]textinput.Model, numInputs)
@@ -244,7 +244,7 @@ func (m wizardModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// Did the user press enter while the submit button was focused?
 			// If so, exit.
 			if t == tea.KeyEnter && m.focusIndex == len(m.textInputs) {
-				options := []*BootstrapCmdOption{}
+				options := make(BootstrapCmdOptions)
 
 				for i, input := range m.textInputs {
 					prompt := m.prompts[i]
@@ -256,12 +256,7 @@ func (m wizardModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 						return m, nil
 					}
 
-					option := BootstrapCmdOption{
-						FlagName:  prompt[:strings.Index(prompt, flagSeparator)],
-						FlagValue: value,
-					}
-
-					options = append(options, &option)
+					options[prompt[:strings.Index(prompt, flagSeparator)]] = value
 				}
 
 				go func() { m.msgChan <- options }()

--- a/pkg/run/bootstrap/bootstrap_wizard_ui.go
+++ b/pkg/run/bootstrap/bootstrap_wizard_ui.go
@@ -162,6 +162,7 @@ type wizardModel struct {
 	msgChan    chan []*BootstrapCmdOption
 	cursorMode textinput.CursorMode
 	focusIndex int
+	errorMsg   string
 }
 
 func makeTextInput(value string, placeholder string, isFocused bool) textinput.Model {
@@ -204,6 +205,7 @@ func initialWizardModel(tasks []*BootstrapWizardTask, msgChan chan []*BootstrapC
 
 	return wizardModel{
 		textInputs: inputs,
+		errorMsg:   "",
 		prompts:    prompts,
 		msgChan:    msgChan,
 	}
@@ -250,7 +252,8 @@ func (m wizardModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					value := strings.TrimSpace(input.Value())
 
 					if value == "" {
-						continue
+						m.errorMsg = "Missing value in " + input.Placeholder
+						return m, nil
 					}
 
 					option := BootstrapCmdOption{
@@ -323,7 +326,7 @@ func (m wizardModel) View() string {
 
 	b.WriteString("Please enter the following values" + "\n" +
 		"(Tab and Shift+Tab to move input selection," + "\n" +
-		"Enter to move tpo the next input or submit the form, " + "\n" +
+		"Enter to move to the next input or submit the form, " + "\n" +
 		"Ctrl + C twice to quit)" + "\n\n\n")
 
 	for i := range m.textInputs {
@@ -341,7 +344,7 @@ func (m wizardModel) View() string {
 		button = &focusedButton
 	}
 
-	fmt.Fprintf(&b, "\n\n%s\n\n", *button)
+	fmt.Fprintf(&b, "\n\n%s  %s\n\n", *button, m.errorMsg)
 
 	b.WriteString(helpStyle.Render("cursor mode is "))
 	b.WriteString(cursorModeHelpStyle.Render(m.cursorMode.String()))


### PR DESCRIPTION
Right now every field in the wizard is mandatory. Therefore, I've made it refuse to accept an empty field.

At some point, we'll probably have to re-introduce optional fields and isRequired, and add some kind of type validation. That day is not today.

Also change the return value to be a map instead of a list.