### PR TITLE
Allow the wego-admin user read access to all objects

### DIFF
--- a/charts/gitops-server/templates/admin-user-roles.yaml
+++ b/charts/gitops-server/templates/admin-user-roles.yaml
@@ -43,24 +43,35 @@ rules:
   - apiGroups: ["*"]
     resources: ["*"]
     verbs: [ "get", "list", "watch" ]
+
   - apiGroups: ["source.toolkit.fluxcd.io"]
     resources: [ "buckets", "helmcharts", "gitrepositories", "helmrepositories", "ocirepositories" ]
     verbs: [ "get", "list", "watch", "patch" ]
+
   - apiGroups: ["kustomize.toolkit.fluxcd.io"]
     resources: [ "kustomizations" ]
     verbs: [ "get", "list", "watch", "patch" ]
+
   - apiGroups: ["helm.toolkit.fluxcd.io"]
     resources: [ "helmreleases" ]
     verbs: [ "get", "list", "watch", "patch" ]
+
   - apiGroups: [ "notification.toolkit.fluxcd.io" ]
     resources: [ "providers", "alerts" ]
     verbs: [ "get", "list", "watch" ]
+
   - apiGroups: ["infra.contrib.fluxcd.io"]
     resources: ["terraforms"]
     verbs: [ "get", "list", "watch", "patch" ]
+
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]
     verbs: ["list", "watch"]
+
+  - apiGroups: [ "notification.toolkit.fluxcd.io" ]
+    resources: [ "providers", "alerts" ]
+    verbs: [ "get", "list", "watch", "patch" ]
+
 {{- if gt (len $.Values.rbac.additionalRules) 0 -}}
 {{- toYaml $.Values.rbac.additionalRules | nindent 2 -}}
 {{- end -}}

--- a/charts/gitops-server/templates/admin-user-roles.yaml
+++ b/charts/gitops-server/templates/admin-user-roles.yaml
@@ -6,42 +6,30 @@ metadata:
   name: wego-admin-role
   namespace: {{ .Release.Namespace }}
 rules:
-  - apiGroups: [""]
-    resources: ["configmaps", "secrets", "pods", "services", "namespaces", "persistentvolumes", "persistentvolumeclaims"]
+  - apiGroups: ["*"]
+    resources: ["*"]
     verbs: [ "get", "list", "watch" ]
-  - apiGroups: ["apps"]
-    resources: [ "deployments", "replicasets", "statefulsets"]
-    verbs: [ "get", "list", "watch" ]
-  - apiGroups: ["batch"]
-    resources: [ "jobs", "cronjobs"]
-    verbs: [ "get", "list", "watch" ]
-  - apiGroups: ["autoscaling"]
-    resources: ["horizontalpodautoscalers"]
-    verbs: [ "get", "list", "watch" ]
-  - apiGroups: ["rbac.authorization.k8s.io"]
-    resources: ["roles", "clusterroles", "rolebindings", "clusterrolebindings"]
-    verbs: [ "get", "list", "watch" ]
-  - apiGroups: ["networking.k8s.io"]
-    resources: ["ingresses"]
-    verbs: [ "get", "list", "watch" ]
-  - apiGroups: [""]
-    resources: ["events"]
-    verbs: ["get", "list", "watch"]
+
   - apiGroups: ["source.toolkit.fluxcd.io"]
     resources: [ "buckets", "helmcharts", "gitrepositories", "helmrepositories", "ocirepositories" ]
     verbs: [ "get", "list", "watch", "patch" ]
+
   - apiGroups: ["kustomize.toolkit.fluxcd.io"]
     resources: [ "kustomizations" ]
     verbs: [ "get", "list", "watch", "patch" ]
+
   - apiGroups: ["helm.toolkit.fluxcd.io"]
     resources: [ "helmreleases" ]
     verbs: [ "get", "list", "watch", "patch" ]
+
   - apiGroups: [ "notification.toolkit.fluxcd.io" ]
     resources: [ "providers", "alerts" ]
-    verbs: [ "get", "list", "watch" ]
+    verbs: [ "get", "list", "watch", "patch" ]
+
   - apiGroups: ["infra.contrib.fluxcd.io"]
     resources: ["terraforms"]
     verbs: [ "get", "list", "watch", "patch" ]
+
 {{- if gt (len $.Values.rbac.additionalRules) 0 -}}
 {{- toYaml $.Values.rbac.additionalRules | nindent 2 -}}
 {{- end }}
@@ -52,27 +40,9 @@ kind: ClusterRole
 metadata:
   name: wego-admin-cluster-role
 rules:
-  - apiGroups: [""]
-    resources: ["configmaps", "secrets", "pods", "services", "namespaces", "persistentvolumes", "persistentvolumeclaims"]
+  - apiGroups: ["*"]
+    resources: ["*"]
     verbs: [ "get", "list", "watch" ]
-  - apiGroups: ["apps"]
-    resources: [ "deployments", "replicasets", "statefulsets", "daemonsets"]
-    verbs: [ "get", "list", "watch" ]
-  - apiGroups: ["batch"]
-    resources: [ "jobs", "cronjobs"]
-    verbs: [ "get", "list", "watch" ]
-  - apiGroups: ["autoscaling"]
-    resources: ["horizontalpodautoscalers"]
-    verbs: [ "get", "list", "watch" ]
-  - apiGroups: ["rbac.authorization.k8s.io"]
-    resources: ["roles", "clusterroles", "rolebindings", "clusterrolebindings"]
-    verbs: [ "get", "list", "watch" ]
-  - apiGroups: ["networking.k8s.io"]
-    resources: ["ingresses"]
-    verbs: [ "get", "list", "watch" ]
-  - apiGroups: [""]
-    resources: ["events"]
-    verbs: ["get", "list", "watch"]
   - apiGroups: ["source.toolkit.fluxcd.io"]
     resources: [ "buckets", "helmcharts", "gitrepositories", "helmrepositories", "ocirepositories" ]
     verbs: [ "get", "list", "watch", "patch" ]

--- a/core/server/fluxruntime.go
+++ b/core/server/fluxruntime.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/weaveworks/weave-gitops/core/clustersmngr"
+	"github.com/weaveworks/weave-gitops/core/logger"
 	coretypes "github.com/weaveworks/weave-gitops/core/server/types"
 	pb "github.com/weaveworks/weave-gitops/pkg/api/core"
 	"github.com/weaveworks/weave-gitops/pkg/server/auth"
@@ -247,6 +248,13 @@ func (cs *coreServer) GetReconciledObjects(ctx context.Context, msg *pb.GetRecon
 
 			if err := clustersClient.List(ctx, msg.ClusterName, &listResult, opts); err != nil {
 				if k8serrors.IsForbidden(err) {
+					cs.logger.V(logger.LogLevelDebug).Info(
+						"forbidden list request",
+						"cluster", msg.ClusterName,
+						"automation", msg.AutomationName,
+						"namespace", msg.Namespace,
+						"gvk", gvk.String(),
+					)
 					// Our service account (or impersonated user) may not have the ability to see the resource in question,
 					// in the given namespace. We pretend it doesn't exist and keep looping.
 					// We need logging to make this error more visible.

--- a/package-lock.json
+++ b/package-lock.json
@@ -15475,7 +15475,8 @@
     "@material-ui/types": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@material-ui/types/-/types-5.1.0.tgz",
-      "integrity": "sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A=="
+      "integrity": "sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A==",
+      "requires": {}
     },
     "@material-ui/utils": {
       "version": "4.11.2",
@@ -17188,7 +17189,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -17905,7 +17907,8 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-3.1.0.tgz",
       "integrity": "sha512-JQNR19/YZhz4psLX/rQ9M83e3z2Wf/HdJbryzte4a3NSuafyp9w/I4U+hx5C2S9g41qlstH7DEWnZaaj83OuEA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "csso": {
       "version": "4.2.0",
@@ -21105,7 +21108,8 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jest-regex-util": {
       "version": "27.5.1",
@@ -22784,25 +22788,29 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.1.1.tgz",
       "integrity": "sha512-5JscyFmvkUxz/5/+TB3QTTT9Gi9jHkcn8dcmmuN68JQcv3aQg4y88yEHHhwFB52l/NkaJ43O0dbksGMAo49nfQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-discard-duplicates": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-5.1.0.tgz",
       "integrity": "sha512-zmX3IoSI2aoenxHV6C7plngHWWhUOV3sP1T8y2ifzxzbtnuhk1EdPwm0S1bIUNaJ2eNbWeGLEwzw8huPD67aQw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-discard-empty": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-5.1.1.tgz",
       "integrity": "sha512-zPz4WljiSuLWsI0ir4Mcnr4qQQ5e1Ukc3i7UfE2XcrwKK2LIPIqE5jxMRxO6GbI3cv//ztXDsXwEWT3BHOGh3A==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-discard-overridden": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-5.1.0.tgz",
       "integrity": "sha512-21nOL7RqWR1kasIVdKs8HNqQJhFxLsyRfAnUDm4Fe4t4mCWL9OJiHvlHPjcd8zc5Myu89b/7wZDnOSjFgeWRtw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-merge-longhand": {
       "version": "5.1.2",
@@ -22870,7 +22878,8 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-5.1.0.tgz",
       "integrity": "sha512-mSgUJ+pd/ldRGVx26p2wz9dNZ7ji6Pn8VWBajMXFf8jk7vUoSrZ2lt/wZR7DtlZYKesmZI680qjr2CeFF2fbUg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-normalize-display-values": {
       "version": "5.1.0",
@@ -24284,7 +24293,8 @@
       "version": "7.5.7",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.7.tgz",
       "integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/website/docs/configuration/user-permissions.mdx
+++ b/website/docs/configuration/user-permissions.mdx
@@ -16,48 +16,34 @@ of the [helm chart](https://github.com/weaveworks/weave-gitops/tree/main/charts/
 By default both a ClusterRole and Role are generated for the static cluster-user.
 Both have the same permissions with former being optional and the latter being
 bound to the `flux-system` namespace (where Flux stores its resources by default).
-The default set of rules fall into three groups, discussed below, they are:
+The default set of rules are configured like this:
 ```yaml
 rules:
-# Flux Resources
-- apiGroups: ["kustomize.toolkit.fluxcd.io"]
-  resources: [ "kustomizations" ]
-  verbs: [ "get", "list", "patch" ]
-- apiGroups: ["helm.toolkit.fluxcd.io"]
-  resources: [ "helmreleases" ]
-  verbs: [ "get", "list", "patch" ]
-- apiGroups: ["source.toolkit.fluxcd.io"]
-  resources: [ "buckets", "helmcharts", "gitrepositories", "helmrepositories", "ocirepositories" ]
-  verbs: [ "get", "list", "patch" ]
-- apiGroups: [ "notification.toolkit.fluxcd.io" ]
-  resources: [ "providers", "alerts" ]
-  verbs: [ "get", "list" ]
-- apiGroups: ["infra.contrib.fluxcd.io"]
-  resources: ["terraforms"]
-  verbs: [ "get", "list", "patch" ]
-# Resources managed via Flux
-- apiGroups: [""]
-  resources: ["configmaps", "secrets", "pods", "services", "namespaces", "persistentvolumes", "persistentvolumeclaims"]
-  verbs: [ "get", "list" ]
-- apiGroups: ["apps"]
-  resources: [ "deployments", "replicasets", "statefulsets"]
-  verbs: [ "get", "list" ]
-- apiGroups: ["batch"]
-  resources: [ "jobs", "cronjobs"]
-  verbs: [ "get", "list" ]
-- apiGroups: ["autoscaling"]
-  resources: ["horizontalpodautoscalers"]
-  verbs: [ "get", "list" ]
-- apiGroups: ["rbac.authorization.k8s.io"]
-  resources: ["roles", "clusterroles", "rolebindings", "clusterrolebindings"]
-  verbs: [ "get", "list" ]
-- apiGroups: ["networking.k8s.io"]
-  resources: ["ingresses"]
-  verbs: [ "get", "list" ]
-# Feedback
-- apiGroups: [""]
-  resources: ["events"]
-  verbs: ["get", "watch", "list"]
+  # Flux Resources
+  - apiGroups: ["source.toolkit.fluxcd.io"]
+    resources: [ "buckets", "helmcharts", "gitrepositories", "helmrepositories", "ocirepositories" ]
+    verbs: [ "get", "list", "watch", "patch" ]
+
+  - apiGroups: ["kustomize.toolkit.fluxcd.io"]
+    resources: [ "kustomizations" ]
+    verbs: [ "get", "list", "watch", "patch" ]
+
+  - apiGroups: ["helm.toolkit.fluxcd.io"]
+    resources: [ "helmreleases" ]
+    verbs: [ "get", "list", "watch", "patch" ]
+
+  - apiGroups: [ "notification.toolkit.fluxcd.io" ]
+    resources: [ "providers", "alerts" ]
+    verbs: [ "get", "list", "watch", "patch" ]
+
+  - apiGroups: ["infra.contrib.fluxcd.io"]
+    resources: ["terraforms"]
+    verbs: [ "get", "list", "watch", "patch" ]
+
+  # Read access for all other Kubernetes objects
+  - apiGroups: ["*"]
+    resources: ["*"]
+    verbs: [ "get", "list", "watch" ]
 ```
 
 


### PR DESCRIPTION
Closes #2966 

After this change, the default service account for the WeGO UI will have read access to all `apiGroups` and all `resources`. This allows objects that we have not enumerated to show up in the list of reconciled objects. Note the `ValidatingWebhookConfiguration` and `Task` objects (`Task` is a Tekton object, which WeGO UI doesn't "understand"):

![Screenshot from 2022-11-28 12-09-39](https://user-images.githubusercontent.com/2802257/204373288-d480ff82-a341-412b-aae0-99e9e2c4a36f.png)
