### PR TITLE
Add DetailModal component, and convert pop up YamlViews to use it

### DIFF
--- a/ui/components/AlertsTable.tsx
+++ b/ui/components/AlertsTable.tsx
@@ -1,7 +1,7 @@
-import { Dialog } from "@material-ui/core";
 import qs from "query-string";
 import * as React from "react";
 import styled from "styled-components";
+import { AppContext } from "../contexts/AppContext";
 import { useFeatureFlags } from "../hooks/featureflags";
 import { Kind } from "../lib/api/core/types.pb";
 import { Alert, CrossNamespaceObjectRef } from "../lib/objects";
@@ -12,11 +12,11 @@ import DataTable, {
   filterByStatusCallback,
   filterConfig,
 } from "./DataTable";
+import { DetailOptions } from "./DetailModal";
 import { filterSeparator } from "./FilterDialog";
 import KubeStatusIndicator from "./KubeStatusIndicator";
 import Link from "./Link";
 import Text from "./Text";
-import { DialogYamlView } from "./YamlView";
 type Props = {
   className?: string;
   rows?: Alert[];
@@ -49,13 +49,22 @@ function AlertsTable({ className, rows = [] }: Props) {
     };
   }
 
-  const [yamlView, setYamlView] = React.useState<Alert>(null);
+  const { setDetailModal } = React.useContext(AppContext);
 
   const alertFields: Field[] = [
     {
       label: "Name",
-      value: (a) => (
-        <Text onClick={() => setYamlView(a)} color="primary10" pointer>
+      value: (a: Alert) => (
+        <Text
+          onClick={() =>
+            setDetailModal({
+              component: DetailOptions.YamlView,
+              props: { object: { ...a, kind: a.type }, yaml: a.yaml },
+            })
+          }
+          color="primary10"
+          pointer
+        >
           {a.name}
         </Text>
       ),
@@ -112,31 +121,12 @@ function AlertsTable({ className, rows = [] }: Props) {
   ];
 
   return (
-    <>
-      <DataTable
-        className={className}
-        fields={alertFields}
-        rows={rows}
-        filters={initialFilterState}
-      />
-      <Dialog
-        open={yamlView !== null}
-        onClose={() => setYamlView(null)}
-        maxWidth="md"
-        fullWidth
-      >
-        {yamlView && (
-          <DialogYamlView
-            object={{
-              name: yamlView.name,
-              namespace: yamlView.namespace,
-              kind: yamlView.type,
-            }}
-            yaml={yamlView.yaml}
-          />
-        )}
-      </Dialog>
-    </>
+    <DataTable
+      className={className}
+      fields={alertFields}
+      rows={rows}
+      filters={initialFilterState}
+    />
   );
 }
 

--- a/ui/components/AlertsTable.tsx
+++ b/ui/components/AlertsTable.tsx
@@ -59,7 +59,15 @@ function AlertsTable({ className, rows = [] }: Props) {
           onClick={() =>
             setDetailModal({
               component: DetailOptions.YamlView,
-              props: { object: { ...a, kind: a.type }, yaml: a.yaml },
+              props: {
+                object: {
+                  name: a.name,
+                  namespace: a.namespace,
+                  clusterName: a.clusterName,
+                  kind: a.type,
+                },
+                yaml: a.yaml,
+              },
             })
           }
           color="primary10"

--- a/ui/components/AlertsTable.tsx
+++ b/ui/components/AlertsTable.tsx
@@ -12,7 +12,6 @@ import DataTable, {
   filterByStatusCallback,
   filterConfig,
 } from "./DataTable";
-import { DetailOptions } from "./DetailModal";
 import { filterSeparator } from "./FilterDialog";
 import KubeStatusIndicator from "./KubeStatusIndicator";
 import Link from "./Link";
@@ -58,16 +57,7 @@ function AlertsTable({ className, rows = [] }: Props) {
         <Text
           onClick={() =>
             setDetailModal({
-              component: DetailOptions.YamlView,
-              props: {
-                object: {
-                  name: a.name,
-                  namespace: a.namespace,
-                  clusterName: a.clusterName,
-                  kind: a.type,
-                },
-                yaml: a.yaml,
-              },
+              object: a,
             })
           }
           color="primary10"

--- a/ui/components/AutomationDetail.tsx
+++ b/ui/components/AutomationDetail.tsx
@@ -1,8 +1,6 @@
-import { Dialog } from "@material-ui/core";
 import * as React from "react";
 import { useRouteMatch } from "react-router-dom";
 import styled from "styled-components";
-import { AppContext } from "../contexts/AppContext";
 import { useSyncFluxObject } from "../hooks/automations";
 import { useGetReconciledTree, useToggleSuspend } from "../hooks/flux";
 import { Condition, Kind, ObjectRef } from "../lib/api/core/types.pb";
@@ -23,7 +21,7 @@ import Spacer from "./Spacer";
 import SubRouterTabs, { RouterTab } from "./SubRouterTabs";
 import SyncButton from "./SyncButton";
 import Text from "./Text";
-import YamlView, { DialogYamlView } from "./YamlView";
+import YamlView from "./YamlView";
 
 type Props = {
   automation: Automation;
@@ -54,8 +52,6 @@ function AutomationDetail({
   customActions,
 }: Props) {
   const { path } = useRouteMatch();
-  const { setNodeYaml, appState } = React.useContext(AppContext);
-  const nodeYaml = appState.nodeYaml;
   const sync = useSyncFluxObject([
     {
       name: automation.name,
@@ -232,23 +228,6 @@ function AutomationDetail({
             )
         )}
       </SubRouterTabs>
-      {nodeYaml && (
-        <Dialog
-          open={!!nodeYaml}
-          onClose={() => setNodeYaml(null)}
-          maxWidth="md"
-          fullWidth
-        >
-          <DialogYamlView
-            object={{
-              name: nodeYaml.name,
-              namespace: nodeYaml.namespace,
-              kind: nodeYaml.type,
-            }}
-            yaml={nodeYaml.yaml}
-          />
-        </Dialog>
-      )}
     </Flex>
   );
 }

--- a/ui/components/DetailModal.tsx
+++ b/ui/components/DetailModal.tsx
@@ -14,7 +14,7 @@ export type DetailViewProps = {
   props: PropOptions;
 };
 
-function DetailModal({ className, props, component }: DetailViewProps) {
+function DetailModal({ props, component }: DetailViewProps) {
   switch (component) {
     case DetailOptions.YamlView:
       return <DialogYamlView {...props} />;

--- a/ui/components/DetailModal.tsx
+++ b/ui/components/DetailModal.tsx
@@ -1,24 +1,47 @@
-import React from "react";
+import { IconButton } from "@material-ui/core";
+import { Close } from "@material-ui/icons";
+import React, { useContext } from "react";
 import styled from "styled-components";
-import { DialogYamlView, YamlViewProps } from "./YamlView";
-
-export enum DetailOptions {
-  YamlView = "YamlView",
-}
-
-export type PropOptions = YamlViewProps;
+import { AppContext } from "../contexts/AppContext";
+import { FluxObject, FluxObjectNode } from "../lib/objects";
+import Flex from "./Flex";
+import Text from "./Text";
+import { DialogYamlView } from "./YamlView";
 
 export type DetailViewProps = {
   className?: string;
-  component: DetailOptions;
-  props: PropOptions;
+  object: FluxObject | FluxObjectNode;
 };
 
-function DetailModal({ props, component }: DetailViewProps) {
-  switch (component) {
-    case DetailOptions.YamlView:
-      return <DialogYamlView {...props} />;
-  }
+const HeaderFlex = styled(Flex)`
+  margin-bottom: ${(props) => props.theme.spacing.xs};
+`;
+
+function DetailModal({ object, className }: DetailViewProps) {
+  const { setDetailModal } = useContext(AppContext);
+  return (
+    <div className={className}>
+      <HeaderFlex between align>
+        <Text size="large" bold color="neutral30">
+          {object.name}
+        </Text>
+        <IconButton onClick={() => setDetailModal(null)}>
+          <Close />
+        </IconButton>
+      </HeaderFlex>
+      <DialogYamlView
+        object={{
+          name: object.name,
+          namespace: object.namespace,
+          clusterName: object.clusterName,
+          kind: object.type,
+        }}
+        yaml={object.yaml}
+      />
+    </div>
+  );
 }
 
-export default styled(DetailModal).attrs({ className: DetailModal.name })``;
+export default styled(DetailModal).attrs({ className: DetailModal.name })`
+  padding: ${(props) => props.theme.spacing.small};
+`;

--- a/ui/components/DetailModal.tsx
+++ b/ui/components/DetailModal.tsx
@@ -1,0 +1,12 @@
+import * as React from "react";
+import styled from "styled-components";
+
+type Props = {
+  className?: string;
+};
+
+function DetailModal({ className }: Props) {
+  return <div className={className}></div>;
+}
+
+export default styled(DetailModal).attrs({ className: DetailModal.name })``;

--- a/ui/components/DetailModal.tsx
+++ b/ui/components/DetailModal.tsx
@@ -1,12 +1,24 @@
-import * as React from "react";
+import React from "react";
 import styled from "styled-components";
+import { DialogYamlView, YamlViewProps } from "./YamlView";
 
-type Props = {
+export enum DetailOptions {
+  YamlView = "YamlView",
+}
+
+export type PropOptions = YamlViewProps;
+
+export type DetailViewProps = {
   className?: string;
+  component: DetailOptions;
+  props: PropOptions;
 };
 
-function DetailModal({ className }: Props) {
-  return <div className={className}></div>;
+function DetailModal({ className, props, component }: DetailViewProps) {
+  switch (component) {
+    case DetailOptions.YamlView:
+      return <DialogYamlView {...props} />;
+  }
 }
 
 export default styled(DetailModal).attrs({ className: DetailModal.name })``;

--- a/ui/components/FluxObjectsTable.tsx
+++ b/ui/components/FluxObjectsTable.tsx
@@ -7,6 +7,7 @@ import { formatURL, objectTypeToRoute } from "../lib/nav";
 import { FluxObject } from "../lib/objects";
 import { makeImageString, statusSortHelper } from "../lib/utils";
 import DataTable from "./DataTable";
+import { DetailOptions, DetailViewProps } from "./DetailModal";
 import ImageLink from "./ImageLink";
 import KubeStatusIndicator, {
   computeMessage,
@@ -19,7 +20,7 @@ import Text from "./Text";
 
 type Props = {
   className?: string;
-  onClick?: (o: FluxObject) => void;
+  onClick?: (o: DetailViewProps) => void;
   objects: FluxObject[];
   initialFilterState?: any;
 };
@@ -59,7 +60,14 @@ function FluxObjectsTable({
 
             return (
               <Text
-                onClick={() => (secret ? null : onClick(u))}
+                onClick={() =>
+                  secret
+                    ? null
+                    : onClick({
+                        component: DetailOptions.YamlView,
+                        props: { object: { ...u, kind: u.type }, yaml: u.yaml },
+                      })
+                }
                 color={secret ? "neutral40" : "primary10"}
                 pointer={!secret}
               >

--- a/ui/components/FluxObjectsTable.tsx
+++ b/ui/components/FluxObjectsTable.tsx
@@ -65,7 +65,15 @@ function FluxObjectsTable({
                     ? null
                     : onClick({
                         component: DetailOptions.YamlView,
-                        props: { object: { ...u, kind: u.type }, yaml: u.yaml },
+                        props: {
+                          object: {
+                            name: u.name,
+                            namespace: u.namespace,
+                            clusterName: u.namespace,
+                            kind: u.type,
+                          },
+                          yaml: u.yaml,
+                        },
                       })
                 }
                 color={secret ? "neutral40" : "primary10"}

--- a/ui/components/FluxObjectsTable.tsx
+++ b/ui/components/FluxObjectsTable.tsx
@@ -7,7 +7,7 @@ import { formatURL, objectTypeToRoute } from "../lib/nav";
 import { FluxObject } from "../lib/objects";
 import { makeImageString, statusSortHelper } from "../lib/utils";
 import DataTable from "./DataTable";
-import { DetailOptions, DetailViewProps } from "./DetailModal";
+import { DetailViewProps } from "./DetailModal";
 import ImageLink from "./ImageLink";
 import KubeStatusIndicator, {
   computeMessage,
@@ -64,16 +64,7 @@ function FluxObjectsTable({
                   secret
                     ? null
                     : onClick({
-                        component: DetailOptions.YamlView,
-                        props: {
-                          object: {
-                            name: u.name,
-                            namespace: u.namespace,
-                            clusterName: u.namespace,
-                            kind: u.type,
-                          },
-                          yaml: u.yaml,
-                        },
+                        object: u,
                       })
                 }
                 color={secret ? "neutral40" : "primary10"}

--- a/ui/components/GraphNode.tsx
+++ b/ui/components/GraphNode.tsx
@@ -7,7 +7,6 @@ import { Kind } from "../lib/api/core/types.pb";
 import images from "../lib/images";
 import { formatURL, objectTypeToRoute } from "../lib/nav";
 import { FluxObjectNode } from "../lib/objects";
-import { DetailOptions } from "./DetailModal";
 import Flex from "./Flex";
 import { computeReady, ReadyType } from "./KubeStatusIndicator";
 import Link from "./Link";
@@ -131,16 +130,7 @@ function GraphNode({ className, object }: Props) {
                   secret
                     ? null
                     : setDetailModal({
-                        component: DetailOptions.YamlView,
-                        props: {
-                          object: {
-                            name: object.name,
-                            namespace: object.namespace,
-                            clusterName: object.clusterName,
-                            kind: object.type,
-                          },
-                          yaml: object.yaml,
-                        },
+                        object: object,
                       })
                 }
                 color={secret ? "neutral40" : "primary10"}

--- a/ui/components/GraphNode.tsx
+++ b/ui/components/GraphNode.tsx
@@ -7,11 +7,11 @@ import { Kind } from "../lib/api/core/types.pb";
 import images from "../lib/images";
 import { formatURL, objectTypeToRoute } from "../lib/nav";
 import { FluxObjectNode } from "../lib/objects";
+import { DetailOptions } from "./DetailModal";
 import Flex from "./Flex";
 import { computeReady, ReadyType } from "./KubeStatusIndicator";
 import Link from "./Link";
 import Text from "./Text";
-
 type Props = {
   className?: string;
   object?: FluxObjectNode;
@@ -85,7 +85,7 @@ function getStatusIcon(status: ReadyType, suspended: boolean) {
 }
 
 function GraphNode({ className, object }: Props) {
-  const { setNodeYaml } = React.useContext(AppContext);
+  const { setDetailModal } = React.useContext(AppContext);
   const status = computeReady(object.conditions);
   const secret = object.type === "Secret";
 
@@ -127,7 +127,17 @@ function GraphNode({ className, object }: Props) {
             ) : (
               <Text
                 size="huge"
-                onClick={() => (secret ? null : setNodeYaml(object))}
+                onClick={() =>
+                  secret
+                    ? null
+                    : setDetailModal({
+                        component: DetailOptions.YamlView,
+                        props: {
+                          object: { ...object, kind: object.type },
+                          yaml: object.yaml,
+                        },
+                      })
+                }
                 color={secret ? "neutral40" : "primary10"}
                 pointer={!secret}
                 semiBold={object.isCurrentNode}

--- a/ui/components/GraphNode.tsx
+++ b/ui/components/GraphNode.tsx
@@ -133,7 +133,12 @@ function GraphNode({ className, object }: Props) {
                     : setDetailModal({
                         component: DetailOptions.YamlView,
                         props: {
-                          object: { ...object, kind: object.type },
+                          object: {
+                            name: object.name,
+                            namespace: object.namespace,
+                            clusterName: object.clusterName,
+                            kind: object.type,
+                          },
                           yaml: object.yaml,
                         },
                       })

--- a/ui/components/Layout.tsx
+++ b/ui/components/Layout.tsx
@@ -1,7 +1,9 @@
+import { Drawer } from "@material-ui/core";
 import React, { useState } from "react";
 import styled from "styled-components";
 import { V2Routes } from "../lib/types";
 import Breadcrumbs from "./Breadcrumbs";
+import DetailModal from "./DetailModal";
 import Flex from "./Flex";
 import { IconType } from "./Icon";
 import Logo from "./Logo";
@@ -114,6 +116,10 @@ function Layout({ className, children }: Props) {
         />
         <ContentContainer>{children}</ContentContainer>
       </Main>
+      <Drawer anchor="right" open={true} ModalProps={{ keepMounted: false }}>
+        <DetailModal />
+        <div>hi</div>
+      </Drawer>
     </AppContainer>
   );
 }

--- a/ui/components/Layout.tsx
+++ b/ui/components/Layout.tsx
@@ -104,7 +104,7 @@ function Layout({ className, children }: Props) {
   const { appState, setDetailModal } = useContext(AppContext);
 
   const detail = appState.detailModal;
-
+  console.log(appState);
   return (
     <AppContainer className={className}>
       <TopToolBar start align wide>
@@ -127,11 +127,7 @@ function Layout({ className, children }: Props) {
         ModalProps={{ keepMounted: false }}
       >
         {detail && (
-          <DetailModal
-            component={detail.component}
-            props={detail.props}
-            className={detail.className}
-          />
+          <DetailModal className={detail.className} object={detail.object} />
         )}
       </Drawer>
     </AppContainer>

--- a/ui/components/Layout.tsx
+++ b/ui/components/Layout.tsx
@@ -104,7 +104,7 @@ function Layout({ className, children }: Props) {
   const { appState, setDetailModal } = useContext(AppContext);
 
   const detail = appState.detailModal;
-  console.log(appState);
+
   return (
     <AppContainer className={className}>
       <TopToolBar start align wide>

--- a/ui/components/Layout.tsx
+++ b/ui/components/Layout.tsx
@@ -1,6 +1,7 @@
 import { Drawer } from "@material-ui/core";
-import React, { useState } from "react";
+import React, { useContext, useState } from "react";
 import styled from "styled-components";
+import { AppContext } from "../contexts/AppContext";
 import { V2Routes } from "../lib/types";
 import Breadcrumbs from "./Breadcrumbs";
 import DetailModal from "./DetailModal";
@@ -100,6 +101,9 @@ const TopToolBar = styled(Flex)`
 
 function Layout({ className, children }: Props) {
   const [collapsed, setCollapsed] = useState<boolean>(false);
+  const { appState, setDetailModal } = useContext(AppContext);
+
+  const detail = appState.detailModal;
 
   return (
     <AppContainer className={className}>
@@ -116,9 +120,19 @@ function Layout({ className, children }: Props) {
         />
         <ContentContainer>{children}</ContentContainer>
       </Main>
-      <Drawer anchor="right" open={true} ModalProps={{ keepMounted: false }}>
-        <DetailModal />
-        <div>hi</div>
+      <Drawer
+        anchor="right"
+        open={detail ? true : false}
+        onClose={() => setDetailModal(null)}
+        ModalProps={{ keepMounted: false }}
+      >
+        {detail && (
+          <DetailModal
+            component={detail.component}
+            props={detail.props}
+            className={detail.className}
+          />
+        )}
       </Drawer>
     </AppContainer>
   );

--- a/ui/components/ReconciledObjectsTable.tsx
+++ b/ui/components/ReconciledObjectsTable.tsx
@@ -23,14 +23,14 @@ function ReconciledObjectsTable({
     ...filterConfig(objects, "status", filterByStatusCallback),
   };
 
-  const { setNodeYaml } = React.useContext(AppContext);
+  const { setDetailModal } = React.useContext(AppContext);
 
   return (
     <RequestStateHandler loading={isLoading} error={error}>
       <FluxObjectsTable
         className={className}
         objects={objects}
-        onClick={setNodeYaml}
+        onClick={setDetailModal}
         initialFilterState={initialFilterState}
       />
     </RequestStateHandler>

--- a/ui/components/YamlView.tsx
+++ b/ui/components/YamlView.tsx
@@ -2,7 +2,8 @@ import * as React from "react";
 import styled from "styled-components";
 import { ObjectRef } from "../lib/api/core/types.pb";
 import CopyToClipboard from "./CopyToCliboard";
-type Props = {
+
+export type YamlViewProps = {
   className?: string;
   yaml: string;
   object?: ObjectRef;
@@ -17,7 +18,7 @@ const YamlHeader = styled.div`
   text-overflow: ellipsis;
 `;
 
-function UnstyledYamlView({ yaml, object, className }: Props) {
+function UnstyledYamlView({ yaml, object, className }: YamlViewProps) {
   const headerText = `kubectl get ${object.kind.toLowerCase()} ${
     object.name
   } -n ${object.namespace} -o yaml `;

--- a/ui/contexts/AppContext.tsx
+++ b/ui/contexts/AppContext.tsx
@@ -1,13 +1,13 @@
 import * as React from "react";
 import { useHistory } from "react-router-dom";
+import { DetailViewProps } from "../components/DetailModal";
 import { formatURL } from "../lib/nav";
-import { FluxObject, FluxObjectNode } from "../lib/objects";
 import { PageRoute, V2Routes } from "../lib/types";
 import { notifySuccess } from "../lib/utils";
 
 type AppState = {
   error: null | { fatal: boolean; message: string; detail?: string };
-  nodeYaml: FluxObjectNode | null;
+  detailModal: DetailViewProps;
 };
 
 type AppSettings = {
@@ -18,7 +18,7 @@ export type AppContextType = {
   userConfigRepoName: string;
   doAsyncError: (message: string, detail: string) => void;
   clearAsyncError: () => void;
-  setNodeYaml: (obj: FluxObject | FluxObjectNode) => void;
+  setDetailModal: (props: DetailViewProps | null) => void;
   appState: AppState;
   settings: AppSettings;
   navigate: {
@@ -43,7 +43,7 @@ export default function AppContextProvider({ ...props }: AppProps) {
   const history = useHistory();
   const [appState, setAppState] = React.useState({
     error: null,
-    nodeYaml: null,
+    detailModal: null,
   });
 
   const clearAsyncError = () => {
@@ -66,16 +66,15 @@ export default function AppContextProvider({ ...props }: AppProps) {
     });
   };
 
-  const setNodeYaml = (obj: FluxObject | FluxObjectNode) => {
-    if (obj) setAppState({ ...appState, nodeYaml: obj });
-    else setAppState({ ...appState, nodeYaml: null });
+  const setDetailModal = (props: DetailViewProps | null) => {
+    setAppState({ ...appState, detailModal: props });
   };
 
   const value: AppContextType = {
     userConfigRepoName: "wego-github-jlw-config-repo",
     doAsyncError,
     clearAsyncError,
-    setNodeYaml,
+    setDetailModal,
     appState,
     notifySuccess: props.notifySuccess || notifySuccess,
     settings: {

--- a/ui/lib/theme.ts
+++ b/ui/lib/theme.ts
@@ -170,5 +170,11 @@ export const muiTheme = createTheme({
         overflowX: "hidden",
       },
     },
+    MuiDrawer: {
+      paper: {
+        width: "60%",
+        minWidth: 600,
+      },
+    },
   },
 });


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes #3439 

UPDATE:

As far as I understand this is actually only going to contain a more generic details screen. So it doesn't need to be as flexible as I made it before. We wanted a header thing in there as well which I've added in this screen: 
<img width="1461" alt="image" src="https://user-images.githubusercontent.com/65822698/222211151-7d03ba4b-c2a0-4778-b69e-677a5c9e4a2a.png">


OLD PR DESCRIPTION BELOW:

The main purpose of this PR is to create a multi-purpose drawer component - the pop-up YamlViews have been converted to use it to start out, but the idea is that _anything_ will be able to go in there. Because we want to be able to trigger it from anywhere, I added it to AppContext. This makes the typing a little tricky since we're using components + props, when before it was just yaml so I always knew what to expect. 
Adding a new component would entail:  
- Adding the name to the `DetailOptions` enum
- Exporting the props and adding them to the combined `PropOptions` type
- Adding it to the switch statement in `DetailModal`

Looking for suggestions on if you would handle the typing any differently @jpellizzari 

https://user-images.githubusercontent.com/65822698/221993241-61650235-5e20-428f-81a8-be8229f57f7c.mov

