### PR TITLE
Add key to text labels in Nav

### DIFF
--- a/ui/components/Nav.tsx
+++ b/ui/components/Nav.tsx
@@ -180,7 +180,13 @@ function Nav({
             if (n.disabled) return;
             if (!n.icon && !n.link)
               return (
-                <Text uppercase color="neutral30" semiBold className="header">
+                <Text
+                  uppercase
+                  color="neutral30"
+                  semiBold
+                  className="header"
+                  key={n.label}
+                >
                   {n.label}
                 </Text>
               );


### PR DESCRIPTION
Adds a label prop to non-tab items in navItems to avoid a lint error in enterprise (items in lists should all have a `key` prop)
