### PR TITLE
Constrain Revision column width on the automations table

### DIFF
--- a/ui/components/AutomationsTable.tsx
+++ b/ui/components/AutomationsTable.tsx
@@ -140,7 +140,8 @@ function AutomationsTable({ className, automations, hideSource }: Props) {
     },
     {
       label: "Revision",
-      value: "lastAttemptedRevision",
+      maxWidth: 36,
+      value: "lastAppliedRevision",
     },
     {
       label: "Last Updated",


### PR DESCRIPTION
Closes #2958 

The `Revision` column appears to be working correctly, but I added a `maxWidth` parameter to ensure the revision gets ellips-ified:
![Screenshot from 2022-11-17 10-23-11](https://user-images.githubusercontent.com/2802257/202527886-8a6f22e1-fe01-47ba-9faa-2588041da6c7.png)
