### PR TITLE
add namespace annotation to gitops run sessions

### DIFF
--- a/cmd/gitops/remove/run/cmd.go
+++ b/cmd/gitops/remove/run/cmd.go
@@ -147,24 +147,24 @@ func removeRunRunE(opts *config.Options) func(cmd *cobra.Command, args []string)
 			}
 
 			for _, internalSession := range internalSessions {
-				log.Actionf("Removing session %s/%s ...", internalSession.Namespace, internalSession.Name)
+				log.Actionf("Removing session %s/%s ...", internalSession.SessionNamespace, internalSession.SessionName)
 
 				if err := session.Remove(kubeClient, internalSession); err != nil {
 					return err
 				}
 
-				log.Successf("Session %s/%s was successfully removed.", internalSession.Namespace, internalSession.Name)
+				log.Successf("Session %s/%s was successfully removed.", internalSession.SessionNamespace, internalSession.SessionName)
 			}
 		} else {
 			internalSession, err := session.Get(kubeClient, args[0], flags.Namespace)
 			if err != nil {
 				return err
 			}
-			log.Actionf("Removing session %s/%s ...", internalSession.Namespace, internalSession.Name)
+			log.Actionf("Removing session %s/%s ...", internalSession.SessionNamespace, internalSession.SessionName)
 			if err := session.Remove(kubeClient, internalSession); err != nil {
 				return err
 			}
-			log.Successf("Session %s/%s was successfully removed.", internalSession.Namespace, internalSession.Name)
+			log.Successf("Session %s/%s was successfully removed.", internalSession.SessionNamespace, internalSession.SessionName)
 		}
 
 		return nil

--- a/pkg/run/install/install_vcluster.go
+++ b/pkg/run/install/install_vcluster.go
@@ -35,10 +35,7 @@ func makeVClusterHelmRepository(namespace string) (*sourcev1.HelmRepository, err
 	return helmRepository, nil
 }
 
-func makeVClusterHelmRelease(name string, namespace string, portForwards []string, automationKind string) (*helmv2.HelmRelease, error) {
-	args := append([]string{filepath.Base(os.Args[0])}, os.Args[1:]...)
-	command := strings.Join(args, " ")
-
+func makeVClusterHelmRelease(name string, namespace string, command string, portForwards []string, automationKind string) (*helmv2.HelmRelease, error) {
 	helmRelease := &helmv2.HelmRelease{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -76,9 +73,16 @@ func makeVClusterHelmRelease(name string, namespace string, portForwards []strin
     "run.weave.works/cli-version": "%s",
     "run.weave.works/port-forward": "%s",
     "run.weave.works/command": "%s",
-    "run.weave.works/automation-kind": "%s"
+    "run.weave.works/automation-kind": "%s",
+    "run.weave.works/namespace": "%s"
   }
-}`, version.Version, strings.Join(portForwards, ","), command, automationKind))},
+}`,
+				version.Version,
+				strings.Join(portForwards, ","),
+				command,
+				automationKind,
+				namespace,
+			))},
 		},
 	}
 
@@ -99,7 +103,10 @@ func installVCluster(kubeClient client.Client, name string, namespace string, po
 		}
 	}
 
-	helmRelease, err := makeVClusterHelmRelease(name, namespace, portForwards, automationKind)
+	args := append([]string{filepath.Base(os.Args[0])}, os.Args[1:]...)
+	command := strings.Join(args, " ")
+
+	helmRelease, err := makeVClusterHelmRelease(name, namespace, command, portForwards, automationKind)
 	if err != nil {
 		return err
 	}

--- a/pkg/run/install/install_vcluster_test.go
+++ b/pkg/run/install/install_vcluster_test.go
@@ -1,0 +1,27 @@
+package install
+
+import (
+	"encoding/json"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestMakeVClusterHelmReleaseAnnotations(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	hl, err := makeVClusterHelmRelease("name", "namespace", "command", []string{"9999", "1111"}, "automationKind")
+	g.Expect(err).ToNot(HaveOccurred())
+
+	g.Expect(hl.Name).To(Equal("name"))
+	g.Expect(hl.Namespace).To(Equal("namespace"))
+
+	values := map[string]interface{}{}
+	g.Expect(json.Unmarshal(hl.Spec.Values.Raw, &values)).ToNot(HaveOccurred())
+
+	annotations := values["annotations"].(map[string]interface{})
+	g.Expect(annotations["run.weave.works/automation-kind"]).To(Equal("automationKind"))
+	g.Expect(annotations["run.weave.works/namespace"]).To(Equal("namespace"))
+	g.Expect(annotations["run.weave.works/command"]).To(Equal("command"))
+	g.Expect(annotations["run.weave.works/port-forward"]).To(Equal("9999,1111"))
+}

--- a/pkg/run/session/get.go
+++ b/pkg/run/session/get.go
@@ -1,0 +1,46 @@
+package session
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func Get(kubeClient client.Client, name string, namespace string) (*InternalSession, error) {
+	var result *InternalSession
+
+	statefulSet := appsv1.StatefulSet{}
+	if err := kubeClient.Get(context.Background(), client.ObjectKey{
+		Namespace: namespace,
+		Name:      name,
+	}, &statefulSet); err != nil {
+		if errors.IsNotFound(err) {
+			return nil, fmt.Errorf("session %s/%s not found", namespace, name)
+		}
+
+		return nil, err
+	}
+
+	labels := statefulSet.GetLabels()
+	if labels != nil {
+		if labels["app"] != "vcluster" || labels["app.kubernetes.io/part-of"] != "gitops-run" {
+			return nil, fmt.Errorf("%s/%s is an invalid GitOps Run session", namespace, name)
+		}
+	}
+
+	annotations := statefulSet.GetAnnotations()
+	result = &InternalSession{
+		SessionName:      statefulSet.Name,
+		SessionNamespace: statefulSet.Namespace,
+		Command:          annotations["run.weave.works/command"],
+		CliVersion:       annotations["run.weave.works/cli-version"],
+		PortForward:      strings.Split(annotations["run.weave.works/port-forward"], ","),
+		Namespace:        annotations["run.weave.works/namespace"],
+	}
+
+	return result, nil
+}

--- a/pkg/run/session/get_test.go
+++ b/pkg/run/session/get_test.go
@@ -1,0 +1,51 @@
+package session
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	v1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type mockGet struct {
+	client.Client
+}
+
+var _ client.Client = &mockGet{}
+
+func (m *mockGet) Get(_ context.Context, key client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+	switch obj := obj.(type) {
+	case *v1.StatefulSet:
+		*obj = v1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      key.Name,
+				Namespace: key.Namespace,
+				Annotations: map[string]string{
+					"run.weave.works/command":      "command",
+					"run.weave.works/cli-version":  "cli-version",
+					"run.weave.works/port-forward": "9999,1111",
+					"run.weave.works/namespace":    "flux-system",
+				},
+			},
+		}
+	}
+
+	return nil
+}
+
+func TestGet(t *testing.T) {
+	g := NewGomegaWithT(t)
+	is, err := Get(&mockGet{}, "name", "namespace")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(is).ToNot(BeNil())
+	g.Expect(is.SessionName).To(Equal("name"))
+	g.Expect(is.SessionNamespace).To(Equal("namespace"))
+	g.Expect(is.PortForward).To(Equal([]string{"9999", "1111"}))
+	g.Expect(is.Command).To(Equal("command"))
+	g.Expect(is.CliVersion).To(Equal("cli-version"))
+	g.Expect(is.Namespace).To(Equal("flux-system"))
+}

--- a/pkg/run/session/list.go
+++ b/pkg/run/session/list.go
@@ -2,53 +2,18 @@ package session
 
 import (
 	"context"
-	"fmt"
-	appsv1 "k8s.io/api/apps/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"strings"
+
+	appsv1 "k8s.io/api/apps/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func Get(kubeClient client.Client, name string, namespace string) (*InternalSession, error) {
-	var result *InternalSession
-
-	statefulSet := appsv1.StatefulSet{}
-	if err := kubeClient.Get(context.Background(), client.ObjectKey{
-		Namespace: namespace,
-		Name:      name,
-	}, &statefulSet); err != nil {
-		if errors.IsNotFound(err) {
-			return nil, fmt.Errorf("session %s/%s not found", namespace, name)
-		}
-
-		return nil, err
-	}
-
-	labels := statefulSet.GetLabels()
-	if labels != nil {
-		if labels["app"] != "vcluster" || labels["app.kubernetes.io/part-of"] != "gitops-run" {
-			return nil, fmt.Errorf("%s/%s is an invalid GitOps Run session", namespace, name)
-		}
-	}
-
-	annotations := statefulSet.GetAnnotations()
-	result = &InternalSession{
-		Name:        statefulSet.Name,
-		Namespace:   statefulSet.Namespace,
-		Command:     annotations["run.weave.works/command"],
-		CliVersion:  annotations["run.weave.works/cli-version"],
-		PortForward: strings.Split(annotations["run.weave.works/port-forward"], ","),
-	}
-
-	return result, nil
-}
-
-func List(kubeClient client.Client, namespace string) ([]*InternalSession, error) {
+func List(kubeClient client.Client, targetNamespace string) ([]*InternalSession, error) {
 	var result []*InternalSession
 
 	statefulSets := appsv1.StatefulSetList{}
 	if err := kubeClient.List(context.Background(), &statefulSets,
-		client.InNamespace(namespace),
+		client.InNamespace(targetNamespace),
 		client.MatchingLabels(map[string]string{
 			"app":                       "vcluster",
 			"app.kubernetes.io/part-of": "gitops-run",
@@ -61,11 +26,12 @@ func List(kubeClient client.Client, namespace string) ([]*InternalSession, error
 		annotations := s.GetAnnotations()
 
 		result = append(result, &InternalSession{
-			Name:        s.Name,
-			Namespace:   s.Namespace,
-			Command:     annotations["run.weave.works/command"],
-			CliVersion:  annotations["run.weave.works/cli-version"],
-			PortForward: strings.Split(annotations["run.weave.works/port-forward"], ","),
+			SessionName:      s.Name,
+			SessionNamespace: s.Namespace,
+			Command:          annotations["run.weave.works/command"],
+			CliVersion:       annotations["run.weave.works/cli-version"],
+			PortForward:      strings.Split(annotations["run.weave.works/port-forward"], ","),
+			Namespace:        annotations["run.weave.works/namespace"],
 		})
 	}
 

--- a/pkg/run/session/list_test.go
+++ b/pkg/run/session/list_test.go
@@ -1,0 +1,56 @@
+package session
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	v1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type mockList struct {
+	client.Client
+}
+
+var _ client.Client = &mockList{}
+
+func (m *mockList) List(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+	switch list := list.(type) {
+	case *v1.StatefulSetList:
+		*list = v1.StatefulSetList{
+			Items: []v1.StatefulSet{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "name",
+						Namespace: "namespace",
+						Annotations: map[string]string{
+							"run.weave.works/command":      "command",
+							"run.weave.works/cli-version":  "cli-version",
+							"run.weave.works/port-forward": "9999,1111",
+							"run.weave.works/namespace":    "flux-system",
+						},
+					},
+				},
+			},
+		}
+	}
+
+	return nil
+}
+
+func TestList(t *testing.T) {
+	g := NewGomegaWithT(t)
+	list, err := List(&mockList{}, "namespace")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(list).ToNot(BeNil())
+	g.Expect(list).To(HaveLen(1))
+	g.Expect(list[0].SessionName).To(Equal("name"))
+	g.Expect(list[0].SessionNamespace).To(Equal("namespace"))
+	g.Expect(list[0].PortForward).To(Equal([]string{"9999", "1111"}))
+	g.Expect(list[0].Command).To(Equal("command"))
+	g.Expect(list[0].CliVersion).To(Equal("cli-version"))
+	g.Expect(list[0].Namespace).To(Equal("flux-system"))
+}

--- a/pkg/run/session/remove.go
+++ b/pkg/run/session/remove.go
@@ -16,11 +16,12 @@ import (
 )
 
 type InternalSession struct {
-	Name        string
-	Namespace   string
-	PortForward []string
-	CliVersion  string
-	Command     string
+	SessionName      string
+	SessionNamespace string
+	PortForward      []string
+	CliVersion       string
+	Command          string
+	Namespace        string
 }
 
 func Remove(kubeClient client.Client, session *InternalSession) error {
@@ -31,8 +32,8 @@ func Remove(kubeClient client.Client, session *InternalSession) error {
 
 	if err := kubeClient.Get(context.Background(),
 		types.NamespacedName{
-			Namespace: session.Namespace,
-			Name:      session.Name,
+			Namespace: session.SessionNamespace,
+			Name:      session.SessionName,
 		}, &helmRelease); err != nil {
 		result = multierror.Append(result, err)
 	}
@@ -46,8 +47,8 @@ func Remove(kubeClient client.Client, session *InternalSession) error {
 		if err := kubeClient.Get(
 			context.Background(),
 			types.NamespacedName{
-				Namespace: session.Namespace,
-				Name:      session.Name},
+				Namespace: session.SessionNamespace,
+				Name:      session.SessionName},
 			&instance,
 		); err != nil && apierrors.IsNotFound(err) {
 			return true, nil
@@ -65,8 +66,8 @@ func Remove(kubeClient client.Client, session *InternalSession) error {
 		if err := kubeClient.Get(
 			context.Background(),
 			types.NamespacedName{
-				Namespace: session.Namespace,
-				Name:      fmt.Sprintf("data-%s-0", session.Name),
+				Namespace: session.SessionNamespace,
+				Name:      fmt.Sprintf("data-%s-0", session.SessionName),
 			},
 			&pvc,
 		); err != nil && apierrors.IsNotFound(err) {


### PR DESCRIPTION
This PR adds the annotation `run.weave.works/namespace` to session objects.
The value of this annotation is taken from `--namespace` (flags.Namespace) of GitOps Run (default to `flux-system`).

Fixes #3126

Signed-off-by: Chanwit Kaewkasi <chanwit@weave.works>