### PR TITLE
Allow overriding the user-clients-cache TTL from env var

### DIFF
--- a/core/clustersmngr/factory.go
+++ b/core/clustersmngr/factory.go
@@ -36,11 +36,11 @@ const (
 	kubeClientDialTimeout   = 5 * time.Second
 	kubeClientDialKeepAlive = 30 * time.Second
 	usersClientResolution   = 30 * time.Second
-	usersClientsTTL         = 30 * time.Minute
 )
 
 var (
 	kubeClientTimeout = getEnvDuration("WEAVE_GITOPS_KUBE_CLIENT_TIMEOUT", 30*time.Second)
+	usersClientsTTL   = getEnvDuration("WEAVE_GITOPS_USERS_CLIENTS_TTL", 30*time.Minute)
 )
 
 func getEnvDuration(key string, defaultDuration time.Duration) time.Duration {


### PR DESCRIPTION
- Some cases 30mins might be too long
- Can experiment

<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->

<!-- Describe what has changed in this PR -->
**What changed?**

Allows overriding of the user-clients-cache TTL via an env var

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**

This is a new feature and 30mins _might_ be a bit long in some cases. Its nice to have a var to tweak to debug in some circumstances.

<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**

Follows a similar pre-existing pattern to read the duration from an env var

<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**

- Tested manually