### PR TITLE
Support supplying multiple fetchers

### DIFF
--- a/cmd/gitops-server/cmd/cmd.go
+++ b/cmd/gitops-server/cmd/cmd.go
@@ -187,10 +187,7 @@ func runCmd(cmd *cobra.Command, args []string) error {
 		cl = cluster.NewDelegatingCacheCluster(cl, rest, scheme)
 	}
 
-	fetcher, err := fetcher.NewSingleClusterFetcher(cl)
-	if err != nil {
-		return fmt.Errorf("failed to create cluster fetcher; %w", err)
-	}
+	fetcher := fetcher.NewSingleClusterFetcher(cl)
 
 	clustersManager := clustersmngr.NewClustersManager([]clustersmngr.ClusterFetcher{fetcher}, nsaccess.NewChecker(nsaccess.DefautltWegoAppRules), log)
 	clustersManager.Start(ctx)

--- a/cmd/gitops-server/cmd/cmd.go
+++ b/cmd/gitops-server/cmd/cmd.go
@@ -192,7 +192,7 @@ func runCmd(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to create cluster fetcher; %w", err)
 	}
 
-	clustersManager := clustersmngr.NewClustersManager(fetcher, nsaccess.NewChecker(nsaccess.DefautltWegoAppRules), log)
+	clustersManager := clustersmngr.NewClustersManager([]clustersmngr.ClusterFetcher{fetcher}, nsaccess.NewChecker(nsaccess.DefautltWegoAppRules), log)
 	clustersManager.Start(ctx)
 
 	coreConfig, err := core.NewCoreConfig(log, rest, clusterName, clustersManager)

--- a/core/clustersmngr/clustersmngr.go
+++ b/core/clustersmngr/clustersmngr.go
@@ -27,6 +27,23 @@ func (e ClusterNotFoundError) Error() string {
 	return fmt.Sprintf("cluster=%s not found", e.Cluster)
 }
 
+type clusterFetchers []ClusterFetcher
+
+func (fetchers clusterFetchers) Fetch(ctx context.Context) ([]cluster.Cluster, error) {
+	clusters := []cluster.Cluster{}
+
+	for _, fetcher := range fetchers {
+		additionalClusters, err := fetcher.Fetch(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		clusters = append(clusters, additionalClusters...)
+	}
+
+	return clusters, nil
+}
+
 // ClusterFetcher fetches all leaf clusters
 //
 //counterfeiter:generate . ClusterFetcher

--- a/core/clustersmngr/factory.go
+++ b/core/clustersmngr/factory.go
@@ -168,9 +168,9 @@ type ClustersManager interface {
 }
 
 type clustersManager struct {
-	clustersFetcher ClusterFetcher
-	nsChecker       nsaccess.Checker
-	log             logr.Logger
+	clustersFetchers clusterFetchers
+	nsChecker        nsaccess.Checker
+	log              logr.Logger
 
 	// list of clusters returned by the clusters fetcher
 	clusters *Clusters
@@ -210,11 +210,11 @@ func (cw *ClustersWatcher) Unsubscribe() {
 	close(cw.Updates)
 }
 
-func NewClustersManager(fetcher ClusterFetcher, nsChecker nsaccess.Checker, logger logr.Logger) ClustersManager {
+func NewClustersManager(fetchers []ClusterFetcher, nsChecker nsaccess.Checker, logger logr.Logger) ClustersManager {
 	registerMetrics()
 
 	return &clustersManager{
-		clustersFetcher:     fetcher,
+		clustersFetchers:    fetchers,
 		nsChecker:           nsChecker,
 		clusters:            &Clusters{},
 		clustersNamespaces:  &ClustersNamespaces{},
@@ -275,7 +275,7 @@ func (cf *clustersManager) watchClusters(ctx context.Context) {
 
 // UpdateClusters updates the clusters list and notifies the registered watchers.
 func (cf *clustersManager) UpdateClusters(ctx context.Context) error {
-	clusters, err := cf.clustersFetcher.Fetch(ctx)
+	clusters, err := cf.clustersFetchers.Fetch(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to fetch clusters: %w", err)
 	}

--- a/core/clustersmngr/factory_test.go
+++ b/core/clustersmngr/factory_test.go
@@ -33,10 +33,10 @@ func TestGetImpersonatedClient(t *testing.T) {
 
 	cluster, err := cluster.NewSingleCluster("test", k8sEnv.Rest, nil, cluster.DefaultKubeConfigOptions...)
 	g.Expect(err).To(BeNil())
-	clustersFetcher, err := fetcher.NewSingleClusterFetcher(cluster)
-	g.Expect(err).To(BeNil())
 
-	clustersManager := clustersmngr.NewClustersManager(clustersFetcher, nsChecker, logger)
+	clustersFetcher := fetcher.NewSingleClusterFetcher(cluster)
+
+	clustersManager := clustersmngr.NewClustersManager([]clustersmngr.ClusterFetcher{clustersFetcher}, nsChecker, logger)
 	err = clustersManager.UpdateClusters(ctx)
 	g.Expect(err).To(BeNil())
 
@@ -75,10 +75,10 @@ func TestGetImpersonatedDiscoveryClient(t *testing.T) {
 
 	cl, err := cluster.NewSingleCluster(cluster.DefaultCluster, k8sEnv.Rest, nil, cluster.DefaultKubeConfigOptions...)
 	g.Expect(err).To(BeNil())
-	clustersFetcher, err := fetcher.NewSingleClusterFetcher(cl)
-	g.Expect(err).To(BeNil())
 
-	clustersManager := clustersmngr.NewClustersManager(clustersFetcher, nsChecker, logger)
+	clustersFetcher := fetcher.NewSingleClusterFetcher(cl)
+
+	clustersManager := clustersmngr.NewClustersManager([]clustersmngr.ClusterFetcher{clustersFetcher}, nsChecker, logger)
 	err = clustersManager.UpdateClusters(ctx)
 	g.Expect(err).To(BeNil())
 
@@ -102,7 +102,7 @@ func TestUpdateNamespaces(t *testing.T) {
 	nsChecker := &nsaccessfakes.FakeChecker{}
 	clustersFetcher := new(clustersmngrfakes.FakeClusterFetcher)
 
-	clustersManager := clustersmngr.NewClustersManager(clustersFetcher, nsChecker, logger)
+	clustersManager := clustersmngr.NewClustersManager([]clustersmngr.ClusterFetcher{clustersFetcher}, nsChecker, logger)
 
 	clusterName1 := "foo"
 	clusterName2 := "bar"
@@ -161,7 +161,7 @@ func TestUpdateUsers(t *testing.T) {
 	nsChecker := &nsaccessfakes.FakeChecker{}
 	clustersFetcher := new(clustersmngrfakes.FakeClusterFetcher)
 
-	clustersManager := clustersmngr.NewClustersManager(clustersFetcher, nsChecker, logger)
+	clustersManager := clustersmngr.NewClustersManager([]clustersmngr.ClusterFetcher{clustersFetcher}, nsChecker, logger)
 
 	clusterName1 := "foo"
 	clusterName2 := "bar"
@@ -207,7 +207,7 @@ func TestUpdateUsersFailsToConnect(t *testing.T) {
 	nsChecker := nsaccess.NewChecker(nil)
 	clustersFetcher := new(clustersmngrfakes.FakeClusterFetcher)
 
-	clustersManager := clustersmngr.NewClustersManager(clustersFetcher, nsChecker, logger)
+	clustersManager := clustersmngr.NewClustersManager([]clustersmngr.ClusterFetcher{clustersFetcher}, nsChecker, logger)
 
 	clusterName1 := "foo"
 
@@ -241,7 +241,7 @@ func TestGetClusters(t *testing.T) {
 	nsChecker := nsaccess.NewChecker(nil)
 	clustersFetcher := new(clustersmngrfakes.FakeClusterFetcher)
 
-	clustersManager := clustersmngr.NewClustersManager(clustersFetcher, nsChecker, logger)
+	clustersManager := clustersmngr.NewClustersManager([]clustersmngr.ClusterFetcher{clustersFetcher}, nsChecker, logger)
 
 	c1 := makeLeafCluster(t, "foo")
 	c2 := makeLeafCluster(t, "foo")
@@ -278,7 +278,7 @@ func TestUpdateClusters(t *testing.T) {
 
 	clustersFetcher := new(clustersmngrfakes.FakeClusterFetcher)
 
-	clustersManager := clustersmngr.NewClustersManager(clustersFetcher, nsChecker, logger)
+	clustersManager := clustersmngr.NewClustersManager([]clustersmngr.ClusterFetcher{clustersFetcher}, nsChecker, logger)
 	err := clustersManager.UpdateClusters(ctx)
 	g.Expect(err).To(BeNil())
 
@@ -404,12 +404,11 @@ func TestClientCaching(t *testing.T) {
 	cluster.GetUserClientsetReturns(cs, nil)
 	cluster.GetServerClientsetReturns(cs, nil)
 
-	clustersFetcher, err := fetcher.NewSingleClusterFetcher(cluster)
-	g.Expect(err).To(BeNil())
+	clustersFetcher := fetcher.NewSingleClusterFetcher(cluster)
 
 	userID := "user-id"
 
-	clustersManager := clustersmngr.NewClustersManager(clustersFetcher, nsChecker, logger)
+	clustersManager := clustersmngr.NewClustersManager([]clustersmngr.ClusterFetcher{clustersFetcher}, nsChecker, logger)
 
 	err = clustersManager.UpdateClusters(ctx)
 	g.Expect(err).To(BeNil())

--- a/core/clustersmngr/fetcher/single.go
+++ b/core/clustersmngr/fetcher/single.go
@@ -11,8 +11,8 @@ type singleClusterFetcher struct {
 	cluster cluster.Cluster
 }
 
-func NewSingleClusterFetcher(cluster cluster.Cluster) (mngr.ClusterFetcher, error) {
-	return singleClusterFetcher{cluster}, nil
+func NewSingleClusterFetcher(cluster cluster.Cluster) mngr.ClusterFetcher {
+	return singleClusterFetcher{cluster}
 }
 
 func (cf singleClusterFetcher) Fetch(ctx context.Context) ([]cluster.Cluster, error) {

--- a/core/clustersmngr/fetcher/single_test.go
+++ b/core/clustersmngr/fetcher/single_test.go
@@ -21,8 +21,7 @@ func TestSingleFetcher(t *testing.T) {
 	cluster, err := cluster.NewSingleCluster("Default", config, nil)
 	g.Expect(err).To(BeNil())
 
-	fetcher, err := fetcher.NewSingleClusterFetcher(cluster)
-	g.Expect(err).To(BeNil())
+	fetcher := fetcher.NewSingleClusterFetcher(cluster)
 
 	clusters, err := fetcher.Fetch(context.TODO())
 	g.Expect(err).To(BeNil())

--- a/core/server/suite_test.go
+++ b/core/server/suite_test.go
@@ -66,12 +66,9 @@ func makeGRPCServer(cfg *rest.Config, t *testing.T) (pb.CoreClient, server.CoreS
 		t.Fatal(err)
 	}
 
-	fetch, err := fetcher.NewSingleClusterFetcher(cluster)
-	if err != nil {
-		t.Fatal(err)
-	}
+	fetch := fetcher.NewSingleClusterFetcher(cluster)
 
-	clustersManager := clustersmngr.NewClustersManager(fetch, &nsChecker, log)
+	clustersManager := clustersmngr.NewClustersManager([]clustersmngr.ClusterFetcher{fetch}, &nsChecker, log)
 
 	coreCfg, err := server.NewCoreConfig(log, cfg, "foobar", clustersManager)
 	if err != nil {
@@ -155,14 +152,11 @@ func makeServerConfig(fakeClient client.Client, t *testing.T) server.CoreServerC
 	cluster.GetUserClientsetReturns(clientset, nil)
 	cluster.GetServerClientReturns(fakeClient, nil)
 
-	fetcher, err := fetcher.NewSingleClusterFetcher(&cluster)
-	if err != nil {
-		t.Fatal(err)
-	}
+	fetcher := fetcher.NewSingleClusterFetcher(&cluster)
 
 	// Don't include the clustersmngr.DefaultKubeConfigOptions here as we're using a fake kubeclient
 	// and the default options include the Flowcontrol setup which is not mocked out
-	clustersManager := clustersmngr.NewClustersManager(fetcher, &nsChecker, log)
+	clustersManager := clustersmngr.NewClustersManager([]clustersmngr.ClusterFetcher{fetcher}, &nsChecker, log)
 
 	coreCfg, err := server.NewCoreConfig(log, &rest.Config{}, "foobar", clustersManager)
 	if err != nil {


### PR DESCRIPTION
We want to be able to create multiple fetchers, for multiple sources of clusters - such as for gitops run sessions.

To allow this, the manager needs to accept an array of fetchers, and combine the output of all of them when invoked.