### PR TITLE
Use dynamic Secret name for admin credentials

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -10,5 +10,5 @@
 # Ignore JSON files
 *.json
 
-# Ignore MDX files
-*.mdx
+# Ignore MD and MDX files
+*.md*

--- a/charts/gitops-server/templates/_helpers.tpl
+++ b/charts/gitops-server/templates/_helpers.tpl
@@ -75,3 +75,14 @@ Return the target Kubernetes version
 {{- default .Capabilities.KubeVersion.Version .Values.kubeVersion -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Create the name of the admin credentials secret to use
+*/}}
+{{- define "chart.adminUserSecret" -}}
+{{- if (and .Values.adminUser.create .Values.adminUser.createSecret) }}
+{{- include "chart.fullname" . }}-user-auth
+{{- else }}
+{{- .Values.adminUser.secretName }}
+{{- end }}
+{{- end -}}

--- a/charts/gitops-server/templates/admin-user-creds.yaml
+++ b/charts/gitops-server/templates/admin-user-creds.yaml
@@ -1,10 +1,9 @@
-{{- if .Values.adminUser.create }}
-{{- if .Values.adminUser.createSecret }}
+{{- if (and .Values.adminUser.create .Values.adminUser.createSecret) }}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: cluster-user-auth
+  name: {{ include "chart.adminUserSecret" . }}
   namespace: {{ .Release.Namespace }}
 type: Opaque
 data:
@@ -12,5 +11,4 @@ data:
   username: {{ .username | b64enc | quote }}
   password: {{ .passwordHash | required "passwordHash must be set!" | b64enc | quote }}
   {{- end }}
-{{- end }}
 {{- end }}

--- a/charts/gitops-server/templates/deployment.yaml
+++ b/charts/gitops-server/templates/deployment.yaml
@@ -53,6 +53,12 @@ spec:
             - "--enable-metrics"
             - "--metrics-address=:{{ .Values.metrics.service.port }}"
             {{- end }}
+            {{- if .Values.adminUser.secretName }}
+            - "--admin-secret={{ .Values.adminUser.secretName }}"
+            {{- end }}
+            {{- if and .Values.adminUser.create .Values.adminUser.createSecret }}
+            - "--admin-secret={{ include "chart.fullname" . }}-user-auth"
+            {{- end }}
           {{- with .Values.additionalArgs }}
             {{- range . }}
             - {{ . | quote }}

--- a/charts/gitops-server/templates/role.yaml
+++ b/charts/gitops-server/templates/role.yaml
@@ -23,7 +23,7 @@ rules:
     {{- fail "You've supplied both rbac.viewSecrets and rbac.viewSecretsResourceNames. Please only use rbac.viewSecretsResourceNames" }}
     {{- end }}
     # or should return the first non-falsy result
-    {{- with (or .Values.rbac.viewSecretsResourceNames .Values.rbac.viewSecrets) }}
+    {{- with concat (or .Values.rbac.viewSecretsResourceNames .Values.rbac.viewSecrets) (list (or .Values.adminUser.secretName (include "chart.adminUserSecret" .))) }}
     resourceNames: {{ . | toJson }}
     {{- end }}
 

--- a/charts/gitops-server/values.yaml
+++ b/charts/gitops-server/values.yaml
@@ -54,7 +54,7 @@ rbac:
   impersonationResources: ["users", "groups"]
   # -- If non-empty, this limits the secrets that can be accessed by
   # the service account to the specified ones, e.g. `['weave-gitops-enterprise-credentials']`
-  viewSecretsResourceNames: ["cluster-user-auth", "oidc-auth"]
+  viewSecretsResourceNames: ["oidc-auth"]
   # -- If non-empty, these additional rules will be appended to the RBAC role and the cluster role.
   # for example,
   # additionalRules:
@@ -76,7 +76,10 @@ adminUser:
   # permissions, but the secret with username and password has to be
   # provided separately.
   createSecret: true
-  # -- Set username for local admin user, this should match the value in the secret `cluster-user-auth`
+  # -- The name of the secret storing admin user credentials. This is only taken into account when `createSecret`
+  # is set `false`.
+  secretName: ""
+  # -- Set username for local admin user, this should match the value in the secret
   # which can be created with `adminUser.createSecret`. Requires `adminUser.create`.
   username: gitops-test-user
   # -- (string) Set the password for local admin user. Requires `adminUser.create` and `adminUser.createSecret`

--- a/cmd/gitops-server/cmd/cmd.go
+++ b/cmd/gitops-server/cmd/cmd.go
@@ -65,6 +65,8 @@ type Options struct {
 	// Stuff for profiles apparently
 	HelmRepoName      string
 	HelmRepoNamespace string
+	// cluster user account
+	AdminSecret string
 	// OIDC
 	OIDC       auth.OIDCConfig
 	OIDCSecret string
@@ -104,6 +106,8 @@ func NewCommand() *cobra.Command {
 	cmd.Flags().BoolVar(&options.MTLS, "mtls", false, "disable enforce mTLS")
 	cmd.Flags().StringVar(&options.TLSCertFile, "tls-cert-file", "", "filename for the TLS certificate, in-memory generated if omitted")
 	cmd.Flags().StringVar(&options.TLSKeyFile, "tls-private-key-file", "", "filename for the TLS key, in-memory generated if omitted")
+	// cluster user account
+	cmd.Flags().StringVar(&options.AdminSecret, "admin-secret", "", "Name of the secret that contains admin credentials")
 	// OIDC
 	cmd.Flags().StringVar(&options.OIDCSecret, "oidc-secret-name", auth.DefaultOIDCAuthSecretName, "Name of the secret that contains OIDC configuration")
 	cmd.Flags().StringVar(&options.OIDC.ClientID, "oidc-client-id", "", "The client ID for the OpenID Connect client")
@@ -172,7 +176,7 @@ func runCmd(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("couldn't get current namespace")
 	}
 
-	authServer, err := auth.InitAuthServer(cmd.Context(), log, rawClient, options.OIDC, options.OIDCSecret, namespace, options.AuthMethods)
+	authServer, err := auth.InitAuthServer(cmd.Context(), log, rawClient, options.OIDC, options.AdminSecret, options.OIDCSecret, namespace, options.AuthMethods)
 
 	if err != nil {
 		return fmt.Errorf("could not initialise authentication server: %w", err)

--- a/pkg/server/auth/auth_test.go
+++ b/pkg/server/auth/auth_test.go
@@ -49,7 +49,7 @@ func TestWithAPIAuthReturns401ForUnauthenticatedRequests(t *testing.T) {
 
 	authMethods := map[auth.AuthMethod]bool{auth.OIDC: true}
 
-	authCfg, err := auth.NewAuthServerConfig(logr.Discard(), oidcCfg, fakeKubernetesClient, tokenSignerVerifier, testNamespace, authMethods)
+	authCfg, err := auth.NewAuthServerConfig(logr.Discard(), oidcCfg, fakeKubernetesClient, tokenSignerVerifier, testNamespace, authMethods, "")
 	g.Expect(err).NotTo(HaveOccurred())
 
 	srv, err := auth.NewAuthServer(context.Background(), authCfg)
@@ -122,7 +122,7 @@ func TestWithAPIAuthOnlyUsesValidMethods(t *testing.T) {
 
 	authMethods := map[auth.AuthMethod]bool{} // This is not a valid AuthMethod
 
-	authCfg, err := auth.NewAuthServerConfig(logr.Discard(), oidcCfg, fakeKubernetesClient, tokenSignerVerifier, testNamespace, authMethods)
+	authCfg, err := auth.NewAuthServerConfig(logr.Discard(), oidcCfg, fakeKubernetesClient, tokenSignerVerifier, testNamespace, authMethods, hashedSecret.Name)
 	g.Expect(err).NotTo(HaveOccurred())
 
 	srv, err := auth.NewAuthServer(context.Background(), authCfg)
@@ -186,7 +186,7 @@ func TestOauth2FlowRedirectsToOIDCIssuerWithCustomScopes(t *testing.T) {
 
 	authMethods := map[auth.AuthMethod]bool{auth.OIDC: true}
 
-	authCfg, err := auth.NewAuthServerConfig(logr.Discard(), oidcCfg, fakeKubernetesClient, tokenSignerVerifier, testNamespace, authMethods)
+	authCfg, err := auth.NewAuthServerConfig(logr.Discard(), oidcCfg, fakeKubernetesClient, tokenSignerVerifier, testNamespace, authMethods, "")
 	g.Expect(err).NotTo(HaveOccurred())
 
 	srv, err := auth.NewAuthServer(context.Background(), authCfg)
@@ -239,7 +239,7 @@ func TestOauth2FlowRedirectsToOIDCIssuerForUnauthenticatedRequests(t *testing.T)
 
 	authMethods := map[auth.AuthMethod]bool{auth.OIDC: true}
 
-	authCfg, err := auth.NewAuthServerConfig(logr.Discard(), oidcCfg, fakeKubernetesClient, tokenSignerVerifier, testNamespace, authMethods)
+	authCfg, err := auth.NewAuthServerConfig(logr.Discard(), oidcCfg, fakeKubernetesClient, tokenSignerVerifier, testNamespace, authMethods, "")
 	g.Expect(err).NotTo(HaveOccurred())
 
 	srv, err := auth.NewAuthServer(context.Background(), authCfg)
@@ -301,7 +301,7 @@ func TestRateLimit(t *testing.T) {
 
 	authMethods := map[auth.AuthMethod]bool{auth.UserAccount: true}
 
-	authCfg, err := auth.NewAuthServerConfig(logr.Discard(), oidcCfg, fakeKubernetesClient, tokenSignerVerifier, testNamespace, authMethods)
+	authCfg, err := auth.NewAuthServerConfig(logr.Discard(), oidcCfg, fakeKubernetesClient, tokenSignerVerifier, testNamespace, authMethods, hashedSecret.Name)
 	g.Expect(err).NotTo(HaveOccurred())
 
 	srv, err := auth.NewAuthServer(context.Background(), authCfg)

--- a/pkg/server/auth/init.go
+++ b/pkg/server/auth/init.go
@@ -13,7 +13,7 @@ import (
 
 // InitAuthServer creates a new AuthServer and configures it for the correct
 // authentication methods.
-func InitAuthServer(ctx context.Context, log logr.Logger, rawKubernetesClient ctrlclient.Client, oidcConfig OIDCConfig, oidcSecret, namespace string, authMethodStrings []string) (*AuthServer, error) {
+func InitAuthServer(ctx context.Context, log logr.Logger, rawKubernetesClient ctrlclient.Client, oidcConfig OIDCConfig, adminSecret, oidcSecret, namespace string, authMethodStrings []string) (*AuthServer, error) {
 	log.V(logger.LogLevelDebug).Info("Registering authentication methods", "methods", authMethodStrings)
 
 	authMethods, err := ParseAuthMethodArray(authMethodStrings)
@@ -64,7 +64,7 @@ func InitAuthServer(ctx context.Context, log logr.Logger, rawKubernetesClient ct
 		tsv.SetDevMode(true)
 	}
 
-	authCfg, err := NewAuthServerConfig(log, oidcConfig, rawKubernetesClient, tsv, namespace, authMethods)
+	authCfg, err := NewAuthServerConfig(log, oidcConfig, rawKubernetesClient, tsv, namespace, authMethods, adminSecret)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/auth/init_test.go
+++ b/pkg/server/auth/init_test.go
@@ -28,7 +28,8 @@ func TestInitAuthServer(t *testing.T) {
 	initTests := []struct {
 		name            string
 		authMethods     []string
-		secrets         []*corev1.Secret
+		oidcSecret      *corev1.Secret
+		adminSecret     *corev1.Secret
 		cliOIDCConfig   auth.OIDCConfig
 		oidcSecretName  string
 		expectErr       bool
@@ -36,12 +37,10 @@ func TestInitAuthServer(t *testing.T) {
 		oidcEnabledFlag string
 	}{
 		{
-			name:        "basic test",
-			authMethods: []string{"user-account", "oidc"},
-			secrets: []*corev1.Secret{
-				makeOIDCSecret(m.Config(), auth.DefaultOIDCAuthSecretName),
-				makeClusterUserSecret("my-secret-password", auth.ClusterUserAuthSecretName),
-			},
+			name:            "basic test",
+			authMethods:     []string{"user-account", "oidc"},
+			oidcSecret:      makeOIDCSecret(m.Config(), auth.DefaultOIDCAuthSecretName),
+			adminSecret:     makeClusterUserSecret("my-secret-password", "admin-credentials"),
 			cliOIDCConfig:   auth.OIDCConfig{},
 			oidcSecretName:  auth.DefaultOIDCAuthSecretName,
 			expectErr:       false,
@@ -49,11 +48,9 @@ func TestInitAuthServer(t *testing.T) {
 			oidcEnabledFlag: "true",
 		},
 		{
-			name:        "OIDC Only",
-			authMethods: []string{"oidc"},
-			secrets: []*corev1.Secret{
-				makeOIDCSecret(m.Config(), auth.DefaultOIDCAuthSecretName),
-			},
+			name:            "OIDC Only",
+			authMethods:     []string{"oidc"},
+			oidcSecret:      makeOIDCSecret(m.Config(), auth.DefaultOIDCAuthSecretName),
 			cliOIDCConfig:   auth.OIDCConfig{},
 			oidcSecretName:  auth.DefaultOIDCAuthSecretName,
 			expectErr:       false,
@@ -61,11 +58,9 @@ func TestInitAuthServer(t *testing.T) {
 			oidcEnabledFlag: "true",
 		},
 		{
-			name:        "OIDC alt-secret",
-			authMethods: []string{"oidc"},
-			secrets: []*corev1.Secret{
-				makeOIDCSecret(m.Config(), "alternate-oidc-secret"),
-			},
+			name:            "OIDC alt-secret",
+			authMethods:     []string{"oidc"},
+			oidcSecret:      makeOIDCSecret(m.Config(), "alternate-oidc-secret"),
 			cliOIDCConfig:   auth.OIDCConfig{},
 			oidcSecretName:  "alternate-oidc-secret",
 			expectErr:       false,
@@ -75,7 +70,6 @@ func TestInitAuthServer(t *testing.T) {
 		{
 			name:        "OIDC via CLI",
 			authMethods: []string{"oidc"},
-			secrets:     []*corev1.Secret{},
 			cliOIDCConfig: auth.OIDCConfig{
 				IssuerURL:    m.Config().Issuer,
 				ClientID:     m.Config().ClientID,
@@ -88,11 +82,9 @@ func TestInitAuthServer(t *testing.T) {
 			oidcEnabledFlag: "true",
 		},
 		{
-			name:        "User only",
-			authMethods: []string{"user-account"},
-			secrets: []*corev1.Secret{
-				makeClusterUserSecret("my-secret-password", auth.ClusterUserAuthSecretName),
-			},
+			name:            "User only",
+			authMethods:     []string{"user-account"},
+			adminSecret:     makeClusterUserSecret("my-secret-password", "admin-credentials"),
 			cliOIDCConfig:   auth.OIDCConfig{},
 			oidcSecretName:  auth.DefaultOIDCAuthSecretName,
 			expectErr:       false,
@@ -102,7 +94,6 @@ func TestInitAuthServer(t *testing.T) {
 		{
 			name:            "No auth methods",
 			authMethods:     []string{},
-			secrets:         []*corev1.Secret{},
 			cliOIDCConfig:   auth.OIDCConfig{},
 			oidcSecretName:  "",
 			expectErr:       true,
@@ -119,14 +110,20 @@ func TestInitAuthServer(t *testing.T) {
 
 			partialKubernetesClient := ctrlclient.NewClientBuilder()
 
-			// This is because I can't (be bothered to) figure out how to []*secret -> []*client.Object
-			for _, obj := range tt.secrets {
-				partialKubernetesClient.WithObjects(obj)
+			if tt.oidcSecret != nil {
+				partialKubernetesClient.WithObjects(tt.oidcSecret)
+			}
+			if tt.adminSecret != nil {
+				partialKubernetesClient.WithObjects(tt.adminSecret)
 			}
 
 			fakeKubernetesClient := partialKubernetesClient.Build()
 
-			srv, err := auth.InitAuthServer(context.Background(), logr.Discard(), fakeKubernetesClient, tt.cliOIDCConfig, tt.oidcSecretName, "test-namespace", tt.authMethods)
+			adminSecret := ""
+			if tt.adminSecret != nil {
+				adminSecret = tt.adminSecret.Name
+			}
+			srv, err := auth.InitAuthServer(context.Background(), logr.Discard(), fakeKubernetesClient, tt.cliOIDCConfig, adminSecret, tt.oidcSecretName, "test-namespace", tt.authMethods)
 
 			if tt.expectErr {
 				g.Expect(err).To(gomega.HaveOccurred())

--- a/tools/helm-values-dev.yaml
+++ b/tools/helm-values-dev.yaml
@@ -7,7 +7,7 @@ image:
 logLevel: debug
 
 rbac:
-  viewSecretsResourceNames: ["cluster-user-auth", "oidc-auth"]
+  viewSecretsResourceNames: ["oidc-auth"]
 
 adminUser:
   create: true

--- a/website/docs/configuration/emergency-user.mdx
+++ b/website/docs/configuration/emergency-user.mdx
@@ -24,7 +24,10 @@ echo -n $PASSWORD | gitops get bcrypt-hash
 $2a$10$OS5NJmPNEb13UgTOSKnMxOWlmS7mlxX77hv4yAiISvZ71Dc7IuN3q
 ```
 
-Now create a Kubernetes secret to store your chosen username and the password hash:
+Now create a Kubernetes secret to store your chosen username and the password hash.
+
+The name of the secret depends on your configuration (`adminUser.secretName` and `adminUser.createSecret` values).
+
 
 ```sh
 kubectl create secret generic cluster-user-auth \

--- a/website/docs/configuration/service-account-permissions.mdx
+++ b/website/docs/configuration/service-account-permissions.mdx
@@ -26,7 +26,7 @@ rules:
   resources: [ "secrets" ]
   verbs: [ "get", "list" ]
   resourceNames:                  # set by rbac.viewSecretsResourceNames
-    - "cluster-user-auth"
+    - "ww-gitops-weave-gitops-user-auth"    # the name of this Secret depends on your configuration, see below for details.
     - "oidc-auth"
 # The service account needs to read namespaces to know where it can query
 - apiGroups: [ "" ]
@@ -37,9 +37,10 @@ rules:
 These allow the pod to do three things:
 * [Impersonate](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#user-impersonation) the user and operate in the cluster as them
 * Read the available namespaces (this is required to understand the users' permissions)
-* Read the `cluster-user-auth` and `oidc-auth` secrets, which are the default secrets
-  to store the emergency cluster user account and OIDC configuration (see
+* Read the `ww-gitops-weave-gitops-user-auth` and `oidc-auth` secrets, which are the secrets
+  to store the emergency cluster-user account and OIDC configuration (see
   [securing access to the dashboard](securing-access-to-the-dashboard.mdx))
+  The name of the `ww-gitops-weave-gitops-user-auth` secret depends on your configuration (`adminUser.createSecret` and `adminUser.secretName` values).
 
 ## The Helm values
 
@@ -47,7 +48,7 @@ These allow the pod to do three things:
 |-----------------------------------|---------------------------------------------------------------------|--------------------------------------|
 | `rbac.impersonationResources`     | Which resource types the service account can impersonate            | `["users", "groups"]`                |
 | `rbac.impersonationResourceNames` | Specific users, groups or services account that can be impersonated | `[]`                                 |
-| `rbac.viewSecretsResourceNames`   | Specific secrets that can be read                                   | `["cluster-user-auth", "oidc-auth"]` |
+| `rbac.viewSecretsResourceNames`   | Specific secrets that can be read                                   | `["oidc-auth"]` |
 
 
 ## Impersonation
@@ -108,9 +109,9 @@ The application itself uses get namespace permissions to pre-cache the list of
 available namespaces. As the user accesses resources their permissions within
 various namespaces is also cached to speed up future operations.
 
-## Reading the `cluster-user-auth` and `oidc-auth secrets`
+## Reading the `ww-gitops-weave-gitops-user-auth` and `oidc-auth secrets`
 
-The `cluster-user-auth` and `oidc-auth` secrets provide information for authenticating
+The `ww-gitops-weave-gitops-user-auth` and `oidc-auth` secrets provide information for authenticating
 to the application. The former holds the username and bcrypt-hashed password
 for the [emergency user](../emergency-user) and the latter holds OIDC configuration.
 

--- a/website/docs/references/helm-reference.md
+++ b/website/docs/references/helm-reference.md
@@ -15,7 +15,7 @@ This reference was generated for the chart version 4.0.17 which installs weave g
 | adminUser.createClusterRole | bool | `true` | Specifies whether the clusterRole & binding to the admin user should be created. Will be created only if `adminUser.create` is enabled. Without this, the adminUser will only be able to see resources in the target namespace. |
 | adminUser.createSecret | bool | `true` | Whether we should create the secret for the local adminUser. Will be created only if `adminUser.create` is enabled. Without this, we'll still set up the roles and permissions, but the secret with username and password has to be provided separately. |
 | adminUser.passwordHash | string | `nil` | Set the password for local admin user. Requires `adminUser.create` and `adminUser.createSecret` This needs to have been hashed using bcrypt. You can do this via our CLI with `gitops get bcrypt-hash`. |
-| adminUser.username | string | `"gitops-test-user"` | Set username for local admin user, this should match the value in the secret `cluster-user-auth` which can be created with `adminUser.createSecret`. Requires `adminUser.create`. |
+| adminUser.username | string | `"gitops-test-user"` | Set username for local admin user, this should match the value in the admin user secret which can be created with `adminUser.createSecret`. Requires `adminUser.create`. |
 | affinity | object | `{}` |  |
 | annotations | object | `{}` | Annotations to add to the deployment |
 | envVars[0].name | string | `"WEAVE_GITOPS_FEATURE_TENANCY"` |  |
@@ -49,7 +49,7 @@ This reference was generated for the chart version 4.0.17 which installs weave g
 | rbac.create | bool | `true` | Specifies whether the clusterRole & binding to the service account should be created |
 | rbac.impersonationResourceNames | list | `[]` | If non-empty, this limits the resources that the service account can impersonate. This applies to both users and groups, e.g. `['user1@corporation.com', 'user2@corporation.com', 'operations']` |
 | rbac.impersonationResources | list | `["users","groups"]` | Limit the type of principal that can be impersonated |
-| rbac.viewSecretsResourceNames | list | `["cluster-user-auth","oidc-auth"]` | If non-empty, this limits the secrets that can be accessed by the service account to the specified ones, e.g. `['weave-gitops-enterprise-credentials']` |
+| rbac.viewSecretsResourceNames | list | `["oidc-auth"]` | If non-empty, this limits the secrets that can be accessed by the service account to the specified ones, e.g. `['weave-gitops-enterprise-credentials']` |
 | replicaCount | int | `1` |  |
 | resources | object | `{}` |  |
 | securityContext.allowPrivilegeEscalation | bool | `false` |  |


### PR DESCRIPTION
Closes #2237 

- Added support for the dynamic admin secret user name to the gitops-server code.

- Updated unit tests.

- Updated documentation related to admin user credentials secret.

Notes:
- Transferred code from the old PR (3149) here because it was outdated and caused merging conflicts + it was easier to understand the changes this way.
- Added minimal updates to the documentation. Adding more minor updates is fine but if any major updates/changes/a new guide on how to configure smth. are needed, they should be covered in a separate issue.

**Questions:**
- I just removed the old hardcoded secret name from `viewSecretsResourceNames`? Is it OK? Will the users be able to add the actual dynamically generated secret name to this array manually, if needed?
- @foot @stefanprodan  Enterprise uses the `NewAuthServerConfig` method here:
https://github.com/weaveworks/weave-gitops-enterprise/blob/main/cmd/clusters-service/app/server.go#L716

What should be changed in enterprise after the current OSS PR is merged? Can I just pass "cluster-user-auth" or a similar hardcoded value to `NewAuthServerConfig` in enterprise or should the same flag `admin-secret` be added there too to support dynamic secret names?

Testing:
Please view the testing logs in the comments.
