### PR TITLE
Publish non-release NPM packages from PRs too

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -241,7 +241,6 @@ jobs:
     name: Publish js library
     runs-on: ubuntu-latest
     needs: [ci-js]
-    if: github.event_name == 'push'
     permissions:
       packages: write
     outputs:


### PR DESCRIPTION
This will publish one package for every successful CI run, including from non-main branches. Because the version is the full `git describe` output, they should all have unique and orderable names.