### PR TITLE
Fix spacing between graph nodes and lines

### DIFF
--- a/ui/components/DagGraph.tsx
+++ b/ui/components/DagGraph.tsx
@@ -97,7 +97,7 @@ function DagGraph({ className, nodes }: Props) {
 
   const graphOffsetX = zoomBox / 2 - width / 2;
   const verticalSeparationHalf = nodeSize.verticalSeparation / 2;
-  console.log("hello from dag graph");
+
   return (
     <Flex className={className} wide tall>
       <GraphDiv

--- a/ui/components/DagGraph.tsx
+++ b/ui/components/DagGraph.tsx
@@ -127,7 +127,7 @@ function DagGraph({ className, nodes }: Props) {
                   <g key={index}>
                     <path
                       fill="#7a7a7a"
-                      d={`M${l.target.x}, ${l.target.y}
+                      d={`M${l.target.x}, ${l.target.y - 10}
                       l${arrowHalfWidth}, ${-nodeSize.arrowHeight}
                       h${-nodeSize.arrowWidth}
                       l${arrowHalfWidth}, ${nodeSize.arrowHeight}`}

--- a/ui/components/DagGraph.tsx
+++ b/ui/components/DagGraph.tsx
@@ -128,7 +128,7 @@ function DagGraph({ className, nodes }: Props) {
                   <g key={index}>
                     <path
                       fill="#7a7a7a"
-                      d={`M${l.target.x}, ${l.target.y + 50}
+                      d={`M${l.target.x}, ${l.target.y - 50}
                       l${arrowHalfWidth}, ${-nodeSize.arrowHeight}
                       h${-nodeSize.arrowWidth}
                       l${arrowHalfWidth}, ${nodeSize.arrowHeight}`}

--- a/ui/components/DagGraph.tsx
+++ b/ui/components/DagGraph.tsx
@@ -127,7 +127,7 @@ function DagGraph({ className, nodes }: Props) {
                   <g key={index}>
                     <path
                       fill="#7a7a7a"
-                      d={`M${l.target.x}, ${l.target.y - 10}
+                      d={`M${l.target.x}, ${l.target.y + 50}
                       l${arrowHalfWidth}, ${-nodeSize.arrowHeight}
                       h${-nodeSize.arrowWidth}
                       l${arrowHalfWidth}, ${nodeSize.arrowHeight}`}

--- a/ui/components/DagGraph.tsx
+++ b/ui/components/DagGraph.tsx
@@ -97,7 +97,7 @@ function DagGraph({ className, nodes }: Props) {
 
   const graphOffsetX = zoomBox / 2 - width / 2;
   const verticalSeparationHalf = nodeSize.verticalSeparation / 2;
-
+  console.log("hello from dag graph");
   return (
     <Flex className={className} wide tall>
       <GraphDiv
@@ -123,6 +123,7 @@ function DagGraph({ className, nodes }: Props) {
                 // M tells the path where to start,
                 // H draws a straight horizontal line (capital letter means absolute coordinates),
                 // and v draws a straight vertical line (lowercase letter means relative to current position)
+
                 return (
                   <g key={index}>
                     <path

--- a/ui/components/DagGraph.tsx
+++ b/ui/components/DagGraph.tsx
@@ -128,15 +128,13 @@ function DagGraph({ className, nodes }: Props) {
                   <g key={index}>
                     <path
                       fill="#7a7a7a"
-                      d={`M${l.target.x}, ${l.target.y - 50}
+                      d={`M${l.target.x}, ${l.target.y}
                       l${arrowHalfWidth}, ${-nodeSize.arrowHeight}
                       h${-nodeSize.arrowWidth}
                       l${arrowHalfWidth}, ${nodeSize.arrowHeight}`}
                     />
                     <path
-                      d={`M${l.source.x}, ${
-                        l.source.y + nodeSize.height + linkStrokeWidth * 2
-                      }
+                      d={`M${l.source.x}, ${l.source.y + nodeSize.height}
                       L${l.target.x}, ${l.target.y - verticalSeparationHalf}
                       v${verticalSeparationHalf}`}
                     />


### PR DESCRIPTION
Closes [#2223](https://github.com/weaveworks/weave-gitops-enterprise/issues/2223): Enterprise issue

Long story short is that adding `linkStrokeWidth * 2` to the path was the cause of a little extra space between the nodes. HOWEVER. The screenshots here seem to indicate that this is necessary in the OSS DagGraph component, and somehow the Enterprise styling effects this svg code. How? Not sure. I'm also noticing there's an extra scroll bar in the graph on Enterprise exclusively in the Terraform version of the graph, which I hate, but that's a conversation for a follow up issue. 

Enterprise Terraform DagGraph (extra scroll bar :(((( ):
<img width="2044" alt="image" src="https://user-images.githubusercontent.com/65822698/214964990-0a41873c-0845-4fa9-b4ce-5d5e9bf5a849.png">

Enterprise Automation DagGraph:
<img width="2046" alt="image" src="https://user-images.githubusercontent.com/65822698/214966410-8336344a-b6df-4b45-aaf6-86a263b81f13.png">

OSS Automation DagGraph:
<img width="2039" alt="image" src="https://user-images.githubusercontent.com/65822698/214965111-cf882c49-e393-4172-856d-e977b7de4039.png">
