### PR TITLE
Set up a new bucket for gitops run logs

### DIFF
--- a/core/server/session_logs.go
+++ b/core/server/session_logs.go
@@ -9,6 +9,7 @@ import (
 	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
 	pb "github.com/weaveworks/weave-gitops/pkg/api/core"
+	"github.com/weaveworks/weave-gitops/pkg/logger"
 	"github.com/weaveworks/weave-gitops/pkg/server/auth"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -45,10 +46,6 @@ type bucketConnectionInfo struct {
 
 // GetSessionLogs returns the logs for a session.
 func (cs *coreServer) GetSessionLogs(ctx context.Context, msg *pb.GetSessionLogsRequest) (*pb.GetSessionLogsResponse, error) {
-	const (
-		bucketName = "gitops-run-logs"
-	)
-
 	clustersClient, err := cs.clustersManager.GetImpersonatedClient(ctx, auth.Principal(ctx))
 	if err != nil {
 		return nil, fmt.Errorf("error getting impersonating client: %w", err)
@@ -76,7 +73,7 @@ func (cs *coreServer) GetSessionLogs(ctx context.Context, msg *pb.GetSessionLogs
 		return nil, err
 	}
 
-	logs, lastToken, err := getLogs(ctx, msg.GetSessionId(), msg.GetToken(), asS3Reader(minioClient), bucketName)
+	logs, lastToken, err := getLogs(ctx, msg.GetSessionId(), msg.GetToken(), asS3Reader(minioClient), logger.SessionLogBucketName)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Closes #3268 

- Added passing a MinIO client to the `NewS3LogWriter` function and removed some other params. The difference between the secure and insecure S3 logger is determined by the MinIO client which is passed to `NewS3LogWriter`. So, I removed the `NewInsecureS3LogWriter` function.

-  Added a new `CreateBucket` function which also accepts a MinIO client (generally, the same client which is used for creating the S3 logger.).

- Add constants for log bucket names.

- Added creating a bucket for pod logs in addition to the existing bucket for session logs.

