### PR TITLE
gitops-run: Session names have to be lower-case

### DIFF
--- a/cmd/gitops/beta/run/cmd.go
+++ b/cmd/gitops/beta/run/cmd.go
@@ -156,7 +156,7 @@ func getSessionNameFromGit() string {
 		sessionName = fmt.Sprintf("%s-%s-%s-dirty", prefix, branch, commit)
 	}
 
-	sessionName = strings.ReplaceAll(sessionName, "/", "-")
+	sessionName = strings.ToLower(strings.ReplaceAll(sessionName, "/", "-"))
 
 	return sessionName
 }


### PR DESCRIPTION
If you manage to generate a session name that isn't lower-case - e.g., if you've not got a branch checked out - then the session can't be created.
