### PR TITLE
Add kind field to HelmRelease and Kustomization detail

### DIFF
--- a/ui/components/HelmReleaseDetail.tsx
+++ b/ui/components/HelmReleaseDetail.tsx
@@ -75,6 +75,7 @@ function HelmReleaseDetail({
       customTabs={customTabs}
       customActions={customActions}
       info={[
+        ["Kind", Kind.HelmRelease],
         ["Source", helmChartLink(helmRelease)],
         ["Chart", helmRelease?.helmChart.chart],
         ["Chart Version", helmRelease.helmChart.version],

--- a/ui/components/KustomizationDetail.tsx
+++ b/ui/components/KustomizationDetail.tsx
@@ -1,14 +1,15 @@
 import * as React from "react";
 import styled from "styled-components";
+import { useFeatureFlags } from "../hooks/featureflags";
+import { Kind } from "../lib/api/core/types.pb";
 import { Kustomization } from "../lib/objects";
 import { automationLastUpdated } from "../lib/utils";
-import { useFeatureFlags } from "../hooks/featureflags";
 import Alert from "./Alert";
 import AutomationDetail from "./AutomationDetail";
+import { InfoField } from "./InfoList";
 import Interval from "./Interval";
 import SourceLink from "./SourceLink";
 import Timestamp from "./Timestamp";
-import { InfoField } from "./InfoList";
 
 export interface routeTab {
   name: string;
@@ -50,6 +51,7 @@ function KustomizationDetail({
       automation={kustomization}
       customActions={customActions}
       info={[
+        ["Kind", Kind.Kustomization],
         [
           "Source",
           <SourceLink


### PR DESCRIPTION
Closes #2965 

Adds a `Kind` key/value to Kustomization and HelmRelease detail pages:
![Screenshot from 2022-11-15 11-48-08](https://user-images.githubusercontent.com/2802257/202012545-17637b4d-6e83-480b-9132-27f82b4240e8.png)
![Screenshot from 2022-11-15 11-48-00](https://user-images.githubusercontent.com/2802257/202012567-c11aee6b-d002-4711-ad22-687f6f1aef80.png)
