### PR TITLE
Create config file on CLI action with user prompt for analytics

### DIFF
--- a/cmd/gitops/get/config/cmd.go
+++ b/cmd/gitops/get/config/cmd.go
@@ -5,13 +5,13 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	"github.com/weaveworks/weave-gitops/cmd/gitops/config"
+	cfg "github.com/weaveworks/weave-gitops/cmd/gitops/config"
 
-	gitopsConfig "github.com/weaveworks/weave-gitops/pkg/config"
+	"github.com/weaveworks/weave-gitops/pkg/config"
 	"github.com/weaveworks/weave-gitops/pkg/logger"
 )
 
-func ConfigCommand(opts *config.Options) *cobra.Command {
+func ConfigCommand(opts *cfg.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "config",
 		Short: "Prints out the CLI configuration for Weave GitOps",
@@ -27,15 +27,15 @@ gitops get config`,
 	return cmd
 }
 
-func getConfigCommandRunE(opts *config.Options) func(*cobra.Command, []string) error {
+func getConfigCommandRunE(opts *cfg.Options) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		var err error
 
 		log := logger.NewCLILogger(os.Stdout)
 
-		cfg, err := gitopsConfig.GetConfig(false)
+		cfg, err := config.GetConfig(false)
 		if err != nil {
-			log.Warningf(gitopsConfig.WrongConfigFormatMsg)
+			log.Warningf(config.WrongConfigFormatMsg)
 			return err
 		}
 

--- a/cmd/gitops/get/config/cmd.go
+++ b/cmd/gitops/get/config/cmd.go
@@ -33,8 +33,9 @@ func getConfigCommandRunE(opts *config.Options) func(*cobra.Command, []string) e
 
 		log := logger.NewCLILogger(os.Stdout)
 
-		cfg, err := gitopsConfig.GetConfig(log, false)
+		cfg, err := gitopsConfig.GetConfig(false)
 		if err != nil {
+			log.Warningf(gitopsConfig.WrongConfigFormatMsg)
 			return err
 		}
 

--- a/cmd/gitops/root/cmd.go
+++ b/cmd/gitops/root/cmd.go
@@ -92,9 +92,8 @@ func RootCmd() *cobra.Command {
 
 			_, err = config.GetConfig(false)
 			if err != nil {
-
 				prompt := promptui.Prompt{
-					Label:     "Creating config file...would you like to turn on analytics to help us improve our product",
+					Label:     "Creating config file... Would you like to turn on analytics to help us improve our product",
 					IsConfirm: true,
 					Default:   "Y",
 				}

--- a/cmd/gitops/root/cmd.go
+++ b/cmd/gitops/root/cmd.go
@@ -117,10 +117,7 @@ func RootCmd() *cobra.Command {
 					Analytics: enableAnalytics,
 				}
 
-				if err = config.SaveConfig(gitopsConfig); err != nil {
-					fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-					os.Exit(1)
-				}
+				_ = config.SaveConfig(gitopsConfig)
 			}
 		},
 	}

--- a/cmd/gitops/root/cmd.go
+++ b/cmd/gitops/root/cmd.go
@@ -2,11 +2,12 @@ package root
 
 import (
 	"fmt"
-	"github.com/weaveworks/weave-gitops/cmd/gitops/remove"
 	"log"
 	"os"
 	"strings"
 	"time"
+
+	"github.com/weaveworks/weave-gitops/cmd/gitops/remove"
 
 	"github.com/manifoldco/promptui"
 	"github.com/spf13/cobra"
@@ -92,22 +93,30 @@ func RootCmd() *cobra.Command {
 
 			_, err = config.GetConfig(false)
 			if err != nil {
+				fmt.Println("To improve our product, we would like to collect analytics data. You can read more about what data we collect here: https://docs.gitops.weave.works/docs/feedback-and-telemetry/")
+
 				prompt := promptui.Prompt{
-					Label:     "Creating config file... Would you like to turn on analytics to help us improve our product",
+					Label:     "Would you like to turn on analytics to help us improve our product",
 					IsConfirm: true,
 					Default:   "Y",
 				}
 
+				enableAnalytics := false
+
 				// Answering "n" causes err to not be nil. Hitting enter without typing
 				// does not return the default.
 				_, err := prompt.Run()
-				gitopsConfig := &config.GitopsCLIConfig{}
-				seed := time.Now().UnixNano()
-				gitopsConfig.UserID = config.GenerateUserID(10, seed)
-				gitopsConfig.Analytics = false
 				if err == nil {
-					gitopsConfig.Analytics = true
+					enableAnalytics = true
 				}
+
+				seed := time.Now().UnixNano()
+
+				gitopsConfig := &config.GitopsCLIConfig{
+					UserID:    config.GenerateUserID(10, seed),
+					Analytics: enableAnalytics,
+				}
+
 				if err = config.SaveConfig(gitopsConfig); err != nil {
 					fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 					os.Exit(1)

--- a/cmd/gitops/set/config/cmd.go
+++ b/cmd/gitops/set/config/cmd.go
@@ -69,7 +69,7 @@ func setConfigCommandRunE(opts *config.Options) func(*cobra.Command, []string) e
 			log.Warningf("This will only turn off analytics for the GitOps CLI. Please refer to the documentation to turn off the analytics in the GitOps Dashboard.")
 		}
 
-		cfg, err := gitopsConfig.GetConfig(log, true)
+		cfg, err := gitopsConfig.GetConfig(true)
 		if err != nil {
 			return err
 		}
@@ -82,7 +82,9 @@ func setConfigCommandRunE(opts *config.Options) func(*cobra.Command, []string) e
 			cfg.UserID = gitopsConfig.GenerateUserID(10, seed)
 		}
 
-		if err = gitopsConfig.SaveConfig(log, cfg); err != nil {
+		log.Actionf("Saving GitOps CLI config ...")
+
+		if err = gitopsConfig.SaveConfig(cfg); err != nil {
 			log.Failuref("Error saving GitOps CLI config")
 			return err
 		}

--- a/cmd/gitops/set/config/cmd.go
+++ b/cmd/gitops/set/config/cmd.go
@@ -10,8 +10,8 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/weaveworks/weave-gitops/cmd/gitops/cmderrors"
-	"github.com/weaveworks/weave-gitops/cmd/gitops/config"
-	gitopsConfig "github.com/weaveworks/weave-gitops/pkg/config"
+	cfg "github.com/weaveworks/weave-gitops/cmd/gitops/config"
+	"github.com/weaveworks/weave-gitops/pkg/config"
 	"github.com/weaveworks/weave-gitops/pkg/logger"
 )
 
@@ -21,7 +21,7 @@ const (
 
 var analyticsValue bool
 
-func ConfigCommand(opts *config.Options) *cobra.Command {
+func ConfigCommand(opts *cfg.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "config",
 		Short: "Set the CLI configuration for Weave GitOps",
@@ -59,7 +59,7 @@ func setConfigCommandPreRunE(endpoint *string) func(*cobra.Command, []string) er
 	}
 }
 
-func setConfigCommandRunE(opts *config.Options) func(*cobra.Command, []string) error {
+func setConfigCommandRunE(opts *cfg.Options) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		var err error
 
@@ -69,7 +69,7 @@ func setConfigCommandRunE(opts *config.Options) func(*cobra.Command, []string) e
 			log.Warningf("This will only turn off analytics for the GitOps CLI. Please refer to the documentation to turn off the analytics in the GitOps Dashboard.")
 		}
 
-		cfg, err := gitopsConfig.GetConfig(true)
+		cfg, err := config.GetConfig(true)
 		if err != nil {
 			return err
 		}
@@ -79,12 +79,12 @@ func setConfigCommandRunE(opts *config.Options) func(*cobra.Command, []string) e
 		if cfg.UserID == "" {
 			seed := time.Now().UnixNano()
 
-			cfg.UserID = gitopsConfig.GenerateUserID(10, seed)
+			cfg.UserID = config.GenerateUserID(10, seed)
 		}
 
 		log.Actionf("Saving GitOps CLI config ...")
 
-		if err = gitopsConfig.SaveConfig(cfg); err != nil {
+		if err = config.SaveConfig(cfg); err != nil {
 			log.Failuref("Error saving GitOps CLI config")
 			return err
 		}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -65,9 +65,7 @@ func GetConfig(shouldCreate bool) (*GitopsCLIConfig, error) {
 	} else if err = parseConfig(data, config); err != nil {
 		if shouldCreate {
 			// just replace invalid config with default config
-
 		} else {
-
 			return nil, fmt.Errorf("error reading config from file: %w", err)
 		}
 	}


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Part of #2843 

<!-- Describe what has changed in this PR -->
all commands now attempt to read the config file before running, and create a config file if it doesn't exist - with a user prompt for analytics!
