### PR TITLE
Do not assume template.spec in images() call

### DIFF
--- a/ui/lib/objects.ts
+++ b/ui/lib/objects.ts
@@ -114,7 +114,9 @@ export class FluxObject {
   get images(): string[] {
     const spec = this.obj.spec;
     if (!spec) return [];
-    if (spec.template) return spec.template.spec.containers.map((x) => x.image);
+    if (spec.template) {
+      return spec.template.spec?.containers.map((x) => x.image);
+    }
     if (spec.containers) return spec.containers.map((x) => x.image);
     return [];
   }


### PR DESCRIPTION
Fixes #2981 (probably?)

We assumed a returned object has a `.spec.containers`, which may not be correct. 