### PR TITLE
Add gitops run command as an alias to gitops beta run

### DIFF
--- a/cmd/gitops/root/cmd.go
+++ b/cmd/gitops/root/cmd.go
@@ -18,6 +18,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/beta"
+	"github.com/weaveworks/weave-gitops/cmd/gitops/beta/run"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/check"
 	cfg "github.com/weaveworks/weave-gitops/cmd/gitops/config"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/create"
@@ -165,6 +166,7 @@ func RootCmd() *cobra.Command {
 	rootCmd.AddCommand(remove.GetCommand(options))
 	rootCmd.AddCommand(replan.Command(options))
 	rootCmd.AddCommand(resume.Command(options))
+	rootCmd.AddCommand(run.RunCommand(options))
 	rootCmd.AddCommand(suspend.Command(options))
 
 	return rootCmd


### PR DESCRIPTION
Closes #3317 

- Added the `run` command to  the root (`gitops`) command. So, calls to `gitops beta run` and `gitops run` will work exactly the same.

Notes:
The only limitation: usage examples in help for `gitops run` will display `gitops beta run`, because they are hardcoded strings, but for our purposes it should work. We can update help after we move GitOps Run our of beta.

Testing that both commands work the same:

`gitops run`

<img width="808" alt="Screenshot 2023-01-31 at 14 09 31" src="https://user-images.githubusercontent.com/8824708/215770361-86b46d88-2ded-4d1e-bac5-df9d2bef22e4.png">

`gitops beta run`

<img width="808" alt="Screenshot 2023-01-31 at 14 16 27" src="https://user-images.githubusercontent.com/8824708/215770841-1fd63241-4e2d-4a6b-8779-2ea9abc5fd8f.png">

