### PR TITLE
Fix Pendo initialization

### DIFF
--- a/ui/components/Pendo.tsx
+++ b/ui/components/Pendo.tsx
@@ -42,7 +42,7 @@ export default function Pendo({
 
   React.useEffect(() => {
     const telemetryFlag =
-      isFlagEnabled("WEAVE_GITOPS_FEATURE_TELEMETRY") || defaultTelemetryFlag;
+      flags.WEAVE_GITOPS_FEATURE_TELEMETRY || defaultTelemetryFlag;
 
     const shouldInitPendo =
       !!flags &&


### PR DESCRIPTION
Part of #3566 

- Restored getting the value of the `WEAVE_GITOPS_FEATURE_TELEMETRY` flag as a string instead of a Boolean value.

Testing:

Tested it locally.
- To test that Pendo is initialized or not, set desired value to `WEAVE_GITOPS_FEATURE_TELEMETRY` flag in `tools/helm-values-dev.yaml` and run:
```
console.log(window.pendo.getSerializedMetadata())
```
in the browser console.

If Pendo was initialized, there will be some data displayed. If not, an error will be thrown.

I am not able to test the fix in enterprise, because after I pull in the current branch from OSS to enterprise, I see errors related to feature flags. Will raised the couterpart PR for enterprise later after enterprise is updated with the new feature flag logic.
