### PR TITLE
Loop over namespaces when listing reconciled objects

### DIFF
--- a/core/server/fluxruntime.go
+++ b/core/server/fluxruntime.go
@@ -238,9 +238,7 @@ func (cs *coreServer) GetReconciledObjects(ctx context.Context, msg *pb.GetRecon
 	clusterUserNamespaces := cs.clustersManager.GetUserNamespaces(auth.Principal(ctx))
 
 	for _, namespaces := range clusterUserNamespaces {
-
 		for _, ns := range namespaces {
-
 			nsOpts := client.InNamespace(ns.Name)
 
 			for _, gvk := range msg.Kinds {

--- a/core/server/fluxruntime.go
+++ b/core/server/fluxruntime.go
@@ -235,62 +235,71 @@ func (cs *coreServer) GetReconciledObjects(ctx context.Context, msg *pb.GetRecon
 		wg = sync.WaitGroup{}
 	)
 
-	for _, gvk := range msg.Kinds {
-		wg.Add(1)
+	clusterUserNamespaces := cs.clustersManager.GetUserNamespaces(auth.Principal(ctx))
 
-		go func(clusterName string, gvk *pb.GroupVersionKind) {
-			defer wg.Done()
+	for _, namespaces := range clusterUserNamespaces {
 
-			listResult := unstructured.UnstructuredList{}
+		for _, ns := range namespaces {
 
-			listResult.SetGroupVersionKind(schema.GroupVersionKind{
-				Group:   gvk.Group,
-				Kind:    gvk.Kind,
-				Version: gvk.Version,
-			})
+			nsOpts := client.InNamespace(ns.Name)
 
-			if err := clustersClient.List(ctx, msg.ClusterName, &listResult, opts); err != nil {
-				if k8serrors.IsForbidden(err) {
-					cs.logger.V(logger.LogLevelDebug).Info(
-						"forbidden list request",
-						"cluster", msg.ClusterName,
-						"automation", msg.AutomationName,
-						"namespace", msg.Namespace,
-						"gvk", gvk.String(),
-					)
-					// Our service account (or impersonated user) may not have the ability to see the resource in question,
-					// in the given namespace. We pretend it doesn't exist and keep looping.
-					// We need logging to make this error more visible.
-					return
-				}
+			for _, gvk := range msg.Kinds {
+				wg.Add(1)
 
-				if k8serrors.IsTimeout(err) {
-					cs.logger.Error(err, "List timedout", "gvk", gvk.String())
+				go func(clusterName string, gvk *pb.GroupVersionKind) {
+					defer wg.Done()
 
-					return
-				}
+					listResult := unstructured.UnstructuredList{}
 
-				errsMu.Lock()
-				errs = multierror.Append(errs, fmt.Errorf("listing unstructured object: %w", err))
-				errsMu.Unlock()
+					listResult.SetGroupVersionKind(schema.GroupVersionKind{
+						Group:   gvk.Group,
+						Kind:    gvk.Kind,
+						Version: gvk.Version,
+					})
+
+					if err := clustersClient.List(ctx, msg.ClusterName, &listResult, opts, nsOpts); err != nil {
+						if k8serrors.IsForbidden(err) {
+							cs.logger.V(logger.LogLevelDebug).Info(
+								"forbidden list request",
+								"cluster", msg.ClusterName,
+								"automation", msg.AutomationName,
+								"namespace", msg.Namespace,
+								"gvk", gvk.String(),
+							)
+							// Our service account (or impersonated user) may not have the ability to see the resource in question,
+							// in the given namespace. We pretend it doesn't exist and keep looping.
+							// We need logging to make this error more visible.
+							return
+						}
+
+						if k8serrors.IsTimeout(err) {
+							cs.logger.Error(err, "List timedout", "gvk", gvk.String())
+
+							return
+						}
+
+						errsMu.Lock()
+						errs = multierror.Append(errs, fmt.Errorf("listing unstructured object: %w", err))
+						errsMu.Unlock()
+					}
+
+					resultMu.Lock()
+					for _, u := range listResult.Items {
+						uid := u.GetUID()
+
+						if !checkDup[uid] {
+							result = append(result, u)
+							checkDup[uid] = true
+						}
+					}
+					resultMu.Unlock()
+				}(msg.ClusterName, gvk)
 			}
-
-			resultMu.Lock()
-			for _, u := range listResult.Items {
-				uid := u.GetUID()
-
-				if !checkDup[uid] {
-					result = append(result, u)
-					checkDup[uid] = true
-				}
-			}
-			resultMu.Unlock()
-		}(msg.ClusterName, gvk)
+		}
 	}
 
 	wg.Wait()
 
-	clusterUserNamespaces := cs.clustersManager.GetUserNamespaces(auth.Principal(ctx))
 	objects := []*pb.Object{}
 	respErrors := multierror.Error{}
 
@@ -327,6 +336,8 @@ func (cs *coreServer) GetChildObjects(ctx context.Context, msg *pb.GetChildObjec
 		return nil, fmt.Errorf("error getting impersonating client: %w", err)
 	}
 
+	opts := client.InNamespace(msg.Namespace)
+
 	listResult := unstructured.UnstructuredList{}
 
 	listResult.SetGroupVersionKind(schema.GroupVersionKind{
@@ -335,7 +346,7 @@ func (cs *coreServer) GetChildObjects(ctx context.Context, msg *pb.GetChildObjec
 		Kind:    msg.GroupVersionKind.Kind,
 	})
 
-	if err := clustersClient.List(ctx, msg.ClusterName, &listResult); err != nil {
+	if err := clustersClient.List(ctx, msg.ClusterName, &listResult, opts); err != nil {
 		return nil, fmt.Errorf("could not get unstructured object: %s", err)
 	}
 

--- a/core/server/fluxruntime_test.go
+++ b/core/server/fluxruntime_test.go
@@ -2,6 +2,7 @@ package server_test
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -12,8 +13,10 @@ import (
 	stypes "github.com/weaveworks/weave-gitops/core/server/types"
 	pb "github.com/weaveworks/weave-gitops/pkg/api/core"
 	"github.com/weaveworks/weave-gitops/pkg/kube"
+	"google.golang.org/grpc/metadata"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -37,53 +40,154 @@ func TestGetReconciledObjects(t *testing.T) {
 	g.Expect(err).NotTo(HaveOccurred())
 
 	automationName := "my-automation"
-	ns := newNamespace(ctx, k, g)
+	ns1 := newNamespace(ctx, k, g)
+	ns2 := newNamespace(ctx, k, g)
 
-	reconciledObj := appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "my-deployment",
-			Namespace: ns.Name,
-			Labels: map[string]string{
-				server.KustomizeNameKey:      automationName,
-				server.KustomizeNamespaceKey: ns.Name,
+	reconciledObjs := []client.Object{
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-deployment",
+				Namespace: ns1.Name,
+				Labels: map[string]string{
+					server.KustomizeNameKey:      automationName,
+					server.KustomizeNamespaceKey: ns1.Name,
+				},
+			},
+			Spec: appsv1.DeploymentSpec{
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"app": automationName,
+					},
+				},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{"app": automationName},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{
+							Name:  "nginx",
+							Image: "nginx",
+						}},
+					},
+				},
 			},
 		},
-		Spec: appsv1.DeploymentSpec{
-			Selector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{
-					"app": automationName,
-				},
-			},
-			Template: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{"app": automationName},
-				},
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{{
-						Name:  "nginx",
-						Image: "nginx",
-					}},
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-configmap",
+				Namespace: ns2.Name,
+				Labels: map[string]string{
+					server.KustomizeNameKey:      automationName,
+					server.KustomizeNamespaceKey: ns1.Name,
 				},
 			},
 		},
 	}
 
-	g.Expect(k.Create(ctx, &reconciledObj)).Should(Succeed())
+	for _, obj := range reconciledObjs {
+		g.Expect(k.Create(ctx, obj)).Should(Succeed())
+	}
 
-	res, err := c.GetReconciledObjects(ctx, &pb.GetReconciledObjectsRequest{
-		AutomationName: automationName,
-		Namespace:      ns.Name,
-		AutomationKind: kustomizev1.KustomizationKind,
-		Kinds:          []*pb.GroupVersionKind{{Group: "apps", Version: "v1", Kind: "Deployment"}},
-		ClusterName:    cluster.DefaultCluster,
-	})
+	crb := rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: ns1.Name,
+			Name:      "ns-admin",
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.SchemeGroupVersion.Group,
+			Kind:     "ClusterRole",
+			Name:     "cluster-admin",
+		},
+		Subjects: []rbacv1.Subject{{
+			APIGroup: rbacv1.SchemeGroupVersion.Group,
+			Kind:     rbacv1.UserKind,
+			Name:     "ns-admin",
+		}},
+	}
+	g.Expect(k.Create(ctx, &crb)).Should((Succeed()))
 
-	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(res.Objects).To(HaveLen(1))
+	type objectAssertion struct {
+		kind string
+		name string
+	}
 
-	first := res.Objects[0]
-	g.Expect(first.Payload).To(ContainSubstring("Deployment"))
-	g.Expect(first.Payload).To(ContainSubstring(reconciledObj.Name))
+	tests := []struct {
+		name            string
+		user            string
+		group           string
+		expectedLen     int
+		expectedObjects []objectAssertion
+	}{
+		{
+			name:        "unknown user doesn't receive any objects",
+			user:        "anne",
+			expectedLen: 0,
+		},
+		{
+			name:        "ns-admin sees only objects in their namespace",
+			user:        "ns-admin",
+			expectedLen: 1,
+			expectedObjects: []objectAssertion{
+				{
+					kind: "Deployment",
+					name: reconciledObjs[0].GetName(),
+				},
+			},
+		},
+		{
+			name:        "master user receives all objects",
+			user:        "anne",
+			group:       "system:masters",
+			expectedLen: 2,
+			expectedObjects: []objectAssertion{
+				{
+					kind: "Deployment",
+					name: reconciledObjs[0].GetName(),
+				},
+				{
+					kind: "ConfigMap",
+					name: reconciledObjs[1].GetName(),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g = NewGomegaWithT(t)
+
+			md := metadata.Pairs(MetadataUserKey, tt.user, MetadataGroupsKey, tt.group)
+			outgoingCtx := metadata.NewOutgoingContext(ctx, md)
+			res, err := c.GetReconciledObjects(outgoingCtx, &pb.GetReconciledObjectsRequest{
+				AutomationName: automationName,
+				Namespace:      ns1.Name,
+				AutomationKind: kustomizev1.KustomizationKind,
+				Kinds: []*pb.GroupVersionKind{
+					{Group: appsv1.SchemeGroupVersion.Group, Version: appsv1.SchemeGroupVersion.Version, Kind: "Deployment"},
+					{Group: corev1.SchemeGroupVersion.Group, Version: corev1.SchemeGroupVersion.Version, Kind: "ConfigMap"},
+				},
+				ClusterName: cluster.DefaultCluster,
+			})
+
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(res.Objects).To(HaveLen(tt.expectedLen), "unexpected size of returned object list")
+
+			actualObjs := make([]objectAssertion, len(res.Objects))
+
+			for idx, actualObj := range res.Objects {
+				var object map[string]interface{}
+
+				g.Expect(json.Unmarshal([]byte(actualObj.Payload), &object)).To(Succeed(), "failed unmarshalling result object")
+				metadata, ok := object["metadata"].(map[string]interface{})
+				g.Expect(ok).To(BeTrue(), "object has unexpected metadata type")
+				actualObjs[idx] = objectAssertion{
+					kind: object["kind"].(string),
+					name: metadata["name"].(string),
+				}
+			}
+			g.Expect(actualObjs).To(ContainElements(tt.expectedObjects))
+		})
+	}
 }
 
 func TestGetReconciledObjectsWithSecret(t *testing.T) {
@@ -120,7 +224,9 @@ func TestGetReconciledObjectsWithSecret(t *testing.T) {
 
 	g.Expect(k.Create(ctx, &reconciledObj)).Should(Succeed())
 
-	res, err := c.GetReconciledObjects(ctx, &pb.GetReconciledObjectsRequest{
+	md := metadata.Pairs(MetadataUserKey, "anne", MetadataGroupsKey, "system:masters")
+	outgoingCtx := metadata.NewOutgoingContext(ctx, md)
+	res, err := c.GetReconciledObjects(outgoingCtx, &pb.GetReconciledObjectsRequest{
 		AutomationName: automationName,
 		Namespace:      ns.Name,
 		AutomationKind: kustomizev1.KustomizationKind,

--- a/core/server/suspend_test.go
+++ b/core/server/suspend_test.go
@@ -10,6 +10,7 @@ import (
 	. "github.com/onsi/gomega"
 	api "github.com/weaveworks/weave-gitops/pkg/api/core"
 	"github.com/weaveworks/weave-gitops/pkg/kube"
+	"google.golang.org/grpc/metadata"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -73,7 +74,9 @@ func TestSuspend_Suspend(t *testing.T) {
 				Objects: []*api.ObjectRef{object},
 				Suspend: true,
 			}
-			_, err = c.ToggleSuspendResource(ctx, req)
+			md := metadata.Pairs(MetadataUserKey, "anne", MetadataGroupsKey, "system:masters")
+			outgoingCtx := metadata.NewOutgoingContext(ctx, md)
+			_, err = c.ToggleSuspendResource(outgoingCtx, req)
 			g.Expect(err).NotTo(HaveOccurred())
 			name := types.NamespacedName{Name: tt.obj.GetName(), Namespace: ns.Name}
 			g.Expect(checkSpec(t, k, name, tt.obj)).To(BeTrue())
@@ -87,7 +90,9 @@ func TestSuspend_Suspend(t *testing.T) {
 			Suspend: false,
 		}
 
-		_, err = c.ToggleSuspendResource(ctx, req)
+		md := metadata.Pairs(MetadataUserKey, "anne", MetadataGroupsKey, "system:masters")
+		outgoingCtx := metadata.NewOutgoingContext(ctx, md)
+		_, err = c.ToggleSuspendResource(outgoingCtx, req)
 		g.Expect(err).NotTo(HaveOccurred())
 
 		for _, tt := range tests {
@@ -98,7 +103,9 @@ func TestSuspend_Suspend(t *testing.T) {
 
 	t.Run("will error", func(t *testing.T) {
 
-		_, err = c.ToggleSuspendResource(ctx, &api.ToggleSuspendResourceRequest{
+		md := metadata.Pairs(MetadataUserKey, "anne", MetadataGroupsKey, "system:masters")
+		outgoingCtx := metadata.NewOutgoingContext(ctx, md)
+		_, err = c.ToggleSuspendResource(outgoingCtx, &api.ToggleSuspendResourceRequest{
 
 			Objects: []*api.ObjectRef{{
 				Kind:        sourcev1.GitRepositoryKind,

--- a/core/server/sync_test.go
+++ b/core/server/sync_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/fluxcd/pkg/apis/meta"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1beta2"
 	. "github.com/onsi/gomega"
+	"google.golang.org/grpc/metadata"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -117,7 +118,9 @@ func TestSync(t *testing.T) {
 			defer close(done)
 
 			go func() {
-				_, err := c.SyncFluxObject(ctx, msg)
+				md := metadata.Pairs(MetadataUserKey, "anne", MetadataGroupsKey, "system:masters")
+				outgoingCtx := metadata.NewOutgoingContext(ctx, md)
+				_, err := c.SyncFluxObject(outgoingCtx, msg)
 				select {
 				case <-done:
 					return

--- a/core/server/version_test.go
+++ b/core/server/version_test.go
@@ -10,6 +10,7 @@ import (
 	pb "github.com/weaveworks/weave-gitops/pkg/api/core"
 	"github.com/weaveworks/weave-gitops/pkg/flux"
 	"github.com/weaveworks/weave-gitops/pkg/kube"
+	"google.golang.org/grpc/metadata"
 	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -49,7 +50,9 @@ func TestGetVersion(t *testing.T) {
 	}
 	g.Expect(k.Create(ctx, fluxNs)).To(Succeed())
 
-	resp, err := c.GetVersion(ctx, &pb.GetVersionRequest{})
+	md := metadata.Pairs(MetadataUserKey, "anne", MetadataGroupsKey, "system:masters")
+	outgoingCtx := metadata.NewOutgoingContext(ctx, md)
+	resp, err := c.GetVersion(outgoingCtx, &pb.GetVersionRequest{})
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(resp.Semver).To(Equal("v0.0.0"))
 	g.Expect(resp.FluxVersion).To(Equal(testVersion))


### PR DESCRIPTION
Fixes #3231 

**What changed?**
When getting reconciled objects, instead of just looping over kinds and retrieving all objects cluster-wide, loop over only namespaces which the current user has access to, as well as kinds as before.

**Why was this change made?**
When an OIDC impersonated user does not have cluster-wide privileges, the weave-gitops UI will not show any resources that are reconciled as part of kustomize/helmrelease etc objects. This change means that only objects in namespaces which the user has permissions in will be listed.


**How was this change implemented?**
Simply providing another option to the client when calling List(), which specifies the namespace to list from, and looping over the namespaces which the user has access to. The list of user-accessible namespaces was already defined a few lines later in the code.

**How did you validate the change?**
Tested locally/in our production clusters. 

We are expecting that existing tests should already cover this and dont need updating.

**Release notes**
Bugfix, nothing notable

**Documentation Changes**
None