### PR TITLE
Fix overlapping UI elements in bootstrap wizard if height of terminal window is insufficient

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11304,9 +11304,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -22431,9 +22431,9 @@
       }
     },
     "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "requires": {
         "brace-expansion": "^1.1.7"
       }

--- a/pkg/run/bootstrap/bootstrap_wizard.go
+++ b/pkg/run/bootstrap/bootstrap_wizard.go
@@ -476,7 +476,7 @@ func SelectGitProvider(log logger.Logger) (GitProvider, error) {
 
 	m := initialPreWizardModel(make(chan GitProvider))
 
-	err := tea.NewProgram(m).Start()
+	err := tea.NewProgram(m, tea.WithAltScreen(), tea.WithMouseCellMotion()).Start()
 	if err != nil {
 		return provider, fmt.Errorf("could not start tea program: %v", err.Error())
 	}
@@ -492,7 +492,7 @@ func (wizard *BootstrapWizard) Run(log logger.Logger) error {
 
 	m := initialWizardModel(wizard.tasks, make(chan BootstrapCmdOptions))
 
-	err := tea.NewProgram(m).Start()
+	err := tea.NewProgram(m, tea.WithAltScreen(), tea.WithMouseCellMotion()).Start()
 	if err != nil {
 		return fmt.Errorf("could not start tea program: %v", err.Error())
 	}


### PR DESCRIPTION
Closes #2920 

- Wrapped CLI UI elements of the Git providers table and the main bootstrap wizard screen with a Bubble Tea viewport component. If the terminal height is insufficient, the viewport can be scrolled with up and down arrow buttons or mouse wheel.

- Removed selecting items in the Git providers table with arrow keys and enter. The git providers table is not focusable now, only the text input is.

- Slightly reworked message handling, returning Bubble Tea commands, and getting view content in the `Update` functions.

- Removed some unneeded comments.

- Ran `npm audit fix` because the JS tests were failing because of a critical vulnerability.

Notes:
- The Bubble Tea programs now run in the CLI alt screen buffer/"fullscreen" (`WithAltScreen()` Bubble Tea program option). As far as I understood, there are fewer side effects (I saw some text getting duplicated if not in "fullscreen"). So, after the Bubble Tea program is exited and control goes back to the main flow, the user selection and the values they entered will disappear from the screen.

- `WithMouseCellMotion()` Bubble Tea program option is used for detecting mouse wheel scroll event for viewports.

- At present, up and down arrow buttons are used for scrolling the view and Tab and Shift+Tab are used to navigate between text inputs. We can make text input focus on mouse click but in a separate ticket or during UI rework. It requires adding mouse click functionality (adding mouse support it is easy, the main thing is detecting where exactly the click happened, so I found a nice `bubblezone` library for this).

- I added a message about scrolling the view with up and down arrows to both viewports. But if the terminal is tall enough, this message is not needed. If you would only like to display the message about scrolling only if terminal height is insufficient to hold the whole view output, additional calculations will be needed.

