### PR TITLE
Pendo Agent for Enterprise

### DIFF
--- a/core/server/server.go
+++ b/core/server/server.go
@@ -7,10 +7,8 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/weaveworks/weave-gitops/core/clustersmngr"
-	"github.com/weaveworks/weave-gitops/core/logger"
 	"github.com/weaveworks/weave-gitops/core/nsaccess"
 	pb "github.com/weaveworks/weave-gitops/pkg/api/core"
-	"github.com/weaveworks/weave-gitops/pkg/telemetry"
 	"k8s.io/client-go/rest"
 )
 
@@ -64,13 +62,6 @@ func NewCoreConfig(log logr.Logger, cfg *rest.Config, clusterName string, cluste
 }
 
 func NewCoreServer(cfg CoreServerConfig) (pb.CoreServer, error) {
-	err := telemetry.InitTelemetry(cfg.ClustersManager)
-	if err != nil {
-		// If there's an error turning on telemetry, that's not a
-		// thing that should interrupt anything else
-		cfg.log.V(logger.LogLevelDebug).Info("Couldn't enable telemetry", "error", err)
-	}
-
 	return &coreServer{
 		logger:          cfg.log,
 		nsChecker:       cfg.NSAccess,

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "jest-canvas-mock": "^2.4.0",
     "jest-fail-on-console": "^3.0.1",
     "jest-worker": "^27.5.1",
+    "js-sha3": "0.8.0",
     "lodash": "^4.17.21",
     "luxon": "^1.27.0",
     "mnemonic-browser": "^0.0.1",

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -1,47 +1,51 @@
 package telemetry
 
 import (
+	"context"
 	"encoding/hex"
+	"fmt"
 
-	"github.com/weaveworks/weave-gitops/core/clustersmngr"
+	"github.com/weaveworks/weave-gitops/core/clustersmngr/cluster"
 	"github.com/weaveworks/weave-gitops/pkg/featureflags"
 	"golang.org/x/crypto/sha3"
-	"k8s.io/apimachinery/pkg/types"
+	v1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func InitTelemetry(factory clustersmngr.ClustersManager) error {
-	if featureflags.Get("WEAVE_GITOPS_FEATURE_TELEMETRY") == "true" {
-		var namespace types.UID
-
-		namespaces := factory.GetClustersNamespaces()["Default"]
-		for _, ns := range namespaces {
-			if ns.GetName() == "kube-system" {
-				namespace = ns.GetUID()
-			}
-		}
-
-		key := []byte("VyzGoWoKvtJHyTnU+GVhDe+wU9bwZDH87bp505/0f/2UIpHzB+tmyZmfsH8/iJoH")
-		buf := []byte(namespace)
-		h := make([]byte, 32)
-		d := sha3.NewShake128()
-
-		_, err := d.Write(key)
-		if err != nil {
-			return err
-		}
-
-		_, err = d.Write(buf)
-		if err != nil {
-			return err
-		}
-
-		_, err = d.Read(h)
-		if err != nil {
-			return err
-		}
-
-		featureflags.Set("ACCOUNT_ID", hex.EncodeToString(h))
+func InitTelemetry(ctx context.Context, cl cluster.Cluster) error {
+	serverClient, err := cl.GetServerClient()
+	if err != nil {
+		return fmt.Errorf("failed to get server client; %w", err)
 	}
+
+	ns := &v1.Namespace{}
+
+	err = serverClient.Get(ctx, client.ObjectKey{Name: "kube-system"}, ns)
+	if err != nil {
+		return fmt.Errorf("failed to get cluster namespace; %w", err)
+	}
+
+	key := []byte("VyzGoWoKvtJHyTnU+GVhDe+wU9bwZDH87bp505/0f/2UIpHzB+tmyZmfsH8/iJoH")
+	buf := []byte(ns.GetUID())
+	h := make([]byte, 32)
+	d := sha3.NewShake128()
+
+	_, err = d.Write(key)
+	if err != nil {
+		return err
+	}
+
+	_, err = d.Write(buf)
+	if err != nil {
+		return err
+	}
+
+	_, err = d.Read(h)
+	if err != nil {
+		return err
+	}
+
+	featureflags.Set("ACCOUNT_ID", hex.EncodeToString(h))
 
 	return nil
 }

--- a/tools/helm-values-dev.yaml
+++ b/tools/helm-values-dev.yaml
@@ -24,6 +24,6 @@ envVars:
   - name: WEAVE_GITOPS_FEATURE_CLUSTER
     value: "false"
   - name: WEAVE_GITOPS_FEATURE_TELEMETRY
-    value: "true"
+    value: "false"
   - name: WEAVE_GITOPS_FEATURE_DEV_MODE
     value: "true"

--- a/ui/App.tsx
+++ b/ui/App.tsx
@@ -112,7 +112,7 @@ export default function AppContainer() {
             <AppContextProvider renderFooter>
               <AuthContextProvider>
                 <CoreClientContextProvider api={Core}>
-                  <Pendo />
+                  <Pendo defaultTelemetryFlag="false" />
                   <Switch>
                     {/* <Signin> does not use the base page <Layout> so pull it up here */}
                     <Route component={SignIn} exact path="/sign_in" />

--- a/ui/components/AlertsTable.tsx
+++ b/ui/components/AlertsTable.tsx
@@ -35,7 +35,7 @@ export const makeEventSourceLink = (obj: CrossNamespaceObjectRef) => {
 
 function AlertsTable({ className, rows = [] }: Props) {
   const { data: flagData } = useFeatureFlags();
-  const flags = flagData?.flags || {};
+  const flags = flagData.flags;
   let initialFilterState = {
     ...filterConfig(rows, "name"),
     ...filterConfig(rows, "namespace"),

--- a/ui/components/AutomationsTable.tsx
+++ b/ui/components/AutomationsTable.tsx
@@ -26,7 +26,7 @@ type Props = {
 
 function AutomationsTable({ className, automations, hideSource }: Props) {
   const { data } = useFeatureFlags();
-  const flags = data?.flags || {};
+  const flags = data.flags;
 
   let initialFilterState = {
     ...filterConfig(automations, "type"),

--- a/ui/components/BucketDetail.tsx
+++ b/ui/components/BucketDetail.tsx
@@ -16,7 +16,7 @@ type Props = {
 
 function BucketDetail({ className, bucket, customActions }: Props) {
   const { data } = useFeatureFlags();
-  const flags = data?.flags || {};
+  const flags = data.flags;
 
   const tenancyInfo: InfoField[] =
     flags.WEAVE_GITOPS_FEATURE_TENANCY === "true" && bucket.tenant

--- a/ui/components/ControllersTable.tsx
+++ b/ui/components/ControllersTable.tsx
@@ -14,7 +14,7 @@ type Props = {
 
 function ControllersTable({ className, controllers = [] }: Props) {
   const { data } = useFeatureFlags();
-  const flags = data?.flags || {};
+  const flags = data.flags;
 
   let initialFilterState = {
     ...filterConfig(controllers, "status", filterByStatusCallback),

--- a/ui/components/CrdsTable.tsx
+++ b/ui/components/CrdsTable.tsx
@@ -11,7 +11,7 @@ type Props = {
 
 function CrdsTable({ className, crds = [] }: Props) {
   const { data } = useFeatureFlags();
-  const flags = data?.flags || {};
+  const flags = data.flags;
 
   let initialFilterState = {
     ...filterConfig(crds, "version"),

--- a/ui/components/GitRepositoryDetail.tsx
+++ b/ui/components/GitRepositoryDetail.tsx
@@ -21,7 +21,7 @@ function GitRepositoryDetail({
   customActions,
 }: Props) {
   const { data } = useFeatureFlags();
-  const flags = data?.flags || {};
+  const flags = data.flags;
 
   const tenancyInfo: InfoField[] =
     flags.WEAVE_GITOPS_FEATURE_TENANCY === "true" && gitRepository.tenant

--- a/ui/components/HelmChartDetail.tsx
+++ b/ui/components/HelmChartDetail.tsx
@@ -16,7 +16,7 @@ type Props = {
 
 function HelmChartDetail({ className, helmChart, customActions }: Props) {
   const { data } = useFeatureFlags();
-  const flags = data?.flags || {};
+  const flags = data.flags;
 
   const tenancyInfo: InfoField[] =
     flags.WEAVE_GITOPS_FEATURE_TENANCY === "true" && helmChart.tenant

--- a/ui/components/HelmReleaseDetail.tsx
+++ b/ui/components/HelmReleaseDetail.tsx
@@ -57,7 +57,7 @@ function HelmReleaseDetail({
   customActions,
 }: Props) {
   const { data } = useFeatureFlags();
-  const flags = data?.flags || {};
+  const flags = data.flags;
 
   const tenancyInfo: InfoField[] =
     flags.WEAVE_GITOPS_FEATURE_TENANCY === "true" && helmRelease?.tenant

--- a/ui/components/HelmRepositoryDetail.tsx
+++ b/ui/components/HelmRepositoryDetail.tsx
@@ -21,7 +21,7 @@ function HelmRepositoryDetail({
   customActions,
 }: Props) {
   const { data } = useFeatureFlags();
-  const flags = data?.flags || {};
+  const flags = data.flags;
 
   const tenancyInfo: InfoField[] =
     flags.WEAVE_GITOPS_FEATURE_TENANCY === "true" && helmRepository.tenant

--- a/ui/components/KustomizationDetail.tsx
+++ b/ui/components/KustomizationDetail.tsx
@@ -32,7 +32,7 @@ function KustomizationDetail({
   customActions,
 }: Props) {
   const { data } = useFeatureFlags();
-  const flags = data?.flags || {};
+  const flags = data.flags;
 
   const tenancyInfo: InfoField[] =
     flags.WEAVE_GITOPS_FEATURE_TENANCY === "true" && kustomization?.tenant

--- a/ui/components/NotificationsTable.tsx
+++ b/ui/components/NotificationsTable.tsx
@@ -24,7 +24,7 @@ type Props = {
 
 function NotificationsTable({ className, rows }: Props) {
   const { data: flagData } = useFeatureFlags();
-  const flags = flagData?.flags || {};
+  const flags = flagData.flags;
 
   let initialFilterState = {
     ...filterConfig(rows, "provider"),

--- a/ui/components/OCIRepositoryDetail.tsx
+++ b/ui/components/OCIRepositoryDetail.tsx
@@ -21,7 +21,7 @@ function OCIRepositoryDetail({
   customActions,
 }: Props) {
   const { data } = useFeatureFlags();
-  const flags = data?.flags || {};
+  const flags = data.flags;
 
   const tenancyInfo: InfoField[] =
     flags.WEAVE_GITOPS_FEATURE_TENANCY === "true" && ociRepository.tenant

--- a/ui/components/SourcesTable.tsx
+++ b/ui/components/SourcesTable.tsx
@@ -29,7 +29,7 @@ type Props = {
 
 function SourcesTable({ className, sources }: Props) {
   const { data } = useFeatureFlags();
-  const flags = data?.flags || {};
+  const flags = data.flags;
 
   let initialFilterState = {
     ...filterConfig(sources, "type"),

--- a/ui/contexts/CoreClientContext.tsx
+++ b/ui/contexts/CoreClientContext.tsx
@@ -54,7 +54,7 @@ function FeatureFlags(api) {
       cacheTime: Infinity,
     }
   );
-  return data?.flags || {};
+  return data?.flags;
 }
 
 export default function CoreClientContextProvider({ api, children }: Props) {

--- a/ui/hooks/featureflags.ts
+++ b/ui/hooks/featureflags.ts
@@ -5,5 +5,5 @@ export type FeatureFlags = { [key: string]: string };
 
 export function useFeatureFlags() {
   const { featureFlags } = useContext(CoreClientContext);
-  return { data: { flags: featureFlags } };
+  return { data: { flags: featureFlags || {} } };
 }

--- a/ui/index.ts
+++ b/ui/index.ts
@@ -28,6 +28,7 @@ import Metadata from "./components/Metadata";
 import NotificationsTable from "./components/NotificationsTable";
 import OCIRepositoryDetail from "./components/OCIRepositoryDetail";
 import Page from "./components/Page";
+import Pendo from "./components/Pendo";
 import ProviderDetail from "./components/ProviderDetail";
 import ReconciledObjectsTable from "./components/ReconciledObjectsTable";
 import ReconciliationGraph from "./components/ReconciliationGraph";
@@ -129,6 +130,7 @@ export {
   OCIRepository,
   OCIRepositoryDetail,
   Page,
+  Pendo,
   ProviderDetail,
   ReconciledObjectsTable,
   ReconciliationGraph,

--- a/ui/pages/SignIn.tsx
+++ b/ui/pages/SignIn.tsx
@@ -63,7 +63,7 @@ const DocsWrapper = styled(Flex)`
 
 function SignIn() {
   const { data } = useFeatureFlags();
-  const flags = data?.flags || {};
+  const flags = data.flags;
 
   const formRef = React.useRef<HTMLFormElement>();
   const {


### PR DESCRIPTION
Part of https://github.com/weaveworks/weave-gitops-enterprise/issues/1941

- Added the `Pendo` component to exports.

- Added the `defaultTelemetryFlag` prop to the `Pendo` component.

- Added the `js-sha3` package to the dependencies.

- Turned telemetry off in Tilt by default.

- Reworked the logic for detecting if Pendo should be initialized (in order to initialize it only after the feature flags are available in enterprise).

- Moved providing the default value for feature flags from `CoreClientContext` to `useFeatureFlags`.

- Removed unneeded default values and optional chaining for data returned by `useFeatureFlags` (it looks like they were not needed even before the latest change).

- Moved initializing telemetry to the gitops server cmd.

- Moved the check if should initialize telemetry to outside the `InitTelemetry` function.
