### PR TITLE
Fix displaying bootstrap wizard error message

### DIFF
--- a/pkg/run/bootstrap/bootstrap_wizard.go
+++ b/pkg/run/bootstrap/bootstrap_wizard.go
@@ -302,7 +302,6 @@ const (
 
 type (
 	GitProvider int32
-	errMsg      error
 )
 
 const (

--- a/pkg/run/bootstrap/bootstrap_wizard_ui.go
+++ b/pkg/run/bootstrap/bootstrap_wizard_ui.go
@@ -17,7 +17,6 @@ type preWizardModel struct {
 	table         table.Model
 	textInput     textinput.Model
 	msgChan       chan GitProvider
-	err           error
 }
 
 const flagSeparator = " - "
@@ -131,9 +130,6 @@ func (m preWizardModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.viewport.Width = msg.Width
 			m.viewport.Height = msg.Height
 		}
-	case errMsg:
-		m.err = msg
-		return m, nil
 	}
 
 	var (
@@ -265,7 +261,14 @@ func (m wizardModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 					if value == "" {
 						m.errorMsg = "Missing value in " + input.Placeholder
-						return m, nil
+
+						m.viewport.SetContent(m.getContent())
+
+						var cmdViewport tea.Cmd
+
+						m.viewport, cmdViewport = m.viewport.Update(msg)
+
+						return m, cmdViewport
 					}
 
 					options[prompt[:strings.Index(prompt, flagSeparator)]] = value


### PR DESCRIPTION
Followup to https://github.com/weaveworks/weave-gitops/pull/2924

Forgot to update the viewport after setting the bootstrap on submit error message (had to trigger a viewport update, for example, with an arrow button, to see the error message)

- Added updating the viewport after setting the on submit bootstrap error message.

- Also removed the unused `err` field of the Git providers view model.