### PR TITLE
add tests for SetupBucketSourceAndKS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 bin
 /.idea
 
+.tool-versions
 tools/bin/*
 *.out
 dist/

--- a/pkg/run/watch/setup_bucket_source.go
+++ b/pkg/run/watch/setup_bucket_source.go
@@ -57,28 +57,36 @@ func reconcileBucketAndSecretObjects(ctx context.Context, log logger.Logger, kub
 	// create secret
 	log.Actionf("Checking secret %s ...", secret.Name)
 
-	if err := kubeClient.Get(ctx, client.ObjectKeyFromObject(&secret), &secret); err != nil && apierrors.IsNotFound(err) {
+	if err := kubeClient.Get(ctx, client.ObjectKeyFromObject(&secret), &secret); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed fetching secret %s/%s: %w", secret.Namespace, secret.Name, err)
+		}
+
 		if err := kubeClient.Create(ctx, &secret); err != nil {
 			return fmt.Errorf("couldn't create secret %s: %v", secret.Name, err.Error())
-		} else {
-			log.Successf("Created secret %s", secret.Name)
 		}
-	} else if err == nil {
-		log.Successf("Secret %s already existed", secret.Name)
+
+		log.Successf("Created secret %s", secret.Name)
 	}
+
+	log.Successf("Secret %s already existed", secret.Name)
 
 	// create source
 	log.Actionf("Checking bucket source %s ...", source.Name)
 
-	if err := kubeClient.Get(ctx, client.ObjectKeyFromObject(&source), &source); err != nil && apierrors.IsNotFound(err) {
+	if err := kubeClient.Get(ctx, client.ObjectKeyFromObject(&source), &source); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed fetching bucket source %s/%s: %w", source.Namespace, source.Name, err)
+		}
+
 		if err := kubeClient.Create(ctx, &source); err != nil {
 			return fmt.Errorf("couldn't create source %s: %v", source.Name, err.Error())
-		} else {
-			log.Successf("Created source %s", source.Name)
 		}
-	} else if err == nil {
-		log.Successf("Source %s already existed", source.Name)
+
+		log.Successf("Created source %s", source.Name)
 	}
+
+	log.Successf("Source %s already existed", source.Name)
 
 	return nil
 }

--- a/pkg/run/watch/watch_suite_test.go
+++ b/pkg/run/watch/watch_suite_test.go
@@ -10,8 +10,9 @@ import (
 )
 
 var (
-	k8sClient client.Client
-	k8sEnv    *testutils.K8sTestEnv
+	k8sClient    client.Client
+	unauthClient client.Client
+	k8sEnv       *testutils.K8sTestEnv
 )
 
 func TestRun(t *testing.T) {
@@ -24,11 +25,14 @@ var cleanupK8s func()
 var _ = BeforeSuite(func() {
 	var err error
 	k8sEnv, err = testutils.StartK8sTestEnvironment([]string{
-		"../../manifests/crds",
-		"../../tools/testcrds",
+		"../../../tools/testcrds",
 	})
 	Expect(err).NotTo(HaveOccurred())
 
 	cleanupK8s = k8sEnv.Stop
 	k8sClient = k8sEnv.Client
+})
+
+var _ = AfterSuite(func() {
+	cleanupK8s()
 })


### PR DESCRIPTION
- SetupBucketSourceAndKS returned a nil error even when some API calls
  would have failed. I fixed this and added regression tests for the
  behavior.
- The envtest setup and cleanup code was buggy and is fixed now (e.g.
  it wasn't able to properly stop the envtest server because the
  controller-runtime manager was still running).
