### PR TITLE
Fix log timestamp format string

### DIFF
--- a/ui/lib/__tests__/utils.test.ts
+++ b/ui/lib/__tests__/utils.test.ts
@@ -367,13 +367,16 @@ describe("utils lib", () => {
   describe("formatLogTimestamp", () => {
     it("should format non-empty timestamp", () => {
       expect(formatLogTimestamp("2023-01-31T13:27:56-05:00", "UTC+1")).toEqual(
-        "2023-01-31 19:01:56 UTC+1"
+        "2023-01-31 19:27:56 UTC+1"
       );
-      expect(formatLogTimestamp("2023-02-02T13:27:56-01:00", "UTC-10")).toEqual(
-        "2023-02-02 04:02:56 UTC-10"
+      expect(formatLogTimestamp("2023-02-03T13:27:56-01:00", "UTC-10")).toEqual(
+        "2023-02-03 04:27:56 UTC-10"
       );
-      expect(formatLogTimestamp("2023-02-02T13:27:56-01:00", "UTC")).toEqual(
-        "2023-02-02 14:02:56 UTC"
+      expect(formatLogTimestamp("2023-02-03T13:27:56-01:00", "UTC")).toEqual(
+        "2023-02-03 14:27:56 UTC"
+      );
+      expect(formatLogTimestamp("2023-02-04T18:36:01+01:00", "UTC+3")).toEqual(
+        "2023-02-04 20:36:01 UTC+3"
       );
     });
     it("should return a hyphen for undefined timestamp", () => {

--- a/ui/lib/utils.ts
+++ b/ui/lib/utils.ts
@@ -193,7 +193,7 @@ export function formatLogTimestamp(timestamp?: string, zone?: string): string {
     dt = dt.setZone(zone);
   }
 
-  let formattedTimestamp = `${dt.toFormat("yyyy-LL-dd HH:MM:ss 'UTC'Z")}`;
+  let formattedTimestamp = `${dt.toFormat("yyyy-LL-dd HH:mm:ss 'UTC'Z")}`;
 
   if (dt.offset === 0) {
     formattedTimestamp = formattedTimestamp.replace("UTC+0", "UTC");


### PR DESCRIPTION
Follow-up fix for https://github.com/weaveworks/weave-gitops/pull/3355

Noticed I had copied a wrong format token from Luxon table.

Updated the token and the tests.