### PR TITLE
wip: Lookup namespaces with user-client and avoid global namespace cache

### DIFF
--- a/core/clustersmngr/factory.go
+++ b/core/clustersmngr/factory.go
@@ -422,7 +422,8 @@ func (cf *clustersManager) GetImpersonatedClient(ctx context.Context, user *auth
 	return NewClient(pool, userNamespaces), partialErr
 }
 
-// getUserClientWithNamespaces returns a client for the user
+// getUserClientsPool returns a pool of clients for each cluster that the user has access to.
+// The pool can be used to instantiate a client once the namespaces are known.
 func (cf *clustersManager) getUserClientsPool(ctx context.Context, user *auth.UserPrincipal) (ClientsPool, error) {
 	if user == nil {
 		return nil, errors.New("no user supplied")
@@ -596,9 +597,9 @@ func (cf *clustersManager) UpdateUserNamespaces(ctx context.Context, user *auth.
 	wg.Wait()
 }
 
-// This method relies on the user namespace cache being up to date.
+// GetUserNamespaces returns the cached namespaces for the given user.
 // Its caller should make sure that the cache is updated before calling this method.
-// (e.g. By calling GetImpersonatedClient which will make sure namespaces are up to date).
+// (e.g. By calling GetImpersonatedClient first)
 func (cf *clustersManager) GetUserNamespaces(user *auth.UserPrincipal) map[string][]v1.Namespace {
 	return cf.usersNamespaces.GetAll(user, cf.clusters.Get())
 }

--- a/core/clustersmngr/factory.go
+++ b/core/clustersmngr/factory.go
@@ -383,6 +383,7 @@ func (cf *clustersManager) getNamespacesWithClient(ctx context.Context, createCl
 	}
 
 	newClustersNamespaces := &ClustersNamespaces{}
+
 	for clusterName, lists := range nsList.Lists() {
 		// This is the "namespace loop", but namespaces aren't
 		// namespaced so only 1 item
@@ -417,6 +418,7 @@ func (cf *clustersManager) syncCaches() {
 func (cf *clustersManager) GetImpersonatedClient(ctx context.Context, user *auth.UserPrincipal) (Client, error) {
 	pool, partialErr := cf.getUserClientsPool(ctx, user)
 	userNamespaces := cf.userNsList(ctx, user)
+
 	return NewClient(pool, userNamespaces), partialErr
 }
 
@@ -553,8 +555,10 @@ func (cf *clustersManager) GetServerClient(ctx context.Context) (Client, error) 
 
 func (cf *clustersManager) UpdateUserNamespaces(ctx context.Context, user *auth.UserPrincipal) {
 	clustersNamespaces := cf.clustersNamespaces
+
 	if cf.useUserClientForNamespaces {
 		var err error
+
 		clustersNamespaces, err = cf.getNamespacesFromUserClient(ctx, user)
 		if err != nil {
 			// This may not completely fail the request, e.g. if some of the clusters

--- a/core/clustersmngr/factory_test.go
+++ b/core/clustersmngr/factory_test.go
@@ -109,6 +109,9 @@ func TestUseUserClientForNamespaces(t *testing.T) {
 		g.Expect(userClient.Namespaces()["test"]).To(HaveLen(1))
 		g.Expect(userClient.Namespaces()["test"][0].GetName()).To(Equal(ns2.Name))
 
+		// clusterNamespaces should be empty because we are using the user client
+		g.Expect(clustersManager.GetClustersNamespaces()).To(HaveLen(0))
+
 		a, b, nss := nsChecker.FilterAccessibleNamespacesArgsForCall(0)
 		fmt.Println(a, b, nss)
 		nsFound := 0

--- a/core/server/fluxruntime.go
+++ b/core/server/fluxruntime.go
@@ -69,7 +69,7 @@ func (cs *coreServer) ListFluxRuntimeObjects(ctx context.Context, msg *pb.ListFl
 
 	var results []*pb.Deployment
 
-	for clusterName, nss := range cs.clustersManager.GetUserNamespaces(auth.Principal(ctx)) {
+	for clusterName, nss := range cs.clustersManager.GetClustersNamespaces() {
 		fluxNamepsaces := filterFluxNamespace(nss)
 		if len(fluxNamepsaces) == 0 {
 			respErrors = append(respErrors, &pb.ListError{ClusterName: clusterName, Namespace: "", Message: ErrFluxNamespaceNotFound.Error()})

--- a/core/server/fluxruntime.go
+++ b/core/server/fluxruntime.go
@@ -69,7 +69,7 @@ func (cs *coreServer) ListFluxRuntimeObjects(ctx context.Context, msg *pb.ListFl
 
 	var results []*pb.Deployment
 
-	for clusterName, nss := range cs.clustersManager.GetClustersNamespaces() {
+	for clusterName, nss := range cs.clustersManager.GetUserNamespaces(auth.Principal(ctx)) {
 		fluxNamepsaces := filterFluxNamespace(nss)
 		if len(fluxNamepsaces) == 0 {
 			respErrors = append(respErrors, &pb.ListError{ClusterName: clusterName, Namespace: "", Message: ErrFluxNamespaceNotFound.Error()})


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->

#3218 introduced a feature flag to calculate the namespaces accessible to a user with the OIDC token alone (without using the server's SA to calculate the global list of namespaces first). This requires the OIDC user has RBAC permissions to list namespaces.

However it has a "bug" where it will still update the global cache list of known namespaces across all clusters while it's updating those known only to the current user.
- In practice these should be the same list, so you _shouldn't_ see any behaviour change, as one of the constraints of using the system is all OIDC users having access to list namespaces.

<!-- Describe what has changed in this PR -->
**What changed?**

Don't update the global namespaces cache, shared between users, when calculating the namespaces for just this user.

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**

Make the behaviour a bit cleaner and and more "functional" and hopefully easier to debug.

<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**

We calculate the global list of namespaces and then hold the value in a variable local to the request. Rather than updating the cache which persists between requests.

<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**

- Unit tests
- Manually

<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**


<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
