### PR TITLE
fix brew install link

### DIFF
--- a/website/versioned_docs/version-0.10.0/getting-started.mdx
+++ b/website/versioned_docs/version-0.10.0/getting-started.mdx
@@ -79,7 +79,7 @@ For this guide we will use the cluster user, for complete documentation includin
 
 1. Install the Weave GitOps CLI
    ```
-   brew install weaveworks/tap/weave-gitops
+   brew install weaveworks/tap/gitops
    ```
 
    For other installation methods, see our [installation doc](./installation.mdx).


### PR DESCRIPTION
Seems the brew command doesn't exist, got the following:

`Warning: No available formula or cask with the name "weaveworks/tap/weave-gitops". Did you mean weaveworks/tap/gitops?`

The proposed update to docs works

<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->


<!-- Describe what has changed in this PR -->
**What changed?**
Brew formula command

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**
To fix the brew formula

<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**
By updating the docs

<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**
Ran the command

<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**
n/a

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
Yep, this.