### PR TITLE
Add Pendo Track Events for Weave GitOps CLI

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -24,6 +24,7 @@ builds:
         - -X github.com/weaveworks/weave-gitops/cmd/gitops/version.Version={{.Version}}
         - -X github.com/weaveworks/weave-gitops/pkg/version.FluxVersion={{ .Env.FLUX_VERSION }}
         - -X github.com/weaveworks/weave-gitops/pkg/run/watch.DevBucketContainerImage={{ .Env.DEV_BUCKET_CONTAINER_IMAGE }}
+        - -X github.com/weaveworks/weave-gitops/pkg/analytics.Tier=oss
         - -X github.com/weaveworks/weave-gitops/core/server.Branch={{ .Env.BRANCH}}
         - -X github.com/weaveworks/weave-gitops/core/server.BuildTime={{.Date}}
         - -X github.com/weaveworks/weave-gitops/core/server.GitCommit={{.Commit}}

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,8 @@ GIT_COMMIT?=$(shell which git > /dev/null && git log -n1 --pretty='%h')
 VERSION?=$(shell which git > /dev/null && git describe --always --match "v*")
 FLUX_VERSION=0.36.0
 CHART_VERSION=$(shell which yq > /dev/null && yq e '.version' charts/gitops-server/Chart.yaml)
-DEV_BUCKET_CONTAINER_IMAGE=ghcr.io/weaveworks/gitops-bucket-server@sha256:8fbb7534e772e14ea598d287a4b54a3f556416cac6621095ce45f78346fda78a
+DEV_BUCKET_CONTAINER_IMAGE=ghcr.io/weaveworks/gitops-bucket-server@sha256:b0446a6c645b5d39cf0db558958bf28363aca3ea80dc9d593983173613a4f290
+TIER=oss
 
 # Go build args
 GOOS=$(shell which go > /dev/null && go env GOOS)
@@ -20,6 +21,7 @@ LDFLAGS?=-X github.com/weaveworks/weave-gitops/cmd/gitops/version.Branch=$(BRANC
 				 -X github.com/weaveworks/weave-gitops/cmd/gitops/version.Version=$(VERSION) \
 				 -X github.com/weaveworks/weave-gitops/pkg/version.FluxVersion=$(FLUX_VERSION) \
 				 -X github.com/weaveworks/weave-gitops/pkg/run/watch.DevBucketContainerImage=$(DEV_BUCKET_CONTAINER_IMAGE) \
+				 -X github.com/weaveworks/weave-gitops/pkg/analytics.Tier=$(TIER) \
 				 -X github.com/weaveworks/weave-gitops/core/server.Branch=$(BRANCH) \
 				 -X github.com/weaveworks/weave-gitops/core/server.Buildtime=$(BUILD_TIME) \
 				 -X github.com/weaveworks/weave-gitops/core/server.GitCommit=$(GIT_COMMIT) \

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ GIT_COMMIT?=$(shell which git > /dev/null && git log -n1 --pretty='%h')
 VERSION?=$(shell which git > /dev/null && git describe --always --match "v*")
 FLUX_VERSION=0.36.0
 CHART_VERSION=$(shell which yq > /dev/null && yq e '.version' charts/gitops-server/Chart.yaml)
-DEV_BUCKET_CONTAINER_IMAGE=ghcr.io/weaveworks/gitops-bucket-server@sha256:b0446a6c645b5d39cf0db558958bf28363aca3ea80dc9d593983173613a4f290
+DEV_BUCKET_CONTAINER_IMAGE=ghcr.io/weaveworks/gitops-bucket-server@sha256:8fbb7534e772e14ea598d287a4b54a3f556416cac6621095ce45f78346fda78a
 TIER=oss
 
 # Go build args

--- a/cmd/gitops/get/config/cmd.go
+++ b/cmd/gitops/get/config/cmd.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/spf13/cobra"
 	cfg "github.com/weaveworks/weave-gitops/cmd/gitops/config"
-
 	"github.com/weaveworks/weave-gitops/pkg/config"
 	"github.com/weaveworks/weave-gitops/pkg/logger"
 )
@@ -33,7 +32,7 @@ func getConfigCommandRunE(opts *cfg.Options) func(*cobra.Command, []string) erro
 
 		log := logger.NewCLILogger(os.Stdout)
 
-		cfg, err := config.GetConfig(false)
+		gitopsConfig, err := config.GetConfig(false)
 		if err != nil {
 			log.Warningf(config.WrongConfigFormatMsg)
 			return err
@@ -41,7 +40,7 @@ func getConfigCommandRunE(opts *cfg.Options) func(*cobra.Command, []string) erro
 
 		log.Successf("Your CLI configuration for Weave GitOps:")
 
-		cfgStr, err := cfg.String()
+		cfgStr, err := gitopsConfig.String()
 		if err != nil {
 			log.Failuref("Error printing config")
 			return err

--- a/cmd/gitops/root/cmd.go
+++ b/cmd/gitops/root/cmd.go
@@ -20,6 +20,7 @@ import (
 	"github.com/weaveworks/weave-gitops/cmd/gitops/get"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/set"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/version"
+	"github.com/weaveworks/weave-gitops/pkg/analytics"
 	"github.com/weaveworks/weave-gitops/pkg/config"
 	"github.com/weaveworks/weave-gitops/pkg/kube"
 	"github.com/weaveworks/weave-gitops/pkg/utils"
@@ -91,7 +92,7 @@ func RootCmd() *cobra.Command {
 				os.Exit(1)
 			}
 
-			_, err = config.GetConfig(false)
+			gitopsConfig, err := config.GetConfig(false)
 			if err != nil {
 				fmt.Println("To improve our product, we would like to collect analytics data. You can read more about what data we collect here: https://docs.gitops.weave.works/docs/feedback-and-telemetry/")
 
@@ -118,6 +119,10 @@ func RootCmd() *cobra.Command {
 				}
 
 				_ = config.SaveConfig(gitopsConfig)
+			}
+
+			if gitopsConfig.Analytics {
+				_ = analytics.TrackCommand(cmd, gitopsConfig.UserID)
 			}
 		},
 	}

--- a/cmd/gitops/root/cmd.go
+++ b/cmd/gitops/root/cmd.go
@@ -92,7 +92,9 @@ func RootCmd() *cobra.Command {
 				os.Exit(1)
 			}
 
-			gitopsConfig, err := config.GetConfig(false)
+			var gitopsConfig *config.GitopsCLIConfig
+
+			gitopsConfig, err = config.GetConfig(false)
 			if err != nil {
 				fmt.Println("To improve our product, we would like to collect analytics data. You can read more about what data we collect here: https://docs.gitops.weave.works/docs/feedback-and-telemetry/")
 
@@ -113,7 +115,7 @@ func RootCmd() *cobra.Command {
 
 				seed := time.Now().UnixNano()
 
-				gitopsConfig := &config.GitopsCLIConfig{
+				gitopsConfig = &config.GitopsCLIConfig{
 					UserID:    config.GenerateUserID(10, seed),
 					Analytics: enableAnalytics,
 				}

--- a/cmd/gitops/set/config/cmd.go
+++ b/cmd/gitops/set/config/cmd.go
@@ -69,22 +69,22 @@ func setConfigCommandRunE(opts *cfg.Options) func(*cobra.Command, []string) erro
 			log.Warningf("This will only turn off analytics for the GitOps CLI. Please refer to the documentation to turn off the analytics in the GitOps Dashboard.")
 		}
 
-		cfg, err := config.GetConfig(true)
+		gitopsConfig, err := config.GetConfig(true)
 		if err != nil {
 			return err
 		}
 
-		cfg.Analytics = analyticsValue
+		gitopsConfig.Analytics = analyticsValue
 
-		if cfg.UserID == "" {
+		if gitopsConfig.UserID == "" {
 			seed := time.Now().UnixNano()
 
-			cfg.UserID = config.GenerateUserID(10, seed)
+			gitopsConfig.UserID = config.GenerateUserID(10, seed)
 		}
 
 		log.Actionf("Saving GitOps CLI config ...")
 
-		if err = config.SaveConfig(cfg); err != nil {
+		if err = config.SaveConfig(gitopsConfig); err != nil {
 			log.Failuref("Error saving GitOps CLI config")
 			return err
 		}

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/go-git/go-git/v5 v5.4.2
 	github.com/go-logr/logr v1.2.3
 	github.com/go-logr/zapr v1.2.3
+	github.com/go-resty/resty/v2 v2.7.0
 	github.com/golang-jwt/jwt/v4 v4.4.1
 	github.com/google/go-cmp v0.5.9
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.1
@@ -212,7 +213,7 @@ require (
 	github.com/spf13/afero v1.8.2 // indirect
 	github.com/spf13/cast v1.4.1 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/spf13/pflag v1.0.5
 	github.com/subosito/gotenv v1.2.0 // indirect
 	github.com/xanzy/go-gitlab v0.73.1 // indirect
 	github.com/xanzy/ssh-agent v0.3.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -312,6 +312,8 @@ github.com/go-openapi/jsonreference v0.20.0/go.mod h1:Ag74Ico3lPc+zR+qjn4XBUmXym
 github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
 github.com/go-openapi/swag v0.21.1 h1:wm0rhTb5z7qpJRHBdPOMuY4QjVUMbF6/kwoYeRAOrKU=
 github.com/go-openapi/swag v0.21.1/go.mod h1:QYRuS/SOXUCsnplDa677K7+DxSOj6IPNl/eQntq43wQ=
+github.com/go-resty/resty/v2 v2.7.0 h1:me+K9p3uhSmXtrBZ4k9jcEAfJmuC8IivWHwaLZwPrFY=
+github.com/go-resty/resty/v2 v2.7.0/go.mod h1:9PWDzw47qPphMRFfhsyk0NnSgvluHcljSMVIq3w7q0I=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
@@ -896,6 +898,7 @@ golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96b
 golang.org/x/net v0.0.0-20210503060351-7fd8e65b6420/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20211029224645-99673261e6eb/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=

--- a/pkg/analytics/analytics.go
+++ b/pkg/analytics/analytics.go
@@ -1,0 +1,115 @@
+package analytics
+
+import (
+	"encoding/json"
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/go-resty/resty/v2"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/weaveworks/weave-gitops/cmd/gitops/version"
+)
+
+// Variables that we'll set @ build time
+var (
+	Tier = "oss"
+)
+
+const (
+	app              = "cli"
+	analyticsType    = "track"
+	commandEvent     = "Command"
+	trackEventURL    = "https://app.pendo.io/data/track"
+	trackEventSecret = "bf6ab33e-cd70-46e7-4b77-279f54cac447"
+)
+
+type analyticsRequestBody struct {
+	AnalyticsType string           `json:"type"`
+	Event         string           `json:"event"`
+	VisitorID     string           `json:"visitorId"`
+	Timestamp     int64            `json:"timestamp"`
+	Properties    *eventProperties `json:"properties"`
+}
+
+type eventProperties struct {
+	Tier    string `json:"tier"`
+	Version string `json:"version"`
+	App     string `json:"app"`
+	Command string `json:"command"`
+	Flags   string `json:"flags"`
+}
+
+// TrackCommand converts the provided command into an event
+// and submits it to the analytics service
+func TrackCommand(cmd *cobra.Command, userID string) error {
+	cmdPath := getCommandPath(cmd)
+
+	flags := getFlags(cmd)
+
+	client := resty.New()
+
+	reqBody := &analyticsRequestBody{
+		AnalyticsType: analyticsType,
+		Event:         commandEvent,
+		VisitorID:     userID,
+		Timestamp:     time.Now().UnixMilli(),
+		Properties: &eventProperties{
+			Tier:    Tier,
+			Version: version.Version,
+			App:     app,
+			Command: cmdPath,
+			Flags:   flags,
+		},
+	}
+
+	reqBodyData, err := json.MarshalIndent(reqBody, "", "  ")
+	if err != nil {
+		reqBodyData = []byte("invalid request body")
+	}
+
+	_, _ = client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("x-pendo-integration-key", trackEventSecret).
+		SetBody(string(reqBodyData)).
+		Post(trackEventURL)
+
+	return nil
+}
+
+func getCommandPath(cmd *cobra.Command) string {
+	cmdPath := cmd.CommandPath()
+
+	r, err := regexp.Compile(`^` + cmd.Root().Name() + ` +`)
+	if err != nil {
+		cmdPath = "unknown command path"
+	}
+
+	return r.ReplaceAllString(cmdPath, "")
+}
+
+func getFlags(cmd *cobra.Command) string {
+	flags := []string{}
+
+	allFlags := cmd.Flags()
+
+	err := allFlags.ParseAll(os.Args[1:], func(flag *pflag.Flag, value string) error {
+
+		flags = append(flags, flag.Name)
+
+		return nil
+	})
+
+	if len(flags) > 0 {
+		sort.Strings(flags)
+	}
+
+	if err != nil {
+		flags = append(flags, "unknown flag")
+	}
+
+	return strings.Join(flags, " ")
+}

--- a/pkg/analytics/analytics_suite_test.go
+++ b/pkg/analytics/analytics_suite_test.go
@@ -1,0 +1,13 @@
+package analytics
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Analytics Suite")
+}

--- a/pkg/analytics/analytics_test.go
+++ b/pkg/analytics/analytics_test.go
@@ -30,3 +30,13 @@ var _ = Describe("getCommandPath", func() {
 
 	})
 })
+
+var _ = Describe("sanitizeFlagName", func() {
+	It("sanitizes flag names", func() {
+		Expect(sanitizeFlagName("timeout")).To(Equal("timeout"))
+		Expect(sanitizeFlagName("port-forward")).To(Equal("port_forward"))
+		Expect(sanitizeFlagName("allow-k8s-context")).To(Equal("allow_k8s_context"))
+		Expect(sanitizeFlagName("very-long-flag-very-long-flag-very-long-flag")).To(Equal("very_long_flag_very_long_flag_ve"))
+		Expect(sanitizeFlagName("short-flag")).To(Equal("short_flag"))
+	})
+})

--- a/pkg/analytics/analytics_test.go
+++ b/pkg/analytics/analytics_test.go
@@ -1,0 +1,32 @@
+package analytics
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
+)
+
+var _ = Describe("getCommandPath", func() {
+	It("gets command path from command", func() {
+		var rootCmd = &cobra.Command{
+			Use: "root",
+		}
+
+		var parentCmd = &cobra.Command{
+			Use: "parent",
+		}
+
+		var cmd = &cobra.Command{
+			Use: "cmd",
+		}
+
+		parentCmd.AddCommand(cmd)
+
+		rootCmd.AddCommand(parentCmd)
+
+		commandPath := getCommandPath(cmd)
+
+		Expect(commandPath).To(Equal("parent cmd"))
+
+	})
+})


### PR DESCRIPTION
Part of #2452 

- Added tracking command events with Pendo.

-  Added a test for the `getCommandPath` function.

- Refactored imports where both `cmd/gitops/import` and `pkg/config` are imported for consistency.

Notes:
- I've rebased on @joshri 's branch `auto-analytics` ( https://github.com/weaveworks/weave-gitops/pull/2868 ), so I'll need to wait until it is merged and rebase on `main` before merging the current PR.

- You can view tracked events in Product > Track Events in the Pendo dashboard, but there is a delay before the events are displayed there.
