### PR TITLE
Support yaml commands for objects without a namespace

### DIFF
--- a/ui/components/FormCheckbox.tsx
+++ b/ui/components/FormCheckbox.tsx
@@ -9,7 +9,7 @@ function FormCheckbox(props: Props) {
   return (
     <FormInput
       {...props}
-      //   Covert to bool to satisfy mui Checkbox props
+      //   Convert to bool to satisfy mui Checkbox props
       component={(p) => (
         <Checkbox {...p} checked={p.checked === "true" || Boolean(p.checked)} />
       )}
@@ -18,4 +18,8 @@ function FormCheckbox(props: Props) {
   );
 }
 
-export default styled(FormCheckbox).attrs({ className: FormCheckbox.name })``;
+export default styled(FormCheckbox).attrs({ className: FormCheckbox.name })`
+  ${FormInput} {
+    min-width: 0;
+  }
+`;

--- a/ui/components/FormCheckbox.tsx
+++ b/ui/components/FormCheckbox.tsx
@@ -18,8 +18,4 @@ function FormCheckbox(props: Props) {
   );
 }
 
-export default styled(FormCheckbox).attrs({ className: FormCheckbox.name })`
-  ${FormInput} {
-    min-width: 0;
-  }
-`;
+export default styled(FormCheckbox).attrs({ className: FormCheckbox.name })``;

--- a/ui/components/YamlView.tsx
+++ b/ui/components/YamlView.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import styled from "styled-components";
 import { ObjectRef } from "../lib/api/core/types.pb";
+import { createYamlCommand } from "../lib/utils";
 import CopyToClipboard from "./CopyToCliboard";
 
 export type YamlViewProps = {
@@ -19,19 +20,23 @@ const YamlHeader = styled.div`
 `;
 
 function UnstyledYamlView({ yaml, object, className }: YamlViewProps) {
-  const headerText = `kubectl get ${object.kind.toLowerCase()} ${
-    object.name
-  } -n ${object.namespace} -o yaml `;
+  const headerText = createYamlCommand(
+    object.kind,
+    object.name,
+    object.namespace
+  );
 
   return (
     <div className={className}>
       <YamlHeader>
         {headerText}
-        <CopyToClipboard
-          value={headerText}
-          className="yaml-copy"
-          size="small"
-        ></CopyToClipboard>
+        {headerText && (
+          <CopyToClipboard
+            value={headerText}
+            className="yaml-copy"
+            size="small"
+          />
+        )}
       </YamlHeader>
       <pre>
         {yaml.split("\n").map((yaml, index) => (

--- a/ui/components/__tests__/__snapshots__/YamlView.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/YamlView.test.tsx.snap
@@ -130,7 +130,7 @@ exports[`YamlView snapshots renders 1`] = `
   <div
     className="c1"
   >
-    kubectl get kustomization podinfo -n flux-system -o yaml 
+    kubectl get kustomization podinfo -n flux-system -o yaml
     <button
       className="MuiButtonBase-root MuiButton-root MuiButton-outlined c2 c3 yaml-copy MuiButton-outlinedPrimary MuiButton-disableElevation"
       disabled={false}

--- a/ui/index.ts
+++ b/ui/index.ts
@@ -100,6 +100,7 @@ import { muiTheme, theme } from "./lib/theme";
 import { showInterval } from "./lib/time";
 import { V2Routes } from "./lib/types";
 import {
+  createYamlCommand,
   formatLogTimestamp,
   isAllowedLink,
   poller,
@@ -123,6 +124,7 @@ export {
   coreClient,
   CoreClientContextProvider,
   CoreClientContext,
+  createYamlCommand,
   CustomActions,
   DataTable,
   DagGraph,

--- a/ui/lib/__tests__/utils.test.ts
+++ b/ui/lib/__tests__/utils.test.ts
@@ -1,8 +1,10 @@
-import { Automation, HelmRelease, Kustomization } from "../objects";
 import { GetVersionResponse } from "../api/core/core.pb";
+import { Kind } from "../api/core/types.pb";
+import { Automation, HelmRelease, Kustomization } from "../objects";
 import {
   convertGitURLToGitProvider,
   convertImage,
+  createYamlCommand,
   formatLogTimestamp,
   formatMetadataKey,
   getAppVersion,
@@ -385,5 +387,23 @@ describe("utils lib", () => {
     it("should return a hyphen for empty string", () => {
       expect(formatLogTimestamp("")).toEqual("-");
     });
+  });
+});
+
+describe.only("createYamlCommand", () => {
+  it("creates kubectl get yaml string for objects with namespaces", () => {
+    expect(
+      createYamlCommand(Kind.Kustomization, "test", "flux-system")
+    ).toEqual(`kubectl get kustomization test -n flux-system -o yaml`);
+  });
+  it("creates kubectl get yaml string for objects without namespaces", () => {
+    expect(createYamlCommand(Kind.Kustomization, "test", undefined)).toEqual(
+      `kubectl get kustomization test -o yaml`
+    );
+  });
+  it("returns null if name or kind are false values", () => {
+    expect(createYamlCommand(undefined, undefined, "flux-system")).toEqual(
+      null
+    );
   });
 });

--- a/ui/lib/__tests__/utils.test.ts
+++ b/ui/lib/__tests__/utils.test.ts
@@ -390,7 +390,7 @@ describe("utils lib", () => {
   });
 });
 
-describe.only("createYamlCommand", () => {
+describe("createYamlCommand", () => {
   it("creates kubectl get yaml string for objects with namespaces", () => {
     expect(
       createYamlCommand(Kind.Kustomization, "test", "flux-system")

--- a/ui/lib/utils.ts
+++ b/ui/lib/utils.ts
@@ -204,6 +204,18 @@ export function formatLogTimestamp(timestamp?: string, zone?: string): string {
   return formattedTimestamp;
 }
 
+export const createYamlCommand = (
+  kind: string,
+  name: string,
+  namespace: string
+): string => {
+  if (kind && name) {
+    const namespaceString = namespace ? ` -n ${namespace}` : "";
+    return `kubectl get ${kind.toLowerCase()} ${name}${namespaceString} -o yaml`;
+  }
+  return null;
+};
+
 export const Fade = styled(Flex)<{
   fade: boolean;
 }>`


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Refs #3530 

Creates a utility function that is exportable for the yaml command. Will import in enterprise once this is merged.
