### PR TITLE
skip port-forward annotation when no port-forward is setup

### DIFF
--- a/cmd/gitops/beta/run/cmd.go
+++ b/cmd/gitops/beta/run/cmd.go
@@ -479,7 +479,7 @@ func runCommandOuterProcess(cmd *cobra.Command, args []string) (retErr error) {
 		return fmt.Errorf("failed to detect or install Flux on the host cluster: %v", err)
 	}
 
-	_, dashboardManifests, dashboardHashedPassword, err := dashboardStep(context.Background(), log, kubeClient, true, flags.DashboardHashedPassword)
+	dashboardType, dashboardManifests, dashboardHashedPassword, err := dashboardStep(context.Background(), log, kubeClient, true, flags.DashboardHashedPassword)
 	if err != nil {
 		return fmt.Errorf("failed to generate dashboard manifests: %v", err)
 	}
@@ -488,7 +488,10 @@ func runCommandOuterProcess(cmd *cobra.Command, args []string) (retErr error) {
 
 	sessionLog.Println("\nYou may see Flux installation logs again, as it is being installed inside the session.\n")
 
-	portForwardsForSession := []string{flags.DashboardPort}
+	portForwardsForSession := []string{}
+	if dashboardType == install.DashboardTypeOSS {
+		portForwardsForSession = append(portForwardsForSession, flags.DashboardPort)
+	}
 
 	if flags.PortForward != "" {
 		spec, err := watch.ParsePortForwardSpec(flags.PortForward)

--- a/pkg/run/install/install_vcluster_test.go
+++ b/pkg/run/install/install_vcluster_test.go
@@ -8,25 +8,56 @@ import (
 )
 
 func TestMakeVClusterHelmReleaseAnnotations(t *testing.T) {
-	g := NewGomegaWithT(t)
 
-	hl, err := makeVClusterHelmRelease(
-		"name",
-		"namespace",
-		"flux-system",
-		"command", []string{"9999", "1111"},
-		"automationKind")
-	g.Expect(err).ToNot(HaveOccurred())
+	tests := []struct {
+		name                  string
+		portForwards          []string
+		expectedAnnotations   map[string]string
+		unexpectedAnnotations []string
+	}{
+		{
+			name:         "port-forwards are properly annotated",
+			portForwards: []string{"9999", "1111"},
+			expectedAnnotations: map[string]string{
+				"run.weave.works/port-forward":    "9999,1111",
+				"run.weave.works/automation-kind": "automationKind",
+				"run.weave.works/namespace":       "namespace",
+				"run.weave.works/command":         "command",
+			},
+		},
+		{
+			name:                  "port-forwards are left out",
+			unexpectedAnnotations: []string{"run.weave.works/port-forward"},
+		},
+	}
 
-	g.Expect(hl.Name).To(Equal("name"))
-	g.Expect(hl.Namespace).To(Equal("namespace"))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			hl, err := makeVClusterHelmRelease(
+				"name",
+				"namespace",
+				"flux-system",
+				"command", tt.portForwards,
+				"automationKind")
+			g.Expect(err).ToNot(HaveOccurred())
 
-	values := map[string]interface{}{}
-	g.Expect(json.Unmarshal(hl.Spec.Values.Raw, &values)).ToNot(HaveOccurred())
+			g.Expect(hl.Name).To(Equal("name"))
+			g.Expect(hl.Namespace).To(Equal("namespace"))
 
-	annotations := values["annotations"].(map[string]interface{})
-	g.Expect(annotations["run.weave.works/automation-kind"]).To(Equal("automationKind"))
-	g.Expect(annotations["run.weave.works/namespace"]).To(Equal("namespace"))
-	g.Expect(annotations["run.weave.works/command"]).To(Equal("command"))
-	g.Expect(annotations["run.weave.works/port-forward"]).To(Equal("9999,1111"))
+			values := map[string]interface{}{}
+			g.Expect(json.Unmarshal(hl.Spec.Values.Raw, &values)).ToNot(HaveOccurred())
+
+			annotations := values["annotations"].(map[string]interface{})
+
+			for k, v := range tt.expectedAnnotations {
+				g.Expect(annotations).To(HaveKeyWithValue(k, v))
+			}
+
+			for _, k := range tt.unexpectedAnnotations {
+				g.Expect(annotations).NotTo(HaveKey(k))
+			}
+		})
+	}
+
 }


### PR DESCRIPTION
When the dashboard is not installed during the GitOps Run session
(either interactively or by providing the `--skip-dashboard-install`
flag), then no `run.weave.works/port-forward` annotation is placed in
the session's StatefulSet.

Apparently the UI still renders a link in the session table so this
commit is part of a two-part fix and the UI part is addressed in the
Enterprise UI code next.

refs weaveworks/weave-gitops-enterprise#2392