### PR TITLE
Fix race condition of byte buffer in port forwarding

### DIFF
--- a/pkg/run/watch/forward_port.go
+++ b/pkg/run/watch/forward_port.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/go-logr/logr"
 	"github.com/mattn/go-tty"
@@ -90,6 +91,32 @@ func generalizeKind(kind string) string {
 	}
 }
 
+type safeBuffer struct {
+	buffer bytes.Buffer
+	mux    sync.RWMutex
+}
+
+func (sb *safeBuffer) Write(p []byte) (n int, err error) {
+	sb.mux.Lock()
+	defer sb.mux.Unlock()
+
+	return sb.buffer.Write(p)
+}
+
+func (sb *safeBuffer) Len() int {
+	sb.mux.RLock()
+	defer sb.mux.RUnlock()
+
+	return sb.buffer.Len()
+}
+
+func (sb *safeBuffer) String() string {
+	sb.mux.RLock()
+	defer sb.mux.RUnlock()
+
+	return sb.buffer.String()
+}
+
 func ForwardPort(log logr.Logger, pod *corev1.Pod, cfg *rest.Config, specMap *PortForwardSpec, waitFwd, readyChannel chan struct{}) error {
 	reqURL, err := url.Parse(
 		fmt.Sprintf("%s/api/v1/namespaces/%s/pods/%s/portforward",
@@ -109,8 +136,8 @@ func ForwardPort(log logr.Logger, pod *corev1.Pod, cfg *rest.Config, specMap *Po
 
 	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, "POST", reqURL)
 
-	outStd := bytes.Buffer{}
-	outErr := bytes.Buffer{}
+	outStd := safeBuffer{}
+	outErr := safeBuffer{}
 
 	fw, err2 := portforward.NewOnAddresses(
 		dialer,


### PR DESCRIPTION
Fixes #3548

This PR is the follow up for #3557.
Please merge #3557 first.

To test this,
1. Compile the `gitops` binary with `CGO_ENABLED=1 go build -race ...`
2. Run `gitops run`

The buffer race condition for port forwarding should not appear there.