### PR TITLE
Flux Runtime Controller view shows controllers from multiple namespaces

### DIFF
--- a/core/clustersmngr/factory.go
+++ b/core/clustersmngr/factory.go
@@ -429,7 +429,7 @@ func (cf *clustersManager) GetImpersonatedClientForCluster(ctx context.Context, 
 		}
 	}
 
-	if cl.GetName() == "" {
+	if cl == nil {
 		return nil, fmt.Errorf("cluster not found: %s", clusterName)
 	}
 

--- a/core/server/fluxruntime.go
+++ b/core/server/fluxruntime.go
@@ -190,12 +190,9 @@ func filterFluxNamespace(nss []v1.Namespace) []v1.Namespace {
 	for _, ns := range nss {
 		if val, ok := ns.Labels[coretypes.PartOfLabel]; ok && val == FluxNamespacePartOf {
 			fluxSystem = append(fluxSystem, ns)
+			continue
 		}
-		// if ns.Name == DefaultFluxNamespace {
-		// 	fluxSystem = append(fluxSystem, ns)
-		// }
 	}
-
 	return fluxSystem
 }
 

--- a/core/server/fluxruntime.go
+++ b/core/server/fluxruntime.go
@@ -88,31 +88,31 @@ func (cs *coreServer) ListFluxRuntimeObjects(ctx context.Context, msg *pb.ListFl
 				respErrors = append(respErrors, &pb.ListError{ClusterName: clusterName, Namespace: fluxNs.Name, Message: fmt.Sprintf("%s, %s", ErrListingDeployments.Error(), err)})
 				continue
 			}
-		}
-		for _, d := range list.Items {
-			r := &pb.Deployment{
-				Name:        d.Name,
-				Namespace:   d.Namespace,
-				Conditions:  []*pb.Condition{},
-				ClusterName: clusterName,
-				Uid:         string(d.GetUID()),
-				Labels:      d.Labels,
-			}
+			for _, d := range list.Items {
+				r := &pb.Deployment{
+					Name:        d.Name,
+					Namespace:   d.Namespace,
+					Conditions:  []*pb.Condition{},
+					ClusterName: clusterName,
+					Uid:         string(d.GetUID()),
+					Labels:      d.Labels,
+				}
 
-			for _, cond := range d.Status.Conditions {
-				r.Conditions = append(r.Conditions, &pb.Condition{
-					Message: cond.Message,
-					Reason:  cond.Reason,
-					Status:  string(cond.Status),
-					Type:    string(cond.Type),
-				})
-			}
+				for _, cond := range d.Status.Conditions {
+					r.Conditions = append(r.Conditions, &pb.Condition{
+						Message: cond.Message,
+						Reason:  cond.Reason,
+						Status:  string(cond.Status),
+						Type:    string(cond.Type),
+					})
+				}
 
-			for _, img := range d.Spec.Template.Spec.Containers {
-				r.Images = append(r.Images, img.Image)
-			}
+				for _, img := range d.Spec.Template.Spec.Containers {
+					r.Images = append(r.Images, img.Image)
+				}
 
-			results = append(results, r)
+				results = append(results, r)
+			}
 		}
 	}
 
@@ -187,14 +187,13 @@ func (cs *coreServer) ListFluxCrds(ctx context.Context, msg *pb.ListFluxCrdsRequ
 func filterFluxNamespace(nss []v1.Namespace) []v1.Namespace {
 	fluxSystem := []v1.Namespace{}
 
-	for i, ns := range nss {
+	for _, ns := range nss {
 		if val, ok := ns.Labels[coretypes.PartOfLabel]; ok && val == FluxNamespacePartOf {
 			fluxSystem = append(fluxSystem, ns)
 		}
-
-		if ns.Name == DefaultFluxNamespace {
-			fluxSystem = append(fluxSystem, nss[i])
-		}
+		// if ns.Name == DefaultFluxNamespace {
+		// 	fluxSystem = append(fluxSystem, ns)
+		// }
 	}
 
 	return fluxSystem

--- a/core/server/fluxruntime.go
+++ b/core/server/fluxruntime.go
@@ -81,11 +81,13 @@ func (cs *coreServer) ListFluxRuntimeObjects(ctx context.Context, msg *pb.ListFl
 		}
 
 		list := &appsv1.DeploymentList{}
+
 		for _, fluxNs := range fluxNamepsaces {
 			if err := clustersClient.List(ctx, clusterName, list, opts, client.InNamespace(fluxNs.Name)); err != nil {
 				respErrors = append(respErrors, &pb.ListError{ClusterName: clusterName, Namespace: fluxNs.Name, Message: fmt.Sprintf("%s, %s", ErrListingDeployments.Error(), err)})
 				continue
 			}
+
 			for _, d := range list.Items {
 				r := &pb.Deployment{
 					Name:        d.Name,
@@ -184,12 +186,14 @@ func (cs *coreServer) ListFluxCrds(ctx context.Context, msg *pb.ListFluxCrdsRequ
 
 func filterFluxNamespace(nss []v1.Namespace) []v1.Namespace {
 	fluxSystem := []v1.Namespace{}
+
 	for _, ns := range nss {
 		if val, ok := ns.Labels[coretypes.PartOfLabel]; ok && val == FluxNamespacePartOf {
 			fluxSystem = append(fluxSystem, ns)
 			continue
 		}
 	}
+
 	return fluxSystem
 }
 

--- a/core/server/fluxruntime.go
+++ b/core/server/fluxruntime.go
@@ -81,9 +81,7 @@ func (cs *coreServer) ListFluxRuntimeObjects(ctx context.Context, msg *pb.ListFl
 		}
 
 		list := &appsv1.DeploymentList{}
-
 		for _, fluxNs := range fluxNamepsaces {
-
 			if err := clustersClient.List(ctx, clusterName, list, opts, client.InNamespace(fluxNs.Name)); err != nil {
 				respErrors = append(respErrors, &pb.ListError{ClusterName: clusterName, Namespace: fluxNs.Name, Message: fmt.Sprintf("%s, %s", ErrListingDeployments.Error(), err)})
 				continue
@@ -186,7 +184,6 @@ func (cs *coreServer) ListFluxCrds(ctx context.Context, msg *pb.ListFluxCrdsRequ
 
 func filterFluxNamespace(nss []v1.Namespace) []v1.Namespace {
 	fluxSystem := []v1.Namespace{}
-
 	for _, ns := range nss {
 		if val, ok := ns.Labels[coretypes.PartOfLabel]; ok && val == FluxNamespacePartOf {
 			fluxSystem = append(fluxSystem, ns)

--- a/core/server/fluxruntime.go
+++ b/core/server/fluxruntime.go
@@ -192,6 +192,10 @@ func filterFluxNamespace(nss []v1.Namespace) []v1.Namespace {
 			fluxSystem = append(fluxSystem, ns)
 			continue
 		}
+
+		if ns.Name == DefaultFluxNamespace {
+			fluxSystem = append(fluxSystem, ns)
+		}
 	}
 
 	return fluxSystem

--- a/core/server/fluxruntime_test.go
+++ b/core/server/fluxruntime_test.go
@@ -268,21 +268,6 @@ func TestListFluxRuntimeObjects(t *testing.T) {
 				g.Expect(res.Deployments[0].Name).To(Equal("random-flux-controller"))
 			},
 		},
-		{
-			"don't use flux-system if other namespace has better labels",
-			[]runtime.Object{
-				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "flux-system"}},
-				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "flux-ns", Labels: map[string]string{
-					stypes.PartOfLabel: server.FluxNamespacePartOf,
-				}}},
-				newDeployment("correct-flux-controller", "flux-ns", map[string]string{stypes.PartOfLabel: server.FluxNamespacePartOf}),
-				newDeployment("incorrect-flux-controller", "flux-system", map[string]string{stypes.PartOfLabel: server.FluxNamespacePartOf}),
-			},
-			func(res *pb.ListFluxRuntimeObjectsResponse) {
-				g.Expect(res.Deployments).To(HaveLen(1), "expected deployments in flux ns to be returned")
-				g.Expect(res.Deployments[0].Name).To(Equal("correct-flux-controller"))
-			},
-		},
 	}
 
 	for _, tt := range tests {

--- a/ui/components/FluxRuntime.tsx
+++ b/ui/components/FluxRuntime.tsx
@@ -51,7 +51,7 @@ function FluxRuntime({ className, deployments, crds }: Props) {
   const fluxVersions: { [key: string]: FluxVersion } = {};
   deployments.forEach((d) => {
     const fv = d.labels[fluxVersionLabel];
-    const k = `${fv}${d.clusterName}`;
+    const k = `${fv}${d.clusterName}${d.namespace}`;
     if (!fluxVersions[k]) {
       fluxVersions[k] = {
         version: fv,


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes #2910 

*Short description*
As a platform operator I want to see all Flux controllers on my cluster, when running multiple instances of Flux for multi-tenancy resource isolation, so that I can monitor their health and check their versions.

*Acceptance criteria*

 - Flux Runtime Controller view shows controllers from multiple namespaces with the part-of: flux label
 - New namespace column is added to the Controller tab