### PR TITLE
Pendo: Track if users are coming from OSS or Ent and latest version

### DIFF
--- a/ui/App.tsx
+++ b/ui/App.tsx
@@ -14,6 +14,7 @@ import { ThemeProvider } from "styled-components";
 import ErrorBoundary from "./components/ErrorBoundary";
 import Layout from "./components/Layout";
 import Pendo from "./components/Pendo";
+import PendoContainer, { tier } from "./components/PendoContainer";
 import AppContextProvider from "./contexts/AppContext";
 import AuthContextProvider, { AuthCheck } from "./contexts/AuthContext";
 import CoreClientContextProvider from "./contexts/CoreClientContext";
@@ -48,6 +49,7 @@ function withSearchParams(Cmp) {
 
 const App = () => (
   <Layout>
+    <PendoContainer />
     <ErrorBoundary>
       <Switch>
         <Route exact path={V2Routes.Automations} component={Automations} />
@@ -112,10 +114,15 @@ export default function AppContainer() {
             <AppContextProvider renderFooter>
               <AuthContextProvider>
                 <CoreClientContextProvider api={Core}>
-                  <Pendo defaultTelemetryFlag="false" />
                   <Switch>
                     {/* <Signin> does not use the base page <Layout> so pull it up here */}
-                    <Route component={SignIn} exact path="/sign_in" />
+                    <Route exact path="/sign_in">
+                      <SignIn
+                        analytics={
+                          <Pendo defaultTelemetryFlag="false" tier={tier} />
+                        }
+                      />
+                    </Route>
                     <Route path="*">
                       {/* Check we've got a logged in user otherwise redirect back to signin */}
                       <AuthCheck>

--- a/ui/components/Footer.tsx
+++ b/ui/components/Footer.tsx
@@ -3,6 +3,7 @@ import styled from "styled-components";
 import p from "../../package.json";
 import { useVersion } from "../hooks/version";
 import { GetVersionResponse } from "../lib/api/core/core.pb";
+import { getAppVersion } from "../lib/utils";
 import Flex from "./Flex";
 import Link from "./Link";
 import Spacer from "./Spacer";
@@ -19,39 +20,29 @@ const RightFoot = styled(Flex)`
 
 const LeftFoot = styled(Flex)``;
 
-const REPO_URL = "https://github.com/weaveworks/weave-gitops";
-
 function Footer({ className }: Props) {
   const { data, isLoading } = useVersion();
   const versionData = data || ({} as GetVersionResponse);
 
-  const shouldDisplayApiVersion =
-    !isLoading &&
-    (versionData.semver || "").replace(/^v+/, "") !== p.version &&
-    versionData.branch &&
-    versionData.commit;
-
-  const wegoVersionText = shouldDisplayApiVersion
-    ? `${versionData.branch}-${versionData.commit}`
-    : `v${p.version}`;
-  const wegoVersionHref = shouldDisplayApiVersion
-    ? `${REPO_URL}/commit/${versionData.commit}`
-    : `${REPO_URL}/releases/tag/v${p.version}`;
+  const appVersion = getAppVersion(data, p.version, isLoading, "v");
 
   const versions: VersionProps[] = !isLoading
     ? [
         {
           productName: "Kubernetes",
-          versionText: versionData.kubeVersion,
+          appVersion: {
+            versionText: versionData.kubeVersion,
+          },
         },
         {
           productName: "Flux",
-          versionText: versionData.fluxVersion,
+          appVersion: {
+            versionText: versionData.fluxVersion,
+          },
         },
         {
           productName: "Weave GitOps",
-          versionText: wegoVersionText,
-          versionHref: wegoVersionHref,
+          appVersion: appVersion,
         },
       ]
     : [];

--- a/ui/components/PendoContainer.tsx
+++ b/ui/components/PendoContainer.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import p from "../../package.json";
+
+import { useVersion } from "../hooks/version";
+import { GetVersionResponse } from "../lib/api/core/core.pb";
+import { getAppVersion } from "../lib/utils";
+import Pendo from "./Pendo";
+import { noVersion } from "./Version";
+
+export const tier = "oss";
+
+/** This component is used to wrap the Pendo component and pass in the version.
+ * Use it where you are authorized to make API calls
+ * and need to track the app version with Pendo.
+ */
+export default function PendoContainer() {
+  const [version, setVersion] = React.useState<string>("");
+  const [shouldWaitForVersion, setShouldWaitForVersion] =
+    React.useState<boolean>(true);
+
+  const { data, isLoading } = useVersion();
+  const versionData = data || ({} as GetVersionResponse);
+
+  React.useEffect(() => {
+    if (isLoading) return;
+
+    if (!versionData) {
+      setShouldWaitForVersion(false);
+      return;
+    }
+
+    const appVersion = getAppVersion(data, p.version, isLoading);
+
+    setVersion(appVersion.versionText || noVersion);
+  }, [versionData, isLoading]);
+
+  return (
+    <Pendo
+      defaultTelemetryFlag="false"
+      tier={tier}
+      shouldWaitForVersion={shouldWaitForVersion}
+      version={version}
+    />
+  );
+}

--- a/ui/components/Version.tsx
+++ b/ui/components/Version.tsx
@@ -5,20 +5,23 @@ import Link from "./Link";
 import Spacer from "./Spacer";
 import Text from "./Text";
 
-export type VersionProps = {
-  className?: string;
-  productName: string;
+export const repoUrl = "https://github.com/weaveworks/weave-gitops";
+
+export const noVersion = "no version";
+
+export type AppVersion = {
   versionText?: string;
   versionHref?: string;
 };
 
-function Version({
-  className,
-  productName,
-  versionText,
-  versionHref,
-}: VersionProps) {
-  const formattedVersionText = versionText || "-";
+export type VersionProps = {
+  className?: string;
+  productName: string;
+  appVersion?: AppVersion;
+};
+
+function Version({ className, productName, appVersion }: VersionProps) {
+  const formattedVersionText = appVersion?.versionText || "-";
 
   return (
     <Flex className={className}>
@@ -26,8 +29,8 @@ function Version({
         {productName}:
       </Text>
       <Spacer padding="xxs" />
-      {versionHref && versionText ? (
-        <Link newTab href={versionHref}>
+      {appVersion?.versionHref && appVersion?.versionText ? (
+        <Link newTab href={appVersion?.versionHref}>
           <Text semiBold>{formattedVersionText}</Text>
         </Link>
       ) : (

--- a/ui/components/__tests__/Version.test.tsx
+++ b/ui/components/__tests__/Version.test.tsx
@@ -14,7 +14,7 @@ describe("Version", () => {
       const tree = renderer
         .create(
           withTheme(
-            <Version productName={productName} versionText={versionText} />
+            <Version productName={productName} appVersion={{ versionText }} />
           )
         )
         .toJSON();
@@ -26,8 +26,7 @@ describe("Version", () => {
           withTheme(
             <Version
               productName={productName}
-              versionText={versionText}
-              versionHref={versionHref}
+              appVersion={{ versionText, versionHref }}
             />
           )
         )
@@ -36,7 +35,14 @@ describe("Version", () => {
     });
     it("renders a dash without version text and without version href", () => {
       const tree = renderer
-        .create(withTheme(<Version productName={productName} versionText="" />))
+        .create(
+          withTheme(
+            <Version
+              productName={productName}
+              appVersion={{ versionText: "" }}
+            />
+          )
+        )
         .toJSON();
       expect(tree).toMatchSnapshot();
     });
@@ -46,8 +52,7 @@ describe("Version", () => {
           withTheme(
             <Version
               productName={productName}
-              versionText=""
-              versionHref={versionHref}
+              appVersion={{ versionText: "", versionHref }}
             />
           )
         )

--- a/ui/components/__tests__/__snapshots__/DataTable.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/DataTable.test.tsx.snap
@@ -164,6 +164,10 @@ exports[`DataTable snapshots renders 1`] = `
   width: 16px;
 }
 
+.c8 {
+  padding: 4px;
+}
+
 .c6.MuiButton-root {
   height: 32px;
   font-size: 12px;
@@ -179,10 +183,6 @@ exports[`DataTable snapshots renders 1`] = `
 .c6.MuiButton-outlined {
   padding: 8px 12px;
   border-color: #d8d8d8;
-}
-
-.c8 {
-  padding: 4px;
 }
 
 .c13 {

--- a/ui/components/__tests__/__snapshots__/Metadata.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/Metadata.test.tsx.snap
@@ -95,6 +95,15 @@ exports[`Metadata snapshots renders with data 1`] = `
   font-style: normal;
 }
 
+.c7 {
+  padding: 12px;
+}
+
+.c5 {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
 .c3 {
   border-spacing: 0;
 }
@@ -112,15 +121,6 @@ exports[`Metadata snapshots renders with data 1`] = `
 
 .c3 tr {
   height: 16px;
-}
-
-.c7 {
-  padding: 12px;
-}
-
-.c5 {
-  -webkit-text-decoration: none;
-  text-decoration: none;
 }
 
 .c11 {

--- a/ui/lib/__tests__/utils.test.ts
+++ b/ui/lib/__tests__/utils.test.ts
@@ -1,9 +1,11 @@
 import { jest } from "@jest/globals";
 import { Automation, HelmRelease, Kustomization } from "../objects";
+import { GetVersionResponse } from "../api/core/core.pb";
 import {
   convertGitURLToGitProvider,
   convertImage,
   formatMetadataKey,
+  getAppVersion,
   getSourceRefForAutomation,
   gitlabOAuthRedirectURI,
   isAllowedLink,
@@ -329,6 +331,61 @@ describe("utils lib", () => {
       let automation: Automation;
 
       expect(getSourceRefForAutomation(automation)).toBeUndefined();
+    });
+  });
+  describe("getAppVersion", () => {
+    const fullResponse: GetVersionResponse = {
+      semver: "semver",
+      commit: "commit",
+      branch: "branch",
+      buildTime: "buildTime",
+      fluxVersion: "flux-version",
+      kubeVersion: "kube-version",
+    };
+    const defaultVersion = "default version";
+    const defaultVersionPrefix = "v";
+
+    it("should return default version for full response if loading data", () => {
+      const appVersion = getAppVersion(
+        fullResponse,
+        defaultVersion,
+        true,
+        defaultVersionPrefix
+      );
+
+      expect(appVersion.versionText).toEqual(`vdefault version`);
+      expect(appVersion.versionHref).toEqual(
+        "https://github.com/weaveworks/weave-gitops/releases/tag/vdefault version"
+      );
+    });
+    it("should return api version for full response if not loading data", () => {
+      const appVersion = getAppVersion(
+        fullResponse,
+        defaultVersion,
+        false,
+        defaultVersionPrefix
+      );
+
+      expect(appVersion.versionText).toEqual("branch-commit");
+      expect(appVersion.versionHref).toEqual(
+        "https://github.com/weaveworks/weave-gitops/commit/commit"
+      );
+    });
+    it("should return default version without prefix for full response if loading data", () => {
+      const appVersion = getAppVersion(fullResponse, defaultVersion, true);
+
+      expect(appVersion.versionText).toEqual(`default version`);
+      expect(appVersion.versionHref).toEqual(
+        "https://github.com/weaveworks/weave-gitops/releases/tag/vdefault version"
+      );
+    });
+    it("should return api version without prefix for full response", () => {
+      const appVersion = getAppVersion(fullResponse, defaultVersion, false);
+
+      expect(appVersion.versionText).toEqual("branch-commit");
+      expect(appVersion.versionHref).toEqual(
+        "https://github.com/weaveworks/weave-gitops/commit/commit"
+      );
     });
   });
 });

--- a/ui/lib/utils.ts
+++ b/ui/lib/utils.ts
@@ -1,6 +1,8 @@
 import _ from "lodash";
 import { toast } from "react-toastify";
 import { computeReady, ReadyType } from "../components/KubeStatusIndicator";
+import { AppVersion, repoUrl } from "../components/Version";
+import { GetVersionResponse } from "../lib/api/core/core.pb";
 import { Condition, Kind, ObjectRef } from "./api/core/types.pb";
 import { Automation, HelmRelease, Kustomization } from "./objects";
 import { PageRoute } from "./types";
@@ -155,4 +157,30 @@ export function getSourceRefForAutomation(
   return automation?.type === Kind.Kustomization
     ? (automation as Kustomization)?.sourceRef
     : (automation as HelmRelease)?.helmChart?.sourceRef;
+}
+
+// getAppVersion returns the app version to display in the UI or track in analytics.
+export function getAppVersion(
+  versionData: GetVersionResponse,
+  defaultVersion: string,
+  isLoading = false,
+  defaultVersionPrefix = ""
+): AppVersion {
+  const shouldDisplayApiVersion =
+    !isLoading &&
+    (versionData.semver || "").replace(/^v+/, "") !== defaultVersion &&
+    versionData.branch &&
+    versionData.commit;
+
+  const versionText = shouldDisplayApiVersion
+    ? `${versionData.branch}-${versionData.commit}`
+    : `${defaultVersionPrefix}${defaultVersion}`;
+  const versionHref = shouldDisplayApiVersion
+    ? `${repoUrl}/commit/${versionData.commit}`
+    : `${repoUrl}/releases/tag/v${defaultVersion}`;
+
+  return {
+    versionText,
+    versionHref,
+  };
 }

--- a/ui/pages/SignIn.tsx
+++ b/ui/pages/SignIn.tsx
@@ -59,7 +59,12 @@ const DocsWrapper = styled(Flex)`
   }
 `;
 
-function SignIn() {
+export interface Props {
+  /** Analytics component */
+  analytics?: React.ReactNode;
+}
+
+function SignIn({ analytics }: Props) {
   const { data } = useFeatureFlags();
   const flags = data.flags;
 
@@ -94,6 +99,7 @@ function SignIn() {
         width: "100vw",
       }}
     >
+      {analytics}
       <React.Suspense fallback={null}>
         <SignInBackgroundAnimation />
       </React.Suspense>


### PR DESCRIPTION
Part of #3154

- Added tier and version to the `Pendo` component props.

- Added analytics as an optional `Signin` component prop.

- Added tracking tier and version as Pendo visitor metadata.

- Switched to initializing and re-identifying Pendo with objects instead of strings.

- Added the `PendoContainer` component to provide the version to Pendo (it should be used where using `useVersion` hook/calling the API in general is possible, within `AuthCheck`, because hooks can be called only at the top level in a function component and not conditionally).

- Switched to rendering the `Pendo` component twice: at the Signin page without the version (= without the `PendoContainer` component) and at other pages with the version.

- Reworked props of the `Footer`, and `Version` components.

- Moved getting the app version to a separate function `getAppVersion` and added unit tests for it.

- Updated some UI test snapshots (which were not updated before probably).

Notes:
- The name of the `shouldDisplayApiVersion` local var within the `getAppVersion` function is a convention from when we discussed adding the get version endpoint. It's like a full version built dynamically from values set at build time vs. the hardcoded release version from package.json.

- There is a known followup issue to this (in OSS only):
https://github.com/weaveworks/weave-gitops/issues/3191

Testing:
- To test if Pendo has been initialized and with which visitor metadata, run the following command in the browser console
```
console.log(window.pendo.getSerializedMetadata().visitor)
```

If Pendo is not initialized, this will throw an error.

In OSS, Pendo should be always initialized (with the version) on pages on which the user is logged in and should only be initialized on the Sign In page (but without the version) if there is a user data stored in the window's localStorage.

To clear localStorage for testing, run:

```
window.localStorage.clear()
```
Tested it locally, works as expected.