### PR TITLE
Minor updates to user docs

### DIFF
--- a/doc/development-process.md
+++ b/doc/development-process.md
@@ -132,6 +132,9 @@ Our frontend tests:
 
 We're re-working our integration tests. Coming back soon.
 
+## Contributing to Weave GitOps documentation
+See [here](../website/README.md) for more details.
+
 
 ## Other optimisations for development setup
 

--- a/website/README.md
+++ b/website/README.md
@@ -1,12 +1,18 @@
 # Website
 
 This website is built using [Docusaurus 2](https://docusaurus.io/), a modern static website generator.
+It requires Node.js installed on your system. Install or Update your current setup for Node.js from [here](https://nodejs.org/en/download/)
+Install yarn from [here](https://classic.yarnpkg.com/en/docs/install)
+
+Following commands can be run within the `website` folder.
 
 ## Installation
 
 ```console
 yarn install
 ```
+
+This will install all the dependencies required for the documentation site.
 
 ## Local Development
 
@@ -20,7 +26,7 @@ export GA_KEY=fakekey
 yarn start
 ```
 
-This command starts a local development server and opens up a browser window. Most changes are reflected live without having to restart the server.
+This command starts a local development server and opens up a browser window. To preview your changes as you edit the files, you can run a local development server that will serve your website and reflect the latest changes.
 
 If you are using newer version of Node (17+):
 
@@ -35,6 +41,8 @@ yarn build
 ```
 
 This command generates static content into the `build` directory and can be served using any static contents hosting service.
+During development once you're happy with your changes, you should run this command to build the site locally to make sure all your changes are good.
+This command can be bit slow and may take some time to build the site. 
 
 ## Deployment
 

--- a/website/docs/releases.mdx
+++ b/website/docs/releases.mdx
@@ -25,7 +25,7 @@ This page details the changes for Weave GitOps Enterprise and its associated com
 - ```gitops create template``` supporting ```--config``` allows you to read command line flags from a config file and ```--output-dir``` allows you to write files out to a directory instead of just stdout
 #### GitOpsSets in preview
 - GitOpsSets enable Platform Operators to have a single definition for an application for multiple environments and a fleet of clusters. A single definition can be used to generate the environment and cluster-specific configuration.
-- GitOpsSets has been released as a feature in preview of WGE. The Preview phase helps us to actively collect feedback and use cases, iterating and improving the feature to reach a level of maturity before we call it stable. Please contact us via [email](david.stauffer@weave.works) or [slack](https://join.slack.com/t/weave-community/shared_invite/zt-1nrm7dc6b-QbCec62CJ7qj_OUOtuJbrw) if you want to get access to  the preview. 
+- GitOpsSets has been released as a feature in preview of WGE. The Preview phase helps us to actively collect feedback and use cases, iterating and improving the feature to reach a level of maturity before we call it stable. Please contact us via [email](mailto:david.stauffer@weave.works) or [slack](https://join.slack.com/t/weave-community/shared_invite/zt-1nrm7dc6b-QbCec62CJ7qj_OUOtuJbrw) if you want to get access to the preview. 
 
 
 

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -82,7 +82,48 @@ module.exports = {
             },
           ],
         },
+        {
+            title: "Community",
+            items: [
+                {
+                label: "GitHub",
+                href: "https://github.com/weaveworks/weave-gitops",
+                },
+            ],
+        },
+        {
+            title: 'Follow us',
+            items: [
+              {
+                label: 'Facebook',
+                href: 'https://www.facebook.com/WeaveworksInc/',
+              },
+              {
+                label: 'LinkedIn',
+                href: 'https://www.linkedin.com/company/weaveworks',
+              },
+              {
+                label: 'Twitter',
+                href: 'https://twitter.com/weaveworks',
+              },
+              {
+                label: 'Slack',
+                href: 'https://slack.weave.works/',
+              },
+              {
+                label: 'Youtube',
+                href: 'https://www.youtube.com/c/WeaveWorksInc',
+              },
+            ],
+        },
       ],
+      logo: {
+        alt: 'Weaveworks Logo',
+        src: 'img/weave-logo.png',
+        href: 'https://weave.works',
+        width: 35,
+        height: 35,
+      },
       copyright: `Copyright © ${new Date().getFullYear()} Weaveworks`,
     },
     algolia: {

--- a/website/versioned_docs/version-0.15.0/releases.mdx
+++ b/website/versioned_docs/version-0.15.0/releases.mdx
@@ -25,7 +25,7 @@ This page details the changes for Weave GitOps Enterprise and its associated com
 - ```gitops create template``` supporting ```--config``` allows you to read command line flags from a config file and ```--output-dir``` allows you to write files out to a directory instead of just stdout
 #### GitOpsSets in preview
 - GitOpsSets enable Platform Operators to have a single definition for an application for multiple environments and a fleet of clusters. A single definition can be used to generate the environment and cluster-specific configuration.
-- GitOpsSets has been released as a feature in preview of WGE. The Preview phase helps us to actively collect feedback and use cases, iterating and improving the feature to reach a level of maturity before we call it stable. Please contact us via [email](david.stauffer@weave.works) or [slack](https://join.slack.com/t/weave-community/shared_invite/zt-1nrm7dc6b-QbCec62CJ7qj_OUOtuJbrw) if you want to get access to  the preview. 
+- GitOpsSets has been released as a feature in preview of WGE. The Preview phase helps us to actively collect feedback and use cases, iterating and improving the feature to reach a level of maturity before we call it stable. Please contact us via [email](mailto:david.stauffer@weave.works) or [slack](https://join.slack.com/t/weave-community/shared_invite/zt-1nrm7dc6b-QbCec62CJ7qj_OUOtuJbrw) if you want to get access to the preview. 
 
 
 


### PR DESCRIPTION
**What changed?**
- fixed the broken links to email on the releases page
- added a link to the website README in the Contributing section and added some more info in the readme for running the documentation commands.
- added social links in the footer similar to the Weaveworks website footer

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**
- The footer looks less empty and more in sync with our company site.
- It took some time for me to find the website readme so I added an extra link in the contribution section for people like me 😛 Also added some helpful links and text for people who might be new to Docusaurus.

**Documentation Changes**
Before: 
![Screenshot 2023-01-26 at 16 54 43](https://user-images.githubusercontent.com/10995114/214899270-99ba589d-94c9-40cd-ada2-6573efa8a4b1.png)
![Screenshot 2023-01-26 at 16 55 02](https://user-images.githubusercontent.com/10995114/214899439-6e136136-5675-49c7-b1e2-a871325df081.png)

After:
![Screenshot 2023-01-26 at 16 54 10](https://user-images.githubusercontent.com/10995114/214899511-9e474a00-f7a3-4881-b306-fda06cefbc73.png)
![Screenshot 2023-01-26 at 16 55 29](https://user-images.githubusercontent.com/10995114/214899573-07a71868-400c-4757-8a4b-c84b98cf69e7.png)
