### PR TITLE
change strategy to revision, and add values.yaml to the chart spec

### DIFF
--- a/cmd/gitops/beta/run/cmd.go
+++ b/cmd/gitops/beta/run/cmd.go
@@ -121,7 +121,7 @@ gitops beta run ./deploy/overlays/dev --timeout 3m --port-forward namespace=dev,
 # Run the sync on the podinfo Helm chart, in the session mode. Please note that file Chart.yaml must exist in the directory.
 git clone https://github.com/stefanprodan/podinfo
 cd podinfo
-gitops beta run ./chart/podinfo --timeout 3m --port-forward namespace=flux-system,resource=svc/run-dev-helm-podinfo,port=9898:9898`,
+gitops beta run ./charts/podinfo --timeout 3m --port-forward namespace=flux-system,resource=svc/run-dev-helm-podinfo,port=9898:9898`,
 		SilenceUsage:      true,
 		SilenceErrors:     true,
 		PreRunE:           betaRunCommandPreRunE(&opts.Endpoint),
@@ -427,7 +427,7 @@ func dashboardStep(ctx context.Context, log logger.Logger, kubeClient *kube.Kube
 	return dashboardInstalled, dashboardManifests, "", nil
 }
 
-func runCommandWithSession(cmd *cobra.Command, args []string) (retErr error) {
+func runCommandOuterProcess(cmd *cobra.Command, args []string) (retErr error) {
 	paths, err := run.NewPaths(args[0], flags.RootDir)
 	if err != nil {
 		return err
@@ -567,7 +567,7 @@ func runCommandWithSession(cmd *cobra.Command, args []string) (retErr error) {
 	return err
 }
 
-func runCommandWithoutSession(cmd *cobra.Command, args []string) error {
+func runCommandInnerProcess(cmd *cobra.Command, args []string) error {
 	// There are two loggers in this function.
 	// 1. log0 is the os.Stdout logger
 	// 2. log is the S3 logger that also delegates its outputs to "log0".
@@ -1248,9 +1248,9 @@ func runBootstrap(ctx context.Context, log logger.Logger, paths *run.Paths, mani
 func betaRunCommandRunE(opts *config.Options) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		if flags.NoSession {
-			return runCommandWithoutSession(cmd, args)
+			return runCommandInnerProcess(cmd, args)
 		} else {
-			return runCommandWithSession(cmd, args)
+			return runCommandOuterProcess(cmd, args)
 		}
 	}
 }

--- a/pkg/run/watch/setup_dev_helm.go
+++ b/pkg/run/watch/setup_dev_helm.go
@@ -3,6 +3,7 @@ package watch
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"time"
 
 	helmv2 "github.com/fluxcd/helm-controller/api/v2beta1"
@@ -36,10 +37,15 @@ func SetupBucketSourceAndHelm(ctx context.Context, log logger.Logger, kubeClient
 			Interval: metav1.Duration{Duration: 30 * 24 * time.Hour}, // 30 days
 			Chart: helmv2.HelmChartTemplate{
 				Spec: helmv2.HelmChartTemplateSpec{
-					Chart: params.Path,
+					Chart:             params.Path,
+					ReconcileStrategy: "Revision",
 					SourceRef: helmv2.CrossNamespaceObjectReference{
 						Kind: sourcev1.BucketKind,
 						Name: RunDevBucketName,
+					},
+					// relative to the root of SourceRef
+					ValuesFiles: []string{
+						filepath.Join(params.Path, "values.yaml"),
 					},
 				},
 			},


### PR DESCRIPTION
Fixes #3376

Signed-off-by: Chanwit Kaewkasi <chanwit@weave.works>

This PR introduces changes to the `SetupBucketSourceAndHelm` function in the `watch` package.
The PR makes the following changes to the code:

-  We set the value of the field `ReconcileStrategy` to "Revision" in the `HelmChartTemplateSpec` struct. According to the CRD docs, this field determines the strategy used to create a new artifact, and it is an optional field. The possible values are "ChartVersion" and "Revision", with "ChartVersion" being the default value when omitted.  This change was made to specify the desired strategy used to create a new artifact.  By setting the value of `ReconcileStrategy` to "Revision", we ensure that a new artifact will be created based on the revision of the chart, rather than the version of the chart. This change provides a more precise control over the creation of new artifacts.

  - We set the value of the field `ValuesFiles` in the `HelmChartTemplateSpec` struct to an array containing `filepath.Join(params.Path, "values.yaml")`. According to the CRD docs, this field is an optional array of alternative values files used as input for the Helm chart. The values files are merged in the order of this list, with the last file in the array overriding the first. This field should contain relative paths in the `SourceRef`.  This change was made to specify the desired input for the Helm chart. By setting the value of `ValuesFiles` to an array containing the path to the "values.yaml" file, we ensure that this file will be used as the source of values for the Helm chart.

Other changes are minor refactoring.