### PR TITLE
Add analytics to helm chart on dashboard installation

### DIFF
--- a/cmd/gitops/root/cmd.go
+++ b/cmd/gitops/root/cmd.go
@@ -96,15 +96,16 @@ func RootCmd() *cobra.Command {
 
 			gitopsConfig, err = config.GetConfig(false)
 			if err != nil {
-				fmt.Println("To improve our product, we would like to collect analytics data. You can read more about what data we collect here: https://docs.gitops.weave.works/docs/feedback-and-telemetry/")
+				fmt.Fprintln(os.Stderr, "To improve our product, we would like to collect analytics data. You can read more about what data we collect here: https://docs.gitops.weave.works/docs/feedback-and-telemetry/")
+
+				enableAnalytics := false
 
 				prompt := promptui.Prompt{
 					Label:     "Would you like to turn on analytics to help us improve our product",
 					IsConfirm: true,
 					Default:   "Y",
+					Stdout:    os.Stderr,
 				}
-
-				enableAnalytics := false
 
 				// Answering "n" causes err to not be nil. Hitting enter without typing
 				// does not return the default.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -21,7 +21,10 @@ const (
 Please set you configuration with: gitops set config`
 )
 
-var letters = []byte("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789+/")
+var (
+	sessionConfig *GitopsCLIConfig
+	letters       = []byte("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789+/")
+)
 
 type GitopsCLIConfig struct {
 	Analytics bool   `json:"analytics"`
@@ -37,8 +40,17 @@ func (config *GitopsCLIConfig) String() (string, error) {
 	return string(data), nil
 }
 
+// SetConfig sets global config to the provided value
+func SetConfig(config *GitopsCLIConfig) {
+	sessionConfig = config
+}
+
 // GetConfig reads the CLI configuration for Weave GitOps from the config file
 func GetConfig(shouldCreate bool) (*GitopsCLIConfig, error) {
+	if sessionConfig != nil {
+		return sessionConfig, nil
+	}
+
 	configPath, err := getConfigPath(ConfigFileName)
 	if err != nil {
 		return nil, err
@@ -69,6 +81,8 @@ func GetConfig(shouldCreate bool) (*GitopsCLIConfig, error) {
 			return nil, fmt.Errorf("error reading config from file: %w", err)
 		}
 	}
+
+	sessionConfig = config
 
 	return config, nil
 }
@@ -106,6 +120,8 @@ func SaveConfig(config *GitopsCLIConfig) error {
 	if err != nil {
 		return fmt.Errorf("error writing to config file: %w", err)
 	}
+
+	sessionConfig = config
 
 	return nil
 }

--- a/pkg/run/install/install_dashboard.go
+++ b/pkg/run/install/install_dashboard.go
@@ -297,8 +297,8 @@ func makeValues(username string, passwordHash string) ([]byte, error) {
 			}
 	}
 
-	gitopsConfig, _ := config.GetConfig(false)
-	if gitopsConfig.Analytics {
+	gitopsConfig, err := config.GetConfig(false)
+	if err == nil && gitopsConfig.Analytics {
 		valuesMap["WEAVE_GITOPS_FEATURE_TELEMETRY"] = "true"
 	}
 

--- a/pkg/run/install/install_dashboard.go
+++ b/pkg/run/install/install_dashboard.go
@@ -297,8 +297,8 @@ func makeValues(username string, passwordHash string) ([]byte, error) {
 			}
 	}
 
-	analytics, _ := config.GetConfig(nil, false)
-	if analytics.Analytics {
+	gitopsConfig, _ := config.GetConfig(false)
+	if gitopsConfig.Analytics {
 		valuesMap["WEAVE_GITOPS_FEATURE_TELEMETRY"] = "true"
 	}
 

--- a/pkg/run/install/install_dashboard_test.go
+++ b/pkg/run/install/install_dashboard_test.go
@@ -52,7 +52,7 @@ var _ = Describe("InstallDashboard", func() {
 	It("should install dashboard successfully", func() {
 		man := &mockResourceManagerForApply{}
 
-		manifests, err := CreateDashboardObjects(fakeLogger, testDashboardName, testNamespace, testAdminUser, testSecret, "3.0.0")
+		manifests, err := CreateDashboardObjects(fakeLogger, testDashboardName, testNamespace, testAdminUser, testSecret, helmChartVersion)
 		Expect(err).NotTo(HaveOccurred())
 
 		err = InstallDashboard(fakeLogger, fakeContext, man, manifests)
@@ -121,7 +121,7 @@ var _ = Describe("generateManifestsForDashboard", func() {
 		fakeLogger = logger.From(logr.Discard())
 	})
 
-	It("generates manifests successfully", func() {
+	It("generates manifests", func() {
 		helmRepository := makeHelmRepository(testDashboardName, testNamespace)
 
 		helmRelease, err := makeHelmRelease(fakeLogger, testDashboardName, testNamespace, testAdminUser, testSecret, helmChartVersion)
@@ -162,7 +162,7 @@ var _ = Describe("makeHelmRelease", func() {
 		fakeLogger = logger.From(logr.Discard())
 	})
 
-	It("creates helmrelease with chart version and values successfully", func() {
+	It("creates helmrelease with chart version and values", func() {
 		config.SetConfig(&config.GitopsCLIConfig{
 			UserID:    testUserID,
 			Analytics: true,
@@ -195,7 +195,7 @@ var _ = Describe("makeHelmRelease", func() {
 		Expect(values["WEAVE_GITOPS_FEATURE_TELEMETRY"]).To(Equal("true"))
 	})
 
-	It("creates helmrelease without chart version successfully", func() {
+	It("creates helmrelease without chart version", func() {
 		actual, err := makeHelmRelease(fakeLogger, testDashboardName, testNamespace, testAdminUser, testSecret, "")
 		Expect(err).NotTo(HaveOccurred())
 
@@ -258,7 +258,7 @@ var _ = Describe("makeHelmRelease", func() {
 })
 
 var _ = Describe("makeHelmRepository", func() {
-	It("creates helmrepository successfully", func() {
+	It("creates helmrepository", func() {
 		actual := makeHelmRepository(testDashboardName, testNamespace)
 		Expect(actual.Kind).To(Equal(sourcev1.HelmRepositoryKind))
 		Expect(actual.APIVersion).To(Equal(sourcev1.GroupVersion.Identifier()))
@@ -280,7 +280,7 @@ var _ = Describe("makeHelmRepository", func() {
 })
 
 var _ = Describe("makeValues", func() {
-	It("creates all values successfully", func() {
+	It("creates all values", func() {
 		config.SetConfig(&config.GitopsCLIConfig{
 			UserID:    testUserID,
 			Analytics: true,


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes #2771 

When creating the Helm Chart for the dashboard, we will now check the user's config file and set analytics accordingly
