### PR TITLE
Fix brew hanging

### DIFF
--- a/.goreleaser.brew.yml
+++ b/.goreleaser.brew.yml
@@ -11,9 +11,9 @@ brews:
     install: |
         bin.install "gitops"
         # Install bash completion
-        output = Utils.popen_read("#{bin}/gitops completion bash")
+        output = Utils.safe_popen_read({ "SHELL" => "bash" }, "#{bin}/gitops completion bash --no-analytics", { :err => :err })
         (bash_completion/"gitops").write output
 
         # Install zsh completion
-        output = Utils.popen_read("#{bin}/gitops completion zsh")
+        output = Utils.safe_popen_read({ "SHELL" => "zsh" }, "#{bin}/gitops completion zsh --no-analytics", { :err => :err })
         (zsh_completion/"_gitops").write output

--- a/cmd/gitops/config/options.go
+++ b/cmd/gitops/config/options.go
@@ -8,4 +8,5 @@ type Options struct {
 	Username              string
 	Password              string
 	Kubeconfig            string
+	NoAnalytics           bool
 }

--- a/cmd/gitops/root/cmd.go
+++ b/cmd/gitops/root/cmd.go
@@ -2,14 +2,15 @@ package root
 
 import (
 	"fmt"
-	"github.com/weaveworks/weave-gitops/cmd/gitops/logs"
-	"github.com/weaveworks/weave-gitops/cmd/gitops/replan"
-	"github.com/weaveworks/weave-gitops/cmd/gitops/resume"
-	"github.com/weaveworks/weave-gitops/cmd/gitops/suspend"
 	"log"
 	"os"
 	"strings"
 	"time"
+
+	"github.com/weaveworks/weave-gitops/cmd/gitops/logs"
+	"github.com/weaveworks/weave-gitops/cmd/gitops/replan"
+	"github.com/weaveworks/weave-gitops/cmd/gitops/resume"
+	"github.com/weaveworks/weave-gitops/cmd/gitops/suspend"
 
 	"github.com/weaveworks/weave-gitops/cmd/gitops/remove"
 
@@ -97,6 +98,10 @@ func RootCmd() *cobra.Command {
 				os.Exit(1)
 			}
 
+			if options.NoAnalytics {
+				return
+			}
+
 			var gitopsConfig *config.GitopsCLIConfig
 
 			gitopsConfig, err = config.GetConfig(false)
@@ -143,8 +148,10 @@ func RootCmd() *cobra.Command {
 	rootCmd.PersistentFlags().StringToStringVar(&options.GitHostTypes, "git-host-types", map[string]string{}, "Specify which custom domains are running what (github or gitlab)")
 	rootCmd.PersistentFlags().BoolVar(&options.InsecureSkipTLSVerify, "insecure-skip-tls-verify", false, "If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure")
 	rootCmd.PersistentFlags().StringVar(&options.Kubeconfig, "kubeconfig", "", "Paths to a kubeconfig. Only required if out-of-cluster.")
+	rootCmd.PersistentFlags().BoolVar(&options.NoAnalytics, "no-analytics", false, "Don't ask to enable/disable analytics.")
 	cobra.CheckErr(rootCmd.PersistentFlags().MarkHidden("override-in-cluster"))
 	cobra.CheckErr(rootCmd.PersistentFlags().MarkHidden("git-host-types"))
+	cobra.CheckErr(rootCmd.PersistentFlags().MarkHidden("no-analytics"))
 
 	rootCmd.AddCommand(version.Cmd)
 	rootCmd.AddCommand(get.GetCommand(options))


### PR DESCRIPTION
Closes #3193

- Replaced `popen_read` with `safe_popen_read` (the way it's recommended in the HomeBrew docs and issues). The actual thing that fixes brew upgrade or install hanging is adding `{ :err => :err }`.
- Added a hidden `no-analytics` flag to the root command in gitops to disable displaying analytics prompt (which runs in PersistentPreRun) when running the auto-generated `completion` command, in the brew formula. After I fixed install hanging, the analytics prompt started displaying while running the formula (maybe it's related to the hanging, like the prompt could be blocking smth. without an error message).

Testing:

I tested it by
- downloading the generated formula (the URL to which is visible when adding the `--verbose` and `--debug` options) from (in my case, `/usr/local/Homebrew/Library/Taps/weaveworks/homebrew-tap/Formula/gitops.rb`)
- adding changes from the current PR to the formula
-  building the gitops executable manually, archiving and serving it to brew from a local server (Chrome WebServer extension) by replacing the archive URL and checksum in the local formula
- uninstalling the gitops formula and installing it with `brew install gitops.rb --verbose --debug`

Maybe there is a better way.

When tested locally, the installation does not hang anymore, the analytics prompt is not displayed, and autocompletion works for the installed binary.

