### PR TITLE
improve detection of flux version

### DIFF
--- a/cmd/gitops/beta/run/cmd.go
+++ b/cmd/gitops/beta/run/cmd.go
@@ -269,7 +269,8 @@ func fluxStep(log logger.Logger, kubeClient *kube.KubeHTTP) (fluxVersion string,
 
 	log.Actionf("Checking if Flux is already installed ...")
 
-	if fluxVersion, err = install.GetFluxVersion(ctx, log, kubeClient); err != nil {
+	guessed := false
+	if fluxVersion, guessed, err = install.GetFluxVersion(ctx, log, kubeClient); err != nil {
 		log.Warningf("Flux is not found: %v", err.Error())
 
 		product := fluxinstall.NewProduct(flags.FluxVersion)
@@ -322,7 +323,11 @@ func fluxStep(log logger.Logger, kubeClient *kube.KubeHTTP) (fluxVersion string,
 
 		return fluxVersion, true, nil
 	} else {
-		log.Successf("Flux version %s is found", fluxVersion)
+		if guessed {
+			log.Warningf("Flux version could not be determined, assuming %s by mapping from the version of the Source controller", fluxVersion)
+		} else {
+			log.Successf("Flux %s is already installed", fluxVersion)
+		}
 	}
 
 	return fluxVersion, false, nil

--- a/cmd/gitops/create/dashboard/cmd.go
+++ b/cmd/gitops/create/dashboard/cmd.go
@@ -203,11 +203,15 @@ func createDashboardCommandRunE(opts *config.Options) func(*cobra.Command, []str
 		ctx, cancel := context.WithTimeout(context.Background(), flags.Timeout)
 		defer cancel()
 
-		if fluxVersion, err := install.GetFluxVersion(ctx, log, kubeClient); err != nil {
+		if fluxVersion, guessed, err := install.GetFluxVersion(ctx, log, kubeClient); err != nil {
 			log.Failuref("Flux is not found")
 			return err
 		} else {
-			log.Successf("Flux version %s is found", fluxVersion)
+			if guessed {
+				log.Warningf("Flux version could not be determined, assuming %s by mapping from the version of the Source controller", fluxVersion)
+			} else {
+				log.Successf("Flux %s is already installed", fluxVersion)
+			}
 		}
 
 		log.Actionf("Applying GitOps Dashboard manifests")

--- a/pkg/run/install/install_flux_test.go
+++ b/pkg/run/install/install_flux_test.go
@@ -2,16 +2,19 @@ package install
 
 import (
 	"context"
+	"github.com/weaveworks/weave-gitops/pkg/flux"
+	"time"
 
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/weaveworks/weave-gitops/core/server"
 	coretypes "github.com/weaveworks/weave-gitops/core/server/types"
-	"github.com/weaveworks/weave-gitops/pkg/flux"
 	"github.com/weaveworks/weave-gitops/pkg/logger"
 	"github.com/weaveworks/weave-gitops/pkg/run"
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -23,6 +26,66 @@ var _ = Describe("GetFluxVersion", func() {
 
 	BeforeEach(func() {
 		fakeLogger = logger.From(logr.Discard())
+	})
+
+	It("guess flux version", func() {
+		kubeClientOpts := run.GetKubeClientOptions()
+
+		contextName := "test-context"
+
+		kubeClient, err := run.GetKubeClient(fakeLogger, contextName, k8sEnv.Rest, kubeClientOpts)
+		Expect(err).NotTo(HaveOccurred())
+
+		ctx := context.Background()
+
+		fluxNs := &v1.Namespace{}
+		fluxNs.Name = "flux-system"
+		fluxNs.Labels = map[string]string{
+			coretypes.PartOfLabel: server.FluxNamespacePartOf,
+		}
+
+		Expect(kubeClient.Create(ctx, fluxNs)).To(Succeed())
+
+		source := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "source-controller",
+				Namespace: "flux-system",
+				Labels: map[string]string{
+					"app": "source-controller",
+				},
+			},
+			Spec: appsv1.DeploymentSpec{
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"app": "source-controller",
+					},
+				},
+				Template: v1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							"app": "source-controller",
+						},
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Name:  "source-controller",
+								Image: "ghcr.io/fluxcd/source-controller:v0.33.0",
+							},
+						},
+					},
+				},
+			},
+		}
+		Expect(kubeClient.Create(ctx, source)).To(Succeed())
+
+		fluxVersion, guessed, err := GetFluxVersion(ctx, fakeLogger, kubeClient)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(fluxVersion).To(Equal("v0.38.0"))
+		Expect(guessed).To(BeTrue())
+
+		Eventually(kubeClient.Delete(ctx, fluxNs)).ProbeEvery(1 * time.Second).Should(Succeed())
 	})
 
 	It("gets flux version", func() {
@@ -44,9 +107,13 @@ var _ = Describe("GetFluxVersion", func() {
 
 		Expect(kubeClient.Create(ctx, fluxNs)).To(Succeed())
 
-		fluxVersion, err := GetFluxVersion(ctx, fakeLogger, kubeClient)
+		fluxVersion, guessed, err := GetFluxVersion(ctx, fakeLogger, kubeClient)
 
 		Expect(err).NotTo(HaveOccurred())
 		Expect(fluxVersion).To(Equal(testVersion))
+		Expect(guessed).To(BeFalse())
+
+		Eventually(kubeClient.Delete(ctx, fluxNs)).ProbeEvery(1 * time.Second).Should(Succeed())
 	})
+
 })


### PR DESCRIPTION
Fixes #3235
Fixes #3049

Signed-off-by: Chanwit Kaewkasi <chanwit@weave.works>

The changes in this PR are used to determine the version of Flux that is currently being used in a Kubernetes cluster. 

- It does this by first searching through the namespaces in the cluster for one that is labeled as being part of Flux and has a version label.
- If it finds such a namespace, it returns the version specified in the label.
- If it doesn't find such a namespace, it then tries to get a hard-coded namespace called "flux-system" and checks its labels for the version.
- If it still can't find the version, it looks for a deployment called "source-controller" in the found namespace and tries to extract the version label if it exists, and guess the flux version from the version from the image used in that deployment.
- If it is still unable to find the version, it returns an error message. The version is returned as a string and a boolean indicating if it was guessed or not.

To test it:

# scenario 1
No labels, install v0.38.3 and guess it to be v0.38.0 (which is the best guess)

1. `kind create cluster`
2.  apply Flux without version labels: 
    ```
    kubectl apply -f https://github.com/fluxcd/flux2/releases/download/v0.38.3/install.yaml
    ```
3. run GitOps Run (`mkdir test-1 && cd test-1 && git init && gitops beta run ./test --no-session`)
4. Flux should be guessed and detected as v0.38.0 (the guess mode)
5. `kind delete cluster`

# scenario 2
No labels, install v0.37.0 and guess it to be v0.37.0 (which is the best guess)

1. `kind create cluster`
2.  apply Flux without version labels: 
    ```
    kubectl apply -f https://github.com/fluxcd/flux2/releases/download/v0.37.0/install.yaml
    ```
3. run GitOps Run (`mkdir test-2 && cd test-2 && git init && gitops beta run ./test --no-session`)
4. Flux should be guessed and detected as v0.37.0 (the guess mode)
5. `kind delete cluster`

# scenario 3
Use Flux version label

1. `kind create cluster`
2. `flux install`
3. run GitOps Run (`mkdir test-3 && cd test-3 && git init && gitops beta run ./test --no-session`)
4. Flux should be detected corrected as the installed version
5. `kind delete cluster`
