### PR TITLE
Error getting GitOps Run logs before GitOps Run objects are ready

### DIFF
--- a/core/server/session_logs.go
+++ b/core/server/session_logs.go
@@ -125,10 +125,13 @@ func (cs *coreServer) GetSessionLogs(ctx context.Context, msg *pb.GetSessionLogs
 
 	logSourceFilter := msg.GetLogSourceFilter()
 	isLoadingGitOpsRunLogs := logSourceFilter == "" || logSourceFilter == logger.SessionLogSource
-	// check if we can get session logs already
-	// if the secret is not created yet, we should not display an error in the browser console
-	if err = isSecretCreated(ctx, cli, constants.GitOpsRunNamespace, constants.RunDevBucketCredentials); err != nil {
-		return &pb.GetSessionLogsResponse{Error: secretNotFound}, nil
+
+	if isLoadingGitOpsRunLogs {
+		// check if we can get session logs already
+		// if the secret is not created yet, we should not display an error in the browser console
+		if err = isSecretCreated(ctx, cli, constants.GitOpsRunNamespace, constants.RunDevBucketCredentials); err != nil {
+			return &pb.GetSessionLogsResponse{Error: secretNotFound}, nil
+		}
 	}
 
 	info, err := getBucketConnectionInfo(ctx, clusterName, fluxNamespace, cli)


### PR DESCRIPTION
Follow-up number 2 to https://github.com/weaveworks/weave-gitops/issues/3379

A minor fix. Didn't push all of my code in the previous PR. Just moved the check for the secret within the condition.

