### PR TITLE
implement gitops-run metadata and the remove run command

### DIFF
--- a/cmd/gitops/beta/run/cmd.go
+++ b/cmd/gitops/beta/run/cmd.go
@@ -423,7 +423,19 @@ func runCommandWithSession(cmd *cobra.Command, args []string) (retErr error) {
 
 	sessionLog.Println("\nYou may see Flux installation logs again, as it is being installed inside the session.\n")
 
-	session, err := install.NewSession(sessionLog, kubeClient, flags.SessionName, flags.SessionNamespace, dashboardHashedPassword)
+	spec, err := watch.ParsePortForwardSpec(flags.PortForward)
+	if err != nil {
+		return err
+	}
+
+	session, err := install.NewSession(
+		sessionLog,
+		kubeClient,
+		flags.SessionName,
+		flags.SessionNamespace,
+		[]string{spec.HostPort, flags.DashboardPort},
+		dashboardHashedPassword,
+	)
 
 	if err != nil {
 		return err

--- a/cmd/gitops/cmderrors/errors.go
+++ b/cmd/gitops/cmderrors/errors.go
@@ -14,4 +14,5 @@ var (
 	ErrGetKubeClient          = errors.New("error getting Kube HTTP client")
 	ErrNoName                 = errors.New("name is required")
 	ErrMultipleNames          = errors.New("only one name is allowed")
+	ErrSessionNameIsRequired  = errors.New("session name is required when --all-sessions is not set")
 )

--- a/cmd/gitops/remove/cmd.go
+++ b/cmd/gitops/remove/cmd.go
@@ -1,0 +1,18 @@
+package remove
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/weaveworks/weave-gitops/cmd/gitops/config"
+	"github.com/weaveworks/weave-gitops/cmd/gitops/remove/run"
+)
+
+func GetCommand(opts *config.Options) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "remove",
+		Short: "Remove various components of Weave GitOps",
+	}
+
+	cmd.AddCommand(run.RunCommand(opts))
+
+	return cmd
+}

--- a/cmd/gitops/remove/run/cmd.go
+++ b/cmd/gitops/remove/run/cmd.go
@@ -1,0 +1,172 @@
+package run
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+	"github.com/weaveworks/weave-gitops/cmd/gitops/cmderrors"
+	"github.com/weaveworks/weave-gitops/cmd/gitops/config"
+	"github.com/weaveworks/weave-gitops/pkg/kube"
+	"github.com/weaveworks/weave-gitops/pkg/logger"
+	"github.com/weaveworks/weave-gitops/pkg/run"
+	"github.com/weaveworks/weave-gitops/pkg/run/session"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/rest"
+	"os"
+)
+
+type RunCommandFlags struct {
+	AllSessions bool
+
+	// Global flags.
+	Namespace  string
+	KubeConfig string
+
+	// Flags, created by genericclioptions.
+	Context string
+}
+
+var flags RunCommandFlags
+
+var kubeConfigArgs *genericclioptions.ConfigFlags
+
+func RunCommand(opts *config.Options) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "run",
+		Short: "Remove GitOps Run sessions",
+		Long:  "Remove GitOps Run sessions",
+		Example: `
+# Remove the GitOps Run session "dev-1234" from the "flux-system" namespace
+gitops remove run --namespace flux-system dev-1234
+
+# Remove all GitOps Run sessions from the default namespace
+gitops remove run --all-sessions
+
+# Remove all GitOps Run sessions from the dev namespace
+gitops remove run -n dev --all-sessions
+`,
+		PreRunE: removeRunPreRunE(opts),
+		RunE:    removeRunRunE(opts),
+
+		SilenceUsage:      true,
+		SilenceErrors:     true,
+		DisableAutoGenTag: true,
+	}
+
+	cmdFlags := cmd.Flags()
+
+	cmdFlags.BoolVar(&flags.AllSessions, "all-sessions", false, "Remove all GitOps Run sessions")
+
+	kubeConfigArgs = run.GetKubeConfigArgs()
+
+	kubeConfigArgs.AddFlags(cmd.Flags())
+
+	return cmd
+}
+
+func getKubeClient(cmd *cobra.Command, args []string) (*kube.KubeHTTP, *rest.Config, error) {
+	var err error
+
+	log := logger.NewCLILogger(os.Stdout)
+
+	if flags.Namespace, err = cmd.Flags().GetString("namespace"); err != nil {
+		return nil, nil, err
+	}
+
+	kubeConfigArgs.Namespace = &flags.Namespace
+
+	if flags.KubeConfig, err = cmd.Flags().GetString("kubeconfig"); err != nil {
+		return nil, nil, err
+	}
+
+	if flags.Context, err = cmd.Flags().GetString("context"); err != nil {
+		return nil, nil, err
+	}
+
+	if flags.KubeConfig != "" {
+		kubeConfigArgs.KubeConfig = &flags.KubeConfig
+
+		if flags.Context == "" {
+			log.Failuref("A context should be provided if a kubeconfig is provided")
+			return nil, nil, cmderrors.ErrNoContextForKubeConfig
+		}
+	}
+
+	var contextName string
+
+	if flags.Context != "" {
+		contextName = flags.Context
+	} else {
+		_, contextName, err = kube.RestConfig()
+		if err != nil {
+			log.Failuref("Error getting a restconfig: %v", err.Error())
+			return nil, nil, cmderrors.ErrNoCluster
+		}
+	}
+
+	cfg, err := kubeConfigArgs.ToRESTConfig()
+	if err != nil {
+		return nil, nil, fmt.Errorf("error getting a restconfig from kube config args: %w", err)
+	}
+
+	kubeClientOpts := run.GetKubeClientOptions()
+	kubeClientOpts.BindFlags(cmd.Flags())
+
+	kubeClient, err := run.GetKubeClient(log, contextName, cfg, kubeClientOpts)
+	if err != nil {
+		return nil, nil, cmderrors.ErrGetKubeClient
+	}
+
+	return kubeClient, cfg, nil
+}
+
+func removeRunPreRunE(opts *config.Options) func(cmd *cobra.Command, args []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		numArgs := len(args)
+
+		if numArgs == 0 && !flags.AllSessions {
+			return cmderrors.ErrSessionNameIsRequired
+		}
+
+		return nil
+	}
+}
+
+func removeRunRunE(opts *config.Options) func(cmd *cobra.Command, args []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		kubeClient, _, err := getKubeClient(cmd, args)
+		if err != nil {
+			return err
+		}
+
+		log := logger.NewCLILogger(os.Stdout)
+
+		if flags.AllSessions {
+			internalSessions, listErr := session.List(kubeClient, flags.Namespace)
+			if listErr != nil {
+				return listErr
+			}
+
+			for _, internalSession := range internalSessions {
+				log.Actionf("Removing session %s/%s ...", internalSession.Namespace, internalSession.Name)
+
+				if err := session.Remove(kubeClient, internalSession); err != nil {
+					return err
+				}
+
+				log.Successf("Session %s/%s was successfully removed.", internalSession.Namespace, internalSession.Name)
+			}
+		} else {
+			internalSession, err := session.Get(kubeClient, args[0], flags.Namespace)
+			if err != nil {
+				return err
+			}
+			log.Actionf("Removing session %s/%s ...", internalSession.Namespace, internalSession.Name)
+			if err := session.Remove(kubeClient, internalSession); err != nil {
+				return err
+			}
+			log.Successf("Session %s/%s was successfully removed.", internalSession.Namespace, internalSession.Name)
+		}
+
+		return nil
+	}
+}

--- a/cmd/gitops/root/cmd.go
+++ b/cmd/gitops/root/cmd.go
@@ -2,6 +2,7 @@ package root
 
 import (
 	"fmt"
+	"github.com/weaveworks/weave-gitops/cmd/gitops/remove"
 	"log"
 	"os"
 	"strings"
@@ -106,6 +107,7 @@ func RootCmd() *cobra.Command {
 	rootCmd.AddCommand(check.Cmd)
 	rootCmd.AddCommand(beta.GetCommand(options))
 	rootCmd.AddCommand(create.GetCommand(options))
+	rootCmd.AddCommand(remove.GetCommand(options))
 
 	return rootCmd
 }

--- a/pkg/run/install/session.go
+++ b/pkg/run/install/session.go
@@ -20,10 +20,11 @@ type Session struct {
 	kubeClient              client.Client
 	log                     logger.Logger
 	dashboardHashedPassword string
+	portForwards            []string
 }
 
 func (s *Session) Start() error {
-	if err := installVCluster(s.kubeClient, s.name, s.namespace); err != nil {
+	if err := installVCluster(s.kubeClient, s.name, s.namespace, s.portForwards); err != nil {
 		return err
 	}
 
@@ -100,12 +101,13 @@ func (s *Session) Close() error {
 	return nil
 }
 
-func NewSession(log logger.Logger, kubeClient client.Client, name string, namespace string, dashboardHashedPassword string) (*Session, error) {
+func NewSession(log logger.Logger, kubeClient client.Client, name string, namespace string, portForwards []string, dashboardHashedPassword string) (*Session, error) {
 	return &Session{
 		name:                    name,
 		namespace:               namespace,
 		kubeClient:              kubeClient,
 		log:                     log,
+		portForwards:            portForwards,
 		dashboardHashedPassword: dashboardHashedPassword,
 	}, nil
 }

--- a/pkg/run/session/list.go
+++ b/pkg/run/session/list.go
@@ -1,0 +1,73 @@
+package session
+
+import (
+	"context"
+	"fmt"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"strings"
+)
+
+func Get(kubeClient client.Client, name string, namespace string) (*InternalSession, error) {
+	var result *InternalSession
+
+	statefulSet := appsv1.StatefulSet{}
+	if err := kubeClient.Get(context.Background(), client.ObjectKey{
+		Namespace: namespace,
+		Name:      name,
+	}, &statefulSet); err != nil {
+		if errors.IsNotFound(err) {
+			return nil, fmt.Errorf("session %s/%s not found", namespace, name)
+		}
+
+		return nil, err
+	}
+
+	labels := statefulSet.GetLabels()
+	if labels != nil {
+		if labels["app"] != "vcluster" || labels["app.kubernetes.io/part-of"] != "gitops-run" {
+			return nil, fmt.Errorf("%s/%s is an invalid GitOps Run session", namespace, name)
+		}
+	}
+
+	annotations := statefulSet.GetAnnotations()
+	result = &InternalSession{
+		Name:        statefulSet.Name,
+		Namespace:   statefulSet.Namespace,
+		Command:     annotations["run.weave.works/command"],
+		CliVersion:  annotations["run.weave.works/cli-version"],
+		PortForward: strings.Split(annotations["run.weave.works/port-forward"], ","),
+	}
+
+	return result, nil
+}
+
+func List(kubeClient client.Client, namespace string) ([]*InternalSession, error) {
+	var result []*InternalSession
+
+	statefulSets := appsv1.StatefulSetList{}
+	if err := kubeClient.List(context.Background(), &statefulSets,
+		client.InNamespace(namespace),
+		client.MatchingLabels(map[string]string{
+			"app":                       "vcluster",
+			"app.kubernetes.io/part-of": "gitops-run",
+		}),
+	); err != nil {
+		return nil, err
+	}
+
+	for _, s := range statefulSets.Items {
+		annotations := s.GetAnnotations()
+
+		result = append(result, &InternalSession{
+			Name:        s.Name,
+			Namespace:   s.Namespace,
+			Command:     annotations["run.weave.works/command"],
+			CliVersion:  annotations["run.weave.works/cli-version"],
+			PortForward: strings.Split(annotations["run.weave.works/port-forward"], ","),
+		})
+	}
+
+	return result, nil
+}

--- a/pkg/run/session/remove.go
+++ b/pkg/run/session/remove.go
@@ -1,0 +1,87 @@
+package session
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	helmv2 "github.com/fluxcd/helm-controller/api/v2beta1"
+	"github.com/hashicorp/go-multierror"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type InternalSession struct {
+	Name        string
+	Namespace   string
+	PortForward []string
+	CliVersion  string
+	Command     string
+}
+
+func Remove(kubeClient client.Client, session *InternalSession) error {
+	var (
+		helmRelease helmv2.HelmRelease
+		result      error
+	)
+
+	if err := kubeClient.Get(context.Background(),
+		types.NamespacedName{
+			Namespace: session.Namespace,
+			Name:      session.Name,
+		}, &helmRelease); err != nil {
+		result = multierror.Append(result, err)
+	}
+
+	if err := kubeClient.Delete(context.Background(), &helmRelease); err != nil {
+		result = multierror.Append(result, err)
+	}
+
+	if err := wait.Poll(2*time.Second, 5*time.Minute, func() (bool, error) {
+		instance := appsv1.StatefulSet{}
+		if err := kubeClient.Get(
+			context.Background(),
+			types.NamespacedName{
+				Namespace: session.Namespace,
+				Name:      session.Name},
+			&instance,
+		); err != nil && apierrors.IsNotFound(err) {
+			return true, nil
+		} else if err != nil {
+			return false, err
+		}
+
+		return false, nil
+	}); err != nil {
+		result = multierror.Append(result, err)
+	}
+
+	if err := wait.Poll(2*time.Second, 5*time.Minute, func() (bool, error) {
+		pvc := corev1.PersistentVolumeClaim{}
+		if err := kubeClient.Get(
+			context.Background(),
+			types.NamespacedName{
+				Namespace: session.Namespace,
+				Name:      fmt.Sprintf("data-%s-0", session.Name),
+			},
+			&pvc,
+		); err != nil && apierrors.IsNotFound(err) {
+			return true, nil
+		} else if err != nil {
+			return false, err
+		}
+
+		if err := kubeClient.Delete(context.Background(), &pvc); err != nil {
+			return false, err
+		}
+		return false, nil
+	}); err != nil {
+		result = multierror.Append(result, err)
+	}
+
+	return result
+}


### PR DESCRIPTION
Fixes #2858 
Fixes #2907 

How to test this PR
1. Start a GitOps session, for example `gitops beta run ./manifests --port-forward port=8080:5000,resource=svc/app`
2. Wait until it starts the reconciliation loop
3. Open another terminal, and run `killall -9 gitops` to kill all `gitops` process so that the session becomes dangling.
4. `gitops remove run --namespace default --all-sessions` to remove all sessions or you can try specify the session name.


Signed-off-by: Chanwit Kaewkasi <chanwit@weave.works>