### PR TITLE
Add initial azure devops  support

### DIFF
--- a/pkg/gitproviders/factory.go
+++ b/pkg/gitproviders/factory.go
@@ -16,6 +16,7 @@ const (
 	GitProviderGitHub          GitProviderName = "github"
 	GitProviderGitLab          GitProviderName = "gitlab"
 	GitProviderBitBucketServer GitProviderName = "bitbucket-server"
+	GitProviderAzureDevOps     GitProviderName = "azure-devops"
 	tokenTypeOauth             string          = "oauth2"
 )
 


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Part of https://github.com/weaveworks/weave-gitops-enterprise/issues/2412

Adds repo URL parsing support for Azure devops using a simple path match.
