### PR TITLE
Add optional tooltip to Timestamp component

### DIFF
--- a/ui/components/AutomationsTable.tsx
+++ b/ui/components/AutomationsTable.tsx
@@ -147,7 +147,6 @@ function AutomationsTable({ className, automations, hideSource }: Props) {
       label: "Last Updated",
       value: (a: Automation) => (
         <Timestamp
-          tooltip
           time={_.get(_.find(a.conditions, { type: "Ready" }), "timestamp")}
         />
       ),

--- a/ui/components/AutomationsTable.tsx
+++ b/ui/components/AutomationsTable.tsx
@@ -147,6 +147,7 @@ function AutomationsTable({ className, automations, hideSource }: Props) {
       label: "Last Updated",
       value: (a: Automation) => (
         <Timestamp
+          tooltip
           time={_.get(_.find(a.conditions, { type: "Ready" }), "timestamp")}
         />
       ),

--- a/ui/components/Timestamp.tsx
+++ b/ui/components/Timestamp.tsx
@@ -14,7 +14,9 @@ function Timestamp({ className, time, hideSeconds, tooltip }: Props) {
   const dateTime = DateTime.fromISO(time);
 
   let relativeTime = dateTime.toRelative();
-  const fullTime = dateTime.toLocaleString();
+  const fullTime = dateTime.toLocaleString(
+    DateTime.DATETIME_SHORT_WITH_SECONDS
+  );
 
   if (hideSeconds && relativeTime.includes("second")) {
     relativeTime = "less than a minute ago";
@@ -22,7 +24,7 @@ function Timestamp({ className, time, hideSeconds, tooltip }: Props) {
 
   if (tooltip)
     return (
-      <Tooltip title={fullTime}>
+      <Tooltip title={fullTime} placement="top">
         <span className={className}>{relativeTime}</span>
       </Tooltip>
     );

--- a/ui/components/Timestamp.tsx
+++ b/ui/components/Timestamp.tsx
@@ -1,3 +1,4 @@
+import { Tooltip } from "@material-ui/core";
 import { DateTime } from "luxon";
 import * as React from "react";
 import styled from "styled-components";
@@ -6,16 +7,26 @@ type Props = {
   className?: string;
   time: string;
   hideSeconds?: boolean;
+  tooltip?: boolean;
 };
 
-function Timestamp({ className, time, hideSeconds }: Props) {
-  let formattedTime = DateTime.fromISO(time).toRelative();
+function Timestamp({ className, time, hideSeconds, tooltip }: Props) {
+  const dateTime = DateTime.fromISO(time);
 
-  if (hideSeconds && formattedTime.includes("second")) {
-    formattedTime = "less than a minute ago";
+  let relativeTime = dateTime.toRelative();
+  const fullTime = dateTime.toLocaleString();
+
+  if (hideSeconds && relativeTime.includes("second")) {
+    relativeTime = "less than a minute ago";
   }
 
-  return <span className={className}>{formattedTime}</span>;
+  if (tooltip)
+    return (
+      <Tooltip title={fullTime}>
+        <span className={className}>{relativeTime}</span>
+      </Tooltip>
+    );
+  else return <span className={className}>{relativeTime}</span>;
 }
 
 export default styled(Timestamp)``;


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Part of #3152 

This tooltip prop is currently only going to be used in the GitOps Run table in Enterprise, hence the specificity on localeString, but it's easy to open it up for different formats if we want it to be more flexible and implemented in other tables/components.

Example:
<img width="271" alt="image" src="https://user-images.githubusercontent.com/65822698/217651291-2d24d6f7-bbd0-44e9-aede-ba27ca1ea3e7.png">
