### PR TITLE
use ua-parser-js 0.7.33 to fix vulnerability

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -41,5 +41,8 @@
   },
   "devDependencies": {
     "yarn-audit-fix": "^9.2.1"
+  },
+  "resolutions": {
+    "ua-parser-js": "^0.7.33"
   }
 }

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -7234,10 +7234,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-ua-parser-js@^0.7.30:
-  version "0.7.31"
-  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.31.tgz#649a656b191dffab4f21d5e053e27ca17cbff5c6"
-  integrity sha512-qLK/Xe9E2uzmYI3qLeOmI0tEOt+TBBQyUIAh4aAgU05FVYzeZrKUdkAZfBNVGRaHVgV0TDkdEngJSw/SyQchkQ==
+ua-parser-js@^0.7.30, ua-parser-js@^0.7.33:
+  version "0.7.33"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.33.tgz#1d04acb4ccef9293df6f70f2c3d22f3030d8b532"
+  integrity sha512-s8ax/CeZdK9R/56Sui0WM6y9OFREJarMRHqLB2EwkovemBxNQ+Bqu8GAsUnVcXKgphb++ghr/B2BZx4mahujPw==
 
 unherit@^1.0.4:
   version "1.1.3"


### PR DESCRIPTION
fixes https://security.snyk.io/vuln/SNYK-JS-UAPARSERJS-3244450

closes #3304