### PR TITLE
Flaky test when running curl to a Flux URL

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -70,7 +70,10 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.go-version }}
-      - run: curl -s https://fluxcd.io/install.sh | sudo bash
+      - name: Setup Flux CLI
+        uses: fluxcd/flux2/action@main
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
       - run: make unit-tests
       # - run: make lib-test
 


### PR DESCRIPTION
Closes #3197 

- Replaced the install script to install the Flux CLI with the `Setup Flux CLI` action.

Based on discussion with @kingdonb  and @chanwit (thank you both!), switched to using the following GitHub action for installing Flux CLI (with the GITHUB_TOKEN to prevent the calls from being rate-limited):
https://github.com/fluxcd/flux2/blob/main/action/README.md

Sample run:

<img width="1508" alt="Screenshot 2023-03-16 at 11 53 49" src="https://user-images.githubusercontent.com/8824708/225595931-8d143472-a4fd-4a58-a1a3-bdd193da4f1c.png">

Notes:
I kept the commented out install.sh script which was used previously — just in case. If everything works as expected, we can remove this comment later. Or I can remove it now, whichever you prefer.