### PR TITLE
fix the clean-up process for gitops run

### DIFF
--- a/cmd/gitops/beta/run/cleanup.go
+++ b/cmd/gitops/beta/run/cleanup.go
@@ -12,7 +12,7 @@ import (
 // is terminating. Each component creating resources on the cluster should
 // return such a function that is then added to the CleanupFuncs stack by
 // the orchestrating code and removed from it and executed during shutdown.
-type CleanupFunc func(ctx context.Context) error
+type CleanupFunc func(ctx context.Context, log logger.Logger) error
 
 // CleanupFuncs is a stack holding CleanupFunc references that are used
 // to roll up all resources created during an GitOps Run session as soon
@@ -24,6 +24,10 @@ type CleanupFuncs struct {
 // Push implements the stack's Push operation, adding the given CleanupFunc
 // to the top of the stack.
 func (c *CleanupFuncs) Push(f CleanupFunc) {
+	if f == nil {
+		return
+	}
+
 	c.fns = append(c.fns, f)
 }
 
@@ -49,7 +53,7 @@ func CleanupCluster(ctx context.Context, log logger.Logger, fns CleanupFuncs) er
 			}
 			break
 		}
-		if err := fn(ctx); err != nil {
+		if err := fn(ctx, log); err != nil {
 			log.Failuref("failed cleaning up: %s", err)
 		}
 	}

--- a/cmd/gitops/remove/run/cmd.go
+++ b/cmd/gitops/remove/run/cmd.go
@@ -63,7 +63,7 @@ gitops remove run --no-session
 	cmdFlags := cmd.Flags()
 
 	cmdFlags.BoolVar(&flags.AllSessions, "all-sessions", false, "Remove all GitOps Run sessions")
-	cmdFlags.BoolVar(&flags.NoSession, "no-session", false, "Remove all GitOps Run sessions")
+	cmdFlags.BoolVar(&flags.NoSession, "no-session", false, "Remove all GitOps Run components in the non-session mode")
 
 	kubeConfigArgs = run.GetKubeConfigArgs()
 
@@ -130,6 +130,7 @@ func getKubeClient(cmd *cobra.Command) (*kube.KubeHTTP, *rest.Config, error) {
 
 func removeRunPreRunE(opts *config.Options) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
+		// if flags.NoSession is set, we don't need to check for session name
 		if flags.NoSession {
 			return nil
 		}

--- a/pkg/run/install/install_fluent_bit.go
+++ b/pkg/run/install/install_fluent_bit.go
@@ -201,7 +201,7 @@ func UninstallFluentBit(ctx context.Context, log logger.Logger, kubeClient clien
 	log.Actionf("Waiting for HelmRelease %s/%s to be deleted...", hr.Namespace, hr.Name)
 
 	if err := wait.ExponentialBackoff(wait.Backoff{
-		Duration: 1 * time.Second,
+		Duration: 4 * time.Second,
 		Factor:   2,
 		Jitter:   1,
 		Steps:    10,

--- a/pkg/run/watch/dashboard.go
+++ b/pkg/run/watch/dashboard.go
@@ -2,6 +2,7 @@ package watch
 
 import (
 	"context"
+	"sync"
 
 	"github.com/weaveworks/weave-gitops/pkg/logger"
 	"github.com/weaveworks/weave-gitops/pkg/run"
@@ -31,8 +32,11 @@ func EnablePortForwardingForDashboard(ctx context.Context, log logger.Logger, ku
 	if pod != nil {
 		waitFwd := make(chan struct{}, 1)
 		readyChannel := make(chan struct{})
+		once := sync.Once{}
 		cancelPortFwd := func() {
-			close(waitFwd)
+			once.Do(func() {
+				close(waitFwd)
+			})
 		}
 
 		log.Actionf("Port forwarding to pod %s/%s ...", pod.Namespace, pod.Name)

--- a/pkg/run/watch/setup_dev_helm.go
+++ b/pkg/run/watch/setup_dev_helm.go
@@ -106,7 +106,7 @@ func CleanupBucketSourceAndHelm(ctx context.Context, log logger.Logger, kubeClie
 
 // ReconcileDevBucketSourceAndHelm reconciles the dev-bucket and dev-helm asynchronously.
 func ReconcileDevBucketSourceAndHelm(ctx context.Context, log logger.Logger, kubeClient client.Client, namespace string, timeout time.Duration) error {
-	const interval = 10 * time.Second
+	const interval = 4 * time.Second
 
 	log.Actionf("Start reconciling %s and %s ...", constants.RunDevBucketName, constants.RunDevHelmName)
 
@@ -127,7 +127,13 @@ func ReconcileDevBucketSourceAndHelm(ctx context.Context, log logger.Logger, kub
 	log.Actionf("Reconciling %s ...", constants.RunDevBucketName)
 
 	// wait for the reconciliation of dev-bucket to be done
-	if err := wait.Poll(interval, timeout, func() (bool, error) {
+	if err := wait.ExponentialBackoff(wait.Backoff{
+		Duration: interval,
+		Factor:   2,
+		Jitter:   1,
+		Steps:    10,
+		Cap:      timeout,
+	}, func() (done bool, err error) {
 		devBucket := &sourcev1.Bucket{}
 		if err := kubeClient.Get(ctx, types.NamespacedName{
 			Name:      constants.RunDevBucketName,
@@ -144,7 +150,13 @@ func ReconcileDevBucketSourceAndHelm(ctx context.Context, log logger.Logger, kub
 	log.Successf("Reconciled %s", constants.RunDevBucketName)
 
 	// wait for devBucket to be ready
-	if err := wait.Poll(interval, timeout, func() (bool, error) {
+	if err := wait.ExponentialBackoff(wait.Backoff{
+		Duration: interval,
+		Factor:   2,
+		Jitter:   1,
+		Steps:    10,
+		Cap:      timeout,
+	}, func() (done bool, err error) {
 		devBucket := &sourcev1.Bucket{}
 		if err := kubeClient.Get(ctx, types.NamespacedName{
 			Name:      constants.RunDevBucketName,
@@ -176,7 +188,13 @@ func ReconcileDevBucketSourceAndHelm(ctx context.Context, log logger.Logger, kub
 
 	log.Actionf("Reconciling %s ...", constants.RunDevHelmName)
 
-	if err := wait.Poll(interval, timeout, func() (bool, error) {
+	if err := wait.ExponentialBackoff(wait.Backoff{
+		Duration: interval,
+		Factor:   2,
+		Jitter:   1,
+		Steps:    10,
+		Cap:      timeout,
+	}, func() (done bool, err error) {
 		devHelm := &helmv2.HelmRelease{}
 		if err := kubeClient.Get(ctx, types.NamespacedName{
 			Name:      constants.RunDevHelmName,
@@ -193,7 +211,14 @@ func ReconcileDevBucketSourceAndHelm(ctx context.Context, log logger.Logger, kub
 	log.Successf("Reconciled %s", constants.RunDevHelmName)
 
 	devHelm := &helmv2.HelmRelease{}
-	devHelmErr := wait.Poll(interval, timeout, func() (bool, error) {
+
+	devHelmErr := wait.ExponentialBackoff(wait.Backoff{
+		Duration: interval,
+		Factor:   2,
+		Jitter:   1,
+		Steps:    10,
+		Cap:      timeout,
+	}, func() (done bool, err error) {
 		if err := kubeClient.Get(ctx, types.NamespacedName{
 			Name:      constants.RunDevHelmName,
 			Namespace: namespace,


### PR DESCRIPTION
Fixes #3428 

Please merge the following PRs first.
- [ ] #3570 

## Summary

- In file `cleanup.go`, this PR adds a new parameter to the `CleanupFunc` type, updates the `Push` method for `CleanupFuncs`, and modifies the signature and usage of `CleanupCluster` to improve logging capabilities and ensure robustness against `nil` values.
  - Modifies the parameter signature of test functions in `cleanup_test.go` to match changes in `cleanup.go`.
- In file `cmd/gitops/beta/run/cmd.go`, this PR adds and changes several functions related to running GitOps with Kubernetes to improve error handling and ensure all resources are properly cleaned up.
  - Changes exponential backoff duration from 1 to 4 seconds in `install_fluent_bit.go`.
- In file `pkg/run/watch/install_dev_bucket_server.go`, this PR changes the implementation for cleaning up the `dev-bucket` namespace to provide a more robust and consistent cleanup process.
- In file `setup_bucket_source.go`, this PR adds error handling to the deletion of secret and source objects in Kubernetes to prevent unnecessary errors from being logged.
- In file `pkg/run/watch/setup_dev_helm.go`, this PR decreases wait intervals and increases the backoff factor to speed up the reconciliation process.
- In file `setup_dev_ks.go`, this PR improves error handling and logging when deleting a Kustomization resource in Kubernetes to avoid logging irrelevant error messages.