### PR TITLE
Add clear docs link to navbar

### DIFF
--- a/website/docs/references/helm-reference.md
+++ b/website/docs/references/helm-reference.md
@@ -5,7 +5,7 @@ This is a reference of all the configurable values in weave gitops's
 helm chart. This is intended for customizing your installation after
 you've gone through the [getting started](../getting-started/intro.mdx) guide.
 
-This reference was generated for the chart version 4.0.15 which installs weave gitops v0.18.0.
+This reference was generated for the chart version 4.0.15 which installs **OSS Weave GitOps** v0.18.0.
 
 ## Values
 

--- a/website/docs/references/helm-reference.md
+++ b/website/docs/references/helm-reference.md
@@ -5,7 +5,7 @@ This is a reference of all the configurable values in weave gitops's
 helm chart. This is intended for customizing your installation after
 you've gone through the [getting started](../getting-started/intro.mdx) guide.
 
-This reference was generated for the chart version 4.0.15 which installs **OSS Weave GitOps** v0.18.0.
+This reference was generated for the chart version 4.0.15 which installs **Weave GitOps OSS** v0.18.0.
 
 ## Values
 

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -45,12 +45,12 @@ module.exports = {
           type: "doc",
           docId: "intro",
           position: "left",
-          label: "Getting Started",
+          label: "Docs",
         },
         {
           type: 'docSidebar',
           position: 'left',
-          label: 'Helm Chart & CLI',
+          label: 'Reference',
           sidebarId: 'ref',
         },
         {

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -247,7 +247,11 @@ module.exports = {
     }
   ],
   ref: [
-    'references/helm-reference',
+    {
+      type: 'doc',
+      label: 'OSS Helm Reference',
+      id: 'references/helm-reference',
+    },
     {
       type: 'category',
       label: 'CLI Reference',


### PR DESCRIPTION
Also make it very clear that the current Chart ref is for OSS only (I would love to change the heading of the doc itself, but I cannot find which bit to configure in the autogen to make that happen).

![image (6)](https://user-images.githubusercontent.com/8898786/222761969-8b8b332e-77b7-474d-bd36-20160f6f10ff.png)

I have switched the `Getting Started` link to `Docs`. I don't want the nav bar getting too crowded, and the `Getting Started` is _right there_ when you click on the `Docs` link. Plus people will return to `Docs` and realistically only go to `Getting Started` once. That said, I can put both there if that is preferred, LMK.