### PR TITLE
docs: remove duplicate "installation" entry from left nav

### DIFF
--- a/website/docs/cluster-management/getting-started.mdx
+++ b/website/docs/cluster-management/getting-started.mdx
@@ -12,7 +12,7 @@ import BrowserOnly from "@docusaurus/BrowserOnly";
 
 ## Creating your first CAPD Cluster
 
-If you've followed the [Upgrade steps](installation/overview.mdx#weave-gitops-enterprise) in the [Installation guide](installation/overview.mdx) you should have:
+If you've followed the [Installation guide](installation/weave-gitops-enterprise.mdx) you should have:
 
 1. Weave GitOps Enterprise installed
 2. A CAPI provider installed (With support for `ClusterResourceSet`s enabled).

--- a/website/docs/getting-started.mdx
+++ b/website/docs/getting-started.mdx
@@ -8,7 +8,7 @@ hide_title: true
 
 This hands-on guide will introduce you to the basics of the GitOps Dashboard web UI, to help you understand the state of your system, before deploying a new application to your cluster. It is adapted from this guide - [Flux - Getting Started](https://fluxcd.io/docs/get-started/).
 
-If you haven't already, be sure to check out our [introduction](./intro.md) to Weave GitOps and our [installation docs](./installation/overview.mdx).
+If you haven't already, be sure to check out our [introduction](./intro.md) to Weave GitOps and our [installation docs](./installation/index.mdx).
 
 ## Part 1 - Weave GitOps overview
 

--- a/website/docs/gitops-run/get-started.mdx
+++ b/website/docs/gitops-run/get-started.mdx
@@ -18,7 +18,7 @@ sessions, whereas the direct mode is intended for a local cluster.
 
 ### Prerequisites
 #### Required
-- Install the GitOps CLI. See [the installation](../installation/overview.mdx#gitops-cli)
+- Install the GitOps CLI. See [the installation](../installation/weave-gitops.mdx#gitops-cli)
 
 #### Optional
 - This guide uses [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) for demonstrations, but it is not required to use GitOps Run

--- a/website/docs/guides/cert-manager.md
+++ b/website/docs/guides/cert-manager.md
@@ -10,7 +10,7 @@ to configure the use of Let's Encrypt to issue TLS certificates.
 
 - A Kubernetes cluster such as [Kind](https://kind.sigs.k8s.io/docs/user/quick-start/) cluster running a
 [Flux-supported version of Kubernetes](https://fluxcd.io/docs/installation/#prerequisites)
-- Weave GitOps is [installed](../installation/overview.mdx)
+- Weave GitOps is [installed](../installation/index.mdx)
 
 ## What is cert-manager?
 

--- a/website/docs/guides/deploying-capa.mdx
+++ b/website/docs/guides/deploying-capa.mdx
@@ -30,7 +30,7 @@ The `AWS_ACCESS_KEY_ID`and `AWS_SECRET_ACCESS_KEY` of a user should be configure
 The `GITHUB_TOKEN` should be set as an environment variable in the current shell. It should have permissions to create Pull Requests against the cluster config repo.
 :::
 
-If you've followed the [Upgrade steps](installation/overview.mdx#weave-gitops-enterprise) in the [Installation guide](installation/overview.mdx) you should have a management cluster ready to roll.
+If you've followed the [Installation guide](installation/weave-gitops-enterprise.mdx) you should have a management cluster ready to roll.
 
 ### 1. Configure a capi provider
 

--- a/website/docs/guides/setting-up-dex.md
+++ b/website/docs/guides/setting-up-dex.md
@@ -11,7 +11,7 @@ This example uses [Dex][tool-dex] and its GitHub connector, and assumes Weave Gi
 
 - A Kubernetes cluster such as [Kind](https://kind.sigs.k8s.io/docs/user/quick-start/) cluster running a
 [Flux-supported version of Kubernetes](https://fluxcd.io/docs/installation/#prerequisites)
-- Weave GitOps is [installed](../installation/overview.mdx) and [TLS has been enabled](../configuration/tls.md).
+- Weave GitOps is [installed](../installation/index.mdx) and [TLS has been enabled](../configuration/tls.md).
 
 ## What is Dex?
 

--- a/website/docs/guides/using-terraform-templates.mdx
+++ b/website/docs/guides/using-terraform-templates.mdx
@@ -12,11 +12,11 @@ This guide will show you how to use a template to create a Terraform resource in
 ## CLI guide
 
 ### Pre-requisites
-- Install [Weave GitOps Enterprise](installation/overview.mdx#weave-gitops-enterprise) with [TF-Controller installed](installation/overview.mdx#optional-install-the-tf-controller) and [TLS enabled](../configuration/tls.md).
+- Install [Weave GitOps Enterprise](installation/weave-gitops-enterprise.mdx) with [TF-Controller installed](installation/weave-gitops-enterprise.mdx#optional-install-the-tf-controller) and [TLS enabled](../configuration/tls.md).
 
 ### 1. Add a template to your cluster
 
-Add the following template to a path in your Git repository that is synced by Flux. For example, in the [quickstart guide](https://docs.gitops.weave.works/docs/installation/#install-flux-onto-your-cluster-with-the-flux-bootstrap-command), we set the path that is synced by Flux to `./clusters/management`.
+Add the following template to a path in your Git repository that is synced by Flux. For example, in the [Installation guide](installation/weave-gitops-enterprise.mdx#install-flux-onto-your-cluster-with-the-flux-bootstrap-command), we set the path that is synced by Flux to `./clusters/management`.
 
 Commit and push these changes. Once a template is available in the cluster, it can be used to create a resource, which will be shown in the next step.
 
@@ -237,7 +237,7 @@ resource "aws_rds_cluster_instance" "cluster_instance" {
 }
 ```
 
-Add the following template to a path in your Git repository that is synced by Flux. In the [quickstart guide](https://docs.gitops.weave.works/docs/installation/#install-flux-onto-your-cluster-with-the-flux-bootstrap-command), we set this path to `./clusters/management`.
+Add the following template to a path in your Git repository that is synced by Flux. In the [quickstart guide](installation/weave-gitops-enterprise.mdx#install-flux-onto-your-cluster-with-the-flux-bootstrap-command), we set this path to `./clusters/management`.
 
 ```yaml title="./clusters/management/rds-template.yaml"
 ---

--- a/website/docs/installation.mdx
+++ b/website/docs/installation.mdx
@@ -1,5 +1,0 @@
-import {Redirect} from '@docusaurus/router';
-
-const Home = () => {
-  return <Redirect to="../installation/overview" />;
-};

--- a/website/docs/installation/index.mdx
+++ b/website/docs/installation/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Overview
+title: Installation
 sidebar_position: 1
 hide_title: true
 ---

--- a/website/docs/installation/weave-gitops.mdx
+++ b/website/docs/installation/weave-gitops.mdx
@@ -11,7 +11,7 @@ pagination_next: "getting-started"
 
 We will provide a complete walk-through of getting Flux installed and Weave GitOps configured. However, if you have:
 - an existing cluster bootstrapped Flux version >= 0.32.0 🎉
-- followed our [installation](./overview.mdx) doc to configure access to the Weave GitOps dashboard then install Weave GitOps 👏
+- followed our [installation](./index.mdx) doc to configure access to the Weave GitOps dashboard then install Weave GitOps 👏
 
 Then you can skip ahead to [the Weave GitOps overview](../getting-started.mdx#part-1---weave-gitops-overview) 🏃
 but note ⚠️ you may need to alter commands where we are committing files to GitHub ⚠️.

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -32,7 +32,7 @@ To learn more about GitOps, check out these resources:
 
 ## Getting Started
 
-To start your own journey with Weave GitOps, please see [Installation](./installation.mdx) and [Getting Started](./getting-started.mdx).
+To start your own journey with Weave GitOps, please see [Installation](./installation/index.mdx) and [Getting Started](./getting-started.mdx).
 
 Here is a quick demo of what you can look forward to:
 


### PR DESCRIPTION
As they were two "installation" pages in the final site, the left navigation had two entries for it. The new structure in this change fixes this by adding an index page to the "installation" folder that is rendered for the '/installation' URL path.
