### PR TITLE
Update 0.16 website docs

### DIFF
--- a/website/docs/releases.mdx
+++ b/website/docs/releases.mdx
@@ -15,15 +15,11 @@ This page details the changes for Weave GitOps Enterprise and its associated com
 
 #### Create External Secrets via WGE UI
 - It's becoming easier to create new a external secret CR through the UI instead of writing the whole CR yaml.
-- The creation form will help users choose which cluster to deploy the External Secret to and which secret store to sync the secrets from. 
-- It's all done in the GitOps way. 
+- The creation form will help users choose which cluster to deploy the External Secret to and which secret store to sync the secrets from.
+- It's all done in the GitOps way.
 
 #### Plan Button in Terraform
-- Adding **Add Plan** button in the terraform plan page to enable users to re-plan changes made. 
-
-#### 
-### Minor fixes
-#### 
+- Adding **Add Plan** button in the terraform plan page to enable users to re-plan changes made.
 
 ### Dependency versions
 
@@ -44,9 +40,9 @@ No breaking changes
 ### Highlights
 
 #### Multi Repository support. Weave GitOps Enterprise adapts and scales to your repository structure
-- Weave GitOps Enterprise, is now supporting via the WGE GUI the selection of the Git Repository. Enabling to scale and match the desired Git Repository structure. 
+- Weave GitOps Enterprise, is now supporting via the WGE GUI the selection of the Git Repository. Enabling to scale and match the desired Git Repository structure.
 
-#### GitOps Templates 
+#### GitOps Templates
 - Supporting path for Profiles, enabling to set the path for profiles in the template to configure where in the directory the HelmRelease gets created.
 - Enhanced Enterprise CLI support for GitOps Templates.
 #### GitOps Templates CLI enhancements
@@ -54,7 +50,7 @@ No breaking changes
 - ```gitops create template``` supporting ```--config``` allows you to read command line flags from a config file and ```--output-dir``` allows you to write files out to a directory instead of just stdout
 #### GitOpsSets in preview
 - GitOpsSets enable Platform Operators to have a single definition for an application for multiple environments and a fleet of clusters. A single definition can be used to generate the environment and cluster-specific configuration.
-- GitOpsSets has been released as a feature in preview of WGE. The Preview phase helps us to actively collect feedback and use cases, iterating and improving the feature to reach a level of maturity before we call it stable. Please contact us via [email](mailto:david.stauffer@weave.works) or [slack](https://join.slack.com/t/weave-community/shared_invite/zt-1nrm7dc6b-QbCec62CJ7qj_OUOtuJbrw) if you want to get access to the preview. 
+- GitOpsSets has been released as a feature in preview of WGE. The Preview phase helps us to actively collect feedback and use cases, iterating and improving the feature to reach a level of maturity before we call it stable. Please contact us via [email](mailto:david.stauffer@weave.works) or [slack](https://join.slack.com/t/weave-community/shared_invite/zt-1nrm7dc6b-QbCec62CJ7qj_OUOtuJbrw) if you want to get access to the preview.
 
 
 
@@ -84,8 +80,8 @@ No breaking changes
 - We are introducing new functionality into Weave GitOps Enterprise to help observe and manage secrets through external secrets operator (ESO). The new secrets UI will enable customers using ESO to observe and manage external secrets, as well as help them troubleshoot issues during their secrets creation and sync operations. In this release, we are including the ability to list all ExternalSecrets custom resources across multi-cluster environments. Users also will have the ability to navigate to each ExternalSecret and know the details of the secret, its sync status, and the last time this secret has been updated, as well as the latest events associated with the secret.
 
 #### Pipelines
-- Retry promotion on failure. Now if a promotion fails there is an automatic retry functionalty, you can configure the threshold and delay via the CLI. 
-- Promotion webhook rate limiting. We enable now the configuration of the rate limit for the promotion webhooks. 
+- Retry promotion on failure. Now if a promotion fails there is an automatic retry functionalty, you can configure the threshold and delay via the CLI.
+- Promotion webhook rate limiting. We enable now the configuration of the rate limit for the promotion webhooks.
 
 ### Minor fixes
 #### Workspaces
@@ -146,10 +142,10 @@ spec:
           ...
 ```
 
-#### Workspace UI 
-- Weave GitOps now provides a GUI for Workspaces. 
+#### Workspace UI
+- Weave GitOps now provides a GUI for Workspaces.
 
-#### Enhanced Terraform Table in UI 
+#### Enhanced Terraform Table in UI
 - Weave GitOps now provides more details on the Terraform inventory GUI page. Adding the type and identifier fields to the inventory table, plus filtering and a 'no data' message.
 
 #### Keyboard shortcuts for "port forwards" on GitOps Run
@@ -157,7 +153,7 @@ spec:
 - Weave GitOps now opening the selected port forward URL on key press. Listening for keypress is performed with the `github.com/mattn/go-tty` package (other options required pressing Enter after a keypress, this catches just a single numeric keypress) and opening URLs with the `github.com/pkg/browser` package.
 
 #### Minor fixes
-**[UI] Notifications** Fixed provider page showing a 404. 
+**[UI] Notifications** Fixed provider page showing a 404.
 
 ### Dependency versions
 
@@ -180,7 +176,7 @@ No breaking changes
 
 #### GitOps Templates
 
-- Support to specify Helm charts inside the CRD, instead of annotations. We’ve provided [documentation](./gitops-templates/templates.mdx) which has a example. 
+- Support to specify Helm charts inside the CRD, instead of annotations. We’ve provided [documentation](./gitops-templates/templates.mdx) which has a example.
 
 ```yaml
 spec:
@@ -216,10 +212,10 @@ config
     claimGroups: ""
 ```
 
-#### Policy commit-time agent 
+#### Policy commit-time agent
 - Support Azure DevOps and auto-remediation in commit-time enforcement.
 
-#### Admin User- simpler RBAC 
+#### Admin User- simpler RBAC
 - Weave GitOps default admin user can now “read” all objects. Why is this important? As users are trying out Weave GitOps they will most likely try it out with some of their favorite Cloud Native tools such as Crossplane, Tekton, Istio, etc. This enables them to see all of those resources and explore the full power of Weave GitOps. We still do not recommend this user for “production-use” cases, and customers should always be pushed towards implementing OIDC with scoped roles.
 
 #### Pipelines - adding Pipelines through Templates
@@ -244,7 +240,7 @@ cluster-bootstrap-controller v0.3.0
 (optional) policy-agent 2.1.1
 
 ### Known issues
-- [UI] Notifications provider page shows a 404. 
+- [UI] Notifications provider page shows a 404.
 
 ## v0.11.0
 2022-11-25
@@ -257,7 +253,7 @@ cluster-bootstrap-controller v0.3.0
 - You can control what [delimiters](./gitops-templates/templates.mdx#custom-delimiters-for-rendertype-templating) you want to use in a template. This provides flexibility for if you want to use the syntax for dynamic functions like the [helper functions](./gitops-templates/templates.mdx#supported-functions-from-sprig-library) we support.
 
 #### Pipelines
-- This [feature](pipelines/intro.mdx) is now enabled by default when you install the Weave GitOps Enterprise Helm Chart. You can toggle this with the `enablePipelines` flag. 
+- This [feature](pipelines/intro.mdx) is now enabled by default when you install the Weave GitOps Enterprise Helm Chart. You can toggle this with the `enablePipelines` flag.
 - GitOpsTemplates are a highly flexible way to create new resources - including Pipelines. We now provide a shortcut on the Pipelines table view to navigate you to Templates with the `weave.works/template-type=pipeline` label.
 
 #### Telemetry
@@ -334,7 +330,7 @@ You can still view and tweak the `values.yaml` when selecting profiles to includ
 - bump pipeline-controller
 - Parse annotations from template
 - Add cost estimate message if available
-- Adds support for showing policy modes and policy configs in the UI 
+- Adds support for showing policy modes and policy configs in the UI
 
 - Show suspended status on pipelines detail
 - YAML view for Pipelines
@@ -417,5 +413,3 @@ policy-agent:
     accountId: "my-account"
     clusterId: "my-cluster"
 ```
-
-

--- a/website/versioned_docs/version-0.16.0/releases.mdx
+++ b/website/versioned_docs/version-0.16.0/releases.mdx
@@ -16,16 +16,12 @@ This page details the changes for Weave GitOps Enterprise and its associated com
 
 #### Create External Secrets via WGE UI
 - It's becoming easier to create a new external secret CR through the UI instead of writing the whole CR yaml.
-- The creation form will help users choose which cluster to deploy the External Secret to and which secret store to sync the secrets from. 
-- It's all done in the GitOps way. 
+- The creation form will help users choose which cluster to deploy the External Secret to and which secret store to sync the secrets from.
+- It's all done in the GitOps way.
 
 
 #### Plan Button in Terraform
-- Adding add plan button in the terraform plan page to enable users to re-plan changes made. 
-
-#### 
-### Minor fixes
-#### 
+- Adding **Add Plan** button in the terraform plan page to enable users to re-plan changes made.
 
 ### Dependency versions
 
@@ -46,9 +42,9 @@ No breaking changes
 ### Highlights
 
 #### Multi Repository support. Weave GitOps Enterprise adapts and scales to your repository structure
-- Weave GitOps Enterprise, is now supporting via the WGE GUI the selection of the Git Repository. Enabling to scale and match the desired Git Repository structure. 
+- Weave GitOps Enterprise, is now supporting via the WGE GUI the selection of the Git Repository. Enabling to scale and match the desired Git Repository structure.
 
-#### GitOps Templates 
+#### GitOps Templates
 - Supporting path for Profiles, enabling to set the path for profiles in the template to configure where in the directory the HelmRelease gets created.
 - Enhanced Enterprise CLI support for GitOps Templates.
 #### GitOps Templates CLI enhancements
@@ -56,7 +52,7 @@ No breaking changes
 - ```gitops create template``` supporting ```--config``` allows you to read command line flags from a config file and ```--output-dir``` allows you to write files out to a directory instead of just stdout
 #### GitOpsSets in preview
 - GitOpsSets enable Platform Operators to have a single definition for an application for multiple environments and a fleet of clusters. A single definition can be used to generate the environment and cluster-specific configuration.
-- GitOpsSets has been released as a feature in preview of WGE. The Preview phase helps us to actively collect feedback and use cases, iterating and improving the feature to reach a level of maturity before we call it stable. Please contact us via [email](mailto:david.stauffer@weave.works) or [slack](https://join.slack.com/t/weave-community/shared_invite/zt-1nrm7dc6b-QbCec62CJ7qj_OUOtuJbrw) if you want to get access to the preview. 
+- GitOpsSets has been released as a feature in preview of WGE. The Preview phase helps us to actively collect feedback and use cases, iterating and improving the feature to reach a level of maturity before we call it stable. Please contact us via [email](mailto:david.stauffer@weave.works) or [slack](https://join.slack.com/t/weave-community/shared_invite/zt-1nrm7dc6b-QbCec62CJ7qj_OUOtuJbrw) if you want to get access to the preview.
 
 
 
@@ -86,8 +82,8 @@ No breaking changes
 - We are introducing new functionality into Weave GitOps Enterprise to help observe and manage secrets through external secrets operator (ESO). The new secrets UI will enable customers using ESO to observe and manage external secrets, as well as help them troubleshoot issues during their secrets creation and sync operations. In this release, we are including the ability to list all ExternalSecrets custom resources across multi-cluster environments. Users also will have the ability to navigate to each ExternalSecret and know the details of the secret, its sync status, and the last time this secret has been updated, as well as the latest events associated with the secret.
 
 #### Pipelines
-- Retry promotion on failure. Now if a promotion fails there is an automatic retry functionalty, you can configure the threshold and delay via the CLI. 
-- Promotion webhook rate limiting. We enable now the configuration of the rate limit for the promotion webhooks. 
+- Retry promotion on failure. Now if a promotion fails there is an automatic retry functionalty, you can configure the threshold and delay via the CLI.
+- Promotion webhook rate limiting. We enable now the configuration of the rate limit for the promotion webhooks.
 
 ### Minor fixes
 #### Workspaces
@@ -148,10 +144,10 @@ spec:
           ...
 ```
 
-#### Workspace UI 
-- Weave GitOps now provides a GUI for Workspaces. 
+#### Workspace UI
+- Weave GitOps now provides a GUI for Workspaces.
 
-#### Enhanced Terraform Table in UI 
+#### Enhanced Terraform Table in UI
 - Weave GitOps now provides more details on the Terraform inventory GUI page. Adding the type and identifier fields to the inventory table, plus filtering and a 'no data' message.
 
 #### Keyboard shortcuts for "port forwards" on GitOps Run
@@ -159,7 +155,7 @@ spec:
 - Weave GitOps now opening the selected port forward URL on key press. Listening for keypress is performed with the `github.com/mattn/go-tty` package (other options required pressing Enter after a keypress, this catches just a single numeric keypress) and opening URLs with the `github.com/pkg/browser` package.
 
 #### Minor fixes
-**[UI] Notifications** Fixed provider page showing a 404. 
+**[UI] Notifications** Fixed provider page showing a 404.
 
 ### Dependency versions
 
@@ -182,7 +178,7 @@ No breaking changes
 
 #### GitOps Templates
 
-- Support to specify Helm charts inside the CRD, instead of annotations. We’ve provided [documentation](./gitops-templates/templates.mdx) which has a example. 
+- Support to specify Helm charts inside the CRD, instead of annotations. We’ve provided [documentation](./gitops-templates/templates.mdx) which has a example.
 
 ```yaml
 spec:
@@ -218,10 +214,10 @@ config
     claimGroups: ""
 ```
 
-#### Policy commit-time agent 
+#### Policy commit-time agent
 - Support Azure DevOps and auto-remediation in commit-time enforcement.
 
-#### Admin User- simpler RBAC 
+#### Admin User- simpler RBAC
 - Weave GitOps default admin user can now “read” all objects. Why is this important? As users are trying out Weave GitOps they will most likely try it out with some of their favorite Cloud Native tools such as Crossplane, Tekton, Istio, etc. This enables them to see all of those resources and explore the full power of Weave GitOps. We still do not recommend this user for “production-use” cases, and customers should always be pushed towards implementing OIDC with scoped roles.
 
 #### Pipelines - adding Pipelines through Templates
@@ -246,7 +242,7 @@ cluster-bootstrap-controller v0.3.0
 (optional) policy-agent 2.1.1
 
 ### Known issues
-- [UI] Notifications provider page shows a 404. 
+- [UI] Notifications provider page shows a 404.
 
 ## v0.11.0
 2022-11-25
@@ -259,7 +255,7 @@ cluster-bootstrap-controller v0.3.0
 - You can control what [delimiters](./gitops-templates/templates.mdx#custom-delimiters-for-rendertype-templating) you want to use in a template. This provides flexibility for if you want to use the syntax for dynamic functions like the [helper functions](./gitops-templates/templates.mdx#supported-functions-from-sprig-library) we support.
 
 #### Pipelines
-- This [feature](pipelines/intro.mdx) is now enabled by default when you install the Weave GitOps Enterprise Helm Chart. You can toggle this with the `enablePipelines` flag. 
+- This [feature](pipelines/intro.mdx) is now enabled by default when you install the Weave GitOps Enterprise Helm Chart. You can toggle this with the `enablePipelines` flag.
 - GitOpsTemplates are a highly flexible way to create new resources - including Pipelines. We now provide a shortcut on the Pipelines table view to navigate you to Templates with the `weave.works/template-type=pipeline` label.
 
 #### Telemetry
@@ -336,7 +332,7 @@ You can still view and tweak the `values.yaml` when selecting profiles to includ
 - bump pipeline-controller
 - Parse annotations from template
 - Add cost estimate message if available
-- Adds support for showing policy modes and policy configs in the UI 
+- Adds support for showing policy modes and policy configs in the UI
 
 - Show suspended status on pipelines detail
 - YAML view for Pipelines
@@ -419,5 +415,3 @@ policy-agent:
     accountId: "my-account"
     clusterId: "my-cluster"
 ```
-
-


### PR DESCRIPTION
Removing empty Minor Fixes section and add missing update in the highlights section that was done in the main docs but not the versioned ones.