### PR TITLE
Add transformFunc argument to filterConfig function

### DIFF
--- a/ui/components/DataTable.tsx
+++ b/ui/components/DataTable.tsx
@@ -141,6 +141,7 @@ export function filterRows<T>(rows: T[], filters: FilterConfig) {
 
       if (!_.includes(vals.options, value)) {
         ok = false;
+        return ok;
       }
     });
 

--- a/ui/components/DataTable.tsx
+++ b/ui/components/DataTable.tsx
@@ -121,7 +121,7 @@ export function filterConfig(
     []
   );
 
-  return { [key]: config };
+  return { [key]: { options: config, transformFunc: computeValue } };
 }
 
 export function filterRows<T>(rows: T[], filters: FilterConfig) {
@@ -134,14 +134,12 @@ export function filterRows<T>(rows: T[], filters: FilterConfig) {
 
     _.each(filters, (vals, category) => {
       let value;
-      // status
-      if (category === "status") {
-        value = filterByStatusCallback(row);
-      }
+
+      if (vals.transformFunc) value = vals.transformFunc(row);
       // strings
       else value = row[category];
 
-      if (!_.includes(vals, value)) {
+      if (!_.includes(vals.options, value)) {
         ok = false;
       }
     });
@@ -339,7 +337,7 @@ function UnstyledDataTable({
 
   const [filterDialogOpen, setFilterDialogOpen] = React.useState(dialogOpen);
   const [filterState, setFilterState] = React.useState<FilterState>({
-    filters: selectionsToFilters(initialSelections),
+    filters: selectionsToFilters(initialSelections, filters),
     formState: initialFormState(filters, initialSelections),
     textFilters: [],
   });
@@ -359,7 +357,7 @@ function UnstyledDataTable({
     }
   };
 
-  const handleChipRemove = (chips: string[]) => {
+  const handleChipRemove = (chips: string[], filterList) => {
     const next = {
       ...filterState,
     };
@@ -368,7 +366,7 @@ function UnstyledDataTable({
       next.formState[chip] = false;
     });
 
-    const filters = selectionsToFilters(next.formState);
+    const filters = selectionsToFilters(next.formState, filterList);
 
     const textFilters = _.filter(
       next.textFilters,
@@ -484,7 +482,7 @@ function UnstyledDataTable({
           <>
             <ChipGroup
               chips={chips}
-              onChipRemove={handleChipRemove}
+              onChipRemove={(chips) => handleChipRemove(chips, filters)}
               onClearAll={handleClearAll}
             />
             <IconFlex align>

--- a/ui/components/FilterDialog.tsx
+++ b/ui/components/FilterDialog.tsx
@@ -7,7 +7,9 @@ import Flex from "./Flex";
 import FormCheckbox from "./FormCheckbox";
 import Text from "./Text";
 
-export type FilterConfig = { [key: string]: string[] };
+export type FilterConfig = {
+  [key: string]: { options: string[]; transformFunc: (option) => string };
+};
 export type FilterSelections = { [inputName: string]: boolean };
 
 const SlideContainer = styled.div`
@@ -108,7 +110,10 @@ export interface Props {
   open?: boolean;
 }
 
-export function selectionsToFilters(values: FilterSelections): FilterConfig {
+export function selectionsToFilters(
+  values: FilterSelections,
+  filterList: FilterConfig
+): FilterConfig {
   const out = {};
   _.each(values, (v, k) => {
     const [key, val] = k.split(filterSeparator);
@@ -117,9 +122,12 @@ export function selectionsToFilters(values: FilterSelections): FilterConfig {
       const el = out[key];
 
       if (el) {
-        el.push(val);
+        el.options.push(val);
       } else {
-        out[key] = [val];
+        out[key] = {
+          options: [val],
+          transformFunc: filterList[key]?.transformFunc,
+        };
       }
     }
   });
@@ -143,13 +151,13 @@ function UnstyledFilterDialog({
   const onSectionSelect = (object: sectionSelectObject) => {
     if (onFilterSelect) {
       const next = { ...formState, ...object };
-      onFilterSelect(selectionsToFilters(next), next);
+      onFilterSelect(selectionsToFilters(next, filterList), next);
     }
   };
   const onFormChange = (name: string, value: any) => {
     if (onFilterSelect) {
       const next = { ...formState, [name]: value };
-      onFilterSelect(selectionsToFilters(next), next);
+      onFilterSelect(selectionsToFilters(next, filterList), next);
     }
   };
 
@@ -171,7 +179,7 @@ function UnstyledFilterDialog({
                     <FilterSection
                       key={header}
                       header={header}
-                      options={options}
+                      options={options.options}
                       formState={formState}
                       onSectionSelect={onSectionSelect}
                     />

--- a/ui/components/FilterDialog.tsx
+++ b/ui/components/FilterDialog.tsx
@@ -8,7 +8,7 @@ import FormCheckbox from "./FormCheckbox";
 import Text from "./Text";
 
 export type FilterConfig = {
-  [key: string]: { options: string[]; transformFunc: (option) => string };
+  [key: string]: { options: string[]; transformFunc?: (option) => string };
 };
 export type FilterSelections = { [inputName: string]: boolean };
 

--- a/ui/components/__tests__/DataTableFilters.test.tsx
+++ b/ui/components/__tests__/DataTableFilters.test.tsx
@@ -121,11 +121,13 @@ describe("DataTableFilters", () => {
       expect(filtered).toHaveLength(4);
     });
     it("filters rows", () => {
-      const filtered = filterRows(rows, { name: ["cool"] });
+      const filtered = filterRows(rows, { name: { options: ["cool"] } });
       expect(filtered).toHaveLength(1);
     });
     it("filters rows with more than one value in a filter key", () => {
-      const filtered = filterRows(rows, { name: ["cool", "slick"] });
+      const filtered = filterRows(rows, {
+        name: { options: ["cool", "slick"] },
+      });
       expect(filtered).toHaveLength(2);
     });
     it("ANDs between categories", () => {
@@ -135,13 +137,13 @@ describe("DataTableFilters", () => {
         { name: "c", namespace: "ns2", type: "git" },
       ];
       const filtered = filterRows(rows, {
-        namespace: ["ns1"],
+        namespace: { options: ["ns1"] },
       });
       expect(filtered).toHaveLength(2);
 
       const filtered2 = filterRows(rows, {
-        namespace: ["ns1"],
-        type: ["git"],
+        namespace: { options: ["ns1"] },
+        type: { options: ["git"] },
       });
       expect(filtered2).toHaveLength(1);
 
@@ -160,13 +162,13 @@ describe("DataTableFilters", () => {
       { name: "c", namespace: "ns2", type: "git" },
     ];
     const filtered = filterRows(rows, {
-      namespace: ["ns1", "ns2"],
+      namespace: { options: ["ns1", "ns2"] },
     });
     expect(filtered).toHaveLength(3);
 
     const filtered2 = filterRows(rows, {
-      namespace: ["ns1"],
-      type: ["git", "bucket"],
+      namespace: { options: ["ns1"] },
+      type: { options: ["git", "bucket"] },
     });
     expect(filtered2).toHaveLength(2);
 

--- a/ui/components/__tests__/FilterDialog.test.tsx
+++ b/ui/components/__tests__/FilterDialog.test.tsx
@@ -8,9 +8,9 @@ import FilterDialog, { filterSeparator } from "../FilterDialog";
 describe("FilterDialog", () => {
   const setActiveFilters = jest.fn();
   const filterList = {
-    Name: ["app", "app2", "app3"],
-    Status: ["Ready", "Failed"],
-    Type: ["Application", "Helm Release"],
+    Name: { options: ["app", "app2", "app3"] },
+    Status: { options: ["Ready", "Failed"] },
+    Type: { options: ["Application", "Helm Release"] },
   };
   it("should not render when closed", () => {
     render(

--- a/ui/components/__tests__/FilterDialog.test.tsx
+++ b/ui/components/__tests__/FilterDialog.test.tsx
@@ -64,7 +64,7 @@ describe("FilterDialog", () => {
 
     const filterResult = onFilterSelect.mock.calls[0][0];
     expect(filterResult).toEqual({
-      Name: ["app"],
+      Name: { options: ["app"] },
     });
   });
 });


### PR DESCRIPTION
Part of #2898 

This PR allows you to supply your own custom filter-value-getter to `filterConfig` without ALSO hard-coding it into the `filterRows` function (you can see this on line 137 of DataTable in the changes).

Removing the hard-coded version from `filterRows` just means we have to pass it through everything else, hence the changes to the `FilterConfig` type.

Doing this lets me provide a custom function to filterConfig inside enterprise without hard-coding it inside core. 
