### PR TITLE
gitops create dashboard half-fails when name is weave-gitops

### DIFF
--- a/cmd/gitops/beta/run/cmd.go
+++ b/cmd/gitops/beta/run/cmd.go
@@ -1000,7 +1000,7 @@ func runCommandInnerProcess(cmd *cobra.Command, args []string) error {
 						)
 
 						if pollErr := wait.PollImmediate(2*time.Second, flags.Timeout, func() (bool, error) {
-							pod, podErr = run.GetPodFromResourceDescription(thisCtx, namespacedName, specMap.Kind, kubeClient)
+							pod, podErr = run.GetPodFromResourceDescription(thisCtx, kubeClient, namespacedName, specMap.Kind, nil)
 							if pod != nil && podErr == nil {
 								return true, nil
 							}

--- a/cmd/gitops/create/dashboard/cmd.go
+++ b/cmd/gitops/create/dashboard/cmd.go
@@ -20,7 +20,6 @@ import (
 )
 
 const (
-	helmChartName        = "weave-gitops"
 	defaultAdminUsername = "admin"
 )
 
@@ -233,9 +232,7 @@ func createDashboardCommandRunE(opts *config.Options) func(*cobra.Command, []str
 
 		log.Waitingf("Waiting for GitOps Dashboard reconciliation")
 
-		dashboardPodName := dashboardName + "-" + helmChartName
-
-		if err := install.ReconcileDashboard(ctx, kubeClient, dashboardName, flags.Namespace, dashboardPodName, flags.Timeout); err != nil {
+		if err := install.ReconcileDashboard(ctx, kubeClient, dashboardName, flags.Namespace, "", flags.Timeout); err != nil {
 			log.Failuref("Error requesting reconciliation of dashboard: %v", err.Error())
 		} else {
 			log.Successf("GitOps Dashboard %s is ready", dashboardName)

--- a/core/server/types/app.go
+++ b/core/server/types/app.go
@@ -5,4 +5,5 @@ const (
 	ManagedByLabel string = "app.kubernetes.io/managed-by"
 	CreatedByLabel string = "app.kubernetes.io/created-by"
 	InstanceLabel  string = "app.kubernetes.io/instance"
+	NameLabel      string = "app.kubernetes.io/name"
 )

--- a/pkg/run/watch/dashboard.go
+++ b/pkg/run/watch/dashboard.go
@@ -23,7 +23,7 @@ func EnablePortForwardingForDashboard(ctx context.Context, log logger.Logger, ku
 	// get pod from specMap
 	namespacedName := types.NamespacedName{Namespace: specMap.Namespace, Name: specMap.Name}
 
-	pod, err := run.GetPodFromResourceDescription(ctx, namespacedName, specMap.Kind, kubeClient)
+	pod, err := run.GetPodFromResourceDescription(ctx, kubeClient, namespacedName, specMap.Kind, nil)
 	if err != nil {
 		log.Failuref("Error getting pod from specMap: %v", err)
 	}

--- a/pkg/run/watch/install_dev_bucket_server.go
+++ b/pkg/run/watch/install_dev_bucket_server.go
@@ -273,7 +273,7 @@ func InstallDevBucketServer(
 	// get pod from specMap
 	namespacedName := types.NamespacedName{Namespace: specMap.Namespace, Name: specMap.Name}
 
-	pod, err := run.GetPodFromResourceDescription(ctx, namespacedName, specMap.Kind, kubeClient)
+	pod, err := run.GetPodFromResourceDescription(ctx, kubeClient, namespacedName, specMap.Kind, nil)
 	if err != nil {
 		log.Failuref("Error getting pod from specMap: %v", err)
 	}


### PR DESCRIPTION
Closes #3129 

- Added passing a kube client as the second argument to `GetPodFromResourceDescription` (for consistency with other methods).

- Added getting pod by name if name is provided in `GetPodFromResourceDescription` or by labels if name is an empty string and labels are provided.

- Switched to getting the dashboard pod by labels instead of pod name during the execution of the `gitops create dashboard` command.

- Updated tests for `GetPodFromResourceDescription`.

- Added a constant for the `app.kubernetes.io/name` label.

Testing:
- For testing please build the gitops binary from this branch and run the following commands, each on a clean cluster and after running `flux install`:

```
gitops create dashboard ww-gitops --password=123
gitops create dashboard weave-gitops --password=123
```
Notes:
- Installing dashboard with different name son the same cluster, even after running `flux uninstall; flux install` is currently not supported because of some dashboard leftover elements preventing the dashboard with a different name from being installed properly.

Test run logs (each on a clean cluster after installing Flux):

```
olga@macbook-pro podinfo % gitops create dashboard ww-gitops --password=123 
✚ Generating GitOps Dashboard manifests ...
► Creating GitOps Dashboard objects ...
✚ Generating GitOps Dashboard manifests ...
✔ Generated GitOps Dashboard manifests
► Checking for a cluster in the kube config ...
► Checking if Flux is already installed ...
► Getting Flux version ...
✔ Flux &{v0.38.2  flux-system} is already installed
► Applying GitOps Dashboard manifests
► Installing the GitOps Dashboard ...
HelmRelease/flux-system/ww-gitops created
HelmRepository/flux-system/ww-gitops created
✔ GitOps Dashboard has been installed
► Request reconciliation of dashboard (timeout 3m0s) ...
◎ Waiting for GitOps Dashboard reconciliation
✔ GitOps Dashboard ww-gitops is ready
✔ Installed GitOps Dashboard
olga@macbook-pro podinfo % 
```

```
olga@macbook-pro podinfo % gitops create dashboard weave-gitops --password=123
✚ Generating GitOps Dashboard manifests ...
► Creating GitOps Dashboard objects ...
✚ Generating GitOps Dashboard manifests ...
✔ Generated GitOps Dashboard manifests
► Checking for a cluster in the kube config ...
► Checking if Flux is already installed ...
► Getting Flux version ...
✔ Flux &{v0.38.2  flux-system} is already installed
► Applying GitOps Dashboard manifests
► Installing the GitOps Dashboard ...
HelmRelease/flux-system/weave-gitops created
HelmRepository/flux-system/weave-gitops created
✔ GitOps Dashboard has been installed
► Request reconciliation of dashboard (timeout 3m0s) ...
◎ Waiting for GitOps Dashboard reconciliation
✔ GitOps Dashboard weave-gitops is ready
✔ Installed GitOps Dashboard
olga@macbook-pro podinfo % 
```