### PR TITLE
docs: More typo fixes

### DIFF
--- a/website/docs/cluster-management/deleting-a-cluster.mdx
+++ b/website/docs/cluster-management/deleting-a-cluster.mdx
@@ -18,5 +18,5 @@ import TierLabel from "../_components/TierLabel";
 
 ### Notes
 
-A current limitation is the inability to apply an _empty_ repository to a cluster. If you have capi clusters and other manifests commited to this repository, and then _delete all of them_ so there are 0 manifests left, then the apply will fail and the resources will not be removed from the cluster.
+A current limitation is the inability to apply an _empty_ repository to a cluster. If you have capi clusters and other manifests committed to this repository, and then _delete all of them_ so there are 0 manifests left, then the apply will fail and the resources will not be removed from the cluster.
 A workaround is to add a dummy _ConfigMap_ back to the git repository after deleting everything else so that there is at least 1 manifest to apply.

--- a/website/docs/cluster-management/profiles.mdx
+++ b/website/docs/cluster-management/profiles.mdx
@@ -81,7 +81,7 @@ spec:
 
 ### 2. Select which profiles you want installed when creating a cluster
 
-Currenly WGE inspects the current namespace that it is deployed in (in the management cluster) for a `HelmRepository` object named `weaveworks-charts`. This Kubernetes object should be pointing to a Helm chart repository that includes the profiles that are available for installation.
+Currently WGE inspects the current namespace that it is deployed in (in the management cluster) for a `HelmRepository` object named `weaveworks-charts`. This Kubernetes object should be pointing to a Helm chart repository that includes the profiles that are available for installation.
 
 When creating a cluster from the UI using a CAPI template, these profiles should be available for selection in the `Profiles` section of the template. For example:
 

--- a/website/docs/enterprise/multi-tenancy.mdx
+++ b/website/docs/enterprise/multi-tenancy.mdx
@@ -17,7 +17,7 @@ WGE multi tenancy expands on the multi tenancy feature provided by `flux`. In ad
 
 ## How it works
 
-`gitops` command line tool is responsible for creating the multi tenancy resources. The tool is distributed as part of WGE offering. It reads the definitions of a yaml file and can either apply the necessary changes directly to the cluster or output it to stdout so it can be saved into a file and pushed to a repo to be reconcilled by `flux`.
+`gitops` command line tool is responsible for creating the multi tenancy resources. The tool is distributed as part of WGE offering. It reads the definitions of a yaml file and can either apply the necessary changes directly to the cluster or output it to stdout so it can be saved into a file and pushed to a repo to be reconciled by `flux`.
 
 To make use of the policy features, [policy agent](../policy/intro.mdx) needs to be installed in the necessary cluster(s). 
 

--- a/website/docs/gitops-run/overview.mdx
+++ b/website/docs/gitops-run/overview.mdx
@@ -29,7 +29,7 @@ get started with GitOps:
 
 ### Additional Benefits
 * No need to run `kubectl`, `helm`, `kustomize`, or `flux` CLI commands.  Just create the manifests and we'll put them on the cluster for you.
-* Reduces the cycle time when configuring your cluster.  With normal GitOps there is a lot of commit/push/reconcile workflows that can be frustrating.  This skips that and you can test your changes directly before commiting and pushing code to yor Git repository.
+* Reduces the cycle time when configuring your cluster.  With normal GitOps there is a lot of commit/push/reconcile workflows that can be frustrating.  This skips that and you can test your changes directly before committing and pushing code to yor Git repository.
 * Multiple options for debugging Flux such as using the Dashboard that comes with Weave GitOps or getting live feedback by leveraging the [GitOps Tools for Flux](https://marketplace.visualstudio.com/items?itemName=Weaveworks.vscode-gitops-tools) VSCode extension.
 
 ## Terminology
@@ -44,7 +44,7 @@ to the cluster.
 
 #### Run:
 This is when the cluster has GitOps Run running on the cluster. There is a live reload session
-that is occuring and the cluster is no longer in a pure GitOps or Snowflake mode. Ideally, when
+that is occurring and the cluster is no longer in a pure GitOps or Snowflake mode. Ideally, when
 GitOps Run stops running that the cluster enters into the GitOps mode that is defined above.
 
 #### Snowflake:

--- a/website/docs/gitops-templates/templates.mdx
+++ b/website/docs/gitops-templates/templates.mdx
@@ -114,7 +114,7 @@ Supported templating languages:
     templating uses text/templating for rendering, using go-templating style syntax `{{ .params.CLUSTER_NAME }}` where params are provided by the `.params` variable. 
     Template functions can also be used with the syntax `{{ .params.CLUSTER_NAME | FUNCTION }}`. 
     
-    #### Supported functions [(from Sprig libray)](http://masterminds.github.io/sprig/)
+    #### Supported functions [(from Sprig library)](http://masterminds.github.io/sprig/)
 
     | __Function Type__                   | __Functions__                                                     |
     | -----------------                   | --------------                                                  |
@@ -207,9 +207,9 @@ spec:
 You can provide additional metadata about the parameters to the templates in the `spec.params` section.
 
 - `name`: The variable name within the resource templates
-- `descripton`: Description of the parameter. This will be rendered in the UI and CLI
+- `description`: Description of the parameter. This will be rendered in the UI and CLI
 - `options`: The list of possible values this parameter can be set to.
-- `required` -  Whether the paramter must contain a non-empty value
+- `required` -  Whether the parameter must contain a non-empty value
 - `default` - Default value of the parameter 
 
 Sample:

--- a/website/docs/installation.mdx
+++ b/website/docs/installation.mdx
@@ -36,13 +36,15 @@ This version of Weave GitOps is tested against the following Flux releases:
 
 Weave GitOps includes a command-line interface to help users create and manage resources.
 
+:::note Installation options
 The `gitops` CLI is currently supported on Mac (x86 and Arm), and Linux - including Windows Subsystem for Linux (WSL).
 
 Windows support is a [planned enhancement](https://github.com/weaveworks/weave-gitops/issues/663).
+:::
 
 To install:
 
-```console
+```bash
 curl --silent --location "https://github.com/weaveworks/weave-gitops/releases/download/v0.10.1/gitops-$(uname)-$(uname -m).tar.gz" | tar xz -C /tmp
 sudo mv /tmp/gitops /usr/local/bin
 gitops version
@@ -59,7 +61,7 @@ brew install weaveworks/tap/gitops
 
 Weave GitOps is provided through a Helm Chart and installed as a Flux resource through a `HelmRepository` and `HelmRelease`. To install on your cluster, adjust the following so that `username` is the username you want and `passwordHash` is a bcrypt hash of your password, and commit the file to the location bootstrapped with Flux so that it is synchronized to your Cluster.
 
-```
+```yaml
 apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease
 metadata:
@@ -207,7 +209,7 @@ aws eks --region "$REGION" update-kubeconfig --name "$CLUSTERNAME"
 <Tabs groupId="infrastructure" default>
 <TabItem value="github" label="GITHUB">
 
-```
+```bash
 flux bootstrap github \
   --owner=<github username> \
   --repository=fleet-infra \
@@ -220,7 +222,7 @@ flux bootstrap github \
 
 <TabItem value="gitlab" label="GITLAB">
 
-```
+```bash
 flux bootstrap gitlab \
   --owner=<gitlab username> \
   --repository=fleet-infra \
@@ -262,7 +264,7 @@ Here we'll continue with our example instructions for CAPD and CAPA.
 <Tabs groupId="infrastructure" default>
 <TabItem value="kind" label="CAPD (kind)">
 
-```
+```bash
 # Enable support for `ClusterResourceSet`s for automatically installing CNIs
 export EXP_CLUSTER_RESOURCE_SET=true
 
@@ -272,7 +274,7 @@ clusterctl init --infrastructure docker
 </TabItem>
 <TabItem value="eks" label="CAPA (EKS)">
 
-```
+```bash
 export EXP_EKS=true
 export EXP_MACHINE_POOL=true
 export CAPA_EKS_IAM=true
@@ -380,7 +382,7 @@ When the new cluster is bootstrapped, flux will be sync the `./clusters/{.namesp
 
 Commit and push all the files
 
-```
+```bash
 git add clusters/management/weave-gitops-enterprise.yaml
 git commit -m "Deploy Weave GitOps Enterprise"
 git push
@@ -414,7 +416,7 @@ kubectl create secret generic cluster-user-auth \
 
 You should now be able to load the WGE UI by port forwarding. 
 
-```bash
+```console
 kubectl port-forward --namespace flux-system svc/clusters-service 8000:8000
 ```
 
@@ -436,7 +438,8 @@ With Flux and the TF-Controller, Weave GitOps Enterprise makes it easy to add Te
 Check out our guide on how to [use Terraform templates](./../guides/using-terraform-templates), and why not try your hands at using it with the RDS example!
 
 Install the TF-Controller to a cluster using Helm:
-```bash
+
+```console
 # Add tf-controller helm repository
 helm repo add tf-controller https://weaveworks.github.io/tf-controller/
 
@@ -451,11 +454,11 @@ Consult the TF-Controller [Installation](https://weaveworks.github.io/tf-control
 Install the Weave GitOps Enterprise CLI tool.
 You can use brew or curl
 
-```
+```console
 brew install weaveworks/tap/gitops-ee
 ```
 
-```
+```bash
 curl -O https://artifacts.wge.dev.weave.works/releases/bin/0.9.5/gitops-linux-x86_64.tar.gz
 ```
 
@@ -537,6 +540,7 @@ Use this `eksctl` configuration below (replacing the placeholder values) to:
 - Create the required service account ARN
 
 Save the example below as `oidc-config.yaml`
+
 ```yaml
 ---
 apiVersion: eksctl.io/v1alpha5
@@ -599,7 +603,8 @@ gitops:
 ```
 
 Then install it:
-```bash
+
+```console
 helm install wego <URL/PATH> \
   --namespace=flux-system \
   --create-namespace \
@@ -619,7 +624,7 @@ helm install wego <URL/PATH> \
 
 Run the following from your workstation:
 
-```bash
+```console
 kubectl get pods -n flux-system
 # you should see something like the following returned
 flux-system          helm-controller-5b96d94c7f-tds9n                    1/1     Running   0          53s
@@ -633,7 +638,9 @@ flux-system          ww-gitops-weave-gitops-5bdc9f7744-vkh65             1/1    
 Your Weave GitOps installation is now ready!
 
 The quickest way to access your dashboard is by setting up a port forward:
-```
+
+```console
 kubectl port-forward svc/ww-gitops-weave-gitops -n flux-system 9001:9001
 ```
+
 Then, [open the dashboard](http://localhost:9001/).

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -5,9 +5,9 @@ hide_title: true
 ---
 # Weave GitOps
 
-Weave GitOps is a powerful extension to [Flux](https://fluxcd.io), a leading GitOps engine and CNCF project, which provides insights into your application deployments, and makes continuous delivery with GitOps easier to adopt and scale across your teams.
+Weave GitOps is a powerful extension to [Flux](https://fluxcd.io), a leading GitOps engine and CNCF project. Weave GitOps provides insights into your application deployments, and makes continuous delivery with GitOps easier to adopt and scale across your teams.
 
-The web UI surfaces key information to help application operators easily discover and resolve issues. The intuitive interface provides a guided experience to build understanding and simplify getting started for new users; they can easily discover the relationship between Flux objects and navigate to deeper levels of information as required.
+Its web UI surfaces key information to help application operators easily discover and resolve issues. The intuitive interface provides a guided experience to build understanding and simplify getting started for new users; they can easily discover the relationship between Flux objects and navigate to deeper levels of information as required.
 
 Weave GitOps is an open source project sponsored by [Weaveworks](https://weave.works) - the GitOps company, and original creators of [Flux](https://fluxcd.io).
 

--- a/website/docs/policy/commit-time-checks.mdx
+++ b/website/docs/policy/commit-time-checks.mdx
@@ -12,7 +12,7 @@ import TierLabel from "../_components/TierLabel";
 # Commit/Build time checks  <TierLabel tiers="enterprise" />
 
 ## Overview
-Weave GitOps Enterprise enable developers and operators to check policy violations early in their software developement life cycle, specifically at commit and build time. Developers and operators can have Weave Policy Validator integrated in their CI tools to validate whether their code changes are violating any policies or not. 
+Weave GitOps Enterprise enable developers and operators to check policy violations early in their software development life cycle, specifically at commit and build time. Developers and operators can have Weave Policy Validator integrated in their CI tools to validate whether their code changes are violating any policies or not. 
 
 Weave GitOps Enterprise offer a policy engine image that can be used to perform commit/build time checks.The image can be found on Docker Hub under the name: `magalixcorp/weave-validator:v1.0.0`. 
 

--- a/website/docs/policy/releases.mdx
+++ b/website/docs/policy/releases.mdx
@@ -40,7 +40,7 @@ import TierLabel from "../_components/TierLabel";
 - v1.0.0
 - v1.1.0
 
-While both v.0.4.0 and v1.0.0 are compatible with the agent. Only v1.1.0 includes the modificaiton needed to make Controller Minimum Replica Count policy with with `horizontalpodautoscalers`
+While both v.0.4.0 and v1.0.0 are compatible with the agent. Only v1.1.0 includes the modification needed to make Controller Minimum Replica Count policy with with `horizontalpodautoscalers`
 
 ## v0.6.1
 

--- a/website/docs/policy/weave-policy-profile.mdx
+++ b/website/docs/policy/weave-policy-profile.mdx
@@ -22,7 +22,7 @@ Weave policy profile provides policies to automate the enforcement of best pract
 
 Policies are provided in the profile as Custom Resources. The agent reads from the policies deployed on the cluster and runs them during each admission request or when auditing a resource.
 
-Policies are hosted in a policy library which is ususally a git repository. They are fetched in the profile through the use of `kustomize.toolkit.fluxcd.io.Kustomization`, that deploys the policies to the cluster.
+Policies are hosted in a policy library which is usually a git repository. They are fetched in the profile through the use of `kustomize.toolkit.fluxcd.io.Kustomization`, that deploys the policies to the cluster.
 
 By default all policies in the specified path would be deployed in order to specify which policies should be deployed in a library, a `kustomize.config.k8s.io.Kustomization` file should be defined in the repository.
 
@@ -83,7 +83,7 @@ policy-agent:
   caCertificate: "---" # CA bundle to validate the webhook server, used by the client
 ```
 
-If the agent webhook could not be reached or the request failed to complete, the corresponding request would be refused. To change that behavior and accepts the reuqest in cases of failure, this needs to be set:
+If the agent webhook could not be reached or the request failed to complete, the corresponding request would be refused. To change that behavior and accepts the request in cases of failure, this needs to be set:
 
 ```yaml
 policy-agent:
@@ -109,7 +109,7 @@ Audit will be performed when the agent starts and then at an interval of your ch
 ---
 ## Policy Sets
 
-Policy set is a custom resource that gives more control over which policies to be used in each scenario. There are cases in which certain policies are required to be observed but denying the requests of violating objects would be disruptive. Policy set allows definining additional filters for each scenario: `Audit` and `Admission` so it is possible to report violations on certain policies without the need of blocking the deployments if certain policies are not as critical as others.
+Policy set is a custom resource that gives more control over which policies to be used in each scenario. There are cases in which certain policies are required to be observed but denying the requests of violating objects would be disruptive. Policy set allows defining additional filters for each scenario: `Audit` and `Admission` so it is possible to report violations on certain policies without the need of blocking the deployments if certain policies are not as critical as others.
 
 Policy set should also be hosted on the policy library. The following definition defines which specific policies should be used using policy names:
 
@@ -245,7 +245,7 @@ policy-agent:
 <TabItem value="elasticsearch" label="Elasticsearch">
 The results of validating entities against policies would be written in Elasticsearch index.
 
-To enable writing to elasticsearh in audit scenario:
+To enable writing to elasticsearch in audit scenario:
 
 ```yaml
 policy-agent:
@@ -292,5 +292,5 @@ status: string # Violation or Compliance
 message: string # message that summarizes the policy validation
 type: string # Admission or Audit
 trigger: string # what triggered the validation, create request or initial audit,..
-created_at: string # time that the validation occured in 
+created_at: string # time that the validation occurred in 
 ```


### PR DESCRIPTION
Also fix some readability by altering the code language in fenced blocks (Using "console" vs "bash" when things were hilighted the wrong way).

Signed-off-by: Daniel Holbach <daniel@weave.works>
