### PR TITLE
Sort port forward shortcuts

### DIFF
--- a/pkg/run/watch/forward_port.go
+++ b/pkg/run/watch/forward_port.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"sort"
 	"strings"
 
 	"github.com/go-logr/logr"
@@ -143,7 +144,11 @@ func ShowPortForwards(ctx context.Context, log clilogger.Logger, portForwards ma
 	// print text in bold
 	fmt.Printf("\n\033[1m%s\033[0m\n\n", "We set up port forwards for you, use the number below to open it in the browser")
 
-	for key, portForward := range portForwards {
+	keys := getSortedPortForwardKeys(portForwards)
+
+	for _, key := range keys {
+		portForward := portForwards[key]
+
 		fmt.Printf("(%c) %s: http://localhost:%s\n", key, portForward.Name, portForward.HostPort)
 	}
 
@@ -194,4 +199,17 @@ func GetNextPortForwardKey(portForwards map[rune]PortForwardShortcut) (rune, err
 	}
 
 	return PortForwardShortcutRunes[numPortForwards+1], nil
+}
+
+func getSortedPortForwardKeys(portForwards map[rune]PortForwardShortcut) []rune {
+	keys := make([]rune, 0)
+	for k := range portForwards {
+		keys = append(keys, k)
+	}
+
+	sort.Slice(keys, func(i, j int) bool {
+		return keys[i] < keys[j]
+	})
+
+	return keys
 }


### PR DESCRIPTION
Closes #3164 

- Add building the list of port forward shortcuts based on sorted keys.

Testing:

To test it locally with a hardcoded portforwards list, you can replace the following lines in `cmd/gitops/beta/run/cmd.go`

```
portForwards := map[rune]watch.PortForwardShortcut{}

if dashboardInstalled {
	portForwardKey, err := watch.GetNextPortForwardKey(portForwards)
	if err != nil {
		log.Failuref("Error adding a portForward: %v", err)
	} else {
		portForwards[portForwardKey] = watch.PortForwardShortcut{
			Name:     dashboardName,
			HostPort: flags.DashboardPort,
		}
	}
}

var specMap *watch.PortForwardSpec

if flags.PortForward != "" {
	specMap, err = watch.ParsePortForwardSpec(flags.PortForward)
	if err != nil {
		log.Failuref("Error parsing port forward spec: %v", err)
	} else {
		serviceName := specMap.Name
		if serviceName == "" {
			serviceName = "service"
		}

		portForwardKey, err := watch.GetNextPortForwardKey(portForwards)
		if err != nil {
			log.Failuref("Error adding a port forward: %v", err)
		} else {
			portForwards[portForwardKey] = watch.PortForwardShortcut{
				Name:     serviceName,
				HostPort: specMap.HostPort,
			}
		}
	}
}
```

with test data:

```
portForwards := map[rune]watch.PortForwardShortcut{}

portForwards['1'] = watch.PortForwardShortcut{
	Name:     "port forward 1",
	HostPort: "9001",
}

portForwards['3'] = watch.PortForwardShortcut{
	Name:     "port forward 3",
	HostPort: "9003",
}

portForwards['2'] = watch.PortForwardShortcut{
	Name:     "port forward 2",
	HostPort: "9002",
}

portForwards['9'] = watch.PortForwardShortcut{
	Name:     "port forward 9",
	HostPort: "9009",
}

portForwards['8'] = watch.PortForwardShortcut{
	Name:     "port forward 8",
	HostPort: "9008",
}

portForwards['7'] = watch.PortForwardShortcut{
	Name:     "port forward 7",
	HostPort: "9007",
}

portForwards['6'] = watch.PortForwardShortcut{
	Name:     "port forward 6",
	HostPort: "9006",
}

portForwards['5'] = watch.PortForwardShortcut{
	Name:     "port forward 5",
	HostPort: "9005",
}

portForwards['4'] = watch.PortForwardShortcut{
	Name:     "port forward 4",
	HostPort: "9004",
}

var specMap *watch.PortForwardSpec

if flags.PortForward != "" {
	specMap, err = watch.ParsePortForwardSpec(flags.PortForward)
	if err != nil {
		log.Failuref("Error parsing port forward spec: %v", err)
	}
}
```

Port forward shortcuts with real-world data with sorting:

<img width="567" alt="Screenshot 2023-01-25 at 12 41 09" src="https://user-images.githubusercontent.com/8824708/214554729-84a824d1-722a-44e2-839a-8aec40b88d26.png">

Port forward shortcuts with test data without sorting:

<img width="638" alt="Screenshot 2023-01-25 at 12 22 13" src="https://user-images.githubusercontent.com/8824708/214554746-65401e3b-6e4f-4203-89e5-25bc87385975.png">

Port forward shortcuts with test data with sorting:

<img width="569" alt="Screenshot 2023-01-25 at 12 26 33" src="https://user-images.githubusercontent.com/8824708/214554768-bab71497-7a35-4455-af6e-973239ff826b.png">
