### PR TITLE
Uninstall Fluent Bit when stopping a GitOps Run session

### DIFF
--- a/cmd/gitops/beta/run/cleanup.go
+++ b/cmd/gitops/beta/run/cleanup.go
@@ -1,0 +1,59 @@
+package run
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/weaveworks/weave-gitops/pkg/logger"
+)
+
+// CleanupFunc is a function supposed to be called while a GitOps Run session
+// is terminating. Each component creating resources on the cluster should
+// return such a function that is then added to the CleanupFuncs stack by
+// the orchestrating code and removed from it and executed during shutdown.
+type CleanupFunc func(ctx context.Context) error
+
+// CleanupFuncs is a stack holding CleanupFunc references that are used
+// to roll up all resources created during an GitOps Run session as soon
+// as the session is terminated.
+type CleanupFuncs struct {
+	fns []CleanupFunc
+}
+
+// Push implements the stack's Push operation, adding the given CleanupFunc
+// to the top of the stack.
+func (c *CleanupFuncs) Push(f CleanupFunc) {
+	c.fns = append(c.fns, f)
+}
+
+var ErrEmptyStack = errors.New("stack is empty")
+
+// Pop implements the stack's Pop operation, returning and removing
+// the top CleanupFunc from the stack.
+func (c *CleanupFuncs) Pop() (CleanupFunc, error) {
+	if len(c.fns) == 0 {
+		return nil, ErrEmptyStack
+	}
+	var res CleanupFunc
+	res, c.fns = c.fns[len(c.fns)-1], c.fns[:len(c.fns)-1]
+	return res, nil
+}
+
+func CleanupCluster(ctx context.Context, log logger.Logger, fns CleanupFuncs) error {
+	for {
+		fn, err := fns.Pop()
+		if err != nil {
+			if err != ErrEmptyStack {
+				return fmt.Errorf("failed fetching next cleanup function: %w", err)
+			}
+			break
+		}
+		if err := fn(ctx); err != nil {
+			log.Failuref("failed cleaning up: %s", err)
+		}
+
+	}
+
+	return nil
+}

--- a/cmd/gitops/beta/run/cleanup_test.go
+++ b/cmd/gitops/beta/run/cleanup_test.go
@@ -1,0 +1,91 @@
+package run_test
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"github.com/weaveworks/weave-gitops/cmd/gitops/beta/run"
+	"github.com/weaveworks/weave-gitops/pkg/logger"
+)
+
+func TestCleanupWorksWithNil(t *testing.T) {
+	g := NewWithT(t)
+
+	var s run.CleanupFuncs
+	f1 := func(ctx context.Context) error { return nil }
+	f2 := func(ctx context.Context) error { return nil }
+
+	s.Push(f1)
+	s.Push(nil)
+	s.Push(f2)
+
+	fn, err := s.Pop()
+	g.Expect(err).NotTo(HaveOccurred(), "pop returned an unexpected error")
+	g.Expect(
+		reflect.ValueOf(fn).Pointer()).
+		To(Equal(reflect.ValueOf(f2).Pointer()), "value returned from stack is not f2")
+
+	fn, err = s.Pop()
+	g.Expect(err).NotTo(HaveOccurred(), "pop returned an unexpected error")
+	g.Expect(fn).To(BeNil(), "unexpected value returned from stack")
+
+	fn, err = s.Pop()
+	g.Expect(err).NotTo(HaveOccurred(), "pop returned an unexpected error")
+	g.Expect(
+		reflect.ValueOf(fn).Pointer()).
+		To(Equal(reflect.ValueOf(f1).Pointer()), "value returned from stack is not f1")
+
+	fn, err = s.Pop()
+	g.Expect(err).To(Equal(run.ErrEmptyStack), "pop returned an unexpected error")
+	g.Expect(fn).To(BeNil(), "unexpected value returned from stack")
+}
+
+func TestCleanupFailsGracefullyOnConsecutiveCallsToPop(t *testing.T) {
+	g := NewWithT(t)
+
+	var s run.CleanupFuncs
+	fn, err := s.Pop()
+	g.Expect(err).To(Equal(run.ErrEmptyStack), "unexpected error returned from pop")
+	g.Expect(fn).To(BeNil(), "unexpected value returned from pop")
+
+	fn, err = s.Pop()
+	g.Expect(err).To(Equal(run.ErrEmptyStack), "unexpected error returned from pop")
+	g.Expect(fn).To(BeNil(), "unexpected value returned from pop")
+}
+
+func TestCleanupClusterRunsAllFunctionsFromStackInCorrectOrder(t *testing.T) {
+	g := NewWithT(t)
+
+	cnt := 0
+	var s run.CleanupFuncs
+
+	s.Push(func(ctx context.Context) error { cnt *= 2; return nil })
+	s.Push(func(ctx context.Context) error { cnt += 4; return nil })
+	s.Push(func(ctx context.Context) error { cnt = 3; return nil })
+
+	err := run.CleanupCluster(context.Background(), nil, s)
+	g.Expect(err).NotTo(HaveOccurred(), "unexpected error returned")
+	g.Expect(cnt).To(Equal(14), "unexpected execution order")
+}
+
+func TestCleanupClusterLogsAllErrors(t *testing.T) {
+	g := NewWithT(t)
+
+	cnt := 0
+	var s run.CleanupFuncs
+
+	s.Push(func(ctx context.Context) error { cnt *= 2; return nil })
+	s.Push(func(ctx context.Context) error { cnt += 4; return nil })
+	s.Push(func(ctx context.Context) error { return fmt.Errorf("foo") })
+	s.Push(func(ctx context.Context) error { cnt = 3; return nil })
+
+	var buf strings.Builder
+	err := run.CleanupCluster(context.Background(), logger.NewCLILogger(&buf), s)
+	g.Expect(err).NotTo(HaveOccurred(), "function should not have returned an error")
+	g.Expect(cnt).To(Equal(14), "unexpected execution order")
+	g.Expect(buf.String()).To(Equal("✗ failed cleaning up: foo\n"), "unexpected log output")
+}

--- a/cmd/gitops/beta/run/cmd.go
+++ b/cmd/gitops/beta/run/cmd.go
@@ -334,15 +334,19 @@ func fluxStep(log logger.Logger, kubeClient *kube.KubeHTTP) (fluxVersion *instal
 	return fluxVersion, false, nil
 }
 
-func fluentBitStep(ctx context.Context, log logger.Logger, kubeClient *kube.KubeHTTP, devBucketHTTPPort int32) error {
+// fluentBitStep installs Fluent Bit on the cluster and returns a CleanupFunc to remove it again. The function
+// ascertains that Fluent Bit is ready before returning.
+func fluentBitStep(ctx context.Context, log logger.Logger, kubeClient *kube.KubeHTTP, devBucketHTTPPort int32) (CleanupFunc, error) {
 	err := install.InstallFluentBit(ctx, log, kubeClient, flags.Namespace, constants.GitOpsRunNamespace, install.FluentBitHRName, logger.PodLogBucketName, devBucketHTTPPort)
 
 	if err != nil {
 		log.Failuref("Fluent Bit installation failed: %v", err.Error())
-		return err
+		return nil, err
 	}
 
-	return nil
+	return func(ctx context.Context) error {
+		return install.UninstallFluentBit(ctx, log, kubeClient, flags.Namespace, install.FluentBitHRName)
+	}, nil
 }
 
 func dashboardStep(ctx context.Context, log logger.Logger, kubeClient *kube.KubeHTTP, generateManifestsOnly bool, dashboardHashedPassword string) (install.DashboardType, []byte, string, error) {
@@ -637,6 +641,8 @@ func runCommandInnerProcess(cmd *cobra.Command, args []string) error {
 	// the outer process traps SIGTERM and SIGINT and sends SIGUSR1 to the inner process.
 	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM, syscall.SIGUSR1)
 
+	cleanupFns := CleanupFuncs{}
+
 	go func() {
 		select {
 		case <-ctx.Done():
@@ -725,10 +731,12 @@ func runCommandInnerProcess(cmd *cobra.Command, args []string) error {
 	}
 
 	// ====================== Fluent-Bit =====================
-	if err := fluentBitStep(ctx, log, kubeClient, devBucketHTTPPort); err != nil {
+	fbCleanupFn, err := fluentBitStep(ctx, log, kubeClient, devBucketHTTPPort)
+	if err != nil {
 		cancel()
 		return err
 	}
+	cleanupFns.Push(fbCleanupFn)
 
 	// ====================== Dashboard ======================
 	var (
@@ -1031,10 +1039,14 @@ func runCommandInnerProcess(cmd *cobra.Command, args []string) error {
 
 	<-ctx.Done()
 
-	close(stopUploadCh)
-	cancel()
-	// create new context that isn't cancelled, for bootstrapping
+	// create new context that isn't cancelled, for cleanup and bootstrapping
 	ctx = context.Background()
+
+	if err := CleanupCluster(ctx, log0, cleanupFns); err != nil {
+		return fmt.Errorf("failed cleaning up: %w", err)
+	}
+
+	close(stopUploadCh)
 
 	if err := watcher.Close(); err != nil {
 		log.Warningf("Error closing watcher: %v", err.Error())

--- a/core/server/session_logs_test.go
+++ b/core/server/session_logs_test.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	pb "github.com/weaveworks/weave-gitops/pkg/api/core"
 	"io"
 	"strings"
 	"testing"
 	"time"
+
+	pb "github.com/weaveworks/weave-gitops/pkg/api/core"
 
 	. "github.com/onsi/gomega"
 
@@ -98,7 +99,6 @@ func TestGetBucketConnectionInfo(t *testing.T) {
 }
 
 type mockS3Reader struct {
-	s3Reader
 }
 
 var _ = s3Reader(&mockS3Reader{})


### PR DESCRIPTION
The Fluent Bit HelmRelease is not removed from the cluster as soon as
the GitOps Run session terminates. Prior to this you weren't able to
start another session after terminating the first one.

This commit introduces the `CleanupFunc` type that `fluentBitStep`
returns. This function is pushed onto a stack and at session
termination each function on that stack is popped and executed,
guaranteeing a reverse rollup of any resources created by GitOps Run itself.

We should gradually add the `CleanupFunc` type to the other steps,
too so that cleanup is done in a standardized manner.

Before:

```
$ gitops run --no-session ./kustomize/
► Checking for a cluster in the kube config ...
[...]
► Request reconciliation of GitOps Run resources (timeout 5m0s) ...
✔ Reconciliation is done.
^C► Received interrupt, quitting...
[...]
$ k get hr -A
NAMESPACE     NAME         AGE   READY   STATUS
flux-system   fluent-bit   62s   True    Release reconciliation succeeded
$ $ gitops run --no-session ./kustomize/
[...]
► waiting for HelmRelease flux-system/fluent-bit to be ready
✗ HelmRelease flux-system/fluent-bit failed to become ready
✗ Fluent Bit installation failed: timed out waiting for the condition
Error: timed out waiting for the condition
```

After:

```
$ gitops run --no-session ./kustomize/
► Checking for a cluster in the kube config ...
[...]
► Request reconciliation of GitOps Run resources (timeout 5m0s) ...
✔ Reconciliation is done.
^C► Received interrupt, quitting...
[...]
$ k get hr -A
No resources found
$ $ gitops run --no-session ./kustomize/
[...]
✔ Reconciliation is done.
```

closes #3375