### PR TITLE
Replace text inputs with checkboxes in the bootstrap wizard UI

### DIFF
--- a/pkg/run/bootstrap/bootstrap_wizard.go
+++ b/pkg/run/bootstrap/bootstrap_wizard.go
@@ -300,9 +300,7 @@ const (
 	branchPrefix   = "refs/heads/"
 )
 
-type (
-	GitProvider int32
-)
+type GitProvider int32
 
 const (
 	GitProviderUnknown         GitProvider = 0

--- a/pkg/run/bootstrap/bootstrap_wizard_ui.go
+++ b/pkg/run/bootstrap/bootstrap_wizard_ui.go
@@ -43,6 +43,7 @@ const (
 
 type bootstrapWizardInput struct {
 	inputType     bootstrapWizardInputType
+	flagName      string
 	prompt        string
 	textInput     textinput.Model
 	checkboxInput *checkbox
@@ -203,6 +204,8 @@ func makeInput(task *BootstrapWizardTask, isFocused bool) *bootstrapWizardInput 
 		inputType = bootstrapWizardInputTypeTextInput
 	}
 
+	flagName := task.flagName
+
 	prompt := task.flagName + flagSeparator + task.flagDescription
 
 	ti := textinput.Model{}
@@ -234,6 +237,7 @@ func makeInput(task *BootstrapWizardTask, isFocused bool) *bootstrapWizardInput 
 
 	return &bootstrapWizardInput{
 		inputType:     inputType,
+		flagName:      flagName,
 		prompt:        prompt,
 		textInput:     ti,
 		checkboxInput: cb,
@@ -265,7 +269,7 @@ func (input *bootstrapWizardInput) getView(isFocused bool) string {
 		close = focusedStyle.Render(close)
 	}
 
-	return fmt.Sprintf("%s%s%s", open, checkmark, close)
+	return fmt.Sprintf("%s%s%s %s", open, checkmark, close, input.flagName)
 }
 
 func initialWizardModel(tasks []*BootstrapWizardTask, msgChan chan BootstrapCmdOptions) wizardModel {
@@ -320,8 +324,6 @@ func (m wizardModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				options := make(BootstrapCmdOptions)
 
 				for _, input := range m.inputs {
-					prompt := input.prompt
-
 					var value string
 
 					if input.inputType == bootstrapWizardInputTypeTextInput {
@@ -342,7 +344,7 @@ func (m wizardModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 						value = strconv.FormatBool(input.checkboxInput.checked)
 					}
 
-					options[prompt[:strings.Index(prompt, flagSeparator)]] = value
+					options[input.flagName] = value
 				}
 
 				go func() { m.msgChan <- options }()

--- a/pkg/run/bootstrap/bootstrap_wizard_ui.go
+++ b/pkg/run/bootstrap/bootstrap_wizard_ui.go
@@ -306,8 +306,7 @@ func (m wizardModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 			cmdsTextInputs := make([]tea.Cmd, len(m.inputs))
 
-			for i := range m.inputs {
-				input := m.inputs[i]
+			for i, input := range m.inputs {
 				if input.inputType == bootstrapWizardInputTypeTextInput {
 					cmdsTextInputs[i] = input.textInput.SetCursorMode(m.cursorMode)
 				}
@@ -365,9 +364,7 @@ func (m wizardModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 			cmdsTextInputs := []tea.Cmd{}
 
-			for i := 0; i <= len(m.inputs)-1; i++ {
-				input := m.inputs[i]
-
+			for i, input := range m.inputs[:len(m.inputs)-1] {
 				if input.inputType == bootstrapWizardInputTypeCheckbox {
 					continue
 				}
@@ -428,9 +425,7 @@ func (m *wizardModel) updateInputs(msg tea.Msg) tea.Cmd {
 
 	// Only text inputs with Focus() set will respond, so it's safe to simply
 	// update all of them here without any further logic.
-	for i := range m.inputs {
-		input := m.inputs[i]
-
+	for i, input := range m.inputs {
 		if input.inputType == bootstrapWizardInputTypeCheckbox {
 			continue
 		}
@@ -450,9 +445,7 @@ func (m wizardModel) getContent() string {
 		"Enter to move to the next input or submit the form, " + "\n" +
 		"up and down arrows to scroll the view, Ctrl+C twice to quit):" + "\n\n\n")
 
-	for i := range m.inputs {
-		input := m.inputs[i]
-
+	for i, input := range m.inputs {
 		b.WriteString(input.prompt)
 		b.WriteRune('\n')
 		b.WriteString(input.getView(i == m.focusIndex))

--- a/pkg/run/bootstrap/bootstrap_wizard_ui.go
+++ b/pkg/run/bootstrap/bootstrap_wizard_ui.go
@@ -2,6 +2,7 @@ package bootstrap
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/table"
@@ -19,7 +20,38 @@ type preWizardModel struct {
 	msgChan       chan GitProvider
 }
 
-const flagSeparator = " - "
+type wizardModel struct {
+	windowIsReady bool
+	viewport      viewport.Model
+	inputs        []*bootstrapWizardInput
+	msgChan       chan BootstrapCmdOptions
+	cursorMode    textinput.CursorMode
+	focusIndex    int
+	errorMsg      string
+}
+
+type checkbox struct {
+	checked bool
+}
+
+type bootstrapWizardInputType int32
+
+const (
+	bootstrapWizardInputTypeTextInput bootstrapWizardInputType = 0
+	bootstrapWizardInputTypeCheckbox  bootstrapWizardInputType = 1
+)
+
+type bootstrapWizardInput struct {
+	inputType     bootstrapWizardInputType
+	prompt        string
+	textInput     textinput.Model
+	checkboxInput *checkbox
+}
+
+const (
+	flagSeparator = " - "
+	buttonText    = "Submit"
+)
 
 // UI styling
 var (
@@ -37,8 +69,8 @@ var (
 	helpStyle           = blurredStyle.Copy()
 	cursorModeHelpStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("244"))
 
-	focusedButton = focusedStyle.Copy().Render("[ Submit ]")
-	blurredButton = fmt.Sprintf("[ %s ]", blurredStyle.Render("Submit"))
+	focusedButton = focusedStyle.Render(fmt.Sprintf("[ %s ]", buttonText))
+	blurredButton = fmt.Sprintf("[ %s ]", blurredStyle.Render(buttonText))
 )
 
 func makeViewport(width int, height int, content string) viewport.Model {
@@ -162,62 +194,93 @@ func (m preWizardModel) getContent() string {
 	) + m.textInput.View()
 }
 
-type wizardModel struct {
-	windowIsReady bool
-	viewport      viewport.Model
-	textInputs    []textinput.Model
-	prompts       []string
-	msgChan       chan BootstrapCmdOptions
-	cursorMode    textinput.CursorMode
-	focusIndex    int
-	errorMsg      string
+func makeInput(task *BootstrapWizardTask, isFocused bool) *bootstrapWizardInput {
+	var inputType bootstrapWizardInputType
+
+	if task.isBoolean {
+		inputType = bootstrapWizardInputTypeCheckbox
+	} else {
+		inputType = bootstrapWizardInputTypeTextInput
+	}
+
+	prompt := task.flagName + flagSeparator + task.flagDescription
+
+	ti := textinput.Model{}
+
+	var cb *checkbox
+
+	if inputType == bootstrapWizardInputTypeCheckbox {
+		cb = &checkbox{
+			checked: task.flagValue == "true",
+		}
+	} else {
+		ti = textinput.New()
+		ti.CursorStyle = cursorStyle
+		ti.CharLimit = 100
+
+		ti.SetValue(task.flagValue)
+		ti.Placeholder = task.flagDescription
+
+		if task.isPassword {
+			ti.EchoMode = textinput.EchoPassword
+		}
+
+		if isFocused {
+			ti.Focus()
+			ti.PromptStyle = focusedStyle
+			ti.TextStyle = focusedStyle
+		}
+	}
+
+	return &bootstrapWizardInput{
+		inputType:     inputType,
+		prompt:        prompt,
+		textInput:     ti,
+		checkboxInput: cb,
+	}
 }
 
-func makeTextInput(task *BootstrapWizardTask, isFocused bool) textinput.Model {
-	ti := textinput.New()
-	ti.CursorStyle = cursorStyle
-	ti.CharLimit = 100
-
-	ti.SetValue(task.flagValue)
-	ti.Placeholder = task.flagDescription
-
-	if task.isPassword {
-		ti.EchoMode = textinput.EchoPassword
+func (input *bootstrapWizardInput) getView(isFocused bool) string {
+	if input.inputType == bootstrapWizardInputTypeTextInput {
+		return input.textInput.View()
 	}
+
+	var checkmark string
+
+	if input.checkboxInput.checked {
+		checkmark = "x"
+
+		if isFocused {
+			checkmark = focusedStyle.Render(checkmark)
+		}
+	} else {
+		checkmark = blurredStyle.Render("_")
+	}
+
+	open := "["
+	close := "]"
 
 	if isFocused {
-		ti.Focus()
-		ti.PromptStyle = focusedStyle
-		ti.TextStyle = focusedStyle
+		open = focusedStyle.Render(open)
+		close = focusedStyle.Render(close)
 	}
 
-	return ti
+	return fmt.Sprintf("%s%s%s", open, checkmark, close)
 }
 
 func initialWizardModel(tasks []*BootstrapWizardTask, msgChan chan BootstrapCmdOptions) wizardModel {
 	numInputs := len(tasks)
 
-	inputs := make([]textinput.Model, numInputs)
+	inputs := make([]*bootstrapWizardInput, numInputs)
 
 	for i := range inputs {
-		task := tasks[i]
-
-		ti := makeTextInput(task, i == 0)
-
-		inputs[i] = ti
-	}
-
-	prompts := []string{}
-
-	for _, task := range tasks {
-		prompts = append(prompts, task.flagName+flagSeparator+task.flagDescription)
+		inputs[i] = makeInput(tasks[i], i == 0)
 	}
 
 	return wizardModel{
-		textInputs: inputs,
-		errorMsg:   "",
-		prompts:    prompts,
-		msgChan:    msgChan,
+		inputs:   inputs,
+		errorMsg: "",
+		msgChan:  msgChan,
 	}
 }
 
@@ -241,34 +304,43 @@ func (m wizardModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.cursorMode = textinput.CursorBlink
 			}
 
-			cmdsTextInputs := make([]tea.Cmd, len(m.textInputs))
+			cmdsTextInputs := make([]tea.Cmd, len(m.inputs))
 
-			for i := range m.textInputs {
-				cmdsTextInputs[i] = m.textInputs[i].SetCursorMode(m.cursorMode)
+			for i := range m.inputs {
+				input := m.inputs[i]
+				if input.inputType == bootstrapWizardInputTypeTextInput {
+					cmdsTextInputs[i] = input.textInput.SetCursorMode(m.cursorMode)
+				}
 			}
 
 			cmds = append(cmds, cmdsTextInputs...)
 		case tea.KeyTab, tea.KeyShiftTab, tea.KeyEnter:
 			t := msg.Type
 
-			if t == tea.KeyEnter && m.focusIndex == len(m.textInputs) {
+			if t == tea.KeyEnter && m.focusIndex == len(m.inputs) {
 				options := make(BootstrapCmdOptions)
 
-				for i, input := range m.textInputs {
-					prompt := m.prompts[i]
+				for _, input := range m.inputs {
+					prompt := input.prompt
 
-					value := strings.TrimSpace(input.Value())
+					var value string
 
-					if value == "" {
-						m.errorMsg = "Missing value in " + input.Placeholder
+					if input.inputType == bootstrapWizardInputTypeTextInput {
+						value = strings.TrimSpace(input.textInput.Value())
 
-						m.viewport.SetContent(m.getContent())
+						if value == "" {
+							m.errorMsg = "Missing value in " + input.textInput.Placeholder
 
-						var cmdViewport tea.Cmd
+							m.viewport.SetContent(m.getContent())
 
-						m.viewport, cmdViewport = m.viewport.Update(msg)
+							var cmdViewport tea.Cmd
 
-						return m, cmdViewport
+							m.viewport, cmdViewport = m.viewport.Update(msg)
+
+							return m, cmdViewport
+						}
+					} else {
+						value = strconv.FormatBool(input.checkboxInput.checked)
 					}
 
 					options[prompt[:strings.Index(prompt, flagSeparator)]] = value
@@ -285,29 +357,43 @@ func (m wizardModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.focusIndex++
 			}
 
-			if m.focusIndex > len(m.textInputs) {
+			if m.focusIndex > len(m.inputs) {
 				m.focusIndex = 0
 			} else if m.focusIndex < 0 {
-				m.focusIndex = len(m.textInputs)
+				m.focusIndex = len(m.inputs)
 			}
 
-			cmdsTextInputs := make([]tea.Cmd, len(m.textInputs))
+			cmdsTextInputs := []tea.Cmd{}
 
-			for i := 0; i <= len(m.textInputs)-1; i++ {
+			for i := 0; i <= len(m.inputs)-1; i++ {
+				input := m.inputs[i]
+
+				if input.inputType == bootstrapWizardInputTypeCheckbox {
+					continue
+				}
+
 				if i == m.focusIndex {
-					cmdsTextInputs[i] = m.textInputs[i].Focus()
-					m.textInputs[i].PromptStyle = focusedStyle
-					m.textInputs[i].TextStyle = focusedStyle
+					cmdsTextInputs = append(cmdsTextInputs, input.textInput.Focus())
+					input.textInput.PromptStyle = focusedStyle
+					input.textInput.TextStyle = focusedStyle
 
 					continue
 				}
 
-				m.textInputs[i].Blur()
-				m.textInputs[i].PromptStyle = noStyle
-				m.textInputs[i].TextStyle = noStyle
+				input.textInput.Blur()
+				input.textInput.PromptStyle = noStyle
+				input.textInput.TextStyle = noStyle
 			}
 
 			cmds = append(cmds, cmdsTextInputs...)
+		case tea.KeySpace:
+			input := m.inputs[m.focusIndex]
+
+			if m.focusIndex == len(m.inputs) || input.inputType != bootstrapWizardInputTypeCheckbox {
+				break
+			}
+
+			input.checkboxInput.checked = !input.checkboxInput.checked
 		}
 	case tea.WindowSizeMsg:
 		if !m.windowIsReady {
@@ -338,12 +424,18 @@ func (m wizardModel) View() string {
 }
 
 func (m *wizardModel) updateInputs(msg tea.Msg) tea.Cmd {
-	cmds := make([]tea.Cmd, len(m.textInputs))
+	cmds := make([]tea.Cmd, len(m.inputs))
 
 	// Only text inputs with Focus() set will respond, so it's safe to simply
 	// update all of them here without any further logic.
-	for i := range m.textInputs {
-		m.textInputs[i], cmds[i] = m.textInputs[i].Update(msg)
+	for i := range m.inputs {
+		input := m.inputs[i]
+
+		if input.inputType == bootstrapWizardInputTypeCheckbox {
+			continue
+		}
+
+		input.textInput, cmds[i] = input.textInput.Update(msg)
 	}
 
 	return tea.Batch(cmds...)
@@ -354,21 +446,24 @@ func (m wizardModel) getContent() string {
 
 	b.WriteString("Please enter the following values" + "\n" +
 		"(Tab and Shift+Tab to move input selection," + "\n" +
+		"(Space to toggle the currently focused checkbox," + "\n" +
 		"Enter to move to the next input or submit the form, " + "\n" +
 		"up and down arrows to scroll the view, Ctrl+C twice to quit):" + "\n\n\n")
 
-	for i := range m.textInputs {
-		b.WriteString(m.prompts[i])
-		b.WriteRune('\n')
-		b.WriteString(m.textInputs[i].View())
+	for i := range m.inputs {
+		input := m.inputs[i]
 
-		if i < len(m.textInputs)-1 {
+		b.WriteString(input.prompt)
+		b.WriteRune('\n')
+		b.WriteString(input.getView(i == m.focusIndex))
+
+		if i < len(m.inputs)-1 {
 			b.WriteRune('\n')
 		}
 	}
 
 	button := &blurredButton
-	if m.focusIndex == len(m.textInputs) {
+	if m.focusIndex == len(m.inputs) {
 		button = &focusedButton
 	}
 


### PR DESCRIPTION
Closes #2870 

- Added type `bootstrapWizardInput` and related types.

- Replaced text fields with checkboxes for Boolean values in the bootstrap wizard. Checkboxes can be toggles with the Space key when focused.

- Minor refactoring:
-- added local variables for input lookup (`input := inputs[i]`) for readability
-- removed unnecessary copying of styles. I previously copied it from Bubble Tea examples, so I'm not sure why `style.Copy()` was used not only when creating new styles based on old styles but also when just rendering elements with in this style. So, removed it and tested it locally, it seems to work fine without the redundant copying. If anything goes wrong, we can always put it back, but it should work fine.

Questions:

- Maybe some type names could be shorter? But they were clashing with some other names or reserved words or didn't informative enough.

Checkbox toggled with space:

<img width="568" alt="Screenshot 2022-10-26 at 13 39 14" src="https://user-images.githubusercontent.com/8824708/198016972-16e0033d-c2e8-4c88-92b4-a9877afbc135.png">

Greyed out underscore marks false value. The color of the underscore can be changed or or the underscore can be removed easily if needed.

Focuses checkbox with true value + unfocused checkbox:

<img width="592" alt="Screenshot 2022-10-26 at 13 39 21" src="https://user-images.githubusercontent.com/8824708/198017024-4530ae03-01b5-4ca0-b8f7-798fd8c9458b.png">

<img width="581" alt="Screenshot 2022-10-26 at 13 39 33" src="https://user-images.githubusercontent.com/8824708/198017027-d99f21a9-c392-4177-af4a-16797a012174.png">
