### PR TITLE
Expose known clusters from the clusters-manager

### DIFF
--- a/core/clustersmngr/clustersmngrfakes/fake_clusters_manager.go
+++ b/core/clustersmngr/clustersmngrfakes/fake_clusters_manager.go
@@ -12,6 +12,16 @@ import (
 )
 
 type FakeClustersManager struct {
+	GetClustersStub        func() []clustersmngr.Cluster
+	getClustersMutex       sync.RWMutex
+	getClustersArgsForCall []struct {
+	}
+	getClustersReturns struct {
+		result1 []clustersmngr.Cluster
+	}
+	getClustersReturnsOnCall map[int]struct {
+		result1 []clustersmngr.Cluster
+	}
 	GetClustersNamespacesStub        func() map[string][]v1.Namespace
 	getClustersNamespacesMutex       sync.RWMutex
 	getClustersNamespacesArgsForCall []struct {
@@ -140,6 +150,59 @@ type FakeClustersManager struct {
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
+}
+
+func (fake *FakeClustersManager) GetClusters() []clustersmngr.Cluster {
+	fake.getClustersMutex.Lock()
+	ret, specificReturn := fake.getClustersReturnsOnCall[len(fake.getClustersArgsForCall)]
+	fake.getClustersArgsForCall = append(fake.getClustersArgsForCall, struct {
+	}{})
+	stub := fake.GetClustersStub
+	fakeReturns := fake.getClustersReturns
+	fake.recordInvocation("GetClusters", []interface{}{})
+	fake.getClustersMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeClustersManager) GetClustersCallCount() int {
+	fake.getClustersMutex.RLock()
+	defer fake.getClustersMutex.RUnlock()
+	return len(fake.getClustersArgsForCall)
+}
+
+func (fake *FakeClustersManager) GetClustersCalls(stub func() []clustersmngr.Cluster) {
+	fake.getClustersMutex.Lock()
+	defer fake.getClustersMutex.Unlock()
+	fake.GetClustersStub = stub
+}
+
+func (fake *FakeClustersManager) GetClustersReturns(result1 []clustersmngr.Cluster) {
+	fake.getClustersMutex.Lock()
+	defer fake.getClustersMutex.Unlock()
+	fake.GetClustersStub = nil
+	fake.getClustersReturns = struct {
+		result1 []clustersmngr.Cluster
+	}{result1}
+}
+
+func (fake *FakeClustersManager) GetClustersReturnsOnCall(i int, result1 []clustersmngr.Cluster) {
+	fake.getClustersMutex.Lock()
+	defer fake.getClustersMutex.Unlock()
+	fake.GetClustersStub = nil
+	if fake.getClustersReturnsOnCall == nil {
+		fake.getClustersReturnsOnCall = make(map[int]struct {
+			result1 []clustersmngr.Cluster
+		})
+	}
+	fake.getClustersReturnsOnCall[i] = struct {
+		result1 []clustersmngr.Cluster
+	}{result1}
 }
 
 func (fake *FakeClustersManager) GetClustersNamespaces() map[string][]v1.Namespace {
@@ -792,6 +855,8 @@ func (fake *FakeClustersManager) UpdateUserNamespacesArgsForCall(i int) (context
 func (fake *FakeClustersManager) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
+	fake.getClustersMutex.RLock()
+	defer fake.getClustersMutex.RUnlock()
 	fake.getClustersNamespacesMutex.RLock()
 	defer fake.getClustersNamespacesMutex.RUnlock()
 	fake.getImpersonatedClientMutex.RLock()

--- a/core/clustersmngr/factory.go
+++ b/core/clustersmngr/factory.go
@@ -99,6 +99,8 @@ type ClustersManager interface {
 	Subscribe() *ClustersWatcher
 	// RemoveWatcher removes the given ClustersWatcher from the list of watchers
 	RemoveWatcher(cw *ClustersWatcher)
+	// GetClusters returns all the currently known clusters
+	GetClusters() []Cluster
 }
 
 var DefaultKubeConfigOptions = []KubeConfigOption{WithFlowControl}

--- a/core/clustersmngr/factory.go
+++ b/core/clustersmngr/factory.go
@@ -192,6 +192,10 @@ func (cf *clustersManager) RemoveWatcher(cw *ClustersWatcher) {
 	cf.watchers = watchers
 }
 
+func (cf *clustersManager) GetClusters() []Cluster {
+	return cf.clusters.Get()
+}
+
 func (cf *clustersManager) Start(ctx context.Context) {
 	go cf.watchClusters(ctx)
 	go cf.watchNamespaces(ctx)

--- a/core/clustersmngr/factory_test.go
+++ b/core/clustersmngr/factory_test.go
@@ -241,6 +241,37 @@ func TestUpdateUsersFailsToConnect(t *testing.T) {
 	})
 }
 
+func TestGetClusters(t *testing.T) {
+	g := NewGomegaWithT(t)
+	logger := logr.Discard()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	nsChecker := nsaccess.NewChecker(nil)
+	clustersFetcher := new(clustersmngrfakes.FakeClusterFetcher)
+
+	scheme, err := kube.CreateScheme()
+	g.Expect(err).To(BeNil())
+
+	clustersManager := clustersmngr.NewClustersManager(clustersFetcher, nsChecker, logger, scheme, clustersmngr.ClientFactory, clustersmngr.DefaultKubeConfigOptions)
+
+	c1 := makeLeafCluster(t, "foo")
+	c2 := makeLeafCluster(t, "foo")
+
+	t.Run("GetClusters returns clusters that were fetched", func(t *testing.T) {
+		g.Expect(clustersManager.GetClusters()).To(BeEmpty())
+
+		clustersFetcher.FetchReturns([]clustersmngr.Cluster{c1}, nil)
+		g.Expect(clustersManager.UpdateClusters(ctx)).To(Succeed())
+		g.Expect(clustersManager.GetClusters()).To(Equal([]clustersmngr.Cluster{c1}))
+
+		clustersFetcher.FetchReturns([]clustersmngr.Cluster{c1, c2}, nil)
+		g.Expect(clustersManager.UpdateClusters(ctx)).To(Succeed())
+		g.Expect(clustersManager.GetClusters()).To(Equal([]clustersmngr.Cluster{c1, c2}))
+	})
+}
+
 func TestUpdateClusters(t *testing.T) {
 	g := NewGomegaWithT(t)
 	logger := logr.Discard()

--- a/core/clustersmngr/factory_test.go
+++ b/core/clustersmngr/factory_test.go
@@ -269,6 +269,14 @@ func TestGetClusters(t *testing.T) {
 		clustersFetcher.FetchReturns([]clustersmngr.Cluster{c1, c2}, nil)
 		g.Expect(clustersManager.UpdateClusters(ctx)).To(Succeed())
 		g.Expect(clustersManager.GetClusters()).To(Equal([]clustersmngr.Cluster{c1, c2}))
+
+		clustersFetcher.FetchReturns([]clustersmngr.Cluster{c2}, nil)
+		g.Expect(clustersManager.UpdateClusters(ctx)).To(Succeed())
+		g.Expect(clustersManager.GetClusters()).To(Equal([]clustersmngr.Cluster{c2}))
+
+		clustersFetcher.FetchReturns([]clustersmngr.Cluster{}, nil)
+		g.Expect(clustersManager.UpdateClusters(ctx)).To(Succeed())
+		g.Expect(clustersManager.GetClusters()).To(BeEmpty())
 	})
 }
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

- Expose the known clusters in the clusters-manager API
- We already have subscribe, this allows you to query the existing clusters if you subscribe after some have been added.

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**

- Allows us to get the `config` for clusters in case we need to make other kind of queries against them that the controller-runtime client does not support. For example `ProxyGet`ing via the client-go.

**How was this change implemented?**

- Add a getter method to expose the internal clusters list.

**How did you validate the change?**

- Manually