### PR TITLE
test: fix occasional panic sending on a closed channel

### DIFF
--- a/core/server/sync_test.go
+++ b/core/server/sync_test.go
@@ -118,7 +118,12 @@ func TestSync(t *testing.T) {
 
 			go func() {
 				_, err := c.SyncFluxObject(ctx, msg)
-				done <- err
+				select {
+				case <-done:
+					return
+				default:
+					done <- err
+				}
 			}()
 
 			ticker := time.NewTicker(500 * time.Millisecond)


### PR DESCRIPTION
The panic obfuscated the actual reason the test failed.
