### PR TITLE
Expand area that is clickable for logo and collapse in nav

### DIFF
--- a/ui/components/Logo.tsx
+++ b/ui/components/Logo.tsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 import styled from "styled-components";
 import images from "../lib/images";
 import { V2Routes } from "../lib/types";
+import { Fade } from "../lib/utils";
 import Flex from "./Flex";
 
 type Props = {
@@ -11,13 +12,17 @@ type Props = {
   link?: string;
 };
 
-function Logo({ className, link }: Props) {
+function Logo({ className, link, collapsed }: Props) {
   return (
     <Flex className={className} wide>
       <Link to={link || V2Routes.Automations}>
         <img src={images.weaveG} />
       </Link>
-      <img src={images.logotype} />
+      <Fade fade={collapsed}>
+        <Link to={link || V2Routes.Automations}>
+          <img src={images.logotype} />
+        </Link>
+      </Fade>
     </Flex>
   );
 }
@@ -29,10 +34,6 @@ export default styled(Logo)`
   }
   img:first-child {
     margin-right: ${(props) => props.theme.spacing.xs};
-  }
-  img:nth-child(2) {
-    opacity: ${(props) => (props.collapsed ? 0 : 1)};
-    transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   }
   img {
     width: auto;

--- a/ui/components/Nav.tsx
+++ b/ui/components/Nav.tsx
@@ -5,6 +5,7 @@ import React, { Dispatch, SetStateAction } from "react";
 import styled from "styled-components";
 import { formatURL } from "../lib/nav";
 import { PageRoute, V2Routes } from "../lib/types";
+import { Fade } from "../lib/utils";
 // eslint-disable-next-line
 import { colors } from "../typedefs/styled";
 
@@ -95,13 +96,9 @@ const NavContent = styled.div<{ collapsed: boolean }>`
   }
 `;
 
-const CollapseFlex = styled(Flex)`
-  .MuiButtonBase-root {
+const CollapseButton = styled(IconButton)`
+  &.MuiIconButton-root {
     margin: 0 18px 0 4px;
-  }
-  ${Text} {
-    opacity: ${(props) => (props.collapsed ? 0 : 1)};
-    transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   }
 `;
 
@@ -200,14 +197,23 @@ function Nav({
             );
           })}
         </Tabs>
-        <CollapseFlex wide align end collapsed={collapsed}>
-          <Text uppercase semiBold color="neutral30" size="small">
-            collapse
-          </Text>
-          <IconButton size="small" onClick={() => setCollapsed(!collapsed)}>
+        <Flex wide align end>
+          <Fade center fade={collapsed}>
+            <Text
+              uppercase
+              semiBold
+              color="neutral30"
+              size="small"
+              onClick={() => setCollapsed(!collapsed)}
+              pointer={!collapsed}
+            >
+              collapse
+            </Text>
+          </Fade>
+          <CollapseButton size="small" onClick={() => setCollapsed(!collapsed)}>
             {collapsed ? <ArrowRight /> : <ArrowLeft />}
-          </IconButton>
-        </CollapseFlex>
+          </CollapseButton>
+        </Flex>
       </NavContent>
     </NavContainer>
   );

--- a/ui/components/__tests__/__snapshots__/Logo.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/Logo.test.tsx.snap
@@ -16,6 +16,27 @@ exports[`Logo snapshots renders collapsed view 1`] = `
   width: 100%;
 }
 
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: start;
+  -webkit-box-align: start;
+  -ms-flex-align: start;
+  align-items: start;
+}
+
+.c3 {
+  opacity: 0;
+  -webkit-transition: opacity 200ms cubic-bezier(0.4,0,0.2,1) 0ms;
+  transition: opacity 200ms cubic-bezier(0.4,0,0.2,1) 0ms;
+  pointer-events: none;
+}
+
 .c1 {
   padding-left: 20px;
   width: 92px;
@@ -38,12 +59,6 @@ exports[`Logo snapshots renders collapsed view 1`] = `
   margin-right: 8px;
 }
 
-.c1 img:nth-child(2) {
-  opacity: 0;
-  -webkit-transition: opacity 200ms cubic-bezier(0.4,0,0.2,1) 0ms;
-  transition: opacity 200ms cubic-bezier(0.4,0,0.2,1) 0ms;
-}
-
 .c1 img {
   width: auto;
   height: 32px;
@@ -60,9 +75,18 @@ exports[`Logo snapshots renders collapsed view 1`] = `
       src=""
     />
   </a>
-  <img
-    src=""
-  />
+  <div
+    className="c2 c3"
+  >
+    <a
+      href="/applications"
+      onClick={[Function]}
+    >
+      <img
+        src=""
+      />
+    </a>
+  </div>
 </div>
 `;
 
@@ -80,6 +104,26 @@ exports[`Logo snapshots renders open view 1`] = `
   -ms-flex-align: start;
   align-items: start;
   width: 100%;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: start;
+  -webkit-box-align: start;
+  -ms-flex-align: start;
+  align-items: start;
+}
+
+.c3 {
+  opacity: 1;
+  -webkit-transition: opacity 200ms cubic-bezier(0.4,0,0.2,1) 0ms;
+  transition: opacity 200ms cubic-bezier(0.4,0,0.2,1) 0ms;
 }
 
 .c1 {
@@ -104,12 +148,6 @@ exports[`Logo snapshots renders open view 1`] = `
   margin-right: 8px;
 }
 
-.c1 img:nth-child(2) {
-  opacity: 1;
-  -webkit-transition: opacity 200ms cubic-bezier(0.4,0,0.2,1) 0ms;
-  transition: opacity 200ms cubic-bezier(0.4,0,0.2,1) 0ms;
-}
-
 .c1 img {
   width: auto;
   height: 32px;
@@ -126,8 +164,17 @@ exports[`Logo snapshots renders open view 1`] = `
       src=""
     />
   </a>
-  <img
-    src=""
-  />
+  <div
+    className="c2 c3"
+  >
+    <a
+      href="/applications"
+      onClick={[Function]}
+    >
+      <img
+        src=""
+      />
+    </a>
+  </div>
 </div>
 `;

--- a/ui/lib/utils.ts
+++ b/ui/lib/utils.ts
@@ -1,6 +1,8 @@
 import _ from "lodash";
 import { DateTime } from "luxon";
 import { toast } from "react-toastify";
+import styled from "styled-components";
+import Flex from "../components/Flex";
 import { computeReady, ReadyType } from "../components/KubeStatusIndicator";
 import { AppVersion, repoUrl } from "../components/Version";
 import { GetVersionResponse } from "../lib/api/core/core.pb";
@@ -201,3 +203,11 @@ export function formatLogTimestamp(timestamp?: string, zone?: string): string {
 
   return formattedTimestamp;
 }
+
+export const Fade = styled(Flex)<{
+  fade: boolean;
+}>`
+  opacity: ${({ fade }) => (fade ? 0 : 1)};
+  transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  ${({ fade }) => fade && "pointer-events: none"};
+`;


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes #3497 

New `Fade` styled component wraps collapse text and logo image - I didn't want to use the MUI version because it is super annoying about refs ala Popovers.


https://user-images.githubusercontent.com/65822698/224410517-16cfdba1-5a39-4eb6-ac3d-9d9f861a598b.mov


