### PR TITLE
helm: Use HTTPS scheme for liveness/readiness probe when serverTLS is enabled

### DIFF
--- a/charts/gitops-server/templates/deployment.yaml
+++ b/charts/gitops-server/templates/deployment.yaml
@@ -68,10 +68,16 @@ spec:
             httpGet:
               path: /
               port: http
+              {{- if .Values.serverTLS.enable }}
+              scheme: HTTPS
+              {{- end }}
           readinessProbe:
             httpGet:
               path: /
               port: http
+              {{- if .Values.serverTLS.enable }}
+              scheme: HTTPS
+              {{- end }}
           env:
           {{- if .Values.envVars }}
           {{- with .Values.envVars }}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Update the helm chart to configure the liveness/readiness probe to use HTTPS scheme when `serverTLS.enable` is `true`.


<!-- Tell your future self why have you made these changes -->
**Why was this change made?**

When I deployed weave-gitops using the helm chart with `serverTLS` configured, the Deployment never reached the ready state. Upon inspection, I noticed the readiness/liveness probes were failing with the following error:

```
  Warning  Unhealthy  2s (x2 over 9s)  kubelet            Readiness probe failed: HTTP probe failed with statuscode: 400
  Warning  Unhealthy  2s               kubelet            Liveness probe failed: HTTP probe failed with statuscode: 400
```

Manually patching the deployment to adjust the scheme to `HTTPS` as I am doing here resolved the issue.

<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**

N/A: the change should be relatively trivial, but happy to explain any questions that may arise.


<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**

Manually patched the `Deployment` object with the same changes.

<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**

None

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**

None