### PR TITLE
Improve detection of OSS dashboard

### DIFF
--- a/cmd/gitops/beta/run/cmd.go
+++ b/cmd/gitops/beta/run/cmd.go
@@ -347,7 +347,7 @@ func fluentBitStep(ctx context.Context, log logger.Logger, kubeClient *kube.Kube
 func dashboardStep(ctx context.Context, log logger.Logger, kubeClient *kube.KubeHTTP, generateManifestsOnly bool, dashboardHashedPassword string) (bool, []byte, string, error) {
 	log.Actionf("Checking if GitOps Dashboard is already installed ...")
 
-	dashboardInstalled := install.IsDashboardInstalled(ctx, log, kubeClient, dashboardName, flags.Namespace)
+	dashboardInstalled := install.IsDashboardInstalled(ctx, kubeClient, flags.Namespace, install.WGDashboardHelmChartName)
 
 	var dashboardManifests []byte
 


### PR DESCRIPTION
Closes https://github.com/weaveworks/weave-gitops/issues/3337

- Switched from using a HelmChart to detect OSS dashboard to using a HelmRelease.

- Added a `helmChartName` parameter to `IsDashboardInstalled` and `getDashboardHelmRelease` functions (with the hope to reuse the dashboard detection code in https://github.com/weaveworks/weave-gitops/issues/2891 ).

- Removed unused function parameters.

- Updated tests for `getDashboardHelmRelease`.

Testing:

Tested it on both regular Kind and enterprise (created with the `./tools/reboot.sh` script) clusters.

To install the OSS dashboard via a HelmChart, please use the following instructions:
https://docs.gitops.weave.works/docs/installation/weave-gitops/#deploying-weave-gitops

Notes:
- I kept the same error-handling logic for getting a list of HelmReleases, as before, when getting a HelmChart. If there is an error when calling the client method, we just return nil for the HelmRelease and do not log the error (= we don't care why exactly we are unable to get the HelmReleases).
