### PR TITLE
Copy to clipboard button on Git auth flow

### DIFF
--- a/ui/components/GithubDeviceAuthModal.tsx
+++ b/ui/components/GithubDeviceAuthModal.tsx
@@ -26,11 +26,23 @@ type Props = {
 const Pad = styled(Flex)`
   padding: 8px 0;
 `;
-
+const PointerIcon = styled(Icon)`
+  cursor: pointer;
+`;
 const ModalContent = styled(({ codeRes, onSuccess, onError, className }) => {
   // Move this to a component so that we get the cancel logic when the modal closes.
   const { getGithubAuthStatus } = useAuth();
   const [loading, setLoading] = React.useState(true);
+  const [copied, setCopied] = React.useState(false);
+
+  const handleCopy = React.useCallback(() => {
+    navigator.clipboard.writeText(codeRes.userCode).then(() => {
+      setCopied(true);
+      setTimeout(() => {
+        setCopied(false);
+      }, 3000);
+    });
+  }, []);
 
   React.useEffect(() => {
     if (!codeRes) {
@@ -54,7 +66,20 @@ const ModalContent = styled(({ codeRes, onSuccess, onError, className }) => {
   return (
     <div className={className}>
       <Pad wide center>
-        <Text size="extraLarge">{codeRes.userCode}</Text>
+        <Text
+          size="extraLarge"
+          onClick={handleCopy}
+          style={{
+            display: "inline-flex",
+          }}
+        >
+          {codeRes.userCode}
+          <PointerIcon
+            type={copied ? IconType.CheckMark : IconType.FileCopyIcon}
+            color={copied ? "primary20" : "black"}
+            size="medium"
+          />
+        </Text>
       </Pad>
       <Pad wide center>
         <a target="_blank" href={codeRes.validationURI}>


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes https://github.com/weaveworks/weave-gitops-enterprise/issues/1713
Currently the user is asked to copy across a code for auth with GitHub. Triple clicking to select all results in an additional space (as shown in screenshot) and then doesn't paste into the field on GitHub.

If we could provide a copy to clipboard button next to the code, that would make things much simpler than having to highlight.

![image](https://user-images.githubusercontent.com/4614360/196730020-b5676674-05c3-48d2-a245-fbaf4c85b251.png)
![image](https://user-images.githubusercontent.com/4614360/196730179-93e8647a-d4de-40f8-b458-e1960c4832d2.png)
