### PR TITLE
Scroll nav at small screen heights

### DIFF
--- a/ui/components/Nav.tsx
+++ b/ui/components/Nav.tsx
@@ -87,7 +87,7 @@ const NavContent = styled.div<{ collapsed: boolean }>`
     }
   }
   .header {
-    margin-top: 9px;
+    margin: ${(props) => props.theme.spacing.xs} 0;
     opacity: ${(props) => (props.collapsed ? 0 : 1)};
     transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   }
@@ -175,6 +175,8 @@ function Nav({
           centered={false}
           orientation="vertical"
           value={currentPage === V2Routes.UserInfo ? false : currentPage}
+          variant="scrollable"
+          scrollButtons="off"
         >
           {_.map(navItems, (n) => {
             if (n.disabled) return;


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Part of #3480 

Adds two mui props to the nav to allow for scrolling at small screen heights.
Also equally spaces header text in nav for enterprise section headers
