### PR TITLE
Make context the first param of Go functions

### DIFF
--- a/cmd/gitops/beta/run/cmd.go
+++ b/cmd/gitops/beta/run/cmd.go
@@ -261,7 +261,7 @@ func fluxStep(log logger.Logger, kubeClient *kube.KubeHTTP) (fluxVersion string,
 
 	log.Actionf("Checking if Flux is already installed ...")
 
-	if fluxVersion, err = install.GetFluxVersion(log, ctx, kubeClient); err != nil {
+	if fluxVersion, err = install.GetFluxVersion(ctx, log, kubeClient); err != nil {
 		log.Warningf("Flux is not found: %v", err.Error())
 
 		product := fluxinstall.NewProduct(flags.FluxVersion)
@@ -320,10 +320,10 @@ func fluxStep(log logger.Logger, kubeClient *kube.KubeHTTP) (fluxVersion string,
 	return fluxVersion, false, nil
 }
 
-func dashboardStep(log logger.Logger, ctx context.Context, kubeClient *kube.KubeHTTP, generateManifestsOnly bool) (bool, []byte, string, error) {
+func dashboardStep(ctx context.Context, log logger.Logger, kubeClient *kube.KubeHTTP, generateManifestsOnly bool) (bool, []byte, string, error) {
 	log.Actionf("Checking if GitOps Dashboard is already installed ...")
 
-	dashboardInstalled := install.IsDashboardInstalled(log, ctx, kubeClient, dashboardName, flags.Namespace)
+	dashboardInstalled := install.IsDashboardInstalled(ctx, log, kubeClient, dashboardName, flags.Namespace)
 
 	var dashboardManifests []byte
 
@@ -376,13 +376,13 @@ func dashboardStep(log logger.Logger, ctx context.Context, kubeClient *kube.Kube
 				return false, dashboardManifests, passwordHash, nil
 			}
 
-			man, err := install.NewManager(log, ctx, kubeClient, kubeConfigArgs)
+			man, err := install.NewManager(ctx, log, kubeClient, kubeConfigArgs)
 			if err != nil {
 				log.Failuref("Error creating resource manager")
 				return false, nil, "", err
 			}
 
-			err = install.InstallDashboard(log, ctx, man, dashboardManifests)
+			err = install.InstallDashboard(ctx, log, man, dashboardManifests)
 			if err != nil {
 				return false, nil, "", fmt.Errorf("gitops dashboard installation failed: %w", err)
 			} else {
@@ -436,7 +436,7 @@ func runCommandWithSession(cmd *cobra.Command, args []string) (retErr error) {
 		return fmt.Errorf("failed to install Flux on the host cluster: %v", err)
 	}
 
-	_, dashboardManifests, dashboardHashedPassword, err := dashboardStep(log, context.Background(), kubeClient, true)
+	_, dashboardManifests, dashboardHashedPassword, err := dashboardStep(context.Background(), log, kubeClient, true)
 	if err != nil {
 		return fmt.Errorf("failed to generate dashboard manifests: %v", err)
 	}
@@ -658,7 +658,7 @@ func runCommandWithoutSession(cmd *cobra.Command, args []string) error {
 		dashboardManifests []byte
 	)
 
-	dashboardInstalled, dashboardManifests, _, err = dashboardStep(log, ctx, kubeClient, false)
+	dashboardInstalled, dashboardManifests, _, err = dashboardStep(ctx, log, kubeClient, false)
 	if err != nil {
 		cancel()
 		return err

--- a/cmd/gitops/create/dashboard/cmd.go
+++ b/cmd/gitops/create/dashboard/cmd.go
@@ -203,7 +203,7 @@ func createDashboardCommandRunE(opts *config.Options) func(*cobra.Command, []str
 		ctx, cancel := context.WithTimeout(context.Background(), flags.Timeout)
 		defer cancel()
 
-		if fluxVersion, err := install.GetFluxVersion(log, ctx, kubeClient); err != nil {
+		if fluxVersion, err := install.GetFluxVersion(ctx, log, kubeClient); err != nil {
 			log.Failuref("Flux is not found")
 			return err
 		} else {
@@ -212,13 +212,13 @@ func createDashboardCommandRunE(opts *config.Options) func(*cobra.Command, []str
 
 		log.Actionf("Applying GitOps Dashboard manifests")
 
-		man, err := install.NewManager(log, ctx, kubeClient, kubeConfigArgs)
+		man, err := install.NewManager(ctx, log, kubeClient, kubeConfigArgs)
 		if err != nil {
 			log.Failuref("Error creating resource manager")
 			return err
 		}
 
-		err = install.InstallDashboard(log, ctx, man, manifests)
+		err = install.InstallDashboard(ctx, log, man, manifests)
 		if err != nil {
 			return fmt.Errorf("gitops dashboard installation failed: %w", err)
 		} else {

--- a/pkg/run/install/apply_manifests_test.go
+++ b/pkg/run/install/apply_manifests_test.go
@@ -68,14 +68,14 @@ var _ = Describe("apply", func() {
 	It("should apply manifests successfully", func() {
 		man := &mockResourceManagerForApply{}
 
-		_, err := apply(logger.From(logr.Discard()), fakeContext, man, fakeManifestsContent)
+		_, err := apply(fakeContext, logger.From(logr.Discard()), man, fakeManifestsContent)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should return an apply all error if the resource manager returns an apply all error", func() {
 		man := &mockResourceManagerForApply{state: stateApplyAllReturnErr}
 
-		_, err := apply(logger.From(logr.Discard()), fakeContext, man, fakeManifestsContent)
+		_, err := apply(fakeContext, logger.From(logr.Discard()), man, fakeManifestsContent)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(Equal(applyAllErrorMsg))
 	})
@@ -83,7 +83,7 @@ var _ = Describe("apply", func() {
 	It("should return a wait for set error if the resource manager returns a wait for set error", func() {
 		man := &mockResourceManagerForApply{state: stateWaitForSetReturnErr}
 
-		_, err := apply(logger.From(logr.Discard()), fakeContext, man, fakeManifestsContent)
+		_, err := apply(fakeContext, logger.From(logr.Discard()), man, fakeManifestsContent)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(Equal(waitForSetErrorMsg))
 	})

--- a/pkg/run/install/install_dashboard.go
+++ b/pkg/run/install/install_dashboard.go
@@ -76,10 +76,10 @@ func CreateDashboardObjects(log logger.Logger, name string, namespace string, us
 }
 
 // InstallDashboard installs the GitOps Dashboard.
-func InstallDashboard(log logger.Logger, ctx context.Context, manager ResourceManagerForApply, manifests []byte) error {
+func InstallDashboard(ctx context.Context, log logger.Logger, manager ResourceManagerForApply, manifests []byte) error {
 	log.Actionf("Installing the GitOps Dashboard ...")
 
-	applyOutput, err := apply(log, ctx, manager, manifests)
+	applyOutput, err := apply(ctx, log, manager, manifests)
 	if err != nil {
 		log.Failuref("GitOps Dashboard install failed")
 		return err
@@ -91,12 +91,12 @@ func InstallDashboard(log logger.Logger, ctx context.Context, manager ResourceMa
 }
 
 // IsDashboardInstalled checks if the GitOps Dashboard is installed.
-func IsDashboardInstalled(log logger.Logger, ctx context.Context, kubeClient client.Client, name string, namespace string) bool {
-	return getDashboardHelmChart(log, ctx, kubeClient, name, namespace) != nil
+func IsDashboardInstalled(ctx context.Context, log logger.Logger, kubeClient client.Client, name string, namespace string) bool {
+	return getDashboardHelmChart(ctx, log, kubeClient, name, namespace) != nil
 }
 
 // GetDashboardHelmChart checks if the GitOps Dashboard is installed.
-func getDashboardHelmChart(log logger.Logger, ctx context.Context, kubeClient client.Client, name string, namespace string) *sourcev1.HelmChart {
+func getDashboardHelmChart(ctx context.Context, log logger.Logger, kubeClient client.Client, name string, namespace string) *sourcev1.HelmChart {
 	helmChart := sourcev1.HelmChart{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      namespace + "-" + name,

--- a/pkg/run/install/install_dashboard_test.go
+++ b/pkg/run/install/install_dashboard_test.go
@@ -55,7 +55,7 @@ var _ = Describe("InstallDashboard", func() {
 		manifests, err := CreateDashboardObjects(fakeLogger, testDashboardName, testNamespace, testAdminUser, testPasswordHash, helmChartVersion, "")
 		Expect(err).NotTo(HaveOccurred())
 
-		err = InstallDashboard(fakeLogger, fakeContext, man, manifests)
+		err = InstallDashboard(fakeContext, fakeLogger, man, manifests)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -65,7 +65,7 @@ var _ = Describe("InstallDashboard", func() {
 		manifests, err := CreateDashboardObjects(fakeLogger, testDashboardName, testNamespace, testAdminUser, testPasswordHash, helmChartVersion, "")
 		Expect(err).NotTo(HaveOccurred())
 
-		err = InstallDashboard(fakeLogger, fakeContext, man, manifests)
+		err = InstallDashboard(fakeContext, fakeLogger, man, manifests)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(Equal(applyAllErrorMsg))
 	})
@@ -102,14 +102,14 @@ var _ = Describe("getDashboardHelmChart", func() {
 	})
 
 	It("returns the dashboard helmchart if there is no error when getting the helmchart", func() {
-		helmChart := getDashboardHelmChart(fakeLogger, fakeContext, &mockClientForGetDashboardHelmChart{}, testDashboardName, testNamespace)
+		helmChart := getDashboardHelmChart(fakeContext, fakeLogger, &mockClientForGetDashboardHelmChart{}, testDashboardName, testNamespace)
 		Expect(helmChart).ToNot(BeNil())
 		Expect(helmChart.Namespace).To(Equal("test-namespace"))
 		Expect(helmChart.Name).To(Equal("test-namespace-ww-gitops"))
 	})
 
 	It("returns nil if there is an error when getting the helmchart", func() {
-		helmChart := getDashboardHelmChart(fakeLogger, fakeContext, &mockClientForGetDashboardHelmChart{state: stateGetDashboardHelmChartGetReturnErr}, testDashboardName, testNamespace)
+		helmChart := getDashboardHelmChart(fakeContext, fakeLogger, &mockClientForGetDashboardHelmChart{state: stateGetDashboardHelmChartGetReturnErr}, testDashboardName, testNamespace)
 		Expect(helmChart).To(BeNil())
 	})
 })

--- a/pkg/run/install/install_flux.go
+++ b/pkg/run/install/install_flux.go
@@ -12,7 +12,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func GetFluxVersion(log logger.Logger, ctx context.Context, kubeClient client.Client) (string, error) {
+func GetFluxVersion(ctx context.Context, log logger.Logger, kubeClient client.Client) (string, error) {
 	log.Actionf("Getting Flux version ...")
 
 	listResult := unstructured.UnstructuredList{}

--- a/pkg/run/install/install_flux_test.go
+++ b/pkg/run/install/install_flux_test.go
@@ -44,7 +44,7 @@ var _ = Describe("GetFluxVersion", func() {
 
 		Expect(kubeClient.Create(ctx, fluxNs)).To(Succeed())
 
-		fluxVersion, err := GetFluxVersion(fakeLogger, ctx, kubeClient)
+		fluxVersion, err := GetFluxVersion(ctx, fakeLogger, kubeClient)
 
 		Expect(err).NotTo(HaveOccurred())
 		Expect(fluxVersion).To(Equal(testVersion))

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -255,7 +255,7 @@ var _ = Describe("ApplicationsServer", func() {
 		})
 	})
 
-	DescribeTable("ValidateProviderToken", func(provider pb.GitProvider, ctx context.Context, errResponse error, expectedCode codes.Code) {
+	DescribeTable("ValidateProviderToken", func(ctx context.Context, provider pb.GitProvider, errResponse error, expectedCode codes.Code) {
 		glAuthClient.ValidateTokenReturns(errResponse)
 		ghAuthClient.ValidateTokenReturns(errResponse)
 
@@ -274,11 +274,11 @@ var _ = Describe("ApplicationsServer", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.Valid).To(BeTrue())
 	},
-		Entry("bad gitlab token", pb.GitProvider_GitLab, contextWithAuth(context.Background()), errors.New("this token is bad"), codes.InvalidArgument),
-		Entry("good gitlab token", pb.GitProvider_GitLab, contextWithAuth(context.Background()), nil, codes.OK),
-		Entry("bad github token", pb.GitProvider_GitHub, contextWithAuth(context.Background()), errors.New("this token is bad"), codes.InvalidArgument),
-		Entry("good github token", pb.GitProvider_GitHub, contextWithAuth(context.Background()), nil, codes.OK),
-		Entry("no gitops jwt", pb.GitProvider_GitHub, context.Background(), errors.New("unauth error"), codes.Unauthenticated),
+		Entry("bad gitlab token", contextWithAuth(context.Background()), pb.GitProvider_GitLab, errors.New("this token is bad"), codes.InvalidArgument),
+		Entry("good gitlab token", contextWithAuth(context.Background()), pb.GitProvider_GitLab, nil, codes.OK),
+		Entry("bad github token", contextWithAuth(context.Background()), pb.GitProvider_GitHub, errors.New("this token is bad"), codes.InvalidArgument),
+		Entry("good github token", contextWithAuth(context.Background()), pb.GitProvider_GitHub, nil, codes.OK),
+		Entry("no gitops jwt", context.Background(), pb.GitProvider_GitHub, errors.New("unauth error"), codes.Unauthenticated),
 	)
 
 	Describe("middleware", func() {


### PR DESCRIPTION
Closes #3165 

- Made any params of type `context.Context` the first param.

Notes:
- Did not touch the `contextName` params, because they are related to Kubernetes contexts not the context form the standard package.
- Tested imported WG OSS in enterprise, have not found anything to fix there, related to this refactoring.