### PR TITLE
feat: support for -n flag for --namespace

### DIFF
--- a/cmd/gitops/root/cmd.go
+++ b/cmd/gitops/root/cmd.go
@@ -130,7 +130,7 @@ func RootCmd() *cobra.Command {
 		},
 	}
 
-	rootCmd.PersistentFlags().String("namespace", defaultNamespace, "The namespace scope for this operation")
+	rootCmd.PersistentFlags().StringP("namespace", "n", defaultNamespace, "The namespace scope for this operation")
 	rootCmd.PersistentFlags().StringVarP(&options.Endpoint, "endpoint", "e", os.Getenv("WEAVE_GITOPS_ENTERPRISE_API_URL"), "The Weave GitOps Enterprise HTTP API endpoint can be set with `WEAVE_GITOPS_ENTERPRISE_API_URL` environment variable")
 	rootCmd.PersistentFlags().StringVarP(&options.Username, "username", "u", "", "The Weave GitOps Enterprise username for authentication can be set with `WEAVE_GITOPS_USERNAME` environment variable")
 	rootCmd.PersistentFlags().StringVarP(&options.Password, "password", "p", "", "The Weave GitOps Enterprise password for authentication can be set with `WEAVE_GITOPS_PASSWORD` environment variable")


### PR DESCRIPTION


Closes: #2982

<!-- Describe what has changed in this PR -->
**What changed?**
Add `-n` flag alias for `--namespace`

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**
The short `-n` flag for `--namespace` is a common practice in the Kuberneres world, not having that and working in multiple namespaces can cause user pain, a lot.

<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**
Changed `PersistentFlags().String(...)` to `PersistentFlags().StringP(...)`.

<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**
Run the following command:
```
go run ./cmd/gitops --help
```

<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**


<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
