### PR TITLE
Add text search to table urls

### DIFF
--- a/ui/components/DataTable.tsx
+++ b/ui/components/DataTable.tsx
@@ -380,7 +380,8 @@ function UnstyledDataTable({
     );
 
     let query = qs.parse(search);
-    if (textFilters.length) query["search"] = textFilters.join("_");
+    console.log(textFilters.join("_"));
+    if (textFilters.length) query["search"] = textFilters.join("_") + "_";
     else if (query["search"]) query = _.omit(query, "search");
     history.replace({ ...location, search: qs.stringify(query) });
 

--- a/ui/components/DataTable.tsx
+++ b/ui/components/DataTable.tsx
@@ -407,7 +407,10 @@ function UnstyledDataTable({
       formState: resetFormState,
       textFilters: [],
     });
-    doChange(resetFormState);
+    const url = qs.parse(location.search);
+    //keeps things like clusterName and namespace for details pages
+    const cleared = _.omit(url, ["filters", "search"]);
+    history.replace({ ...location, search: qs.stringify(cleared) });
   };
 
   const handleFilterSelect = (filters, formState) => {

--- a/ui/components/__tests__/DataTableFilters.test.tsx
+++ b/ui/components/__tests__/DataTableFilters.test.tsx
@@ -567,7 +567,7 @@ describe("DataTableFilters", () => {
       ...filterConfig(rows, "type"),
     };
 
-    const search = `?filters=type${uriEncodedSeparator}foo_`;
+    const search = `?filters=type${uriEncodedSeparator}foo_&search=cool_`;
 
     render(
       withTheme(
@@ -584,8 +584,8 @@ describe("DataTableFilters", () => {
       )
     );
     const tableRows = document.querySelectorAll("tbody tr");
-    expect(tableRows).toHaveLength(2);
-    expect(tableRows[0].innerHTML).toContain("foo");
+    expect(tableRows).toHaveLength(1);
+    expect(tableRows[0].innerHTML).toContain("cool");
   });
   it("returns a query string on filter change", () => {
     const queryString = filterSelectionsToQueryString({
@@ -593,7 +593,8 @@ describe("DataTableFilters", () => {
     });
     expect(queryString).toEqual(`filters=type${uriEncodedSeparator}foo_`);
     expect(parseFilterStateFromURL(queryString)).toEqual({
-      [`type${filterSeparator}foo`]: true,
+      initialSelections: { [`type${filterSeparator}foo`]: true },
+      textFilters: [],
     });
   });
 });


### PR DESCRIPTION
Closes #3359 

Out of the two proposed ideas in 3359, adding the text search to urls gave the most value - as I was coding this it got a little scary to start slapping these query-string and history.replace actions everywhere. It's fewer clicks to sort by a column/reverse sort and I don't think the hit to the code/performance is worth adding it to the url. 