### PR TITLE
[fix] Chip filters are lost on refresh

### DIFF
--- a/ui/components/DataTable.tsx
+++ b/ui/components/DataTable.tsx
@@ -186,7 +186,7 @@ function filterText(
   });
 }
 
-export function initialFormState(cfg: FilterConfig, initialSelections?) { 
+export function initialFormState(cfg: FilterConfig, initialSelections?) {
   if (!initialSelections) {
     return {};
   }

--- a/ui/components/DataTable.tsx
+++ b/ui/components/DataTable.tsx
@@ -186,14 +186,14 @@ function filterText(
   });
 }
 
-export function initialFormState(cfg: FilterConfig, initialSelections?) {
+export function initialFormState(cfg: FilterConfig, initialSelections?) { 
   if (!initialSelections) {
     return {};
   }
   const allFilters = _.reduce(
     cfg,
     (r, vals, k) => {
-      _.each(vals, (v) => {
+      _.each(vals.options, (v) => {
         const key = `${k}${filterSeparator}${v}`;
         const selection = _.get(initialSelections, key);
         if (selection) {

--- a/ui/components/FluxRuntime.tsx
+++ b/ui/components/FluxRuntime.tsx
@@ -25,7 +25,6 @@ type Props = {
   className?: string;
   deployments?: Deployment[];
   crds?: Crd[];
-  supportMultipleFlux?: boolean;
 };
 const fluxVersionLabel = "app.kubernetes.io/version";
 


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes #3074 

<!-- Describe what has changed in this PR -->
**What changed?**
```
FilterConfig = {
    [key: string]: {
        options: string[];
        transformFunc?: (option: any) => string;
    };
}
```
filterConfig now has an `options` instead of setting the value directly to the `key` and that was the issue to not display chips and selected filters.

changing the `initialFormState` to bind to the new field solves it  

