### PR TITLE
another attempt to fix ARM builds

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 @weaveworks:registry=https://npm.pkg.github.com
 fetch-timeout=1500000
+maxsockets=1


### PR DESCRIPTION
We're still seeing socket timeouts in CI and the interwebs suggest
reducing the maximum number of open sockets. Let's see if that helps
anything.

refs #3229
