### PR TITLE
Enable unparam linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -34,7 +34,7 @@ linters:
     #- tparallel
     - typecheck
     #- unconvert
-    #- unparam
+    - unparam
     - unused
     - varcheck
     #- whitespace

--- a/cmd/gitops/beta/run/cmd.go
+++ b/cmd/gitops/beta/run/cmd.go
@@ -206,7 +206,7 @@ func betaRunCommandPreRunE(endpoint *string) func(*cobra.Command, []string) erro
 	}
 }
 
-func getKubeClient(cmd *cobra.Command, args []string) (*kube.KubeHTTP, *rest.Config, error) {
+func getKubeClient(cmd *cobra.Command) (*kube.KubeHTTP, *rest.Config, error) {
 	var err error
 
 	log := logger.NewCLILogger(os.Stdout)
@@ -456,7 +456,7 @@ func runCommandOuterProcess(cmd *cobra.Command, args []string) (retErr error) {
 		return err
 	}
 
-	kubeClient, _, err := getKubeClient(cmd, args)
+	kubeClient, _, err := getKubeClient(cmd)
 	if err != nil {
 		return err
 	}
@@ -605,7 +605,7 @@ func runCommandInnerProcess(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	kubeClient, cfg, err := getKubeClient(cmd, args)
+	kubeClient, cfg, err := getKubeClient(cmd)
 	if err != nil {
 		return err
 	}
@@ -884,7 +884,7 @@ func runCommandInnerProcess(cmd *cobra.Command, args []string) error {
 	ticker := time.NewTicker(680 * time.Millisecond)
 
 	go func() {
-		for { // nolint:gosimple
+		for { //nolint:gosimple
 			select {
 			case <-stopUploadCh:
 				return

--- a/cmd/gitops/remove/run/cmd.go
+++ b/cmd/gitops/remove/run/cmd.go
@@ -2,6 +2,8 @@ package run
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/spf13/cobra"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/cmderrors"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/config"
@@ -11,7 +13,6 @@ import (
 	"github.com/weaveworks/weave-gitops/pkg/run/session"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/rest"
-	"os"
 )
 
 type RunCommandFlags struct {
@@ -63,7 +64,7 @@ gitops remove run -n dev --all-sessions
 	return cmd
 }
 
-func getKubeClient(cmd *cobra.Command, args []string) (*kube.KubeHTTP, *rest.Config, error) {
+func getKubeClient(cmd *cobra.Command) (*kube.KubeHTTP, *rest.Config, error) {
 	var err error
 
 	log := logger.NewCLILogger(os.Stdout)
@@ -133,7 +134,7 @@ func removeRunPreRunE(opts *config.Options) func(cmd *cobra.Command, args []stri
 
 func removeRunRunE(opts *config.Options) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
-		kubeClient, _, err := getKubeClient(cmd, args)
+		kubeClient, _, err := getKubeClient(cmd)
 		if err != nil {
 			return err
 		}

--- a/core/clustersmngr/client_test.go
+++ b/core/clustersmngr/client_test.go
@@ -501,7 +501,7 @@ func createClusterRoleBinding(g *GomegaWithT, user string) *rbacv1.ClusterRoleBi
 	return crb
 }
 
-func createClusterClientsPool(g *GomegaWithT, clusterName string) clustersmngr.ClientsPool {
+func createClusterClientsPool(g *GomegaWithT, clusterName string) clustersmngr.ClientsPool { //nolint:unparam
 	scheme, err := kube.CreateScheme()
 	g.Expect(err).To(BeNil())
 

--- a/core/clustersmngr/cluster/delegating_cache.go
+++ b/core/clustersmngr/cluster/delegating_cache.go
@@ -138,7 +138,7 @@ func (dc delegatingCache) Get(ctx context.Context, key client.ObjectKey, obj cli
 		return err
 	}
 
-	bypass := dc.shouldBypassCheck(obj, gvk)
+	bypass := dc.shouldBypassCheck(gvk)
 	if !bypass {
 		partial := &metav1.PartialObjectMetadata{}
 		partial.SetGroupVersionKind(gvk)
@@ -159,7 +159,7 @@ func (dc delegatingCache) List(ctx context.Context, list client.ObjectList, opts
 		return err
 	}
 
-	bypass := dc.shouldBypassCheck(list, gvk)
+	bypass := dc.shouldBypassCheck(gvk)
 	if !bypass {
 		partial := &metav1.PartialObjectMetadataList{}
 		partial.SetGroupVersionKind(gvk)
@@ -174,7 +174,7 @@ func (dc delegatingCache) List(ctx context.Context, list client.ObjectList, opts
 	return dc.Cache.List(ctx, list, opts...)
 }
 
-func (dc *delegatingCache) shouldBypassCheck(obj runtime.Object, gvk schema.GroupVersionKind) bool {
+func (dc *delegatingCache) shouldBypassCheck(gvk schema.GroupVersionKind) bool {
 	dc.checkedGVKsMu.Lock()
 	defer dc.checkedGVKsMu.Unlock()
 

--- a/core/clustersmngr/factory.go
+++ b/core/clustersmngr/factory.go
@@ -425,7 +425,7 @@ func (cf *clustersManager) getUserClientWithNamespaces(ctx context.Context, user
 		go func(cluster cluster.Cluster, pool ClientsPool, errChan chan error) {
 			defer wg.Done()
 
-			client, err := cf.getOrCreateClient(ctx, user, cluster)
+			client, err := cf.getOrCreateClient(user, cluster)
 			if err != nil {
 				errChan <- &ClientError{ClusterName: cluster.GetName(), Err: fmt.Errorf("failed creating user client to pool: %w", err)}
 				return
@@ -475,7 +475,7 @@ func (cf *clustersManager) GetImpersonatedClientForCluster(ctx context.Context, 
 		return nil, fmt.Errorf("cluster not found: %s", clusterName)
 	}
 
-	client, err := cf.getOrCreateClient(ctx, user, cl)
+	client, err := cf.getOrCreateClient(user, cl)
 	if err != nil {
 		return nil, fmt.Errorf("failed creating cluster client: %w", err)
 	}
@@ -520,7 +520,7 @@ func (cf *clustersManager) GetServerClient(ctx context.Context) (Client, error) 
 		go func(cluster cluster.Cluster, pool ClientsPool, errChan chan error) {
 			defer wg.Done()
 
-			client, err := cf.getOrCreateClient(ctx, nil, cluster)
+			client, err := cf.getOrCreateClient(nil, cluster)
 			if err != nil {
 				errChan <- &ClientError{ClusterName: cluster.GetName(), Err: fmt.Errorf("failed creating server client to pool: %w", err)}
 				return
@@ -598,7 +598,7 @@ func (cf *clustersManager) userNsList(ctx context.Context, user *auth.UserPrinci
 	return cf.GetUserNamespaces(user)
 }
 
-func (cf *clustersManager) getOrCreateClient(ctx context.Context, user *auth.UserPrincipal, cluster cluster.Cluster) (client.Client, error) {
+func (cf *clustersManager) getOrCreateClient(user *auth.UserPrincipal, cluster cluster.Cluster) (client.Client, error) {
 	isServer := false
 
 	if user == nil {

--- a/core/nsaccess/nsaccess.go
+++ b/core/nsaccess/nsaccess.go
@@ -93,7 +93,7 @@ func userCanUseNamespace(ctx context.Context, auth typedauth.AuthorizationV1Inte
 		return false, err
 	}
 
-	return hasAllRules(authRes.Status, rules, ns.Name), nil
+	return hasAllRules(authRes.Status, rules), nil
 }
 
 var allK8sVerbs = []string{"create", "get", "list", "watch", "patch", "delete", "deletecollection"}
@@ -158,7 +158,7 @@ func allAPIGroups(rules []rbacv1.PolicyRule) []string {
 //
 // Secrets don't exist in "apps" according to k8s,
 // but the "index checker" that checks this struct does not mind.
-func hasAllRules(status authorizationv1.SubjectRulesReviewStatus, rules []rbacv1.PolicyRule, ns string) bool {
+func hasAllRules(status authorizationv1.SubjectRulesReviewStatus, rules []rbacv1.PolicyRule) bool {
 	derivedAccess := map[string]map[string]map[string]bool{}
 
 	allResourcesInRules := allResources(rules)

--- a/core/server/crd_test.go
+++ b/core/server/crd_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestIsAvailable(t *testing.T) {
 	g := NewGomegaWithT(t)
-	c, _ := makeGRPCServer(k8sEnv.Rest, t)
+	c := makeGRPCServer(k8sEnv.Rest, t)
 
 	scheme, err := kube.CreateScheme()
 	g.Expect(err).NotTo(HaveOccurred())
@@ -62,7 +62,7 @@ func newCRD(
 	g *GomegaWithT,
 	k client.Client,
 	info CRDInfo,
-) extv1.CustomResourceDefinition {
+) {
 	resource := extv1.CustomResourceDefinition{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: fmt.Sprintf("%s.%s", info.Plural, info.Group),
@@ -96,6 +96,4 @@ func newCRD(
 	if !info.NoTest {
 		g.Expect(err).NotTo(HaveOccurred())
 	}
-
-	return resource
 }

--- a/core/server/events_test.go
+++ b/core/server/events_test.go
@@ -23,7 +23,7 @@ func TestListEvents(t *testing.T) {
 
 	ctx := context.Background()
 
-	c, _ := makeGRPCServer(k8sEnv.Rest, t)
+	c := makeGRPCServer(k8sEnv.Rest, t)
 
 	scheme, err := kube.CreateScheme()
 	g.Expect(err).To(BeNil())

--- a/core/server/fluxruntime.go
+++ b/core/server/fluxruntime.go
@@ -259,7 +259,7 @@ func (cs *coreServer) GetReconciledObjects(ctx context.Context, msg *pb.GetRecon
 						Version: gvk.Version,
 					})
 
-					if err := clustersClient.List(ctx, msg.ClusterName, &listResult, opts, client.InNamespace(namespace)); err != nil {
+					if err := clustersClient.List(ctx, clusterName, &listResult, opts, client.InNamespace(namespace)); err != nil {
 						if k8serrors.IsForbidden(err) {
 							cs.logger.V(logger.LogLevelDebug).Info(
 								"forbidden list request",

--- a/core/server/fluxruntime_test.go
+++ b/core/server/fluxruntime_test.go
@@ -29,7 +29,7 @@ func TestGetReconciledObjects(t *testing.T) {
 
 	ctx := context.Background()
 
-	c, _ := makeGRPCServer(k8sEnv.Rest, t)
+	c := makeGRPCServer(k8sEnv.Rest, t)
 
 	scheme, err := kube.CreateScheme()
 	g.Expect(err).To(BeNil())
@@ -195,7 +195,7 @@ func TestGetReconciledObjectsWithSecret(t *testing.T) {
 
 	ctx := context.Background()
 
-	c, _ := makeGRPCServer(k8sEnv.Rest, t)
+	c := makeGRPCServer(k8sEnv.Rest, t)
 
 	scheme, err := kube.CreateScheme()
 	g.Expect(err).To(BeNil())

--- a/core/server/objects.go
+++ b/core/server/objects.go
@@ -125,12 +125,12 @@ func (cs *coreServer) ListObjects(ctx context.Context, msg *pb.ListObjectsReques
 						cs.logger.V(logger.LogLevelDebug).Info("Couldn't grab inventory for helm release", "error", err)
 					}
 				case "StatefulSet":
-					name, clusterName, kind, err := parseSessionInfo(unstructuredObj)
+					clusterName, kind, err := parseSessionInfo(unstructuredObj)
 					if err != nil {
 						break
 					}
 
-					created, _ := cs.sessionObjectsCreated(ctx, name, clusterName, "flux-system", kind)
+					created, _ := cs.sessionObjectsCreated(ctx, clusterName, "flux-system", kind)
 
 					if created {
 						info = sessionObjectsInfo
@@ -154,18 +154,18 @@ func (cs *coreServer) ListObjects(ctx context.Context, msg *pb.ListObjectsReques
 	}, nil
 }
 
-func parseSessionInfo(unstructuredObj unstructured.Unstructured) (string, string, string, error) {
+func parseSessionInfo(unstructuredObj unstructured.Unstructured) (string, string, error) {
 	var set v1.StatefulSet
 
 	err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredObj.UnstructuredContent(), &set)
 	if err != nil {
-		return "", "", "", fmt.Errorf("converting unstructured to statefulset: %w", err)
+		return "", "", fmt.Errorf("converting unstructured to statefulset: %w", err)
 	}
 
 	labels := set.GetLabels()
 
 	if labels["app"] != "vcluster" || labels["app.kubernetes.io/part-of"] != "gitops-run" {
-		return "", "", "", fmt.Errorf("unexpected format of labels")
+		return "", "", fmt.Errorf("unexpected format of labels")
 	}
 
 	annotations := set.GetAnnotations()
@@ -179,17 +179,15 @@ func parseSessionInfo(unstructuredObj unstructured.Unstructured) (string, string
 
 	ns := annotations["run.weave.works/namespace"]
 	if ns == "" {
-		return "", "", "", fmt.Errorf("empty session namespace")
+		return "", "", fmt.Errorf("empty session namespace")
 	}
 
-	name := set.GetName()
+	clusterName := ns + "/" + set.GetName()
 
-	clusterName := ns + "/" + name
-
-	return name, clusterName, kind, nil
+	return clusterName, kind, nil
 }
 
-func (cs *coreServer) sessionObjectsCreated(ctx context.Context, sessionName string, clusterName string, objectNamespace string, automationKind string) (bool, error) {
+func (cs *coreServer) sessionObjectsCreated(ctx context.Context, clusterName string, objectNamespace string, automationKind string) (bool, error) {
 	automationName := constants.RunDevHelmName
 
 	if automationKind == kustomizev1.KustomizationKind {

--- a/core/server/server.go
+++ b/core/server/server.go
@@ -66,7 +66,7 @@ func NewCoreConfig(log logr.Logger, cfg *rest.Config, clusterName string, cluste
 
 func NewCoreServer(cfg CoreServerConfig) (pb.CoreServer, error) {
 	if cfg.CRDService == nil {
-		cfg.CRDService = crd.NewFetcher(context.Background(), cfg.log, cfg.ClustersManager)
+		cfg.CRDService = crd.NewFetcher(cfg.log, cfg.ClustersManager)
 	}
 
 	return &coreServer{

--- a/core/server/session_logs.go
+++ b/core/server/session_logs.go
@@ -204,7 +204,7 @@ func (cs *coreServer) GetSessionLogs(ctx context.Context, msg *pb.GetSessionLogs
 	}, nil
 }
 
-func isSecretCreated(ctx context.Context, cli client.Client, namespace string, name string) error {
+func isSecretCreated(ctx context.Context, cli client.Client, namespace string, name string) error { //nolint:unparam
 	secret := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,

--- a/core/server/suite_test.go
+++ b/core/server/suite_test.go
@@ -51,7 +51,7 @@ func TestMain(m *testing.M) {
 	os.Exit(code)
 }
 
-func makeGRPCServer(cfg *rest.Config, t *testing.T) (pb.CoreClient, server.CoreServerConfig) {
+func makeGRPCServer(cfg *rest.Config, t *testing.T) pb.CoreClient {
 	log := logr.Discard()
 	nsChecker = nsaccessfakes.FakeChecker{}
 	nsChecker.FilterAccessibleNamespacesStub = func(ctx context.Context, t typedauth.AuthorizationV1Interface, n []v1.Namespace) ([]v1.Namespace, error) {
@@ -118,7 +118,7 @@ func makeGRPCServer(cfg *rest.Config, t *testing.T) (pb.CoreClient, server.CoreS
 		conn.Close()
 	})
 
-	return pb.NewCoreClient(conn), coreCfg
+	return pb.NewCoreClient(conn)
 }
 
 type userKey struct{}

--- a/core/server/suspend_test.go
+++ b/core/server/suspend_test.go
@@ -28,7 +28,7 @@ func TestSuspend_Suspend(t *testing.T) {
 	})
 	g.Expect(err).NotTo(HaveOccurred())
 
-	c, _ := makeGRPCServer(k8sEnv.Rest, t)
+	c := makeGRPCServer(k8sEnv.Rest, t)
 
 	ns := newNamespace(ctx, k, g)
 

--- a/core/server/sync_test.go
+++ b/core/server/sync_test.go
@@ -27,7 +27,7 @@ func TestSync(t *testing.T) {
 
 	ctx := context.Background()
 
-	c, _ := makeGRPCServer(k8sEnv.Rest, t)
+	c := makeGRPCServer(k8sEnv.Rest, t)
 
 	scheme, err := kube.CreateScheme()
 	g.Expect(err).To(BeNil())

--- a/core/server/version_test.go
+++ b/core/server/version_test.go
@@ -21,7 +21,7 @@ const (
 
 func TestGetVersion(t *testing.T) {
 	g := NewGomegaWithT(t)
-	c, _ := makeGRPCServer(k8sEnv.Rest, t)
+	c := makeGRPCServer(k8sEnv.Rest, t)
 
 	scheme, err := kube.CreateScheme()
 	g.Expect(err).To(BeNil())

--- a/pkg/fluxexec/bootstrap_bitbucket.go
+++ b/pkg/fluxexec/bootstrap_bitbucket.go
@@ -80,10 +80,7 @@ func (opt *UsernameOption) configureBootstrapBitbucketServer(conf *bootstrapBitb
 }
 
 func (flux *Flux) BootstrapBitbucketServer(ctx context.Context, opts ...BootstrapBitbucketServerOption) error {
-	bootstrapBitbucketServerCmd, err := flux.bootstrapBitbucketServerCmd(ctx, opts...)
-	if err != nil {
-		return err
-	}
+	bootstrapBitbucketServerCmd := flux.bootstrapBitbucketServerCmd(ctx, opts...)
 
 	if err := flux.runFluxCmd(ctx, bootstrapBitbucketServerCmd); err != nil {
 		return err
@@ -92,7 +89,7 @@ func (flux *Flux) BootstrapBitbucketServer(ctx context.Context, opts ...Bootstra
 	return nil
 }
 
-func (flux *Flux) bootstrapBitbucketServerCmd(ctx context.Context, opts ...BootstrapBitbucketServerOption) (*exec.Cmd, error) {
+func (flux *Flux) bootstrapBitbucketServerCmd(ctx context.Context, opts ...BootstrapBitbucketServerOption) *exec.Cmd {
 	c := defaultBootstrapBitbucketServerOptions
 	for _, opt := range opts {
 		opt.configureBootstrapBitbucketServer(&c)
@@ -152,5 +149,5 @@ func (flux *Flux) bootstrapBitbucketServerCmd(ctx context.Context, opts ...Boots
 		args = append(args, "--username", c.username)
 	}
 
-	return flux.buildFluxCmd(ctx, flux.env, args...), nil
+	return flux.buildFluxCmd(ctx, flux.env, args...)
 }

--- a/pkg/fluxexec/bootstrap_bitbucket_test.go
+++ b/pkg/fluxexec/bootstrap_bitbucket_test.go
@@ -2,6 +2,7 @@ package fluxexec
 
 import (
 	"context"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -12,8 +13,7 @@ var _ = Describe("bootstrapBitBucketServerCmd", func() {
 			flux, err := NewFlux(".", "/path/to/flux")
 			Expect(err).To(BeNil())
 
-			initCmd, err := flux.bootstrapBitbucketServerCmd(context.TODO())
-			Expect(err).To(BeNil())
+			initCmd := flux.bootstrapBitbucketServerCmd(context.TODO())
 			Expect(initCmd.Args[1:]).To(Equal([]string{
 				"bootstrap",
 				"bitbucket-server",
@@ -24,7 +24,7 @@ var _ = Describe("bootstrapBitBucketServerCmd", func() {
 			flux, err := NewFlux(".", "/path/to/flux")
 			Expect(err).To(BeNil())
 
-			initCmd, err := flux.bootstrapBitbucketServerCmd(context.TODO(),
+			initCmd := flux.bootstrapBitbucketServerCmd(context.TODO(),
 				WithGlobalOptions(
 					Namespace("weave-gitops-system"),
 				),
@@ -34,7 +34,6 @@ var _ = Describe("bootstrapBitBucketServerCmd", func() {
 				),
 				Group("group1", "group2"),
 			)
-			Expect(err).To(BeNil())
 			Expect(initCmd.Args[1:]).To(Equal([]string{
 				"bootstrap",
 				"bitbucket-server",

--- a/pkg/fluxexec/bootstrap_git.go
+++ b/pkg/fluxexec/bootstrap_git.go
@@ -58,10 +58,7 @@ func (opt *UsernameOption) configureBootstrapGit(conf *bootstrapGitConfig) {
 }
 
 func (flux *Flux) BootstrapGit(ctx context.Context, opts ...BootstrapGitOption) error {
-	bootstrapGitCmd, err := flux.bootstrapGitCmd(ctx, opts...)
-	if err != nil {
-		return err
-	}
+	bootstrapGitCmd := flux.bootstrapGitCmd(ctx, opts...)
 
 	if err := flux.runFluxCmd(ctx, bootstrapGitCmd); err != nil {
 		return err
@@ -70,7 +67,7 @@ func (flux *Flux) BootstrapGit(ctx context.Context, opts ...BootstrapGitOption) 
 	return nil
 }
 
-func (flux *Flux) bootstrapGitCmd(ctx context.Context, opts ...BootstrapGitOption) (*exec.Cmd, error) {
+func (flux *Flux) bootstrapGitCmd(ctx context.Context, opts ...BootstrapGitOption) *exec.Cmd {
 	c := defaultBootstrapGitOptions
 	for _, o := range opts {
 		o.configureBootstrapGit(&c)
@@ -114,5 +111,5 @@ func (flux *Flux) bootstrapGitCmd(ctx context.Context, opts ...BootstrapGitOptio
 		args = append(args, "--username", c.username)
 	}
 
-	return flux.buildFluxCmd(ctx, nil, args...), nil
+	return flux.buildFluxCmd(ctx, nil, args...)
 }

--- a/pkg/fluxexec/bootstrap_git_test.go
+++ b/pkg/fluxexec/bootstrap_git_test.go
@@ -2,6 +2,7 @@ package fluxexec
 
 import (
 	"context"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -12,8 +13,7 @@ var _ = Describe("bootstrapGitCmd", func() {
 			flux, err := NewFlux(".", "/path/to/flux")
 			Expect(err).To(BeNil())
 
-			initCmd, err := flux.bootstrapGitCmd(context.TODO())
-			Expect(err).To(BeNil())
+			initCmd := flux.bootstrapGitCmd(context.TODO())
 			Expect(initCmd.Args[1:]).To(Equal([]string{
 				"bootstrap",
 				"git",
@@ -24,7 +24,7 @@ var _ = Describe("bootstrapGitCmd", func() {
 			flux, err := NewFlux(".", "/path/to/flux")
 			Expect(err).To(BeNil())
 
-			initCmd, err := flux.bootstrapGitCmd(context.TODO(),
+			initCmd := flux.bootstrapGitCmd(context.TODO(),
 				WithGlobalOptions(
 					Namespace("weave-gitops-system"),
 				),
@@ -39,7 +39,6 @@ var _ = Describe("bootstrapGitCmd", func() {
 				Silent(true),
 				URL("git@git.example.com"),
 				Username("username"))
-			Expect(err).To(BeNil())
 			Expect(initCmd.Args[1:]).To(Equal([]string{
 				"bootstrap",
 				"git",

--- a/pkg/fluxexec/bootstrap_github.go
+++ b/pkg/fluxexec/bootstrap_github.go
@@ -76,10 +76,7 @@ func (opt *TeamOption) configureBootstrapGitHub(conf *bootstrapGitHubConfig) {
 }
 
 func (flux *Flux) BootstrapGitHub(ctx context.Context, opts ...BootstrapGitHubOption) error {
-	bootstrapGitHubCmd, err := flux.bootstrapGitHubCmd(ctx, opts...)
-	if err != nil {
-		return err
-	}
+	bootstrapGitHubCmd := flux.bootstrapGitHubCmd(ctx, opts...)
 
 	if err := flux.runFluxCmd(ctx, bootstrapGitHubCmd); err != nil {
 		return err
@@ -88,7 +85,7 @@ func (flux *Flux) BootstrapGitHub(ctx context.Context, opts ...BootstrapGitHubOp
 	return nil
 }
 
-func (flux *Flux) bootstrapGitHubCmd(ctx context.Context, opts ...BootstrapGitHubOption) (*exec.Cmd, error) {
+func (flux *Flux) bootstrapGitHubCmd(ctx context.Context, opts ...BootstrapGitHubOption) *exec.Cmd {
 	c := defaultBootstrapGitHubOptions
 	for _, o := range opts {
 		o.configureBootstrapGitHub(&c)
@@ -145,5 +142,5 @@ func (flux *Flux) bootstrapGitHubCmd(ctx context.Context, opts ...BootstrapGitHu
 		args = append(args, "--team", strings.Join(c.team, ","))
 	}
 
-	return flux.buildFluxCmd(ctx, flux.env, args...), nil
+	return flux.buildFluxCmd(ctx, flux.env, args...)
 }

--- a/pkg/fluxexec/bootstrap_github_test.go
+++ b/pkg/fluxexec/bootstrap_github_test.go
@@ -2,6 +2,7 @@ package fluxexec
 
 import (
 	"context"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -12,8 +13,7 @@ var _ = Describe("bootstrapGitHubCmd", func() {
 			flux, err := NewFlux(".", "/path/to/flux")
 			Expect(err).To(BeNil())
 
-			initCmd, err := flux.bootstrapGitHubCmd(context.TODO())
-			Expect(err).To(BeNil())
+			initCmd := flux.bootstrapGitHubCmd(context.TODO())
 			Expect(initCmd.Args[1:]).To(Equal([]string{
 				"bootstrap",
 				"github",
@@ -24,12 +24,11 @@ var _ = Describe("bootstrapGitHubCmd", func() {
 			flux, err := NewFlux(".", "/path/to/flux")
 			Expect(err).To(BeNil())
 
-			initCmd, err := flux.bootstrapGitHubCmd(context.TODO(),
+			initCmd := flux.bootstrapGitHubCmd(context.TODO(),
 				WithBootstrapOptions(
 					TokenAuth(true),
 					NetworkPolicy(false)),
 				Private(false))
-			Expect(err).To(BeNil())
 			Expect(initCmd.Args[1:]).To(Equal([]string{
 				"bootstrap",
 				"github",
@@ -43,7 +42,7 @@ var _ = Describe("bootstrapGitHubCmd", func() {
 			flux, err := NewFlux(".", "/path/to/flux")
 			Expect(err).To(BeNil())
 
-			initCmd, err := flux.bootstrapGitHubCmd(context.TODO(),
+			initCmd := flux.bootstrapGitHubCmd(context.TODO(),
 				WithGlobalOptions(
 					Namespace("weave-gitops-system"),
 				),
@@ -52,7 +51,6 @@ var _ = Describe("bootstrapGitHubCmd", func() {
 					SecretName("weave-gitops-system"),
 				),
 				Private(false))
-			Expect(err).To(BeNil())
 			Expect(initCmd.Args[1:]).To(Equal([]string{
 				"bootstrap",
 				"github",

--- a/pkg/fluxexec/bootstrap_gitlab.go
+++ b/pkg/fluxexec/bootstrap_gitlab.go
@@ -74,7 +74,7 @@ func (opt *TeamOption) configureBootstrapGitLab(conf *bootstrapGitLabConfig) {
 	conf.team = opt.team
 }
 
-func (flux *Flux) bootstrapGitLabCmd(ctx context.Context, opts ...BootstrapGitLabOption) (*exec.Cmd, error) {
+func (flux *Flux) bootstrapGitLabCmd(ctx context.Context, opts ...BootstrapGitLabOption) *exec.Cmd {
 	c := defaultBootstrapGitLabOptions
 	for _, opt := range opts {
 		opt.configureBootstrapGitLab(&c)
@@ -130,14 +130,11 @@ func (flux *Flux) bootstrapGitLabCmd(ctx context.Context, opts ...BootstrapGitLa
 		args = append(args, "--team", strings.Join(c.team, ","))
 	}
 
-	return flux.buildFluxCmd(ctx, flux.env, args...), nil
+	return flux.buildFluxCmd(ctx, flux.env, args...)
 }
 
 func (flux *Flux) BootstrapGitlab(ctx context.Context, opts ...BootstrapGitLabOption) error {
-	bootstrapGitLabCmd, err := flux.bootstrapGitLabCmd(ctx, opts...)
-	if err != nil {
-		return err
-	}
+	bootstrapGitLabCmd := flux.bootstrapGitLabCmd(ctx, opts...)
 
 	if err := flux.runFluxCmd(ctx, bootstrapGitLabCmd); err != nil {
 		return err

--- a/pkg/fluxexec/bootstrap_gitlab_test.go
+++ b/pkg/fluxexec/bootstrap_gitlab_test.go
@@ -2,6 +2,7 @@ package fluxexec
 
 import (
 	"context"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -12,7 +13,7 @@ var _ = Describe("bootstrapGitLabCmd", func() {
 			flux, err := NewFlux(".", "/path/to/flux")
 			Expect(err).To(BeNil())
 
-			initCmd, err := flux.bootstrapGitLabCmd(context.TODO(),
+			initCmd := flux.bootstrapGitLabCmd(context.TODO(),
 				WithGlobalOptions(
 					Namespace("weave-gitops-system"),
 				),
@@ -21,7 +22,6 @@ var _ = Describe("bootstrapGitLabCmd", func() {
 					SecretName("weave-gitops-system"),
 				),
 			)
-			Expect(err).To(BeNil())
 			Expect(initCmd.Args[1:]).To(Equal([]string{
 				"bootstrap",
 				"gitlab",

--- a/pkg/fluxexec/install.go
+++ b/pkg/fluxexec/install.go
@@ -81,10 +81,7 @@ func (opt *WatchAllNamespacesOption) configureInstall(conf *installConfig) {
 }
 
 func (flux *Flux) Install(ctx context.Context, opts ...InstallOption) error {
-	installCmd, err := flux.installCmd(ctx, opts...)
-	if err != nil {
-		return err
-	}
+	installCmd := flux.installCmd(ctx, opts...)
 
 	if err := flux.runFluxCmd(ctx, installCmd); err != nil {
 		return err
@@ -93,7 +90,7 @@ func (flux *Flux) Install(ctx context.Context, opts ...InstallOption) error {
 	return nil
 }
 
-func (flux *Flux) installCmd(ctx context.Context, opts ...InstallOption) (*exec.Cmd, error) {
+func (flux *Flux) installCmd(ctx context.Context, opts ...InstallOption) *exec.Cmd {
 	c := defaultInstallOptions
 	for _, o := range opts {
 		o.configureInstall(&c)
@@ -155,5 +152,5 @@ func (flux *Flux) installCmd(ctx context.Context, opts ...InstallOption) (*exec.
 		args = append(args, "--components-extra", strings.Join(extras, ","))
 	}
 
-	return flux.buildFluxCmd(ctx, nil, args...), nil
+	return flux.buildFluxCmd(ctx, nil, args...)
 }

--- a/pkg/fluxexec/install_test.go
+++ b/pkg/fluxexec/install_test.go
@@ -2,6 +2,7 @@ package fluxexec
 
 import (
 	"context"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -12,8 +13,7 @@ var _ = Describe("installCmd", func() {
 			flux, err := NewFlux(".", "/mock/path/to/flux")
 			Expect(err).To(BeNil())
 
-			initCmd, err := flux.installCmd(context.TODO())
-			Expect(err).To(BeNil())
+			initCmd := flux.installCmd(context.TODO())
 			Expect(initCmd.Args[1:]).To(Equal([]string{
 				"install",
 			}))
@@ -23,8 +23,7 @@ var _ = Describe("installCmd", func() {
 			flux, err := NewFlux(".", "/mock/path/to/flux")
 			Expect(err).To(BeNil())
 
-			initCmd, err := flux.installCmd(context.TODO(), NetworkPolicy(false))
-			Expect(err).To(BeNil())
+			initCmd := flux.installCmd(context.TODO(), NetworkPolicy(false))
 			Expect(initCmd.Args[1:]).To(Equal([]string{
 				"install",
 				"--network-policy", "false",
@@ -34,8 +33,7 @@ var _ = Describe("installCmd", func() {
 			flux, err := NewFlux(".", "/mock/path/to/flux")
 			Expect(err).To(BeNil())
 
-			initCmd, err := flux.installCmd(context.TODO(), Components(ComponentSourceController, ComponentHelmController))
-			Expect(err).To(BeNil())
+			initCmd := flux.installCmd(context.TODO(), Components(ComponentSourceController, ComponentHelmController))
 			Expect(initCmd.Args[1:]).To(Equal([]string{
 				"install",
 				"--components", "source-controller,helm-controller",
@@ -46,8 +44,7 @@ var _ = Describe("installCmd", func() {
 			flux, err := NewFlux(".", "/mock/path/to/flux")
 			Expect(err).To(BeNil())
 
-			initCmd, err := flux.installCmd(context.TODO(), ComponentsExtra(ComponentImageReflectorController, ComponentImageAutomationController))
-			Expect(err).To(BeNil())
+			initCmd := flux.installCmd(context.TODO(), ComponentsExtra(ComponentImageReflectorController, ComponentImageAutomationController))
 			Expect(initCmd.Args[1:]).To(Equal([]string{
 				"install",
 				"--components-extra",

--- a/pkg/gitproviders/provider_org.go
+++ b/pkg/gitproviders/provider_org.go
@@ -32,7 +32,7 @@ func (p orgGitProvider) RepositoryExists(ctx context.Context, repoURL RepoURL) (
 }
 
 func (p orgGitProvider) DeployKeyExists(ctx context.Context, repoURL RepoURL) (bool, error) {
-	orgRepo, err := p.getOrgRepo(ctx, repoURL)
+	orgRepo, err := p.getOrgRepo(repoURL)
 	if err != nil {
 		return false, fmt.Errorf("error getting org repo reference for owner %s, repo %s, %s", repoURL.Owner(), repoURL.RepositoryName(), err)
 	}
@@ -41,7 +41,7 @@ func (p orgGitProvider) DeployKeyExists(ctx context.Context, repoURL RepoURL) (b
 }
 
 func (p orgGitProvider) UploadDeployKey(ctx context.Context, repoURL RepoURL, deployKey []byte) error {
-	orgRepo, err := p.getOrgRepo(ctx, repoURL)
+	orgRepo, err := p.getOrgRepo(repoURL)
 	if err != nil {
 		return fmt.Errorf("error getting org repo reference for owner %s, repo %s, %w", repoURL.Owner(), repoURL.RepositoryName(), err)
 	}
@@ -56,7 +56,7 @@ func (p orgGitProvider) UploadDeployKey(ctx context.Context, repoURL RepoURL, de
 }
 
 func (p orgGitProvider) GetDefaultBranch(ctx context.Context, repoURL RepoURL) (string, error) {
-	repoInfoRef, err := p.getRepoInfoFromURL(ctx, repoURL)
+	repoInfoRef, err := p.getRepoInfoFromURL(repoURL)
 	if err != nil {
 		return "main", err
 	}
@@ -65,7 +65,7 @@ func (p orgGitProvider) GetDefaultBranch(ctx context.Context, repoURL RepoURL) (
 }
 
 func (p orgGitProvider) GetRepoVisibility(ctx context.Context, repoURL RepoURL) (*gitprovider.RepositoryVisibility, error) {
-	repoInfoRef, err := p.getRepoInfoFromURL(ctx, repoURL)
+	repoInfoRef, err := p.getRepoInfoFromURL(repoURL)
 	if err != nil {
 		return nil, err
 	}
@@ -73,8 +73,8 @@ func (p orgGitProvider) GetRepoVisibility(ctx context.Context, repoURL RepoURL) 
 	return repoInfoRef.Visibility, nil
 }
 
-func (p orgGitProvider) getRepoInfoFromURL(ctx context.Context, repoURL RepoURL) (*gitprovider.RepositoryInfo, error) {
-	repoInfo, err := p.getRepoInfo(ctx, repoURL)
+func (p orgGitProvider) getRepoInfoFromURL(repoURL RepoURL) (*gitprovider.RepositoryInfo, error) {
+	repoInfo, err := p.getRepoInfo(repoURL)
 	if err != nil {
 		return nil, err
 	}
@@ -82,8 +82,8 @@ func (p orgGitProvider) getRepoInfoFromURL(ctx context.Context, repoURL RepoURL)
 	return repoInfo, nil
 }
 
-func (p orgGitProvider) getRepoInfo(ctx context.Context, repoURL RepoURL) (*gitprovider.RepositoryInfo, error) {
-	repo, err := p.getOrgRepo(ctx, repoURL)
+func (p orgGitProvider) getRepoInfo(repoURL RepoURL) (*gitprovider.RepositoryInfo, error) {
+	repo, err := p.getOrgRepo(repoURL)
 	if err != nil {
 		return nil, err
 	}
@@ -93,7 +93,7 @@ func (p orgGitProvider) getRepoInfo(ctx context.Context, repoURL RepoURL) (*gitp
 	return &info, nil
 }
 
-func (p orgGitProvider) getOrgRepo(ctx context.Context, repoURL RepoURL) (gitprovider.OrgRepository, error) {
+func (p orgGitProvider) getOrgRepo(repoURL RepoURL) (gitprovider.OrgRepository, error) {
 	orgRepoRef := NewOrgRepositoryRef(p.domain, repoURL.Owner(), repoURL.RepositoryName())
 
 	repo, err := p.provider.OrgRepositories().Get(context.Background(), orgRepoRef)
@@ -105,7 +105,7 @@ func (p orgGitProvider) getOrgRepo(ctx context.Context, repoURL RepoURL) (gitpro
 }
 
 func (p orgGitProvider) CreatePullRequest(ctx context.Context, repoURL RepoURL, prInfo PullRequestInfo) (gitprovider.PullRequest, error) {
-	orgRepo, err := p.getOrgRepo(ctx, repoURL)
+	orgRepo, err := p.getOrgRepo(repoURL)
 	if err != nil {
 		return nil, fmt.Errorf("error getting org repo for owner %s, repo %s, %w", repoURL.Owner(), repoURL.RepositoryName(), err)
 	}
@@ -114,7 +114,7 @@ func (p orgGitProvider) CreatePullRequest(ctx context.Context, repoURL RepoURL, 
 }
 
 func (p orgGitProvider) GetCommits(ctx context.Context, repoURL RepoURL, targetBranch string, pageSize int, pageToken int) ([]gitprovider.Commit, error) {
-	orgRepo, err := p.getOrgRepo(ctx, repoURL)
+	orgRepo, err := p.getOrgRepo(repoURL)
 	if err != nil {
 		return nil, fmt.Errorf("error getting repo for owner %s, repo %s, %w", repoURL.Owner(), repoURL.RepositoryName(), err)
 	}
@@ -129,7 +129,7 @@ func (p orgGitProvider) GetProviderDomain() string {
 // GetRepoDirFiles returns the files found in the subdirectory of a repository.
 // Note that the current implementation only gets an end subdirectory. It does not get multiple directories recursively. See https://github.com/fluxcd/go-git-providers/issues/143.
 func (p orgGitProvider) GetRepoDirFiles(ctx context.Context, repoURL RepoURL, dirPath, targetBranch string) ([]*gitprovider.CommitFile, error) {
-	repo, err := p.getOrgRepo(ctx, repoURL)
+	repo, err := p.getOrgRepo(repoURL)
 	if err != nil {
 		return nil, err
 	}
@@ -144,7 +144,7 @@ func (p orgGitProvider) GetRepoDirFiles(ctx context.Context, repoURL RepoURL, di
 
 // MergePullRequest merges a pull request given the repository's URL and the PR's number with a commit message.
 func (p orgGitProvider) MergePullRequest(ctx context.Context, repoURL RepoURL, pullRequestNumber int, commitMesage string) error {
-	repo, err := p.getOrgRepo(ctx, repoURL)
+	repo, err := p.getOrgRepo(repoURL)
 	if err != nil {
 		return err
 	}

--- a/pkg/run/install/apply_manifests.go
+++ b/pkg/run/install/apply_manifests.go
@@ -69,7 +69,7 @@ func apply(ctx context.Context, log logger.Logger, manager ResourceManagerForApp
 	}
 
 	if len(stageOne) > 0 {
-		cs, err := applySet(ctx, log, manager, stageOne)
+		cs, err := applySet(ctx, manager, stageOne)
 		if err != nil {
 			log.Failuref("Error applying stage one objects")
 			return "", err
@@ -77,14 +77,14 @@ func apply(ctx context.Context, log logger.Logger, manager ResourceManagerForApp
 
 		changeSet.Append(cs.Entries)
 
-		if err := waitForSet(ctx, log, manager, changeSet); err != nil {
+		if err := waitForSet(manager, changeSet); err != nil {
 			log.Failuref("Error waiting for set")
 			return "", err
 		}
 	}
 
 	if len(stageTwo) > 0 {
-		cs, err := applySet(ctx, log, manager, stageTwo)
+		cs, err := applySet(ctx, manager, stageTwo)
 		if err != nil {
 			log.Failuref("Error applying stage two objects")
 			return "", err
@@ -96,10 +96,10 @@ func apply(ctx context.Context, log logger.Logger, manager ResourceManagerForApp
 	return changeSet.String(), nil
 }
 
-func applySet(ctx context.Context, log logger.Logger, manager ResourceManagerForApply, objects []*unstructured.Unstructured) (*ssa.ChangeSet, error) {
+func applySet(ctx context.Context, manager ResourceManagerForApply, objects []*unstructured.Unstructured) (*ssa.ChangeSet, error) {
 	return manager.ApplyAll(ctx, objects, ssa.DefaultApplyOptions())
 }
 
-func waitForSet(ctx context.Context, log logger.Logger, manager ResourceManagerForApply, changeSet *ssa.ChangeSet) error {
+func waitForSet(manager ResourceManagerForApply, changeSet *ssa.ChangeSet) error {
 	return manager.WaitForSet(changeSet.ToObjMetadataSet(), ssa.WaitOptions{Interval: 2 * time.Second, Timeout: time.Minute})
 }

--- a/pkg/run/install/install_fluent_bit.go
+++ b/pkg/run/install/install_fluent_bit.go
@@ -98,7 +98,7 @@ func mapToJSON(m map[string]interface{}) (*v1.JSON, error) {
 	return result, nil
 }
 
-func makeFluentBitHelmRepository(namespace string) (*sourcev1.HelmRepository, error) {
+func makeFluentBitHelmRepository(namespace string) *sourcev1.HelmRepository {
 	helmRepository := &sourcev1.HelmRepository{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "fluent",
@@ -109,7 +109,7 @@ func makeFluentBitHelmRepository(namespace string) (*sourcev1.HelmRepository, er
 		},
 	}
 
-	return helmRepository, nil
+	return helmRepository
 }
 
 func makeFluentBitHelmRelease(name string, fluxNamespace string, targetNamespace string, bucketName string, bucketServerPort int32) (*helmv2.HelmRelease, error) {
@@ -222,10 +222,7 @@ func UninstallFluentBit(ctx context.Context, log logger.Logger, kubeClient clien
 }
 
 func InstallFluentBit(ctx context.Context, log logger.Logger, kubeClient client.Client, fluxNamespace string, targetNamespace string, name string, bucketName string, bucketServerPort int32) error {
-	helmRepo, err := makeFluentBitHelmRepository(fluxNamespace)
-	if err != nil {
-		return err
-	}
+	helmRepo := makeFluentBitHelmRepository(fluxNamespace)
 
 	log.Actionf("creating HelmRepository %s/%s", helmRepo.Namespace, helmRepo.Name)
 

--- a/pkg/run/install/install_vcluster.go
+++ b/pkg/run/install/install_vcluster.go
@@ -22,7 +22,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func makeVClusterHelmRepository(namespace string) (*sourcev1.HelmRepository, error) {
+func makeVClusterHelmRepository(namespace string) *sourcev1.HelmRepository {
 	helmRepository := &sourcev1.HelmRepository{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "loft-sh",
@@ -33,10 +33,10 @@ func makeVClusterHelmRepository(namespace string) (*sourcev1.HelmRepository, err
 		},
 	}
 
-	return helmRepository, nil
+	return helmRepository
 }
 
-func makeVClusterHelmRelease(name string, namespace string, fluxNamespace string, command string, portForwards []string, automationKind string) (*helmv2.HelmRelease, error) {
+func makeVClusterHelmRelease(name string, namespace string, fluxNamespace string, command string, portForwards []string, automationKind string) *helmv2.HelmRelease {
 	annotations := []string{
 		`"run.weave.works/cli-version": "` + version.Version + `"`,
 		`"run.weave.works/command": "` + command + `"`,
@@ -105,14 +105,11 @@ func makeVClusterHelmRelease(name string, namespace string, fluxNamespace string
 		},
 	}
 
-	return helmRelease, nil
+	return helmRelease
 }
 
 func installVCluster(kubeClient client.Client, name string, namespace string, fluxNamespace string, portForwards []string, automationKind string) error {
-	helmRepo, err := makeVClusterHelmRepository(namespace)
-	if err != nil {
-		return err
-	}
+	helmRepo := makeVClusterHelmRepository(namespace)
 
 	if err := kubeClient.Create(context.Background(), helmRepo); err != nil {
 		if apierrors.IsAlreadyExists(err) {
@@ -125,10 +122,7 @@ func installVCluster(kubeClient client.Client, name string, namespace string, fl
 	args := append([]string{filepath.Base(os.Args[0])}, os.Args[1:]...)
 	command := strings.Join(args, " ")
 
-	helmRelease, err := makeVClusterHelmRelease(name, namespace, fluxNamespace, command, portForwards, automationKind)
-	if err != nil {
-		return err
-	}
+	helmRelease := makeVClusterHelmRelease(name, namespace, fluxNamespace, command, portForwards, automationKind)
 
 	if err := kubeClient.Create(context.Background(), helmRelease); err != nil {
 		if apierrors.IsAlreadyExists(err) {
@@ -178,10 +172,7 @@ func uninstallVcluster(kubeClient client.Client, name string, namespace string) 
 	}
 
 	// clean up repo
-	helmRepo, err := makeVClusterHelmRepository(namespace)
-	if err != nil {
-		return err
-	}
+	helmRepo := makeVClusterHelmRepository(namespace)
 
 	if err := kubeClient.Delete(context.Background(), helmRepo); err != nil {
 		if apierrors.IsNotFound(err) {

--- a/pkg/run/install/install_vcluster_test.go
+++ b/pkg/run/install/install_vcluster_test.go
@@ -34,13 +34,12 @@ func TestMakeVClusterHelmReleaseAnnotations(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewGomegaWithT(t)
-			hl, err := makeVClusterHelmRelease(
+			hl := makeVClusterHelmRelease(
 				"name",
 				"namespace",
 				"flux-system",
 				"command", tt.portForwards,
 				"automationKind")
-			g.Expect(err).ToNot(HaveOccurred())
 
 			g.Expect(hl.Name).To(Equal("name"))
 			g.Expect(hl.Namespace).To(Equal("namespace"))

--- a/pkg/run/session/connect/connect.go
+++ b/pkg/run/session/connect/connect.go
@@ -377,10 +377,7 @@ func (conn *Connection) getVClusterKubeConfig(vclusterName string, command []str
 	}
 
 	// exchange context name in virtual kube config
-	err = conn.exchangeContextName(kubeConfig, vclusterName)
-	if err != nil {
-		return nil, err
-	}
+	conn.exchangeContextName(kubeConfig, vclusterName)
 
 	// check if the vcluster is exposed and set server
 	if vclusterName != "" && conn.Server == "" && len(command) == 0 {
@@ -509,7 +506,7 @@ func (conn *Connection) setServerIfExposed(vClusterName string, vClusterConfig *
 	return nil
 }
 
-func (conn *Connection) exchangeContextName(kubeConfig *api.Config, vclusterName string) error {
+func (conn *Connection) exchangeContextName(kubeConfig *api.Config, vclusterName string) {
 	if conn.KubeConfigContextName == "" {
 		if vclusterName != "" {
 			conn.KubeConfigContextName = find.VClusterContextName(vclusterName, conn.Namespace, conn.rawConfig.CurrentContext)
@@ -544,7 +541,6 @@ func (conn *Connection) exchangeContextName(kubeConfig *api.Config, vclusterName
 
 	// update current-context
 	kubeConfig.CurrentContext = conn.KubeConfigContextName
-	return nil
 }
 
 func (conn *Connection) getLocalVClusterConfig(vKubeConfig api.Config) api.Config {

--- a/pkg/run/session/localkubernetes/configure.go
+++ b/pkg/run/session/localkubernetes/configure.go
@@ -149,7 +149,7 @@ func CleanupBackgroundProxy(proxyName string, log log.Logger) error {
 	return nil
 }
 
-func cleanupProxy(vClusterName, vClusterNamespace string, rawConfig *clientcmdapi.Config, log log.Logger) error {
+func cleanupProxy(vClusterName, vClusterNamespace string, rawConfig *clientcmdapi.Config, log log.Logger) {
 	// construct proxy name
 	proxyName := find.VClusterContextName(vClusterName, vClusterNamespace, rawConfig.CurrentContext)
 
@@ -161,7 +161,6 @@ func cleanupProxy(vClusterName, vClusterNamespace string, rawConfig *clientcmdap
 	)
 	log.Actionf("Stopping docker proxy...")
 	_, _ = cmd.Output()
-	return nil
 }
 
 func kindProxy(vClusterName, vClusterNamespace string, rawConfig *clientcmdapi.Config, vRawConfig *clientcmdapi.Config, service *corev1.Service, localPort int, timeout time.Duration, log log.Logger) (string, error) {
@@ -387,10 +386,7 @@ func getServerFromExistingProxyContainer(vClusterName, vClusterNamespace string,
 	}
 
 	if containerExists(proxyName) {
-		err := cleanupProxy(vClusterName, vClusterNamespace, rawConfig, log)
-		if err != nil {
-			return "", err
-		}
+		cleanupProxy(vClusterName, vClusterNamespace, rawConfig, log)
 	}
 
 	return "", nil

--- a/pkg/server/auth/server_test.go
+++ b/pkg/server/auth/server_test.go
@@ -538,7 +538,7 @@ func TestUserInfoAdminFlowBadCookie(t *testing.T) {
 	g.Expect(info.Email).To(Equal(""))
 }
 
-func getVerifyTokens(t *testing.T, s *auth.AuthServer, m *mockoidc.MockOIDC) map[string]interface{} {
+func getVerifyTokens(t *testing.T, m *mockoidc.MockOIDC) map[string]interface{} {
 	const (
 		state = "abcdef"
 		nonce = "ghijkl"
@@ -609,7 +609,7 @@ func TestUserInfoOIDCFlow(t *testing.T) {
 
 	s, m := makeAuthServer(t, nil, tokenSignerVerifier, []auth.AuthMethod{auth.OIDC})
 
-	tokens := getVerifyTokens(t, s, m)
+	tokens := getVerifyTokens(t, m)
 
 	_, err = m.Keypair.VerifyJWT(tokens["access_token"].(string))
 	g.Expect(err).NotTo(HaveOccurred())
@@ -733,7 +733,7 @@ func TestRefresh(t *testing.T) {
 
 	s, m := makeAuthServer(t, nil, tokenSignerVerifier, []auth.AuthMethod{auth.OIDC})
 
-	tokens := getVerifyTokens(t, s, m)
+	tokens := getVerifyTokens(t, m)
 
 	tf := tokens["refresh_token"].(string)
 

--- a/pkg/services/crd/fetcher.go
+++ b/pkg/services/crd/fetcher.go
@@ -23,14 +23,14 @@ type Fetcher interface {
 //
 // With NewFetcher, it will automatically start a background go routine to watch
 // CRDs.
-func NewFetcher(ctx context.Context, logger logr.Logger, clustersManager clustersmngr.ClustersManager) Fetcher {
+func NewFetcher(logger logr.Logger, clustersManager clustersmngr.ClustersManager) Fetcher {
 	fetcher := &defaultFetcher{
 		logger:          logger,
 		clustersManager: clustersManager,
 		crds:            map[string][]v1.CustomResourceDefinition{},
 	}
 
-	go fetcher.watchCRDs(ctx)
+	go fetcher.watchCRDs()
 
 	return fetcher
 }
@@ -42,7 +42,7 @@ type defaultFetcher struct {
 	crds            map[string][]v1.CustomResourceDefinition
 }
 
-func (s *defaultFetcher) watchCRDs(ctx context.Context) {
+func (s *defaultFetcher) watchCRDs() {
 	_ = wait.PollImmediateInfinite(watchCRDsFrequency, func() (bool, error) {
 		s.UpdateCRDList()
 

--- a/pkg/services/crd/fetcher_test.go
+++ b/pkg/services/crd/fetcher_test.go
@@ -17,7 +17,7 @@ func TestFetcher_IsAvailable(t *testing.T) {
 
 	defer cancelFn()
 
-	service, err := newService(ctx, k8sEnv)
+	service, err := newService(k8sEnv)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
 	k, err := client.New(k8sEnv.Rest, client.Options{
@@ -60,7 +60,7 @@ func TestFetcher_IsAvailableOnClusters(t *testing.T) {
 
 	defer cancelFn()
 
-	service, err := newService(ctx, k8sEnv)
+	service, err := newService(k8sEnv)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
 	k, err := client.New(k8sEnv.Rest, client.Options{

--- a/pkg/services/crd/suite_test.go
+++ b/pkg/services/crd/suite_test.go
@@ -43,7 +43,7 @@ func TestMain(m *testing.M) {
 	os.Exit(code)
 }
 
-func newService(ctx context.Context, k8sEnv *testutils.K8sTestEnv) (crd.Fetcher, error) {
+func newService(k8sEnv *testutils.K8sTestEnv) (crd.Fetcher, error) {
 	_, clustersManager, err := createClient(k8sEnv)
 	if err != nil {
 		return nil, err
@@ -51,7 +51,7 @@ func newService(ctx context.Context, k8sEnv *testutils.K8sTestEnv) (crd.Fetcher,
 
 	log := logr.Discard()
 
-	return crd.NewFetcher(ctx, log, clustersManager), nil
+	return crd.NewFetcher(log, clustersManager), nil
 }
 
 func createClient(k8sEnv *testutils.K8sTestEnv) (clustersmngr.Client, clustersmngr.ClustersManager, error) {
@@ -97,7 +97,7 @@ func newCRD(
 	g *gomega.GomegaWithT,
 	k client.Client,
 	info CRDInfo,
-) v1.CustomResourceDefinition {
+) {
 	resource := v1.CustomResourceDefinition{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: fmt.Sprintf("%s.%s", info.Plural, info.Group),
@@ -131,6 +131,4 @@ func newCRD(
 	if !info.NoTest {
 		g.Expect(err).ToNot(gomega.HaveOccurred(), "should be able to create crd: %s", resource.GetName())
 	}
-
-	return resource
 }


### PR DESCRIPTION
Closes #3284

- Enabled the `unparam` linter, which finds unused function parameters and unused return values.

- Updated the code according to the unparam linter rules.

- Added two cases (in which a function always receives a constant value) when the unparam linter is disabled with `//nolint:unparam`: for the `createClusterClientsPool` function and for the `isSecretCreated` function.

This "always receives" sub-check is a known issue with the unparam linter and, unfortunately, it cannot be disabled individually.
https://github.com/mvdan/unparam/issues/31
