### PR TITLE
Fix incorrect message display for reconciled objects

### DIFF
--- a/ui/components/ReconciledObjectsTable.tsx
+++ b/ui/components/ReconciledObjectsTable.tsx
@@ -1,4 +1,3 @@
-import _ from "lodash";
 import * as React from "react";
 import styled from "styled-components";
 import { AppContext } from "../contexts/AppContext";
@@ -136,8 +135,7 @@ function ReconciledObjectsTable({
           },
           {
             label: "Message",
-            value: (u: FluxObject) => _.first(u.conditions)?.message,
-            sortValue: ({ conditions }) => computeMessage(conditions),
+            value: (u: FluxObject) => computeMessage(u.conditions),
             maxWidth: 600,
           },
           {


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes #3109 

<!-- Describe what has changed in this PR -->
If we always display the message of the first conditions object, we sometimes don't prioritize conditions with types of `Ready` or `Available`. It looks like if conditions are not undefined, don't have types of ready or available, and don't have a condition with a status of false, `computeMessage` will return the first condition's message anyway, even without the code I've removed here in `ReconciledObjectsTable`.

@jpellizzari Am I missing something related to the `DaemonSets` here that require the message of the first condition?

before:
![image](https://user-images.githubusercontent.com/65822698/205730791-cc5467c7-6518-4be3-8af5-ec7a4c393185.png)

after:
![image](https://user-images.githubusercontent.com/65822698/205730880-cb9e9fa7-57e6-4def-9ed7-377a027d5cb4.png)

