### PR TITLE
fix: Ctrl+C not working during GitOps Run setup phase

### DIFF
--- a/pkg/run/install/install_fluent_bit.go
+++ b/pkg/run/install/install_fluent_bit.go
@@ -207,7 +207,7 @@ func InstallFluentBit(ctx context.Context, log logger.Logger, kubeClient client.
 
 	log.Actionf("creating HelmRelease %s/%s", helmRelease.Namespace, helmRelease.Name)
 
-	if err := kubeClient.Create(context.Background(), helmRelease); err != nil {
+	if err := kubeClient.Create(ctx, helmRelease); err != nil {
 		if apierrors.IsAlreadyExists(err) {
 			// do nothing
 		} else {
@@ -220,7 +220,7 @@ func InstallFluentBit(ctx context.Context, log logger.Logger, kubeClient client.
 	if err := wait.Poll(2*time.Second, 5*time.Minute, func() (bool, error) {
 		instance := appsv1.DaemonSet{}
 		if err := kubeClient.Get(
-			context.Background(),
+			ctx,
 			types.NamespacedName{
 				Name:      name,
 				Namespace: targetNamespace,


### PR DESCRIPTION
The source of the issues was that a signal handler was installed
before the setup phase but the signal was not actually handled until
after the setup phase has successfully completed.

Now we spawn a goroutine handling the subscribed signals right after
subscribing to them. The goroutine then cancels the context used
throughout the function so that any action is immediately cancelled
during the setup phase. After the setup phase we now wait for the
context do be done instead of handling the actual signal.

I also changed the `InstallFluentBit` function so that it re-uses the
passed-in context when creating and waiting for the Fluent Bit
HelmRelease so that it is interruptible by Ctrl+C as well.

One caveat that is not handled in this commit is that in the case
where a user hits Ctrl+C during the setup phase no cleanup is
performed. This is also true when something during setup fails in
which case the runCommandInnerProcess function just returns so it's
not a problem introduced with this commit and needs to be fixed as
part of a subsequent change.

How to test this change:

1. Without session mode:
   1. Call `gitops run --no-session .`
   2. Hit Ctrl+C during setup, e.g. when you see the "Waiting for
   deployment run-dev-bucket to be ready" message.
2. With session mode:
   1. Call `gitops run .`
   2. Hit Ctrl+C during setup, e.g. when you see the "Waiting for
   deployment run-dev-bucket to be ready" message.

This should immediately print "Received interrupt, quitting" and stop
the process 1-2 seconds later.

closes #3113
