### PR TITLE
Fix dashboard password prompt accepting an empty string as a 

### DIFF
--- a/cmd/gitops/beta/run/cmd.go
+++ b/cmd/gitops/beta/run/cmd.go
@@ -394,6 +394,10 @@ func dashboardStep(ctx context.Context, log logger.Logger, kubeClient *kube.Kube
 					return install.DashboardTypeNone, nil, "", err
 				}
 
+				if password == "" {
+					return install.DashboardTypeNone, nil, "", fmt.Errorf("dashboard password is an empty string")
+				}
+
 				passwordHash, err = install.GeneratePasswordHash(log, password)
 				if err != nil {
 					return install.DashboardTypeNone, nil, "", err

--- a/pkg/run/install/install_dashboard.go
+++ b/pkg/run/install/install_dashboard.go
@@ -50,7 +50,7 @@ func ReadPassword(log logger.Logger) (string, error) {
 		return "", err
 	}
 
-	return password, nil
+	return strings.TrimSpace(password), nil
 }
 
 func GeneratePasswordHash(log logger.Logger, password string) (string, error) {


### PR DESCRIPTION
Closes #3237 

- Added trimming the password string after reading it.

- Added returning an error and existing GitOps Run if the trimmed dashboard password string entered during a GitOpsRun run is empty.

Testing:
- Please run a `gitops run` command without the `--skip-dashboard-install` flag and when prompted to install the dashboard, enter `y` and then, when prompted for a password, please enter either an empty string or a string which consists of whitespaces only. You should see the error returned and the GitOps run run should be terminated.

Sample run logs:

```
olga@macbook-pro podinfo % gitops beta run ./deploy/overlays/dev --timeout=3m --port-forward namespace=dev,resource=svc/backend,port=9898:9898 
► Checking for a cluster in the kube config ...
► Preparing the cluster for GitOps Run session ...

You can run `gitops beta run --no-session` to disable session management.

If you are running GitOps Run for the first time, it may take a few minutes to download the required images.
GitOps Run session is also required to install Flux components, if it is not installed yet.
You may see Flux installation logs in the next step.

Would you like to install the GitOps Dashboard: y
Please enter a password for logging into the dashboard: 
Error: failed to generate dashboard manifests: dashboard password is an empty string
olga@macbook-pro podinfo % 
```
