### PR TITLE
rename gitops run objects and add metadata

### DIFF
--- a/pkg/run/install/session.go
+++ b/pkg/run/install/session.go
@@ -35,6 +35,8 @@ func (s *Session) Connect() error {
 	subProcArgs := append(os.Args,
 		// we must run the sub-process without a session.
 		"--no-session",
+		// we must let the sub-run know that this is the session name of the sub-process
+		"--x-session-name", s.name,
 		// vclusters are always new clusters, that doesn't mean we haven't bootstrapped the outer cluster.
 		"--no-bootstrap",
 		// allow the sub-process to connect to the vcluster context.


### PR DESCRIPTION
Fixes #2813 

- rename objects to run-dev-bucket, and run-dev-ks
- add metadata to run-dev-bucket and run-dev-ks
- rename dev-bucket server namespace to gitops-run
- add a hidden flag --x-session-name to pass down the session name to the sub-process

Signed-off-by: Chanwit Kaewkasi <chanwit@weave.works>
