### PR TITLE
Update filterByTypeCallback

### DIFF
--- a/ui/components/DataTable.tsx
+++ b/ui/components/DataTable.tsx
@@ -103,7 +103,7 @@ export const filterByStatusCallback = (v) => {
   else return ReadyType.NotReady;
 };
 
-export const filterByTypeCallback = (v) => _.get(v, "groupVersionKind.kind");
+export const filterByTypeCallback = (v) => v.type;
 
 export function filterConfig(
   rows,

--- a/ui/components/DataTable.tsx
+++ b/ui/components/DataTable.tsx
@@ -103,8 +103,6 @@ export const filterByStatusCallback = (v) => {
   else return ReadyType.NotReady;
 };
 
-export const filterByTypeCallback = (v) => v.type;
-
 export function filterConfig(
   rows,
   key: string,
@@ -139,10 +137,6 @@ export function filterRows<T>(rows: T[], filters: FilterConfig) {
       // status
       if (category === "status") {
         value = filterByStatusCallback(row);
-      }
-      // type
-      else if (category === "type" && typeof row[category] !== "string") {
-        value = filterByTypeCallback(row);
       }
       // strings
       else value = row[category];

--- a/ui/components/ReconciledObjectsTable.tsx
+++ b/ui/components/ReconciledObjectsTable.tsx
@@ -9,11 +9,7 @@ import { formatURL, objectTypeToRoute } from "../lib/nav";
 import { Automation, FluxObject } from "../lib/objects";
 import { NoNamespace } from "../lib/types";
 import { makeImageString, statusSortHelper } from "../lib/utils";
-import DataTable, {
-  filterByStatusCallback,
-  filterByTypeCallback,
-  filterConfig,
-} from "./DataTable";
+import DataTable, { filterByStatusCallback, filterConfig } from "./DataTable";
 import ImageLink from "./ImageLink";
 import KubeStatusIndicator, { computeMessage } from "./KubeStatusIndicator";
 import Link from "./Link";
@@ -41,7 +37,7 @@ function ReconciledObjectsTable({
   );
 
   const initialFilterState = {
-    ...filterConfig(objs, "type", filterByTypeCallback),
+    ...filterConfig(objs, "type"),
     ...filterConfig(objs, "namespace"),
     ...filterConfig(objs, "status", filterByStatusCallback),
   };

--- a/ui/components/__tests__/DataTableFilters.test.tsx
+++ b/ui/components/__tests__/DataTableFilters.test.tsx
@@ -7,7 +7,6 @@ import { statusSortHelper } from "../../lib/utils";
 import DataTable, {
   Field,
   filterByStatusCallback,
-  filterByTypeCallback,
   filterConfig,
   filterRows,
   filterSelectionsToQueryString,
@@ -283,112 +282,6 @@ describe("DataTableFilters", () => {
     expect(tableRows2[0].innerHTML).toContain("cool");
 
     const chip2 = screen.getByText(`status${filterSeparator}Suspended`);
-    expect(chip2).toBeTruthy();
-  });
-  it("should filter by type with callback", () => {
-    const rows = [
-      {
-        name: "cool",
-        groupVersionKind: {
-          kind: "foo",
-        },
-      },
-      {
-        name: "slick",
-        groupVersionKind: {
-          kind: "bar",
-        },
-      },
-      {
-        name: "neat",
-        groupVersionKind: {
-          kind: "bar",
-        },
-      },
-      {
-        name: "rad",
-        groupVersionKind: {
-          kind: "bar",
-        },
-      },
-    ];
-
-    const fields: Field[] = [
-      {
-        label: "Name",
-        value: "name",
-        textSearchable: true,
-      },
-      {
-        label: "Type",
-        value: (v: any) => v.groupVersionKind.kind,
-      },
-      {
-        label: "Status",
-        value: "success",
-      },
-      {
-        label: "Qty",
-        value: "count",
-      },
-    ];
-
-    const initialFilterState = {
-      ...filterConfig(rows, "type", filterByTypeCallback),
-    };
-
-    render(
-      withTheme(
-        withContext(
-          <DataTable
-            fields={fields}
-            rows={rows}
-            filters={initialFilterState}
-            dialogOpen
-          />,
-          "/applications",
-          {}
-        )
-      )
-    );
-
-    const tableRows1 = document.querySelectorAll("tbody tr");
-
-    expect(tableRows1).toHaveLength(4);
-    expect(tableRows1[0].innerHTML).toContain("foo");
-
-    const checkbox1 = document.getElementById(
-      `type${filterSeparator}foo`
-    ) as HTMLInputElement;
-    fireEvent.click(checkbox1);
-
-    const tableRows2 = document.querySelectorAll("tbody tr");
-    expect(tableRows2).toHaveLength(1);
-    expect(tableRows2[0].innerHTML).toContain("foo");
-
-    const chip1 = screen.getByText(`type${filterSeparator}foo`);
-    expect(chip1).toBeTruthy();
-
-    const clearAll = screen.getByText("Clear All");
-    const svgButton = clearAll.parentElement.getElementsByTagName("svg")[0];
-    fireEvent.click(svgButton);
-
-    const tableRows3 = document.querySelectorAll("tbody tr");
-
-    expect(tableRows3).toHaveLength(rows.length);
-
-    const checkbox2 = document.getElementById(
-      `type${filterSeparator}bar`
-    ) as HTMLInputElement;
-    fireEvent.click(checkbox2);
-
-    const tableRows4 = document.querySelectorAll("tbody tr");
-    expect(tableRows4).toHaveLength(3);
-    expect(tableRows4[0].innerHTML).toContain("bar");
-    expect(tableRows4[1].innerHTML).toContain("bar");
-    expect(tableRows4[2].innerHTML).toContain("bar");
-
-    const chip2 = screen.getByText(`type${filterSeparator}bar`);
     expect(chip2).toBeTruthy();
   });
   it("should select/deselect all when category checkbox is clicked", () => {

--- a/ui/index.ts
+++ b/ui/index.ts
@@ -4,7 +4,6 @@ import Button from "./components/Button";
 import DagGraph from "./components/DagGraph";
 import DataTable, {
   filterByStatusCallback,
-  filterByTypeCallback,
   filterConfig,
 } from "./components/DataTable";
 import DependenciesView from "./components/DependenciesView";
@@ -97,7 +96,6 @@ export {
   EventsTable,
   Flex,
   filterByStatusCallback,
-  filterByTypeCallback,
   filterConfig,
   FluxRuntime,
   Footer,


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes #2959 

We had a special method for filtering type in the ReconciledObjectsTable that isn't needed anymore - especially since it breaks things now. Removed. I removed the specific test for it as well (we're already testing filtering type as a string from key 'type'). Also removed from exports - I checked the enterprise repo and it's not being used there so we should be good. 

<img width="2048" alt="image" src="https://user-images.githubusercontent.com/65822698/199581563-404b9dfc-338a-402f-a9c8-d8aa9445e7a5.png">

