### PR TITLE
fix bootstrapping process in the session mode

### DIFF
--- a/pkg/run/install/session.go
+++ b/pkg/run/install/session.go
@@ -15,10 +15,11 @@ import (
 )
 
 type Session struct {
-	name       string
-	namespace  string
-	kubeClient client.Client
-	log        logger.Logger
+	name                    string
+	namespace               string
+	kubeClient              client.Client
+	log                     logger.Logger
+	dashboardHashedPassword string
 }
 
 func (s *Session) Start() error {
@@ -40,6 +41,8 @@ func (s *Session) Connect() error {
 		// we must skip resource cleanup in the sub-process because we are already deleting the vcluster.
 		// it's for optimization purposes.
 		"--skip-resource-cleanup",
+		// we forward dashboard password from host to session too.
+		"--dashboard-hashed-password="+s.dashboardHashedPassword,
 	)
 
 	connect := vcluster.ConnectCmd{
@@ -96,6 +99,12 @@ func (s *Session) Close() error {
 	return nil
 }
 
-func NewSession(log logger.Logger, kubeClient client.Client, name string, namespace string) (*Session, error) {
-	return &Session{name: name, namespace: namespace, kubeClient: kubeClient, log: log}, nil
+func NewSession(log logger.Logger, kubeClient client.Client, name string, namespace string, dashboardHashedPassword string) (*Session, error) {
+	return &Session{
+		name:                    name,
+		namespace:               namespace,
+		kubeClient:              kubeClient,
+		log:                     log,
+		dashboardHashedPassword: dashboardHashedPassword,
+	}, nil
 }


### PR DESCRIPTION
This PR fixes the bootstrap process after closing a session by:
  - Making GitOps Run aware of bootstrapping after closing a session
  - Adding `--dashboard-hashed-password`. The outer process is now responsible for asking the dashboard question and it passes the hashed password into the inner process.

Fixes #2863 

