### PR TITLE
Error getting GitOps Run logs before GitOps Run objects are ready

### DIFF
--- a/core/server/session_logs_int_test.go
+++ b/core/server/session_logs_int_test.go
@@ -9,13 +9,18 @@ import (
 
 	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"net/http/httptest"
 
 	"github.com/johannesboyne/gofakes3"
 	"github.com/johannesboyne/gofakes3/backend/s3mem"
 	. "github.com/onsi/gomega"
+	"github.com/weaveworks/weave-gitops/pkg/kube"
 	logger2 "github.com/weaveworks/weave-gitops/pkg/logger"
+	"github.com/weaveworks/weave-gitops/pkg/run/constants"
 )
 
 func TestGetSessionLogsIntegration(t *testing.T) {
@@ -116,4 +121,52 @@ func TestGetSessionLogsIntegration(t *testing.T) {
 	g.Expect(logEntries[1].Message).Should(Equal("✗ round 2 - test failure"))
 	g.Expect(logEntries[1].Level).Should(Equal("error"))
 	g.Expect(logEntries[1].Source).Should(Equal(logger2.SessionLogSource))
+}
+
+func TestIsSecretCreatedSecretFound(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	scheme, err := kube.CreateScheme()
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      constants.RunDevBucketCredentials,
+			Namespace: constants.GitOpsRunNamespace,
+		},
+		Data: map[string][]byte{
+			"key": []byte("value"),
+		},
+	}
+
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(secret).Build()
+
+	created, err := isSecretCreated(context.Background(), cli, constants.GitOpsRunNamespace, constants.RunDevBucketCredentials)
+
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(created).To(BeTrue())
+}
+
+func TestIsSecretCreatedSecretNotFound(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	scheme, err := kube.CreateScheme()
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-name",
+			Namespace: "test-namespace",
+		},
+		Data: map[string][]byte{
+			"key": []byte("value"),
+		},
+	}
+
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(secret).Build()
+
+	created, err := isSecretCreated(context.Background(), cli, constants.GitOpsRunNamespace, constants.RunDevBucketCredentials)
+
+	g.Expect(err).Should(HaveOccurred())
+	g.Expect(created).To(BeFalse())
 }

--- a/ui/components/AutomationDetail.tsx
+++ b/ui/components/AutomationDetail.tsx
@@ -94,8 +94,6 @@ function AutomationDetail({
         automation.clusterName
       )
     : { data: [], error: null, isLoading: false };
-  //add extra nodes
-
   const reconciledObjectsAutomation: ReconciledObjectsAutomation = {
     objects,
     error,

--- a/ui/components/DataTable.tsx
+++ b/ui/components/DataTable.tsx
@@ -380,7 +380,7 @@ function UnstyledDataTable({
     );
 
     let query = qs.parse(search);
-    console.log(textFilters.join("_"));
+
     if (textFilters.length) query["search"] = textFilters.join("_") + "_";
     else if (query["search"]) query = _.omit(query, "search");
     history.replace({ ...location, search: qs.stringify(query) });


### PR DESCRIPTION
Closes https://github.com/weaveworks/weave-gitops/issues/3379

- Updated the error message for getting a scoped client.

- Added a check for the log secret already existing.

- Added unit tests for `isSecretCreated`.

- Removed unneeded comments.

Testing:

- Pull in the current PR branch, GitOps Run and go to the session details page before the session is completely ready (you should see the "cluster not found" error in the UI, this is expected behavior).
- 
When the session objects get ready and polling logs succeeds, logs are displayed without errors.
