### PR TITLE
Pendo during signup screen

### DIFF
--- a/ui/components/Pendo.tsx
+++ b/ui/components/Pendo.tsx
@@ -10,64 +10,99 @@ declare global {
   }
 }
 
+const key = "VyzGoWoKvtJHyTnU+GVhDe+wU9bwZDH87bp505/0f/2UIpHzB+tmyZmfsH8/iJoH";
+
 export default function Pendo() {
   const { data } = useFeatureFlags();
   const flags = data?.flags || {};
   const { userInfo } = useContext(Auth);
+  const [isPendoInitialized, setIsPendoInitialized] = React.useState(false);
+  const [isPendoAgentReady, setIsPendoAgentReady] = React.useState(false);
 
-  if (flags.WEAVE_GITOPS_FEATURE_TELEMETRY == "true") {
-    if (!userInfo || !userInfo.email) {
-      return <></>;
+  const shouldInitPendo = flags.WEAVE_GITOPS_FEATURE_TELEMETRY === "true";
+
+  React.useEffect(() => {
+    if (!shouldInitPendo) {
+      return;
     }
 
-    const key =
-      "VyzGoWoKvtJHyTnU+GVhDe+wU9bwZDH87bp505/0f/2UIpHzB+tmyZmfsH8/iJoH";
+    let visitorId = "";
+    const userEmail = userInfo?.email;
 
-    const hasher = shake128.create(128);
-    hasher.update(key);
-    hasher.update(userInfo.email);
+    if (userEmail) {
+      const hasher = shake128.create(128);
+      hasher.update(key);
+      hasher.update(userEmail);
+      visitorId = Mnemonic.fromHex(hasher.hex()).toWords().join("-");
+    }
 
-    const visitorId = Mnemonic.fromHex(hasher.hex()).toWords().join("-");
+    const visitor = {
+      id: visitorId,
+    };
+
     const accountId = Mnemonic.fromHex(flags.ACCOUNT_ID).toWords().join("-");
 
     // This is copied from the pendo docs
     // eslint unwrapps it, and the initialize call has been customized
     /* eslint-disable */
     (function (apiKey) {
-      (function (p, e, n, d, o) {
-        let v, w, x, y, z;
-        o = p[d] = p[d] || {};
-        o._q = o._q || [];
-        v = ["initialize", "identify", "updateOptions", "pageLoad", "track"];
-        for (w = 0, x = v.length; w < x; ++w)
-          (function (m) {
-            o[m] =
-              o[m] ||
-              function () {
-                o._q[m === v[0] ? "unshift" : "push"](
-                  [m].concat([].slice.call(arguments, 0))
-                );
-              };
-          })(v[w]);
-        y = e.createElement(n);
-        y.async = !0;
-        y.src = "https://cdn.pendo.io/agent/static/" + apiKey + "/pendo.js";
-        z = e.getElementsByTagName(n)[0];
-        z.parentNode.insertBefore(y, z);
-      })(window, document, "script", "pendo");
+      if (isPendoInitialized) {
+        let shouldIdentify = true;
 
-      window.pendo.initialize({
-        visitor: {
-          id: visitorId,
-        },
+        if (isPendoAgentReady) {
+          const currentVisitorId = window.pendo.getVisitorId();
+          const currentAccountId = window.pendo.getAccountId();
 
-        account: {
-          id: accountId,
-          devMode: flags.WEAVE_GITOPS_FEATURE_DEV_MODE == "true",
-        },
-      });
+          if (currentVisitorId == visitorId && currentAccountId == accountId) {
+            shouldIdentify = false;
+          }
+        }
+
+        if (shouldIdentify) {
+          window.pendo.identify(visitorId, accountId);
+        }
+      } else {
+        (function (p, e, n, d, o) {
+          let v, w, x, y, z;
+          o = p[d] = p[d] || {};
+          o._q = o._q || [];
+          v = ["initialize", "identify", "updateOptions", "pageLoad", "track"];
+          for (w = 0, x = v.length; w < x; ++w)
+            (function (m) {
+              o[m] =
+                o[m] ||
+                function () {
+                  o._q[m === v[0] ? "unshift" : "push"](
+                    [m].concat([].slice.call(arguments, 0))
+                  );
+                };
+            })(v[w]);
+          y = e.createElement(n);
+          y.async = !0;
+          y.src = "https://cdn.pendo.io/agent/static/" + apiKey + "/pendo.js";
+          z = e.getElementsByTagName(n)[0];
+          z.parentNode.insertBefore(y, z);
+        })(window, document, "script", "pendo");
+
+        window.pendo.initialize({
+          visitor: visitor,
+
+          account: {
+            id: accountId,
+            devMode: flags.WEAVE_GITOPS_FEATURE_DEV_MODE == "true",
+          },
+
+          events: {
+            ready: function () {
+              setIsPendoAgentReady(true);
+            },
+          },
+        });
+
+        setIsPendoInitialized(true);
+      }
     })("7a83d612-fa5b-4bfe-4544-861a89ceaf89");
-  }
+  }, [shouldInitPendo, userInfo]);
 
   return <></>;
 }

--- a/ui/pages/SignIn.tsx
+++ b/ui/pages/SignIn.tsx
@@ -11,6 +11,8 @@ import { useFeatureFlags } from "../hooks/featureflags";
 import images from "../lib/images";
 import { theme } from "../lib/theme";
 
+const pendoKey = "pendo";
+
 const SignInBackgroundAnimation = React.lazy(
   () => import("../components/Animations/SignInBackground")
 );
@@ -81,6 +83,19 @@ function SignIn() {
   };
 
   const handleUserPassSubmit = () => signIn({ username, password });
+
+  React.useEffect(() => {
+    if (!window.localStorage) {
+      console.warn("no local storage found");
+      return;
+    }
+
+    const pendoKeys = Object.keys(window.localStorage).filter(
+      (key) => key.toLowerCase().indexOf(pendoKey) != -1
+    );
+
+    pendoKeys.forEach((key) => window.localStorage.removeItem(key));
+  }, []);
 
   return (
     <Flex


### PR DESCRIPTION
Closes #3046 

- Refactored the Pendo agent initialization code (mostly early exit the telemetry flag is is not "true").

- Fixed the issue with multiple Pendo scripts added to the page (your suggestion with wrapping code with `useEffect` worked like a charm, @ozamosi ✨ ).

- Added calling `identify` vs `initialize` if the Pendo agent has been initialized already (`Pendo.initialize` initializes the whole Pendo agent from scratch, `Pendo.identify` only updates `visitorId` and `accountId` based on the following explanation https://support.pendo.io/hc/en-us/community/posts/360077999992/comments/360015452792 ).

- Added switching from an anonymous Pendo user to a user with a generated `visitorId` on login (with `identify`).

- Added `window.localStorage` cleanup for Pendo after switching to the Sign In screen to switch back to the anonymous user from a logged in user (this is required if we want to switch to the anonymous user after the current user logs out, because otherwise Pendo would pick already stored visitorId from the `localStorage`).

- Added checks to prevent multiple calls to Pendo `identify` on route change if Pendo `visitorId` and `accountId` stay the same. This was probably not critical but, just in case, to avoid any potential duplicates in the submitted data (although I hope that `identify` is idempotent and if the visitor ID and account ID are set in Pendo to the same values it does nothing, but I am not sure).

**Question:**
- Do I need to add anything else to pick up "whether users are using OIDC or just the default admin user", as stated in the ticket description? Or will it be picked automatically?

Local testing:

Initial sign in screen with print-debugging temporarily added for `shouldIdentify` and with printing the current Pendo `visitorId` in the console:

<img width="1535" alt="Screenshot 2022-11-28 at 03 56 37" src="https://user-images.githubusercontent.com/8824708/204184564-9727cf77-b37e-452f-803d-c64d195c2650.png">

Screen after logged in:

<img width="1520" alt="Screenshot 2022-11-28 at 03 57 17" src="https://user-images.githubusercontent.com/8824708/204184585-3ac617af-ead3-4ba2-affc-f96c6d2a6fe7.png">

Sign in screen after logging out (in our app, it's a new screen (probably because of a redirect), so Pendo is re-initialized without calling `identify`):

<img width="1536" alt="Screenshot 2022-11-28 at 03 57 30" src="https://user-images.githubusercontent.com/8824708/204184937-c2abd564-118b-4005-b864-11300aecc2db.png">

Only one Pendo script is added now, as expected:

<img width="1520" alt="Screenshot 2022-11-28 at 04 46 01" src="https://user-images.githubusercontent.com/8824708/204189831-f0a79273-b149-4561-8663-a5e591ac86c2.png">
