### PR TITLE
address GitOps Run "ask twice" issue by handling "no" answer correctly

### DIFF
--- a/cmd/gitops/beta/run/cmd.go
+++ b/cmd/gitops/beta/run/cmd.go
@@ -356,7 +356,6 @@ func dashboardStep(ctx context.Context, log logger.Logger, kubeClient *kube.Kube
 	switch dashboardType {
 	case install.DashboardTypeEnterprise:
 		flags.SkipDashboardInstall = true
-
 		log.Warningf("GitOps Enterprise Dashboard is found. GitOps OSS Dashboard will not be installed")
 	case install.DashboardTypeOSS:
 		log.Successf("GitOps Dashboard is found")
@@ -373,9 +372,12 @@ func dashboardStep(ctx context.Context, log logger.Logger, kubeClient *kube.Kube
 
 			// Answering "n" causes err to not be nil. Hitting enter without typing
 			// does not return the default.
-			_, err := prompt.Run()
+			answer, err := prompt.Run()
 			if err == nil {
 				wantToInstallTheDashboard = true
+			} else if answer == "n" || answer == "N" {
+				wantToInstallTheDashboard = false
+				flags.SkipDashboardInstall = true
 			}
 		}
 
@@ -508,6 +510,7 @@ func runCommandOuterProcess(cmd *cobra.Command, args []string) (retErr error) {
 		flags.SessionNamespace,
 		fluxVersionInfo.FluxNamespace, // flux namespace of the session
 		portForwardsForSession,
+		flags.SkipDashboardInstall,
 		dashboardHashedPassword,
 		kind,
 	)

--- a/pkg/run/install/session.go
+++ b/pkg/run/install/session.go
@@ -21,6 +21,7 @@ type Session struct {
 	kubeClient              client.Client
 	log                     logger.Logger
 	dashboardHashedPassword string
+	skipDashboardInstall    bool
 	portForwards            []string
 	automationKind          string
 }
@@ -46,9 +47,15 @@ func (s *Session) Connect() error {
 		// we must skip resource cleanup in the sub-process because we are already deleting the vcluster.
 		// it's for optimization purposes.
 		"--skip-resource-cleanup",
-		// we forward dashboard password from host to session too.
-		"--dashboard-hashed-password="+s.dashboardHashedPassword,
 	)
+
+	if s.skipDashboardInstall {
+		// we skip dashboard install in the sub-process.
+		subProcArgs = append(subProcArgs, "--skip-dashboard-install")
+	} else if s.dashboardHashedPassword != "" {
+		// we forward dashboard password from host to session too.
+		subProcArgs = append(subProcArgs, "--dashboard-hashed-password="+s.dashboardHashedPassword)
+	}
 
 	connect := vcluster.ConnectCmd{
 		GlobalFlags: &flags.GlobalFlags{
@@ -105,7 +112,12 @@ func (s *Session) Close() error {
 	return nil
 }
 
-func NewSession(log logger.Logger, kubeClient client.Client, name string, namespace string, fluxNamespace string, portForwards []string, dashboardHashedPassword string, automationKind string) (*Session, error) {
+func NewSession(log logger.Logger,
+	kubeClient client.Client,
+	name string, namespace string,
+	fluxNamespace string, portForwards []string,
+	skipDashboardInstall bool, dashboardHashedPassword string,
+	automationKind string) (*Session, error) {
 	return &Session{
 		name:                    name,
 		namespace:               namespace,
@@ -113,6 +125,7 @@ func NewSession(log logger.Logger, kubeClient client.Client, name string, namesp
 		kubeClient:              kubeClient,
 		log:                     log,
 		portForwards:            portForwards,
+		skipDashboardInstall:    skipDashboardInstall,
 		dashboardHashedPassword: dashboardHashedPassword,
 		automationKind:          automationKind,
 	}, nil


### PR DESCRIPTION
Fixes #3038

The reason for these changes is that the previous implementation of the GitOps Dashboard installation process had a flaw in the dashboard prompt. When the prompt was answered with "no," it was still asked again by the sub-process, resulting in a redundant prompt. 

This PR makes changes in two files. In the `cmd/gitops/beta/run/cmd.go` file, the `dashboardStep` function is modified by adding a constant block with three possible values, `unknown`, `wantToInstall`, and `doNotWantToInstall`. The function handles these values and updates the `wantToInstallTheDashboard` variable accordingly.  If the user chooses not to install the dashboard, it sets the `flags.SkipDashboardInstall` to true.

In the `pkg/run/install/session.go` file, the "NewSession" function, and the "Session" struct have a new parameter `skipDashboardInstall`. The "vcluster.ConnectCmd" command receives this value as a flag. If the "skipDashboardInstall" flag is set to true, then the `--skip-dashboard-install` flag is passed to the sub-process. The "Connect" function checks for the "skipDashboardInstall" flag, and if set, it will not forward the dashboard password to the session.

To test this PR:
- Run GitOps Run in session mode.
- Answer "n" when it asks to install the dashboard, and we should not see the redundant prompt asked by the sub-process.