### PR TITLE
Dashboard reconciliation stuck when running GitOps Run in the no session mode with OSS dashboard already installed

### DIFF
--- a/charts/gitops-server/templates/_helpers.tpl
+++ b/charts/gitops-server/templates/_helpers.tpl
@@ -51,6 +51,14 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+App selector labels
+*/}}
+{{- define "chart.appSelectorLabels" -}}
+app.kubernetes.io/part-of: weave-gitops
+weave.works/app: weave-gitops-oss
+{{- end }}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "chart.serviceAccountName" -}}

--- a/charts/gitops-server/templates/deployment.yaml
+++ b/charts/gitops-server/templates/deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ include "chart.fullname" . }}
   labels:
     {{- include "chart.labels" . | nindent 4 }}
+    {{- include "chart.appSelectorLabels" . | nindent 4 }}
   {{- with .Values.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -21,6 +22,7 @@ spec:
       {{- end }}
       labels:
         {{- include "chart.selectorLabels" . | nindent 8 }}
+        {{- include "chart.appSelectorLabels" . | nindent 8 }}
         {{- with .Values.podLabels }}
           {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/core/server/fluxruntime_test.go
+++ b/core/server/fluxruntime_test.go
@@ -10,7 +10,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/weaveworks/weave-gitops/core/clustersmngr/cluster"
 	"github.com/weaveworks/weave-gitops/core/server"
-	stypes "github.com/weaveworks/weave-gitops/core/server/types"
+	coretypes "github.com/weaveworks/weave-gitops/core/server/types"
 	pb "github.com/weaveworks/weave-gitops/pkg/api/core"
 	"github.com/weaveworks/weave-gitops/pkg/kube"
 	"google.golang.org/grpc/metadata"
@@ -56,12 +56,12 @@ func TestGetReconciledObjects(t *testing.T) {
 			Spec: appsv1.DeploymentSpec{
 				Selector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
-						"app": automationName,
+						coretypes.AppLabel: automationName,
 					},
 				},
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
-						Labels: map[string]string{"app": automationName},
+						Labels: map[string]string{coretypes.AppLabel: automationName},
 					},
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{{
@@ -263,12 +263,12 @@ func TestGetChildObjects(t *testing.T) {
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					"app": automationName,
+					coretypes.AppLabel: automationName,
 				},
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{"app": automationName},
+					Labels: map[string]string{coretypes.AppLabel: automationName},
 				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{{
@@ -352,9 +352,9 @@ func TestListFluxRuntimeObjects(t *testing.T) {
 			"flux namespace label, with controllers",
 			[]runtime.Object{
 				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "flux-ns", Labels: map[string]string{
-					stypes.PartOfLabel: server.FluxNamespacePartOf,
+					coretypes.PartOfLabel: server.FluxNamespacePartOf,
 				}}},
-				newDeployment("random-flux-controller", "flux-ns", map[string]string{stypes.PartOfLabel: server.FluxNamespacePartOf}),
+				newDeployment("random-flux-controller", "flux-ns", map[string]string{coretypes.PartOfLabel: server.FluxNamespacePartOf}),
 				newDeployment("other-controller-in-flux-ns", "flux-ns", map[string]string{}),
 			},
 			func(res *pb.ListFluxRuntimeObjectsResponse) {
@@ -366,7 +366,7 @@ func TestListFluxRuntimeObjects(t *testing.T) {
 			"use flux-system namespace when no namespace label available",
 			[]runtime.Object{
 				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "flux-system"}},
-				newDeployment("random-flux-controller", "flux-system", map[string]string{stypes.PartOfLabel: server.FluxNamespacePartOf}),
+				newDeployment("random-flux-controller", "flux-system", map[string]string{coretypes.PartOfLabel: server.FluxNamespacePartOf}),
 				newDeployment("other-controller-in-flux-ns", "flux-system", map[string]string{}),
 			},
 			func(res *pb.ListFluxRuntimeObjectsResponse) {
@@ -401,12 +401,12 @@ func newDeployment(name, ns string, labels map[string]string) *appsv1.Deployment
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					"app": name,
+					coretypes.AppLabel: name,
 				},
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{"app": name},
+					Labels: map[string]string{coretypes.AppLabel: name},
 				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{{
@@ -426,7 +426,7 @@ func TestListFluxCrds(t *testing.T) {
 
 	crd1 := &apiextensions.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{
 		Name:   "crd1",
-		Labels: map[string]string{stypes.PartOfLabel: "flux"},
+		Labels: map[string]string{coretypes.PartOfLabel: "flux"},
 	}, Spec: apiextensions.CustomResourceDefinitionSpec{
 		Group:    "group",
 		Names:    apiextensions.CustomResourceDefinitionNames{Plural: "plural", Kind: "kind"},
@@ -434,7 +434,7 @@ func TestListFluxCrds(t *testing.T) {
 	}}
 	crd2 := &apiextensions.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{
 		Name:   "crd2",
-		Labels: map[string]string{stypes.PartOfLabel: "flux"},
+		Labels: map[string]string{coretypes.PartOfLabel: "flux"},
 	}, Spec: apiextensions.CustomResourceDefinitionSpec{
 		Group: "group",
 		Versions: []apiextensions.CustomResourceDefinitionVersion{

--- a/core/server/inventory_test.go
+++ b/core/server/inventory_test.go
@@ -46,12 +46,12 @@ func TestGetInventoryKustomization(t *testing.T) {
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					"app": automationName,
+					types.AppLabel: automationName,
 				},
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{"app": automationName},
+					Labels: map[string]string{types.AppLabel: automationName},
 				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{{

--- a/core/server/objects.go
+++ b/core/server/objects.go
@@ -164,7 +164,7 @@ func parseSessionInfo(unstructuredObj unstructured.Unstructured) (string, string
 
 	labels := set.GetLabels()
 
-	if labels["app"] != "vcluster" || labels["app.kubernetes.io/part-of"] != "gitops-run" {
+	if labels[types.AppLabel] != "vcluster" || labels[types.PartOfLabel] != "gitops-run" {
 		return "", "", fmt.Errorf("unexpected format of labels")
 	}
 

--- a/core/server/objects_test.go
+++ b/core/server/objects_test.go
@@ -786,8 +786,8 @@ func TestListObjectsGitOpsRunSessions(t *testing.T) {
 			Name:      "session-1",
 			Namespace: ns.Name,
 			Labels: map[string]string{
-				"app":                       "vcluster",
-				"app.kubernetes.io/part-of": "gitops-run",
+				types.AppLabel:    "vcluster",
+				types.PartOfLabel: "gitops-run",
 			},
 			Annotations: map[string]string{
 				"run.weave.works/automation-kind": "ks",
@@ -801,8 +801,8 @@ func TestListObjectsGitOpsRunSessions(t *testing.T) {
 			Name:      "session-2",
 			Namespace: ns.Name,
 			Labels: map[string]string{
-				"app":                       "vcluster",
-				"app.kubernetes.io/part-of": "gitops-run",
+				types.AppLabel:    "vcluster",
+				types.PartOfLabel: "gitops-run",
 			},
 			Annotations: map[string]string{
 				"run.weave.works/automation-kind": "helm",

--- a/core/server/session_logs.go
+++ b/core/server/session_logs.go
@@ -19,7 +19,6 @@ import (
 	"github.com/weaveworks/weave-gitops/core/clustersmngr/cluster"
 	coretypes "github.com/weaveworks/weave-gitops/core/server/types"
 	pb "github.com/weaveworks/weave-gitops/pkg/api/core"
-	"github.com/weaveworks/weave-gitops/pkg/flux"
 	"github.com/weaveworks/weave-gitops/pkg/logger"
 	"github.com/weaveworks/weave-gitops/pkg/run/constants"
 	"github.com/weaveworks/weave-gitops/pkg/server/auth"
@@ -74,7 +73,7 @@ func (cs *coreServer) getFluxNamespace(ctx context.Context, k8sClient client.Cli
 		return "", fmt.Errorf("error getting list of objects")
 	} else {
 		for _, item := range namespaceList.Items {
-			if item.GetLabels()[flux.VersionLabelKey] != "" {
+			if item.GetLabels()[coretypes.VersionLabel] != "" {
 				ns = &item
 				break
 			}

--- a/core/server/types/app.go
+++ b/core/server/types/app.go
@@ -1,9 +1,13 @@
 package types
 
 const (
-	PartOfLabel    string = "app.kubernetes.io/part-of"
-	ManagedByLabel string = "app.kubernetes.io/managed-by"
-	CreatedByLabel string = "app.kubernetes.io/created-by"
-	InstanceLabel  string = "app.kubernetes.io/instance"
-	NameLabel      string = "app.kubernetes.io/name"
+	AppLabel          string = "app"
+	ComponentLabel    string = "app.kubernetes.io/component"
+	CreatedByLabel    string = "app.kubernetes.io/created-by"
+	DashboardAppLabel string = "weave.works/app"
+	InstanceLabel     string = "app.kubernetes.io/instance"
+	ManagedByLabel    string = "app.kubernetes.io/managed-by"
+	NameLabel         string = "app.kubernetes.io/name"
+	PartOfLabel       string = "app.kubernetes.io/part-of"
+	VersionLabel      string = "app.kubernetes.io/version"
 )

--- a/core/server/version.go
+++ b/core/server/version.go
@@ -7,7 +7,6 @@ import (
 	"github.com/weaveworks/weave-gitops/core/clustersmngr/cluster"
 	coretypes "github.com/weaveworks/weave-gitops/core/server/types"
 	pb "github.com/weaveworks/weave-gitops/pkg/api/core"
-	"github.com/weaveworks/weave-gitops/pkg/flux"
 	"github.com/weaveworks/weave-gitops/pkg/server/auth"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -60,7 +59,7 @@ func (cs *coreServer) getFluxVersion(ctx context.Context, k8sClient client.Clien
 		return "", fmt.Errorf("error getting list of objects")
 	} else {
 		for _, item := range listResult.Items {
-			if item.GetLabels()[flux.VersionLabelKey] != "" {
+			if item.GetLabels()[coretypes.VersionLabel] != "" {
 				u = item
 				break
 			}
@@ -72,7 +71,7 @@ func (cs *coreServer) getFluxVersion(ctx context.Context, k8sClient client.Clien
 		return "", fmt.Errorf("error getting labels")
 	}
 
-	fluxVersion := labels[flux.VersionLabelKey]
+	fluxVersion := labels[coretypes.VersionLabel]
 	if fluxVersion == "" {
 		return "", fmt.Errorf("no flux version found")
 	}

--- a/core/server/version_test.go
+++ b/core/server/version_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/weaveworks/weave-gitops/core/server"
 	coretypes "github.com/weaveworks/weave-gitops/core/server/types"
 	pb "github.com/weaveworks/weave-gitops/pkg/api/core"
-	"github.com/weaveworks/weave-gitops/pkg/flux"
 	"github.com/weaveworks/weave-gitops/pkg/kube"
 	"google.golang.org/grpc/metadata"
 	v1 "k8s.io/api/core/v1"
@@ -39,8 +38,8 @@ func TestGetVersion(t *testing.T) {
 	fluxNs := &v1.Namespace{}
 	fluxNs.Name = "flux-ns-test"
 	fluxNs.Labels = map[string]string{
-		coretypes.PartOfLabel: server.FluxNamespacePartOf,
-		flux.VersionLabelKey:  testVersion,
+		coretypes.PartOfLabel:  server.FluxNamespacePartOf,
+		coretypes.VersionLabel: testVersion,
 	}
 	g.Expect(k.Create(ctx, fluxNs)).To(Succeed())
 

--- a/pkg/flux/flux.go
+++ b/pkg/flux/flux.go
@@ -15,9 +15,7 @@ type Flux interface {
 }
 
 const (
-	PartOfLabelKey   = "app.kubernetes.io/part-of"
 	PartOfLabelValue = "flux"
-	VersionLabelKey  = "app.kubernetes.io/version"
 )
 
 type FluxClient struct {

--- a/pkg/run/install/install_flux.go
+++ b/pkg/run/install/install_flux.go
@@ -3,12 +3,12 @@ package install
 import (
 	"context"
 	"fmt"
-	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
 	"strings"
 
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+
 	coretypes "github.com/weaveworks/weave-gitops/core/server/types"
-	"github.com/weaveworks/weave-gitops/pkg/flux"
 	"github.com/weaveworks/weave-gitops/pkg/logger"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -59,7 +59,7 @@ func GetFluxVersion(ctx context.Context, log logger.Logger, kubeClient client.Cl
 		return nil, false, err
 	} else {
 		for _, item := range namespaceList.Items {
-			if item.GetLabels()[flux.VersionLabelKey] != "" {
+			if item.GetLabels()[coretypes.VersionLabel] != "" {
 				foundNamespace = item
 				break
 			}
@@ -80,7 +80,7 @@ func GetFluxVersion(ctx context.Context, log logger.Logger, kubeClient client.Cl
 			return nil, false, fmt.Errorf("error getting Flux labels")
 		}
 
-		fluxVersion := labels[flux.VersionLabelKey]
+		fluxVersion := labels[coretypes.VersionLabel]
 		if fluxVersion != "" {
 			// ok, we found the version
 			return &FluxVersionInfo{

--- a/pkg/run/install/install_flux_test.go
+++ b/pkg/run/install/install_flux_test.go
@@ -9,7 +9,6 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/weaveworks/weave-gitops/core/server"
 	coretypes "github.com/weaveworks/weave-gitops/core/server/types"
-	"github.com/weaveworks/weave-gitops/pkg/flux"
 	"github.com/weaveworks/weave-gitops/pkg/logger"
 	"github.com/weaveworks/weave-gitops/pkg/run"
 	appsv1 "k8s.io/api/apps/v1"
@@ -51,19 +50,19 @@ var _ = Describe("GetFluxVersion", func() {
 				Name:      "source-controller",
 				Namespace: "flux-system",
 				Labels: map[string]string{
-					"app": "source-controller",
+					coretypes.AppLabel: "source-controller",
 				},
 			},
 			Spec: appsv1.DeploymentSpec{
 				Selector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
-						"app": "source-controller",
+						coretypes.AppLabel: "source-controller",
 					},
 				},
 				Template: v1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Labels: map[string]string{
-							"app": "source-controller",
+							coretypes.AppLabel: "source-controller",
 						},
 					},
 					Spec: v1.PodSpec{
@@ -102,8 +101,8 @@ var _ = Describe("GetFluxVersion", func() {
 		fluxNs := &v1.Namespace{}
 		fluxNs.Name = "flux-ns-test"
 		fluxNs.Labels = map[string]string{
-			coretypes.PartOfLabel: server.FluxNamespacePartOf,
-			flux.VersionLabelKey:  testVersion,
+			coretypes.PartOfLabel:  server.FluxNamespacePartOf,
+			coretypes.VersionLabel: testVersion,
 		}
 
 		Expect(kubeClient.Create(ctx, fluxNs)).To(Succeed())

--- a/pkg/run/install/install_vcluster.go
+++ b/pkg/run/install/install_vcluster.go
@@ -11,6 +11,7 @@ import (
 	helmv2 "github.com/fluxcd/helm-controller/api/v2beta1"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1beta2"
 	"github.com/weaveworks/weave-gitops/cmd/gitops/version"
+	coretypes "github.com/weaveworks/weave-gitops/core/server/types"
 	"github.com/weaveworks/weave-gitops/pkg/run/constants"
 	"github.com/weaveworks/weave-gitops/pkg/run/session"
 	appsv1 "k8s.io/api/apps/v1"
@@ -54,8 +55,8 @@ func makeVClusterHelmRelease(name, namespace, fluxNamespace, command string, por
 			Name:      name,
 			Namespace: namespace,
 			Labels: map[string]string{
-				"app":                       "vcluster",
-				"app.kubernetes.io/part-of": "gitops-run",
+				coretypes.AppLabel:    "vcluster",
+				coretypes.PartOfLabel: "gitops-run",
 			},
 		},
 		Spec: helmv2.HelmReleaseSpec{

--- a/pkg/run/session/get.go
+++ b/pkg/run/session/get.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/weaveworks/weave-gitops/core/server/types"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -27,7 +28,7 @@ func Get(kubeClient client.Client, name, namespace string) (*InternalSession, er
 
 	labels := statefulSet.GetLabels()
 	if labels != nil {
-		if labels["app"] != "vcluster" || labels["app.kubernetes.io/part-of"] != "gitops-run" {
+		if labels[types.AppLabel] != "vcluster" || labels[types.PartOfLabel] != "gitops-run" {
 			return nil, fmt.Errorf("%s/%s is an invalid GitOps Run session", namespace, name)
 		}
 	}

--- a/pkg/run/session/list.go
+++ b/pkg/run/session/list.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/weaveworks/weave-gitops/core/server/types"
 	appsv1 "k8s.io/api/apps/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -15,8 +16,8 @@ func List(kubeClient client.Client, targetNamespace string) ([]*InternalSession,
 	if err := kubeClient.List(context.Background(), &statefulSets,
 		client.InNamespace(targetNamespace),
 		client.MatchingLabels(map[string]string{
-			"app":                       "vcluster",
-			"app.kubernetes.io/part-of": "gitops-run",
+			types.AppLabel:    "vcluster",
+			types.PartOfLabel: "gitops-run",
 		}),
 	); err != nil {
 		return nil, err

--- a/pkg/run/utils_test.go
+++ b/pkg/run/utils_test.go
@@ -212,7 +212,7 @@ func (c *mockClientForGetPodFromResourceDescription) Get(_ context.Context, key 
 				},
 				Spec: corev1.ServiceSpec{
 					Selector: map[string]string{
-						"app": key.Name,
+						coretypes.AppLabel: key.Name,
 					},
 				},
 			}
@@ -226,7 +226,7 @@ func (c *mockClientForGetPodFromResourceDescription) Get(_ context.Context, key 
 				Spec: appsv1.DeploymentSpec{
 					Selector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
-							"app": key.Name,
+							coretypes.AppLabel: key.Name,
 						},
 					},
 				},

--- a/pkg/run/watch/install_dev_bucket_server.go
+++ b/pkg/run/watch/install_dev_bucket_server.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"time"
 
+	coretypes "github.com/weaveworks/weave-gitops/core/server/types"
 	"github.com/weaveworks/weave-gitops/pkg/logger"
 	"github.com/weaveworks/weave-gitops/pkg/run"
 	"github.com/weaveworks/weave-gitops/pkg/run/constants"
@@ -40,7 +41,7 @@ func InstallDevBucketServer(
 	var (
 		err                error
 		devBucketAppLabels = map[string]string{
-			"app": constants.RunDevBucketName,
+			coretypes.AppLabel: constants.RunDevBucketName,
 		}
 	)
 


### PR DESCRIPTION
Part of #3546 

- Added exiting the dashboard type switch statement earlier for readability.

- Added reconciling the OSS dashboard only if it was installed by GitOps Run.

**- Added app selector labels to be able to identify the dashboard deployment and pods. The same labels will be added to the enterprise Helm chart.**

- Added a constant for the app selector label.

- Replaced hardcoded label key strings with constants for consistency (we already had many of those constants but we we not using them in many places).

- Improved dashboard detection.

- Updated tests for `GetInstalledDashboard`.

Tested it locally for the following cases (that the dashboard is installed, if no other dashboard is found, or the dashboard already installed is detected):

without dashboard:

- test with no dashboard installed in no session and in session mode

OSS:

- test with dashboard installed with gitops run

- test with dashboard installed in Tilt
 test with dashboard installed with helm install

- test with dashboard installed with a HelmRelease (the recommended way).


enterprise:

- test with dashboard installed with Tilt

- test with dashboard installed via a HelmRelease (the recommended way)
