### PR TITLE
add rlock to clustermgr hash to avoid a race condition

### DIFF
--- a/core/clustersmngr/factory_caches.go
+++ b/core/clustersmngr/factory_caches.go
@@ -72,8 +72,10 @@ func (c *Clusters) Get() []cluster.Cluster {
 }
 
 func (c *Clusters) Hash() string {
-	names := []string{}
+	c.RLock()
+	defer c.RUnlock()
 
+	names := []string{}
 	for _, cluster := range c.clusters {
 		names = append(names, cluster.GetName())
 	}


### PR DESCRIPTION
Fixes #3536 

How to confirm the fix:
```
KUBEBUILDER_ASSETS=$(setup-envtest use -p path 1.24.2) go test -race -v ./core/clustersmngr/...
```

Test logs:
```
❯ KUBEBUILDER_ASSETS=$(setup-envtest use -p path 1.24.2) go test -race -v ./core/clustersmngr/...
=== RUN   TestClientGet
--- PASS: TestClientGet (2.04s)
=== RUN   TestClientClusteredList
--- PASS: TestClientClusteredList (0.04s)
=== RUN   TestClientClusteredListPagination
--- PASS: TestClientClusteredListPagination (0.02s)
=== RUN   TestClientClusteredListClusterScoped
--- PASS: TestClientClusteredListClusterScoped (0.02s)
=== RUN   TestClientCLusteredListErrors
--- PASS: TestClientCLusteredListErrors (0.02s)
=== RUN   TestClientList
--- PASS: TestClientList (0.02s)
=== RUN   TestClientCreate
--- PASS: TestClientCreate (0.02s)
=== RUN   TestClientDelete
--- PASS: TestClientDelete (0.02s)
=== RUN   TestClientUpdate
--- PASS: TestClientUpdate (0.02s)
=== RUN   TestClientPatch
--- PASS: TestClientPatch (0.02s)
=== RUN   TestUsersNamespaces
=== RUN   TestUsersNamespaces/namespaces_of_a_single_cluster
=== RUN   TestUsersNamespaces/all_namespaces_from_all
--- PASS: TestUsersNamespaces (0.00s)
    --- PASS: TestUsersNamespaces/namespaces_of_a_single_cluster (0.00s)
    --- PASS: TestUsersNamespaces/all_namespaces_from_all (0.00s)
=== RUN   TestClusters
--- PASS: TestClusters (0.00s)
=== RUN   TestClustersNamespaces
--- PASS: TestClustersNamespaces (0.00s)
=== RUN   TestClusterSet_Set
--- PASS: TestClusterSet_Set (0.00s)
=== RUN   TestGetImpersonatedClient
=== RUN   TestGetImpersonatedClient/checks_all_namespaces_in_the_cluster_when_through_the_filtering
--- PASS: TestGetImpersonatedClient (0.03s)
    --- PASS: TestGetImpersonatedClient/checks_all_namespaces_in_the_cluster_when_through_the_filtering (0.00s)
=== RUN   TestUseUserClientForNamespaces
=== RUN   TestUseUserClientForNamespaces/checks_all_namespaces_in_the_cluster_when_through_the_filtering
context.Background.WithCancel &{0xc0003afea0} [{{ } {default    15a1cc24-f7a2-4abf-b50a-677c6cd23557 195 0 2023-03-23 19:42:36 +0700 +07 <nil> <nil> map[kubernetes.io/metadata.name:default] map[] [] [] [{kube-apiserver Update v1 2023-03-23 19:42:36 +0700 +07 FieldsV1 {"f:metadata":{"f:labels":{".":{},"f:kubernetes.io/metadata.name":{}}}} }]} {[kubernetes]} {Active []}} {{ } {kube-node-lease    da4a311c-ae9d-4019-bc0e-f19eafbc101b 6 0 2023-03-23 19:42:35 +0700 +07 <nil> <nil> map[kubernetes.io/metadata.name:kube-node-lease] map[] [] [] [{kube-apiserver Update v1 2023-03-23 19:42:35 +0700 +07 FieldsV1 {"f:metadata":{"f:labels":{".":{},"f:kubernetes.io/metadata.name":{}}}} }]} {[kubernetes]} {Active []}} {{ } {kube-public    0d5a5ae7-0bcf-4f3c-a8ee-e72fe3665d9d 5 0 2023-03-23 19:42:35 +0700 +07 <nil> <nil> map[kubernetes.io/metadata.name:kube-public] map[] [] [] [{kube-apiserver Update v1 2023-03-23 19:42:35 +0700 +07 FieldsV1 {"f:metadata":{"f:labels":{".":{},"f:kubernetes.io/metadata.name":{}}}} }]} {[kubernetes]} {Active []}} {{ } {kube-system    6630983e-252f-4b8f-ade5-d2578b30642c 4 0 2023-03-23 19:42:35 +0700 +07 <nil> <nil> map[kubernetes.io/metadata.name:kube-system] map[] [] [] [{kube-apiserver Update v1 2023-03-23 19:42:35 +0700 +07 FieldsV1 {"f:metadata":{"f:labels":{".":{},"f:kubernetes.io/metadata.name":{}}}} }]} {[kubernetes]} {Active []}} {{ } {kube-test-4qz9s    681c8bda-aed6-48c9-81ce-ff51629e76fa 226 0 2023-03-23 19:42:38 +0700 +07 <nil> <nil> map[kubernetes.io/metadata.name:kube-test-4qz9s] map[] [] [] [{clustersmngr.test Update v1 2023-03-23 19:42:38 +0700 +07 FieldsV1 {"f:metadata":{"f:labels":{".":{},"f:kubernetes.io/metadata.name":{}}}} }]} {[kubernetes]} {Active []}} {{ } {kube-test-5xw8b    8f45604d-2300-4e6e-bcf6-41f1ab93f009 246 0 2023-03-23 19:42:38 +0700 +07 <nil> <nil> map[kubernetes.io/metadata.name:kube-test-5xw8b] map[] [] [] [{clustersmngr.test Update v1 2023-03-23 19:42:38 +0700 +07 FieldsV1 {"f:metadata":{"f:labels":{".":{},"f:kubernetes.io/metadata.name":{}}}} }]} {[kubernetes]} {Active []}} {{ } {kube-test-9bmjd    83a5c4b0-e5f5-421f-9e54-ad2b23cfc563 243 0 2023-03-23 19:42:38 +0700 +07 <nil> <nil> map[kubernetes.io/metadata.name:kube-test-9bmjd] map[] [] [] [{clustersmngr.test Update v1 2023-03-23 19:42:38 +0700 +07 FieldsV1 {"f:metadata":{"f:labels":{".":{},"f:kubernetes.io/metadata.name":{}}}} }]} {[kubernetes]} {Active []}} {{ } {kube-test-bmt6s    01a747e1-2f11-4238-862c-3844913cbd65 240 0 2023-03-23 19:42:38 +0700 +07 <nil> <nil> map[kubernetes.io/metadata.name:kube-test-bmt6s] map[] [] [] [{clustersmngr.test Update v1 2023-03-23 19:42:38 +0700 +07 FieldsV1 {"f:metadata":{"f:labels":{".":{},"f:kubernetes.io/metadata.name":{}}}} }]} {[kubernetes]} {Active []}} {{ } {kube-test-dm2l5    ae34c9e9-659b-46ce-8347-e139cea4d9f2 248 0 2023-03-23 19:42:38 +0700 +07 <nil> <nil> map[kubernetes.io/metadata.name:kube-test-dm2l5] map[] [] [] [{clustersmngr.test Update v1 2023-03-23 19:42:38 +0700 +07 FieldsV1 {"f:metadata":{"f:labels":{".":{},"f:kubernetes.io/metadata.name":{}}}} }]} {[kubernetes]} {Active []}} {{ } {kube-test-fsbhk    773a4b19-3eeb-422b-bc12-a15c57655d30 238 0 2023-03-23 19:42:38 +0700 +07 <nil> <nil> map[kubernetes.io/metadata.name:kube-test-fsbhk] map[] [] [] [{clustersmngr.test Update v1 2023-03-23 19:42:38 +0700 +07 FieldsV1 {"f:metadata":{"f:labels":{".":{},"f:kubernetes.io/metadata.name":{}}}} }]} {[kubernetes]} {Active []}} {{ } {kube-test-js2lb    6baa6696-8f91-4e62-986f-02efca5cc582 224 0 2023-03-23 19:42:36 +0700 +07 <nil> <nil> map[kubernetes.io/metadata.name:kube-test-js2lb] map[] [] [] [{clustersmngr.test Update v1 2023-03-23 19:42:36 +0700 +07 FieldsV1 {"f:metadata":{"f:labels":{".":{},"f:kubernetes.io/metadata.name":{}}}} }]} {[kubernetes]} {Active []}} {{ } {kube-test-k97kn    739aef37-0453-49cd-9b48-21abfa368ee0 251 0 2023-03-23 19:42:38 +0700 +07 <nil> <nil> map[kubernetes.io/metadata.name:kube-test-k97kn] map[] [] [] [{clustersmngr.test Update v1 2023-03-23 19:42:38 +0700 +07 FieldsV1 {"f:metadata":{"f:labels":{".":{},"f:kubernetes.io/metadata.name":{}}}} }]} {[kubernetes]} {Active []}} {{ } {kube-test-kg54x    451b7d05-f64f-4231-b570-3242e8f0d6ef 229 0 2023-03-23 19:42:38 +0700 +07 <nil> <nil> map[kubernetes.io/metadata.name:kube-test-kg54x] map[] [] [] [{clustersmngr.test Update v1 2023-03-23 19:42:38 +0700 +07 FieldsV1 {"f:metadata":{"f:labels":{".":{},"f:kubernetes.io/metadata.name":{}}}} }]} {[kubernetes]} {Active []}} {{ } {kube-test-nqp7h    b5bf0d02-55dc-41e5-b894-59bed4570f90 250 0 2023-03-23 19:42:38 +0700 +07 <nil> <nil> map[kubernetes.io/metadata.name:kube-test-nqp7h] map[] [] [] [{clustersmngr.test Update v1 2023-03-23 19:42:38 +0700 +07 FieldsV1 {"f:metadata":{"f:labels":{".":{},"f:kubernetes.io/metadata.name":{}}}} }]} {[kubernetes]} {Active []}} {{ } {kube-test-pr7rr    ccf6647e-b055-4d8e-a842-dce4640121c3 249 0 2023-03-23 19:42:38 +0700 +07 <nil> <nil> map[kubernetes.io/metadata.name:kube-test-pr7rr] map[] [] [] [{clustersmngr.test Update v1 2023-03-23 19:42:38 +0700 +07 FieldsV1 {"f:metadata":{"f:labels":{".":{},"f:kubernetes.io/metadata.name":{}}}} }]} {[kubernetes]} {Active []}} {{ } {kube-test-qrj95    e29fd783-7d84-485c-a763-d7e6c5d45547 235 0 2023-03-23 19:42:38 +0700 +07 <nil> <nil> map[kubernetes.io/metadata.name:kube-test-qrj95] map[] [] [] [{clustersmngr.test Update v1 2023-03-23 19:42:38 +0700 +07 FieldsV1 {"f:metadata":{"f:labels":{".":{},"f:kubernetes.io/metadata.name":{}}}} }]} {[kubernetes]} {Active []}} {{ } {kube-test-rl7xv    fa47d9cd-ff83-4a31-9cd6-c8b32c01cb46 236 0 2023-03-23 19:42:38 +0700 +07 <nil> <nil> map[kubernetes.io/metadata.name:kube-test-rl7xv] map[] [] [] [{clustersmngr.test Update v1 2023-03-23 19:42:38 +0700 +07 FieldsV1 {"f:metadata":{"f:labels":{".":{},"f:kubernetes.io/metadata.name":{}}}} }]} {[kubernetes]} {Active []}} {{ } {kube-test-rpz96    66fb914f-a7af-4ff9-a3ba-57713609d987 230 0 2023-03-23 19:42:38 +0700 +07 <nil> <nil> map[kubernetes.io/metadata.name:kube-test-rpz96] map[] [] [] [{clustersmngr.test Update v1 2023-03-23 19:42:38 +0700 +07 FieldsV1 {"f:metadata":{"f:labels":{".":{},"f:kubernetes.io/metadata.name":{}}}} }]} {[kubernetes]} {Active []}}]
--- PASS: TestUseUserClientForNamespaces (0.02s)
    --- PASS: TestUseUserClientForNamespaces/checks_all_namespaces_in_the_cluster_when_through_the_filtering (0.00s)
=== RUN   TestGetImpersonatedDiscoveryClient
--- PASS: TestGetImpersonatedDiscoveryClient (0.02s)
=== RUN   TestUpdateNamespaces
=== RUN   TestUpdateNamespaces/UpdateNamespaces_will_return_a_map_based_on_the_clusters_returned_by_Fetch
=== RUN   TestUpdateNamespaces/When_a_cluster_is_no_longer_in_the_clusters_cache,_the_clustersNamespaces_cache_updates_to_reflect_this
=== RUN   TestUpdateNamespaces/UpdateNamespaces_will_return_partial_results_if_a_single_cluster_fails_to_connect
--- PASS: TestUpdateNamespaces (0.02s)
    --- PASS: TestUpdateNamespaces/UpdateNamespaces_will_return_a_map_based_on_the_clusters_returned_by_Fetch (0.01s)
    --- PASS: TestUpdateNamespaces/When_a_cluster_is_no_longer_in_the_clusters_cache,_the_clustersNamespaces_cache_updates_to_reflect_this (0.00s)
    --- PASS: TestUpdateNamespaces/UpdateNamespaces_will_return_partial_results_if_a_single_cluster_fails_to_connect (0.00s)
=== RUN   TestUpdateUserNamespaces
=== RUN   TestUpdateUserNamespaces/UpdateUserNamespaces_will_return_a_map_based_on_the_clusters_returned_by_Fetch
=== RUN   TestUpdateUserNamespaces/GetUsersNamespaces_will_only_return_cached_items_matched_to_the_current_clusters_list
--- PASS: TestUpdateUserNamespaces (0.00s)
    --- PASS: TestUpdateUserNamespaces/UpdateUserNamespaces_will_return_a_map_based_on_the_clusters_returned_by_Fetch (0.00s)
    --- PASS: TestUpdateUserNamespaces/GetUsersNamespaces_will_only_return_cached_items_matched_to_the_current_clusters_list (0.00s)
=== RUN   TestUpdateUserNamespacesFailsToConnect
=== RUN   TestUpdateUserNamespacesFailsToConnect/UpdateUserNamespaces_remains_unchanged_if_a_connection_failure_occurs
--- PASS: TestUpdateUserNamespacesFailsToConnect (0.01s)
    --- PASS: TestUpdateUserNamespacesFailsToConnect/UpdateUserNamespaces_remains_unchanged_if_a_connection_failure_occurs (0.01s)
=== RUN   TestGetClusters
=== RUN   TestGetClusters/GetClusters_returns_clusters_that_were_fetched
--- PASS: TestGetClusters (0.00s)
    --- PASS: TestGetClusters/GetClusters_returns_clusters_that_were_fetched (0.00s)
=== RUN   TestUpdateClusters
=== RUN   TestUpdateClusters/watcher_should_be_notified_with_two_clusters_added
=== RUN   TestUpdateClusters/watcher_should_be_notified_with_one_cluster_removed
=== RUN   TestUpdateClusters/watcher_shouldn't_be_notified_when_there_are_no_updates
=== RUN   TestUpdateClusters/Updates_channel_should_be_closed_when_calling_Unsubscribe
=== RUN   TestUpdateClusters/Unsubscribe_should_close_the_correct_channel
--- PASS: TestUpdateClusters (0.00s)
    --- PASS: TestUpdateClusters/watcher_should_be_notified_with_two_clusters_added (0.00s)
    --- PASS: TestUpdateClusters/watcher_should_be_notified_with_one_cluster_removed (0.00s)
    --- PASS: TestUpdateClusters/watcher_shouldn't_be_notified_when_there_are_no_updates (0.00s)
    --- PASS: TestUpdateClusters/Updates_channel_should_be_closed_when_calling_Unsubscribe (0.00s)
    --- PASS: TestUpdateClusters/Unsubscribe_should_close_the_correct_channel (0.00s)
=== RUN   TestClientCaching
--- PASS: TestClientCaching (0.00s)
PASS
ok      github.com/weaveworks/weave-gitops/core/clustersmngr    7.080s
=== RUN   TestDelegatingCacheGet
--- PASS: TestDelegatingCacheGet (0.11s)
=== RUN   TestDelegatingCacheList
--- PASS: TestDelegatingCacheList (0.11s)
=== RUN   TestSingleCluster
--- PASS: TestSingleCluster (0.00s)
=== RUN   TestClientConfigWithUser
=== RUN   TestClientConfigWithUser/good_user_and_cluster_in:_good_config_out
=== RUN   TestClientConfigWithUser/good_token_and_cluster_in:_good_config_out
=== RUN   TestClientConfigWithUser/No_token_or_user_Id_should_error
--- PASS: TestClientConfigWithUser (1.07s)
    --- PASS: TestClientConfigWithUser/good_user_and_cluster_in:_good_config_out (0.00s)
    --- PASS: TestClientConfigWithUser/good_token_and_cluster_in:_good_config_out (0.00s)
    --- PASS: TestClientConfigWithUser/No_token_or_user_Id_should_error (0.00s)
PASS
ok      github.com/weaveworks/weave-gitops/core/clustersmngr/cluster    4.559s
?       github.com/weaveworks/weave-gitops/core/clustersmngr/cluster/clusterfakes       [no test files]
?       github.com/weaveworks/weave-gitops/core/clustersmngr/clustersmngrfakes  [no test files]
=== RUN   TestSingleFetcher
--- PASS: TestSingleFetcher (0.00s)
PASS
ok      github.com/weaveworks/weave-gitops/core/clustersmngr/fetcher    (cached)
```