### PR TITLE
Openshift: Allow removal of securityContext with Helm values

### DIFF
--- a/charts/gitops-server/templates/deployment.yaml
+++ b/charts/gitops-server/templates/deployment.yaml
@@ -32,12 +32,16 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "chart.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
       securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
+          {{- with .Values.securityContext }}
           securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes

<!-- Describe what has changed in this PR -->
**What changed?**

This PR puts a conditional `with` block around the `securityContext` properties in the Deployment Helm template. This will ensure that the element is not rendered if the corresponding value is empty. This seems to be the pattern used in this, and other templates of the Helm chart.

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**

This allows installation on Openshift without elevated SCC permissions. This is a common problem when provisioning community software to Openshift. The intentions of default security contexts are good, but sadly Openshift does not allow it. Here's a random goog explanation: https://github.com/bitnami/charts/issues/4884#issuecomment-754648273

<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**

n/a (trivial change)

<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**

n/a (trivial change)

<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**

n/a

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**

n/a