### PR TITLE
Remove Pendo init from the Signin page

### DIFF
--- a/ui/App.tsx
+++ b/ui/App.tsx
@@ -13,8 +13,7 @@ import "react-toastify/dist/ReactToastify.css";
 import { ThemeProvider } from "styled-components";
 import ErrorBoundary from "./components/ErrorBoundary";
 import Layout from "./components/Layout";
-import Pendo from "./components/Pendo";
-import PendoContainer, { tier } from "./components/PendoContainer";
+import PendoContainer from "./components/PendoContainer";
 import AppContextProvider from "./contexts/AppContext";
 import AuthContextProvider, { AuthCheck } from "./contexts/AuthContext";
 import CoreClientContextProvider from "./contexts/CoreClientContext";
@@ -117,11 +116,7 @@ export default function AppContainer() {
                   <Switch>
                     {/* <Signin> does not use the base page <Layout> so pull it up here */}
                     <Route exact path="/sign_in">
-                      <SignIn
-                        analytics={
-                          <Pendo defaultTelemetryFlag="false" tier={tier} />
-                        }
-                      />
+                      <SignIn />
                     </Route>
                     <Route path="*">
                       {/* Check we've got a logged in user otherwise redirect back to signin */}

--- a/ui/pages/SignIn.tsx
+++ b/ui/pages/SignIn.tsx
@@ -59,12 +59,7 @@ const DocsWrapper = styled(Flex)`
   }
 `;
 
-export interface Props {
-  /** Analytics component */
-  analytics?: React.ReactNode;
-}
-
-function SignIn({ analytics }: Props) {
+function SignIn() {
   const { data } = useFeatureFlags();
   const flags = data.flags;
 
@@ -99,7 +94,6 @@ function SignIn({ analytics }: Props) {
         width: "100vw",
       }}
     >
-      {analytics}
       <React.Suspense fallback={null}>
         <SignInBackgroundAnimation />
       </React.Suspense>


### PR DESCRIPTION
Closes #3191 

- Removed Pendo initialization/re-identification (= removed the Pendo component) from the Signin page.
