### PR TITLE
dashboard: Use fallback namespace if no part-of=flux label

### DIFF
--- a/core/server/objects_test.go
+++ b/core/server/objects_test.go
@@ -109,7 +109,7 @@ func TestGetObjectOtherKinds(t *testing.T) {
 	}
 	appName := "myapp"
 
-	dep := newDeployment(appName, ns.Name)
+	dep := newDeployment(appName, ns.Name, map[string]string{})
 
 	scheme, err := kube.CreateScheme()
 	g.Expect(err).To(BeNil())


### PR DESCRIPTION
If flux was installed through mechanisms other than the flux CLI (operatorhub, aws marketplace, microsoft.flux, etc), then the namespace usually doesn't have the part-of=flux label.

As a workaround, this still prefers the part-of label if it's set, but if we can't find one then we fall back to the namespace "flux-system". I hope this will be harmless - it's only used when the "proper" way has already failed, so I expect it'll either "fix" the feature, or do nothing.

However, the default in those third party installers might be to install flux somewhere else - e.g. operatorhub defaults to "operators". For that case I made a random undocumented environment variable that a user could set so that they get a different default than flux-system. I don't expect end users to do anything with that, but it could be used to ship this software together with flux in one of these stores - so e.g. if we throw in weave-gitops in the operatorhub flux installation, then we'd set `WEAVE_GITOPS_FALLBACK_NAMESPACE` in that distribution to make it match where flux goes.

This fixes #2382.