### PR TITLE
Improve formatting of log message timestamp in the log UI

### DIFF
--- a/ui/index.ts
+++ b/ui/index.ts
@@ -67,7 +67,12 @@ import {
 } from "./lib/objects";
 import { muiTheme, theme } from "./lib/theme";
 import { V2Routes } from "./lib/types";
-import { isAllowedLink, poller, statusSortHelper } from "./lib/utils";
+import {
+  formatLogTimestamp,
+  isAllowedLink,
+  poller,
+  statusSortHelper,
+} from "./lib/utils";
 import SignIn from "./pages/SignIn";
 
 export {
@@ -92,6 +97,7 @@ export {
   filterConfig,
   FluxRuntime,
   Footer,
+  formatLogTimestamp,
   formatURL,
   GitRepository,
   GitRepositoryDetail,

--- a/ui/lib/__tests__/utils.test.ts
+++ b/ui/lib/__tests__/utils.test.ts
@@ -3,6 +3,7 @@ import { GetVersionResponse } from "../api/core/core.pb";
 import {
   convertGitURLToGitProvider,
   convertImage,
+  formatLogTimestamp,
   formatMetadataKey,
   getAppVersion,
   getSourceRefForAutomation,
@@ -361,6 +362,25 @@ describe("utils lib", () => {
       expect(appVersion.versionHref).toEqual(
         "https://github.com/weaveworks/weave-gitops/commit/commit"
       );
+    });
+  });
+  describe("formatLogTimestamp", () => {
+    it("should format non-empty timestamp", () => {
+      expect(formatLogTimestamp("2023-01-31T13:27:56-05:00", "UTC+1")).toEqual(
+        "2023-01-31 19:01:56 UTC+1"
+      );
+      expect(formatLogTimestamp("2023-02-02T13:27:56-01:00", "UTC-10")).toEqual(
+        "2023-02-02 04:02:56 UTC-10"
+      );
+      expect(formatLogTimestamp("2023-02-02T13:27:56-01:00", "UTC")).toEqual(
+        "2023-02-02 14:02:56 UTC"
+      );
+    });
+    it("should return a hyphen for undefined timestamp", () => {
+      expect(formatLogTimestamp(undefined)).toEqual("-");
+    });
+    it("should return a hyphen for empty string", () => {
+      expect(formatLogTimestamp("")).toEqual("-");
     });
   });
 });

--- a/ui/lib/utils.ts
+++ b/ui/lib/utils.ts
@@ -1,4 +1,5 @@
 import _ from "lodash";
+import { DateTime } from "luxon";
 import { toast } from "react-toastify";
 import { computeReady, ReadyType } from "../components/KubeStatusIndicator";
 import { AppVersion, repoUrl } from "../components/Version";
@@ -176,4 +177,27 @@ export function getAppVersion(
     versionText,
     versionHref,
   };
+}
+
+// formatLogTimestamp formats a timestamp string in the RFC3339 format
+// to a human-readable format with UTC offset.
+// If the timestamp is undefined or an empty string, it returns "-".
+export function formatLogTimestamp(timestamp?: string, zone?: string): string {
+  if (!timestamp) {
+    return "-";
+  }
+
+  let dt = DateTime.fromISO(timestamp);
+
+  if (zone) {
+    dt = dt.setZone(zone);
+  }
+
+  let formattedTimestamp = `${dt.toFormat("yyyy-LL-dd HH:MM:ss 'UTC'Z")}`;
+
+  if (dt.offset === 0) {
+    formattedTimestamp = formattedTimestamp.replace("UTC+0", "UTC");
+  }
+
+  return formattedTimestamp;
 }


### PR DESCRIPTION
Part of https://github.com/weaveworks/weave-gitops-enterprise/issues/2319

- Add the `formatLogTimestamp` function to format log timestamp with a custom format string with a UTC timezone offset.

- Add unit tests for `formatLogTimestamp`.

Notes:
- There is a technical problem with importing the luxon package directly into enterprise (a type-related error message which is unresolvable for now, so I decided to export this function from OSS and import in the other PR to enterprise, because luxon is already imported in OSS).

Design from Figma:
<img width="285" alt="Screenshot 2023-02-02 at 23 54 04" src="https://user-images.githubusercontent.com/8824708/216470056-565af22a-a0b3-452b-82e1-20b699978e23.png">

Results of formatting with this function (in enterprise UI), the only difference with Figma is, as @josefaworks  suggested, it should display local UI user's time, not time in +0 UTC timezone (we can change exact UTC format later):

<img width="1523" alt="Screenshot 2023-02-02 at 23 37 50" src="https://user-images.githubusercontent.com/8824708/216470068-89385802-8072-4d20-ac5a-05b0f9aefe80.png">

- I also applied the current timestamp formatter to the header timestamp, because in Figma it shows some short time format and this needs to be refined, for now the long timestamp should work.

- The `zone` function param is used for unit tests only, otherwise the string would be formatted to local time which would be different on a developer machine and on server (so the tests would fail). 

- We could in principle remove zero UTC from timestamp but in this case the `UTC` strings will not be roughly at the same level as UTC in other timestamps with non-zero UTC, so we can remove it later if needed.
