### PR TITLE
Fixes the PR commit hash we publish npm modules under

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -247,8 +247,13 @@ jobs:
       js-version: ${{ steps.package-version.outputs.js-version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2
         with:
+          # avoid the merge commit that on.pull_request creates
+          # fallback to github.sha if not present (e.g. on.push(main))
+          # https://github.com/actions/checkout#checkout-pull-request-head-commit-instead-of-merge-commit
+          # We want the correct sha so we can tag the npm package correctly
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
       - uses: actions/setup-node@v2
         with:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -247,7 +247,7 @@ jobs:
       js-version: ${{ steps.package-version.outputs.js-version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - uses: actions/setup-node@v2


### PR DESCRIPTION
- We derive the name of the npm artifact from the git ref.
- on.pull_request creates an intermediate merge commit and messes this up


<!-- Describe what has changed in this PR -->
**What changed?**

Updates the actions/checkout step to avoid a quirk of `on.pull_request` checking out the code to a "non-existant" merge commit. 

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**

We use the ref from the commit to name the npm package. This should reflect the actual commit and not the temporary merge commit actions/checkout creates.

<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**

Straight up yaml engineering.

<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**

Checked the _publish js library_ CI output which now shows:
> `npm notice 📦  @weaveworks/weave-gitops-main@0.12.0-20-g116fd4bc`

For the head of this PR as of writing which matches the last commit.

<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**


<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
