### PR TITLE
fix npm timeouts in docker builds

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 @weaveworks:registry=https://npm.pkg.github.com
+fetch-timeout=1500000

--- a/gitops-server.dockerfile
+++ b/gitops-server.dockerfile
@@ -8,6 +8,7 @@ COPY --chown=node:node package*.json /home/app/
 COPY --chown=node:node Makefile /home/app/
 COPY --chown=node:node tsconfig.json /home/app/
 COPY --chown=node:node .parcelrc /home/app/
+COPY --chown=node:node .npmrc /home/app/
 RUN make node_modules
 COPY --chown=node:node ui /home/app/ui
 RUN --mount=type=cache,target=/home/app/ui/.parcel-cache make ui


### PR DESCRIPTION
We've been experiencing an increased number of build failures in the
release GitHub workflow, manifested by error messages like this:

```
> [linux/arm64 ui  9/11] RUN make node_modules:
 ERR! network Socket timeout
```

These failures only happen in the ARM64 builds which are executed in
a qemu emulation that apparently is so slow that it causes these
network timeouts. This is just a hypothesis, though, and this commit
is supposed to mitigate these timeouts by increasing npm's HTTP
timeouts.

See https://docs.npmjs.com/cli/v9/using-npm/config#fetch-timeout for
further documentation of the configuration parameter changed in this
commit.

closes #3229 