### PR TITLE
fix flaky multi-server test

### DIFF
--- a/pkg/http/server_test.go
+++ b/pkg/http/server_test.go
@@ -70,8 +70,14 @@ func TestMultiServerServesOverBothProtocols(t *testing.T) {
 
 	// test HTTP
 
-	resp, err := http.Get(fmt.Sprintf("http://localhost:%d/", httpPort))
-	g.Expect(err).NotTo(HaveOccurred())
+	var resp *http.Response
+
+	g.Eventually(func() error {
+		var err error
+		resp, err = http.Get(fmt.Sprintf("http://localhost:%d/", httpPort))
+		return err
+	}).Should(Succeed())
+	g.Expect(resp).NotTo(BeNil(), "response is nil even though no error has been returned")
 	g.Expect(resp.StatusCode).To(Equal(http.StatusOK))
 	body, err := io.ReadAll(resp.Body)
 	g.Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
The HTTP server might take some time to boot up so the `http.Get` call
failed sometimes. This race condition is now fixed by using
`g.Eventually` to try the request until it succeeds.

```
$ (pass=0; fail=0; for i in $(seq 1 1000) ; do go test -count=1 -v -run '^TestMultiServerServesOverBothProtocols$' ./pkg/http/ && pass=$(($pass+1)) || fail=$(($fail+1)) ; done; echo -e "Pass: $pass\nFail: $fail")

[...]

Pass: 1000
Fail: 0
```
closes #3144
