### PR TITLE
Fix return of false on images getter

### DIFF
--- a/ui/lib/objects.ts
+++ b/ui/lib/objects.ts
@@ -115,7 +115,7 @@ export class FluxObject {
     const spec = this.obj.spec;
     if (!spec) return [];
     if (spec.template) {
-      return spec.template.spec?.containers.map((x) => x.image);
+      return spec.template.spec?.containers.map((x) => x.image) || [];
     }
     if (spec.containers) return spec.containers.map((x) => x.image);
     return [];


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes #3188 

<!-- Describe what has changed in this PR -->
Certain objects can have a `spec.template` with no images and still be valid - we were half-checking this, but returning `false` instead of `[]`
