### PR TITLE
Take "storage" version into account for Flux CRDs

### DIFF
--- a/core/server/fluxruntime.go
+++ b/core/server/fluxruntime.go
@@ -162,8 +162,13 @@ func (cs *coreServer) ListFluxCrds(ctx context.Context, msg *pb.ListFluxCrdsRequ
 			for _, d := range list.Items {
 				version := ""
 
-				if len(d.Spec.Versions) > 0 {
-					version = d.Spec.Versions[0].Name
+				for _, v := range d.Spec.Versions {
+					// This is the "active" version of the CRD in etcd, and a CRD
+					// can only have one version marked as such.
+					if v.Storage {
+						version = v.Name
+						break
+					}
 				}
 
 				r := &pb.Crd{

--- a/core/server/fluxruntime_test.go
+++ b/core/server/fluxruntime_test.go
@@ -436,8 +436,12 @@ func TestListFluxCrds(t *testing.T) {
 		Name:   "crd2",
 		Labels: map[string]string{stypes.PartOfLabel: "flux"},
 	}, Spec: apiextensions.CustomResourceDefinitionSpec{
-		Group:    "group",
-		Versions: []apiextensions.CustomResourceDefinitionVersion{{Name: "0"}},
+		Group: "group",
+		Versions: []apiextensions.CustomResourceDefinitionVersion{
+			{Name: "0"},
+			// "Active" version in etcd, use this one.
+			{Name: "1", Storage: true},
+		},
 	}}
 	scheme, err := kube.CreateScheme()
 	g.Expect(err).To(BeNil())
@@ -457,5 +461,5 @@ func TestListFluxCrds(t *testing.T) {
 	g.Expect(first.Name.Group).To(Equal("group"))
 	g.Expect(first.Kind).To(Equal("kind"))
 	g.Expect(first.ClusterName).To(Equal(cluster.DefaultCluster))
-	g.Expect(res.Crds[1].Version).To(Equal("0"))
+	g.Expect(res.Crds[1].Version).To(Equal("1"))
 }


### PR DESCRIPTION
This ensures the active version stored in etcd is showed in the UI, instead of the first version on the list. Providing a more accurate view of the current version existing in the cluster.

Fixes #3446