### PR TITLE
Pendo: Get rid of anonymous visitors on sign in page

### DIFF
--- a/ui/components/Pendo.tsx
+++ b/ui/components/Pendo.tsx
@@ -10,7 +10,9 @@ declare global {
   }
 }
 
-const key = "VyzGoWoKvtJHyTnU+GVhDe+wU9bwZDH87bp505/0f/2UIpHzB+tmyZmfsH8/iJoH";
+const pendoKey = "pendo";
+const hashKey =
+  "VyzGoWoKvtJHyTnU+GVhDe+wU9bwZDH87bp505/0f/2UIpHzB+tmyZmfsH8/iJoH";
 
 export interface Props {
   /** Value to use as default if the telemetry flag cannot be read. */
@@ -33,12 +35,27 @@ export default function Pendo({ defaultTelemetryFlag }: Props) {
       return;
     }
 
-    let visitorId = "";
+    let pendoKeys: string[] = [];
+
+    if (!window.localStorage) {
+      console.warn("no local storage found");
+    } else {
+      pendoKeys = Object.keys(window.localStorage).filter(
+        (key) => key.toLowerCase().indexOf(pendoKey) != -1
+      );
+    }
+
     const userEmail = userInfo?.email;
+
+    if (!userEmail && pendoKeys.length == 0) {
+      return;
+    }
+
+    let visitorId = "";
 
     if (userEmail) {
       const hasher = shake128.create(128);
-      hasher.update(key);
+      hasher.update(hashKey);
       hasher.update(userEmail);
       visitorId = Mnemonic.fromHex(hasher.hex()).toWords().join("-");
     }

--- a/ui/pages/SignIn.tsx
+++ b/ui/pages/SignIn.tsx
@@ -11,8 +11,6 @@ import { useFeatureFlags } from "../hooks/featureflags";
 import images from "../lib/images";
 import { theme } from "../lib/theme";
 
-const pendoKey = "pendo";
-
 const SignInBackgroundAnimation = React.lazy(
   () => import("../components/Animations/SignInBackground")
 );
@@ -83,19 +81,6 @@ function SignIn() {
   };
 
   const handleUserPassSubmit = () => signIn({ username, password });
-
-  React.useEffect(() => {
-    if (!window.localStorage) {
-      console.warn("no local storage found");
-      return;
-    }
-
-    const pendoKeys = Object.keys(window.localStorage).filter(
-      (key) => key.toLowerCase().indexOf(pendoKey) != -1
-    );
-
-    pendoKeys.forEach((key) => window.localStorage.removeItem(key));
-  }, []);
 
   return (
     <Flex


### PR DESCRIPTION
Closes https://github.com/weaveworks/weave-gitops/issues/3153

- Removed clean-up of Pendo user data stored in browser's `localStorage`.

- Added returning without initializing Pendo if there is no user email available and no Pendo user stored in the local storage (to prevent logging anonymous users to Pendo on the Signin page).

**Testing**

Tested it in OSS and in enterprise against this branch, works as expected.

Set `WEAVE_GITOPS_FEATURE_TELEMETRY` to "true" before testing, it's turned off in development environments by default.

Helpful browser console commands for testing:
- Clear browser local storage to delete a stored Pendo user info.
```
window.localStorage.clear()
```
- Check if there is a Pendo user stored in the browser's `localStorage` (see if there are any Pendo-related keys in the localStorage):
```
console.log(window.localStorage)
```
- Print the current Pendo object attached to the window (= Pendo agent) or undefined if the Pendo agent has not been initialized:
```
console.log(window.pendo)
```
- If the Pendo agent has been initialized (happens only if the visitor is logged in or a previously logged in/their email is available in user is picked up from the local storage on the Signin  page), show the current visitor ID:
```
console.log(window.pendo.visitorId);
```

How to test it (how I test it):
- Run the UI.
- Log out if needed.
- go to the Signin page and clear the window's localStorage with `window.localStorage.clear()` (or do it before entering the Signin screen).
- Then, after you entered the Signin page for the first time after clearing the local storage (or just clear localStorage on the Signin screen and reload the page), check if Pendo agent has been initialized. The `window.pendo` object returned for `console.log(window.pendo)` should be undefined.
- Log into the UI, the Pendo agent should be initialized with the randomly generated visitor and account ID.
Log the Pendo's visitor ID with `console.log(window.pendo.visitorId);`
- Log out of the UI to go back to the Signin page. Reload the page on the Signin page and check that `console.log(window.pendo.visitorId);` returns a string value (since the user has logged in successfully before, the Pendo user should be picked from the user stored in the local storage).