### PR TITLE
Add DaemonSet support to KubeStatusIndicator

### DIFF
--- a/charts/gitops-server/templates/admin-user-roles.yaml
+++ b/charts/gitops-server/templates/admin-user-roles.yaml
@@ -56,7 +56,7 @@ rules:
     resources: ["configmaps", "secrets", "pods", "services", "namespaces", "persistentvolumes", "persistentvolumeclaims"]
     verbs: [ "get", "list", "watch" ]
   - apiGroups: ["apps"]
-    resources: [ "deployments", "replicasets", "statefulsets"]
+    resources: [ "deployments", "replicasets", "statefulsets", "daemonsets"]
     verbs: [ "get", "list", "watch" ]
   - apiGroups: ["batch"]
     resources: [ "jobs", "cronjobs"]

--- a/ui/components/KubeStatusIndicator.tsx
+++ b/ui/components/KubeStatusIndicator.tsx
@@ -30,6 +30,7 @@ export function computeReady(conditions: Condition[]): ReadyType {
   const readyCondition =
     _.find(conditions, (c) => c.type === "Ready") ||
     _.find(conditions, (c) => c.type === "Available");
+
   if (readyCondition) {
     if (readyCondition.status === ReadyStatusValue.True) {
       return ReadyType.Ready;
@@ -77,7 +78,7 @@ export function computeMessage(conditions: Condition[]) {
   return conditions[0].message;
 }
 
-export type SpecialObject = "Daemonset";
+export type SpecialObject = "DaemonSet";
 
 interface DaemonSetStatus {
   currentNumberScheduled: number;
@@ -89,30 +90,34 @@ interface DaemonSetStatus {
   updatedNumberScheduled: number;
 }
 
-const NotReady: Condition[] = [
-  {
-    type: ReadyType.Ready,
-    status: ReadyStatusValue.False,
-    message: "Not Ready",
-  },
-];
-const Ready: Condition[] = [
-  { type: ReadyType.Ready, status: ReadyStatusValue.True, message: "Ready" },
-];
-const Unknown: Condition[] = [
-  { type: ReadyType.Ready, status: ReadyStatusValue.Unknown },
-];
+const NotReady: Condition = {
+  type: ReadyType.Ready,
+  status: ReadyStatusValue.False,
+  message: "Not Ready",
+};
+
+const Ready: Condition = {
+  type: ReadyType.Ready,
+  status: ReadyStatusValue.True,
+  message: "Ready",
+};
+
+const Unknown: Condition = {
+  type: ReadyType.Ready,
+  status: ReadyStatusValue.Unknown,
+  message: "Unknown",
+};
 
 // Certain objects to not have a status.conditions key, so we generate those conditions
 // and feed it into the `KubeStatusIndicator` to keep the public API consistent.
-export function createSyntheticConditions(
+export function createSyntheticCondition(
   kind: SpecialObject,
   // This will eventually be a union type when we add another special object.
   // Example: DaemonSetStatus | CoolObjectStatus | ...
   status: DaemonSetStatus
-): Condition[] {
+): Condition {
   switch (kind) {
-    case "Daemonset":
+    case "DaemonSet":
       if (status.numberReady === status.desiredNumberScheduled) {
         return Ready;
       }

--- a/ui/components/KubeStatusIndicator.tsx
+++ b/ui/components/KubeStatusIndicator.tsx
@@ -77,7 +77,7 @@ export function computeMessage(conditions: Condition[]) {
   return conditions[0].message;
 }
 
-type SpecialObject = "Daemonset";
+export type SpecialObject = "Daemonset";
 
 interface DaemonSetStatus {
   currentNumberScheduled: number;

--- a/ui/components/ReconciledObjectsTable.tsx
+++ b/ui/components/ReconciledObjectsTable.tsx
@@ -11,7 +11,11 @@ import { NoNamespace } from "../lib/types";
 import { makeImageString, statusSortHelper } from "../lib/utils";
 import DataTable, { filterByStatusCallback, filterConfig } from "./DataTable";
 import ImageLink from "./ImageLink";
-import KubeStatusIndicator, { computeMessage } from "./KubeStatusIndicator";
+import KubeStatusIndicator, {
+  computeMessage,
+  createSyntheticConditions,
+  SpecialObject,
+} from "./KubeStatusIndicator";
 import Link from "./Link";
 import RequestStateHandler from "./RequestStateHandler";
 import Text from "./Text";
@@ -97,14 +101,30 @@ function ReconciledObjectsTable({
           },
           {
             label: "Status",
-            value: (u: FluxObject) =>
-              u.conditions.length > 0 ? (
+            value: (u: FluxObject) => {
+              const status = u.obj.status;
+
+              if (!status || !status.conditions) {
+                return (
+                  <KubeStatusIndicator
+                    conditions={createSyntheticConditions(
+                      u.type as SpecialObject,
+                      status
+                    )}
+                    suspended={u.suspended}
+                    short
+                  />
+                );
+              }
+
+              return u.conditions.length > 0 ? (
                 <KubeStatusIndicator
                   conditions={u.conditions}
                   suspended={u.suspended}
                   short
                 />
-              ) : null,
+              ) : null;
+            },
             sortValue: statusSortHelper,
           },
           {

--- a/ui/components/ReconciledObjectsTable.tsx
+++ b/ui/components/ReconciledObjectsTable.tsx
@@ -13,7 +13,8 @@ import DataTable, { filterByStatusCallback, filterConfig } from "./DataTable";
 import ImageLink from "./ImageLink";
 import KubeStatusIndicator, {
   computeMessage,
-  createSyntheticConditions,
+  createSyntheticCondition,
+  ReadyStatusValue,
   SpecialObject,
 } from "./KubeStatusIndicator";
 import Link from "./Link";
@@ -105,12 +106,18 @@ function ReconciledObjectsTable({
               const status = u.obj.status;
 
               if (!status || !status.conditions) {
+                const cond = createSyntheticCondition(
+                  u.type as SpecialObject,
+                  status
+                );
+
+                if (cond.status === ReadyStatusValue.Unknown) {
+                  return null;
+                }
+
                 return (
                   <KubeStatusIndicator
-                    conditions={createSyntheticConditions(
-                      u.type as SpecialObject,
-                      status
-                    )}
+                    conditions={[cond]}
                     suspended={u.suspended}
                     short
                   />

--- a/ui/components/__tests__/KubeStatusIndicator.test.tsx
+++ b/ui/components/__tests__/KubeStatusIndicator.test.tsx
@@ -4,7 +4,7 @@ import React from "react";
 import renderer from "react-test-renderer";
 import { withTheme } from "../../lib/test-utils";
 import KubeStatusIndicator, {
-  createSyntheticConditions,
+  createSyntheticCondition,
 } from "../KubeStatusIndicator";
 
 describe("KubeStatusIndicator", () => {
@@ -169,9 +169,9 @@ describe("KubeStatusIndicator", () => {
         updatedNumberScheduled: 0,
       };
 
-      const conditions = createSyntheticConditions("Daemonset", status);
+      const condition = createSyntheticCondition("DaemonSet", status);
 
-      render(withTheme(<KubeStatusIndicator conditions={conditions} />));
+      render(withTheme(<KubeStatusIndicator conditions={[condition]} />));
 
       expect(screen.getByText("Not Ready")).toBeTruthy();
     });
@@ -186,9 +186,9 @@ describe("KubeStatusIndicator", () => {
         updatedNumberScheduled: 0,
       };
 
-      const conditions = createSyntheticConditions("Daemonset", status);
+      const condition = createSyntheticCondition("DaemonSet", status);
 
-      render(withTheme(<KubeStatusIndicator conditions={conditions} />));
+      render(withTheme(<KubeStatusIndicator conditions={[condition]} />));
 
       expect(screen.getByText("Ready")).toBeTruthy();
     });

--- a/ui/components/__tests__/KubeStatusIndicator.test.tsx
+++ b/ui/components/__tests__/KubeStatusIndicator.test.tsx
@@ -3,7 +3,9 @@ import "jest-styled-components";
 import React from "react";
 import renderer from "react-test-renderer";
 import { withTheme } from "../../lib/test-utils";
-import KubeStatusIndicator from "../KubeStatusIndicator";
+import KubeStatusIndicator, {
+  createSyntheticConditions,
+} from "../KubeStatusIndicator";
 
 describe("KubeStatusIndicator", () => {
   it("renders ready", () => {
@@ -155,6 +157,43 @@ describe("KubeStatusIndicator", () => {
     render(withTheme(<KubeStatusIndicator conditions={notReady} />));
     expect(screen.getByText(notReady[0].message)).toBeTruthy();
   });
+  describe("special objects", () => {
+    it("daemonset - not ready", () => {
+      const status = {
+        currentNumberScheduled: 0,
+        desiredNumberScheduled: 2,
+        numberMisscheduled: 0,
+        numberReady: 0,
+        numberUnavailable: 2,
+        observedGeneration: 0,
+        updatedNumberScheduled: 0,
+      };
+
+      const conditions = createSyntheticConditions("Daemonset", status);
+
+      render(withTheme(<KubeStatusIndicator conditions={conditions} />));
+
+      expect(screen.getByText("Not Ready")).toBeTruthy();
+    });
+    it("daemonset - ready", () => {
+      const status = {
+        currentNumberScheduled: 0,
+        desiredNumberScheduled: 2,
+        numberMisscheduled: 0,
+        numberReady: 2,
+        numberUnavailable: 0,
+        observedGeneration: 0,
+        updatedNumberScheduled: 0,
+      };
+
+      const conditions = createSyntheticConditions("Daemonset", status);
+
+      render(withTheme(<KubeStatusIndicator conditions={conditions} />));
+
+      expect(screen.getByText("Ready")).toBeTruthy();
+    });
+  });
+
   describe("snapshots", () => {
     it("renders success", () => {
       const conditions = [


### PR DESCRIPTION
Closes #2967 

Adds support for `DaemonSets` and a (hopefully) future-proof pattern for supporting other objects.

![Screenshot from 2022-11-15 11-33-43](https://user-images.githubusercontent.com/2802257/202010175-a26a90f0-54da-48f4-a575-8798a46a00c0.png)
