### PR TITLE
Protect against undefined labels in ControllersTable

### DIFF
--- a/ui/components/ControllersTable.tsx
+++ b/ui/components/ControllersTable.tsx
@@ -59,7 +59,8 @@ function ControllersTable({ className, controllers = [] }: Props) {
           : []),
         {
           label: "Flux Version",
-          value: (d: Deployment) => d.labels[fluxVersionLabel],
+          value: (d: Deployment) =>
+            d.labels ? d.labels[fluxVersionLabel] : "",
         },
         {
           value: (d: Deployment) => (


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes #2963

So I'm pretty sure this was just because I hadn't refreshed my backend in Tilt....but hey - it's good to protect against undefined anyway right? The FluxRuntime api requests should probably be returning FluxObjects at this point, but that can be addressed in a separate issue
