### PR TITLE
Split up DataTable component and add column click handler (v2)

### DIFF
--- a/ui/components/DataTable/DataTable.tsx
+++ b/ui/components/DataTable/DataTable.tsx
@@ -50,6 +50,8 @@ export interface Props {
   hasCheckboxes?: boolean;
   hideSearchAndFilters?: boolean;
   emptyMessagePlaceholder?: React.ReactNode;
+  onColumnHeaderClick?: (field: Field) => void;
+  disableSort?: boolean;
 }
 //styled components
 const EmptyRow = styled(TableRow)<{ colSpan: number }>`
@@ -77,6 +79,8 @@ function UnstyledDataTable({
   dialogOpen,
   hideSearchAndFilters,
   emptyMessagePlaceholder,
+  onColumnHeaderClick,
+  disableSort,
 }: Props) {
   //URL info
   const history = useHistory();
@@ -199,7 +203,8 @@ function UnstyledDataTable({
     filtered,
     reverseSort,
     sortFields,
-    useSecondarySort
+    useSecondarySort,
+    disableSort
   );
 
   const [checked, setChecked] = React.useState([]);
@@ -296,10 +301,20 @@ function UnstyledDataTable({
                         fieldIndex={index}
                         sortFieldIndex={sortFieldIndex}
                         reverseSort={reverseSort}
-                        setSortFieldIndex={setSortFieldIndex}
-                        setReverseSort={(isReverse) =>
-                          setReverseSort(isReverse)
-                        }
+                        setSortFieldIndex={(...args) => {
+                          if (onColumnHeaderClick) {
+                            onColumnHeaderClick(f);
+                          }
+
+                          setSortFieldIndex(...args);
+                        }}
+                        setReverseSort={(isReverse) => {
+                          if (onColumnHeaderClick) {
+                            onColumnHeaderClick(f);
+                          }
+
+                          setReverseSort(isReverse);
+                        }}
                       />
                     )}
                   </TableCell>

--- a/ui/components/DataTable/SortableLabel.tsx
+++ b/ui/components/DataTable/SortableLabel.tsx
@@ -1,0 +1,72 @@
+import { Button } from "@material-ui/core";
+import * as React from "react";
+import styled from "styled-components";
+import Flex from "../Flex";
+import Icon, { IconType } from "../Icon";
+import Spacer from "../Spacer";
+import { Field } from "./types";
+
+type labelProps = {
+  fields: Field[];
+  fieldIndex: number;
+  sortFieldIndex: number;
+  reverseSort: boolean;
+  setSortFieldIndex: (index: number) => void;
+  setReverseSort: (b: boolean) => void;
+};
+
+const TableButton = styled(Button)`
+  &.MuiButton-root {
+    margin: 0;
+    text-transform: none;
+    letter-spacing: 0;
+  }
+  &.MuiButton-text {
+    min-width: 0px;
+    .selected {
+      color: ${(props) => props.theme.colors.neutral40};
+    }
+  }
+  &.arrow {
+    min-width: 0px;
+  }
+`;
+
+export default function SortableLabel({
+  fields,
+  fieldIndex,
+  sortFieldIndex,
+  reverseSort,
+  setSortFieldIndex,
+  setReverseSort,
+}: labelProps) {
+  const field = fields[fieldIndex];
+  const sort = fields[sortFieldIndex];
+
+  return (
+    <Flex align start>
+      <TableButton
+        color="inherit"
+        variant="text"
+        onClick={() => {
+          setReverseSort(sortFieldIndex === fieldIndex ? !reverseSort : false);
+          setSortFieldIndex(fieldIndex);
+        }}
+      >
+        <h2 className={sort.label === field.label ? "selected" : ""}>
+          {field.label}
+        </h2>
+      </TableButton>
+      <Spacer padding="xxs" />
+      {sort.label === field.label ? (
+        <Icon
+          type={IconType.ArrowUpwardIcon}
+          size="base"
+          className={reverseSort ? "upward" : "downward"}
+        />
+      ) : (
+        <div style={{ width: "16px" }} />
+      )}
+    </Flex>
+  );
+}

--- a/ui/components/DataTable/__tests__/DataTable.test.tsx
+++ b/ui/components/DataTable/__tests__/DataTable.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import "jest-styled-components";
 import React from "react";
 import renderer from "react-test-renderer";
-import { withContext, withTheme } from "../../lib/test-utils";
+import { withContext, withTheme } from "../../../lib/test-utils";
 import DataTable from "../DataTable";
 
 describe("DataTable", () => {

--- a/ui/components/DataTable/__tests__/DataTable.test.tsx
+++ b/ui/components/DataTable/__tests__/DataTable.test.tsx
@@ -155,6 +155,42 @@ describe("DataTable", () => {
       firstRow = screen.getAllByRole("row")[1];
       expect(firstRow.innerHTML).toMatch(/c/);
     });
+    it("disables sorting", () => {
+      const rows = [
+        {
+          name: "b",
+        },
+        {
+          name: "c",
+        },
+        {
+          name: "a",
+        },
+      ];
+
+      const fields = [
+        {
+          label: "Name",
+          value: "name",
+        },
+      ];
+
+      render(
+        withTheme(
+          withContext(
+            <DataTable disableSort fields={fields} rows={rows} />,
+            "/applications",
+            {}
+          )
+        )
+      );
+
+      const nameButton = screen.getByText("Name");
+      fireEvent.click(nameButton);
+
+      const firstRow = screen.getAllByRole("row")[1];
+      expect(firstRow.innerHTML).toMatch(/b/);
+    });
   });
 
   describe("snapshots", () => {

--- a/ui/components/DataTable/__tests__/DataTableFilters.test.tsx
+++ b/ui/components/DataTable/__tests__/DataTableFilters.test.tsx
@@ -2,17 +2,18 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import "jest-styled-components";
 import _ from "lodash";
 import React from "react";
-import { withContext, withTheme } from "../../lib/test-utils";
-import { statusSortHelper } from "../../lib/utils";
-import DataTable, {
-  Field,
+import { withContext, withTheme } from "../../../lib/test-utils";
+import { statusSortHelper } from "../../../lib/utils";
+import { filterSeparator } from "../../FilterDialog";
+import DataTable from "../DataTable";
+import {
   filterByStatusCallback,
   filterConfig,
   filterRows,
   filterSelectionsToQueryString,
   parseFilterStateFromURL,
-} from "../DataTable";
-import { filterSeparator } from "../FilterDialog";
+} from "../helpers";
+import { Field } from "../types";
 
 const uriEncodedSeparator = encodeURIComponent(filterSeparator);
 

--- a/ui/components/DataTable/__tests__/__snapshots__/DataTable.test.tsx.snap
+++ b/ui/components/DataTable/__tests__/__snapshots__/DataTable.test.tsx.snap
@@ -70,7 +70,7 @@ exports[`DataTable snapshots renders 1`] = `
   justify-content: flex-start;
 }
 
-.c9 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -84,7 +84,7 @@ exports[`DataTable snapshots renders 1`] = `
   align-items: center;
 }
 
-.c15 {
+.c14 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -102,7 +102,7 @@ exports[`DataTable snapshots renders 1`] = `
   justify-content: flex-start;
 }
 
-.c17 {
+.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -121,7 +121,7 @@ exports[`DataTable snapshots renders 1`] = `
   justify-content: flex-start;
 }
 
-.c12 {
+.c11 {
   font-family: 'proxima-nova',Helvetica,Arial,sans-serif;
   font-size: 14px;
   font-weight: 400;
@@ -129,7 +129,7 @@ exports[`DataTable snapshots renders 1`] = `
   font-style: normal;
 }
 
-.c18 {
+.c17 {
   font-family: 'proxima-nova',Helvetica,Arial,sans-serif;
   font-size: 20px;
   font-weight: 400;
@@ -138,73 +138,56 @@ exports[`DataTable snapshots renders 1`] = `
   color: #737373;
 }
 
-.c10 svg {
+.c9 svg {
   height: 16px;
   width: 16px;
 }
 
-.c10 svg path.path-fill {
+.c9 svg path.path-fill {
   fill: !important;
   -webkit-transition: fill 200ms cubic-bezier(0.4,0,0.2,1) 0ms;
   transition: fill 200ms cubic-bezier(0.4,0,0.2,1) 0ms;
 }
 
-.c10 svg rect.rect-height {
+.c9 svg rect.rect-height {
   height: 16px;
   width: 16px;
 }
 
-.c10 svg rect.rect-stroke {
+.c9 svg rect.rect-stroke {
   -webkit-transition: stroke 200ms cubic-bezier(0.4,0,0.2,1) 0ms;
   transition: stroke 200ms cubic-bezier(0.4,0,0.2,1) 0ms;
 }
 
-.c10 svg.no-fill {
+.c9 svg.no-fill {
   fill: none !important;
 }
 
-.c10.downward {
+.c9.downward {
   -webkit-transform: rotate(180deg);
   -ms-transform: rotate(180deg);
   transform: rotate(180deg);
 }
 
-.c10.upward {
+.c9.upward {
   -webkit-transform: initial;
   -ms-transform: initial;
   transform: initial;
 }
 
-.c10 .c11 {
+.c9 .c10 {
   margin-left: 4px;
 }
 
-.c10 img {
+.c9 img {
   width: 16px;
 }
 
-.c8 {
+.c7 {
   padding: 4px;
 }
 
-.c6.MuiButton-root {
-  height: 32px;
-  font-size: 12px;
-  -webkit-letter-spacing: 1px;
-  -moz-letter-spacing: 1px;
-  -ms-letter-spacing: 1px;
-  letter-spacing: 1px;
-  line-height: 1;
-  border-radius: 2px;
-  font-weight: 600;
-}
-
-.c6.MuiButton-outlined {
-  padding: 8px 12px;
-  border-color: #d8d8d8;
-}
-
-.c13 {
+.c12 {
   position: relative;
   height: 100%;
   width: 0px;
@@ -217,12 +200,12 @@ exports[`DataTable snapshots renders 1`] = `
   transition-timing-function: ease-in-out;
 }
 
-.c13.open {
+.c12.open {
   left: 0px;
   width: 350px;
 }
 
-.c14 {
+.c13 {
   background: rbga(255,255,255,0.75);
   height: 100%;
   width: 100%;
@@ -231,19 +214,19 @@ exports[`DataTable snapshots renders 1`] = `
   padding-left: 32px;
 }
 
-.c16 .MuiListItem-gutters {
+.c15 .MuiListItem-gutters {
   padding-left: 0px;
 }
 
-.c16 .MuiCheckbox-root {
+.c15 .MuiCheckbox-root {
   padding: 0px;
 }
 
-.c16 .MuiCheckbox-colorSecondary.Mui-checked {
+.c15 .MuiCheckbox-colorSecondary.Mui-checked {
   color: #00b3ec;
 }
 
-.c7.MuiButton-root {
+.c6.MuiButton-root {
   margin: 0;
   text-transform: none;
   -webkit-letter-spacing: 0;
@@ -252,15 +235,15 @@ exports[`DataTable snapshots renders 1`] = `
   letter-spacing: 0;
 }
 
-.c7.MuiButton-text {
+.c6.MuiButton-text {
   min-width: 0px;
 }
 
-.c7.MuiButton-text .selected {
+.c6.MuiButton-text .selected {
   color: #1a1a1a;
 }
 
-.c7.arrow {
+.c6.arrow {
   min-width: 0px;
 }
 
@@ -361,7 +344,7 @@ exports[`DataTable snapshots renders 1`] = `
                 className="c5"
               >
                 <button
-                  className="MuiButtonBase-root MuiButton-root MuiButton-text c6 c7 MuiButton-colorInherit MuiButton-disableElevation"
+                  className="MuiButtonBase-root MuiButton-root MuiButton-text c6 MuiButton-colorInherit"
                   disabled={false}
                   onBlur={[Function]}
                   onClick={[Function]}
@@ -389,10 +372,10 @@ exports[`DataTable snapshots renders 1`] = `
                   </span>
                 </button>
                 <div
-                  className="c8"
+                  className="c7"
                 />
                 <div
-                  className="c9 c10 downward"
+                  className="c8 c9 downward"
                 >
                   <svg
                     aria-hidden={true}
@@ -416,7 +399,7 @@ exports[`DataTable snapshots renders 1`] = `
                 className="c5"
               >
                 <button
-                  className="MuiButtonBase-root MuiButton-root MuiButton-text c6 c7 MuiButton-colorInherit MuiButton-disableElevation"
+                  className="MuiButtonBase-root MuiButton-root MuiButton-text c6 MuiButton-colorInherit"
                   disabled={false}
                   onBlur={[Function]}
                   onClick={[Function]}
@@ -444,7 +427,7 @@ exports[`DataTable snapshots renders 1`] = `
                   </span>
                 </button>
                 <div
-                  className="c8"
+                  className="c7"
                 />
                 <div
                   style={
@@ -464,7 +447,7 @@ exports[`DataTable snapshots renders 1`] = `
                 className="c5"
               >
                 <button
-                  className="MuiButtonBase-root MuiButton-root MuiButton-text c6 c7 MuiButton-colorInherit MuiButton-disableElevation"
+                  className="MuiButtonBase-root MuiButton-root MuiButton-text c6 MuiButton-colorInherit"
                   disabled={false}
                   onBlur={[Function]}
                   onClick={[Function]}
@@ -492,7 +475,7 @@ exports[`DataTable snapshots renders 1`] = `
                   </span>
                 </button>
                 <div
-                  className="c8"
+                  className="c7"
                 />
                 <div
                   style={
@@ -512,7 +495,7 @@ exports[`DataTable snapshots renders 1`] = `
                 className="c5"
               >
                 <button
-                  className="MuiButtonBase-root MuiButton-root MuiButton-text c6 c7 MuiButton-colorInherit MuiButton-disableElevation"
+                  className="MuiButtonBase-root MuiButton-root MuiButton-text c6 MuiButton-colorInherit"
                   disabled={false}
                   onBlur={[Function]}
                   onClick={[Function]}
@@ -540,7 +523,7 @@ exports[`DataTable snapshots renders 1`] = `
                   </span>
                 </button>
                 <div
-                  className="c8"
+                  className="c7"
                 />
                 <div
                   style={
@@ -566,7 +549,7 @@ exports[`DataTable snapshots renders 1`] = `
               className="MuiTableCell-root MuiTableCell-body"
             >
               <span
-                className="c11 c12"
+                className="c10 c11"
                 size="medium"
               >
                 <a
@@ -581,7 +564,7 @@ exports[`DataTable snapshots renders 1`] = `
               className="MuiTableCell-root MuiTableCell-body"
             >
               <span
-                className="c11 c12"
+                className="c10 c11"
                 size="medium"
               >
                 Ready
@@ -592,7 +575,7 @@ exports[`DataTable snapshots renders 1`] = `
               className="MuiTableCell-root MuiTableCell-body"
             >
               <span
-                className="c11 c12"
+                className="c10 c11"
                 size="medium"
               >
                 2004-01-02T15:04:05-0700
@@ -603,7 +586,7 @@ exports[`DataTable snapshots renders 1`] = `
               className="MuiTableCell-root MuiTableCell-body"
             >
               <span
-                className="c11 c12"
+                className="c10 c11"
                 size="medium"
               >
                 3000
@@ -619,7 +602,7 @@ exports[`DataTable snapshots renders 1`] = `
               className="MuiTableCell-root MuiTableCell-body"
             >
               <span
-                className="c11 c12"
+                className="c10 c11"
                 size="medium"
               >
                 <a
@@ -634,7 +617,7 @@ exports[`DataTable snapshots renders 1`] = `
               className="MuiTableCell-root MuiTableCell-body"
             >
               <span
-                className="c11 c12"
+                className="c10 c11"
                 size="medium"
               >
                 -
@@ -645,7 +628,7 @@ exports[`DataTable snapshots renders 1`] = `
               className="MuiTableCell-root MuiTableCell-body"
             >
               <span
-                className="c11 c12"
+                className="c10 c11"
                 size="medium"
               >
                 2006-01-02T15:04:05-0700
@@ -656,7 +639,7 @@ exports[`DataTable snapshots renders 1`] = `
               className="MuiTableCell-root MuiTableCell-body"
             >
               <span
-                className="c11 c12"
+                className="c10 c11"
                 size="medium"
               >
                 2000
@@ -672,7 +655,7 @@ exports[`DataTable snapshots renders 1`] = `
               className="MuiTableCell-root MuiTableCell-body"
             >
               <span
-                className="c11 c12"
+                className="c10 c11"
                 size="medium"
               >
                 <a
@@ -687,7 +670,7 @@ exports[`DataTable snapshots renders 1`] = `
               className="MuiTableCell-root MuiTableCell-body"
             >
               <span
-                className="c11 c12"
+                className="c10 c11"
                 size="medium"
               />
             </td>
@@ -696,7 +679,7 @@ exports[`DataTable snapshots renders 1`] = `
               className="MuiTableCell-root MuiTableCell-body"
             >
               <span
-                className="c11 c12"
+                className="c10 c11"
                 size="medium"
               >
                 2005-01-02T15:04:05-0700
@@ -707,7 +690,7 @@ exports[`DataTable snapshots renders 1`] = `
               className="MuiTableCell-root MuiTableCell-body"
             >
               <span
-                className="c11 c12"
+                className="c10 c11"
                 size="medium"
               >
                 1000
@@ -718,20 +701,20 @@ exports[`DataTable snapshots renders 1`] = `
       </table>
     </div>
     <div
-      className="c13"
+      className="c12"
       data-testid="container"
     >
       <div
-        className="c14"
+        className="c13"
       >
         <div
-          className="c15 c16"
+          className="c14 c15"
         >
           <div
-            className="c17"
+            className="c16"
           >
             <span
-              className="c11 c18"
+              className="c10 c17"
               color="neutral30"
               size="large"
             >

--- a/ui/components/DataTable/helpers.ts
+++ b/ui/components/DataTable/helpers.ts
@@ -1,0 +1,190 @@
+//funcs
+import _ from "lodash";
+import qs from "query-string";
+import {
+  FilterConfig,
+  FilterSelections,
+  filterSeparator,
+} from "../FilterDialog";
+import { computeReady, ReadyType } from "../KubeStatusIndicator";
+import { Field, FilterState } from "./types";
+
+export const filterByStatusCallback = (v) => {
+  if (v.suspended) return ReadyType.Suspended;
+  const ready = computeReady(v["conditions"]);
+  if (ready === ReadyType.Reconciling) return ReadyType.Reconciling;
+  if (ready === ReadyType.Ready) return ReadyType.Ready;
+  return ReadyType.NotReady;
+};
+
+export function filterConfig(
+  rows,
+  key: string,
+  computeValue?: (k: any) => any
+): FilterConfig {
+  const config = _.reduce(
+    rows,
+    (r, v) => {
+      const t = computeValue ? computeValue(v) : v[key];
+      if (!_.includes(r, t)) {
+        r.push(t);
+      }
+
+      return r;
+    },
+    []
+  );
+
+  return { [key]: { options: config, transformFunc: computeValue } };
+}
+
+export function filterRows<T>(rows: T[], filters: FilterConfig) {
+  if (_.keys(filters).length === 0) {
+    return rows;
+  }
+
+  return _.filter(rows, (row) => {
+    let ok = true;
+
+    _.each(filters, (vals, category) => {
+      let value;
+
+      if (vals.transformFunc) value = vals.transformFunc(row);
+      // strings
+      else value = row[category];
+
+      if (!_.includes(vals.options, value)) {
+        ok = false;
+        return ok;
+      }
+    });
+
+    return ok;
+  });
+}
+
+export function filterText(
+  rows,
+  fields: Field[],
+  textFilters: FilterState["textFilters"]
+) {
+  if (textFilters.length === 0) {
+    return rows;
+  }
+
+  return _.filter(rows, (row) => {
+    let matches = false;
+
+    fields.forEach((field) => {
+      if (!field.textSearchable) return matches;
+
+      let value;
+      if (field.sortValue) {
+        value = field.sortValue(row);
+      } else {
+        value =
+          typeof field.value === "function"
+            ? field.value(row)
+            : row[field.value];
+      }
+
+      for (let i = 0; i < textFilters.length; i++) {
+        matches = value.includes(textFilters[i]);
+        if (!matches) {
+          break;
+        }
+      }
+    });
+
+    return matches;
+  });
+}
+
+export function initialFormState(cfg: FilterConfig, initialSelections?) {
+  if (!initialSelections) {
+    return {};
+  }
+  const allFilters = _.reduce(
+    cfg,
+    (r, vals, k) => {
+      _.each(vals.options, (v) => {
+        const key = `${k}${filterSeparator}${v}`;
+        const selection = _.get(initialSelections, key);
+        if (selection) {
+          r[key] = selection;
+        } else {
+          r[key] = false;
+        }
+      });
+
+      return r;
+    },
+    {}
+  );
+  return allFilters;
+}
+
+export function toPairs(state: FilterState): string[] {
+  const result = _.map(state.formState, (val, key) => (val ? key : null));
+  const out = _.compact(result);
+  return _.concat(out, state.textFilters);
+}
+
+export function parseFilterStateFromURL(search: string) {
+  const query = qs.parse(search) as any;
+  const state = { initialSelections: {}, textFilters: [] };
+  if (query.filters) {
+    const split = query.filters.split("_");
+    const next = {};
+    _.each(split, (filterString) => {
+      if (filterString) next[filterString] = true;
+    });
+    state.initialSelections = next;
+  }
+  if (query.search) {
+    state.textFilters = query.search.split("_").filter((item) => item);
+  }
+  return state;
+}
+
+export function filterSelectionsToQueryString(sel: FilterSelections) {
+  let url = "";
+  _.each(sel, (value, key) => {
+    if (value) {
+      url += `${key}_`;
+    }
+  });
+  //this is an object with all the different queries as keys
+  let query = qs.parse(location.search);
+  //if there are any filters, reassign/create filter query key
+  if (url) query["filters"] = url;
+  //if the update leaves no filters, remove the filter query key from the object
+  else if (query["filters"]) query = _.omit(query, "filters");
+  //this turns a parsed search into a legit query string
+  return qs.stringify(query);
+}
+
+export const sortByField = (
+  rows: any[],
+  reverseSort: boolean,
+  sortFields: Field[],
+  useSecondarySort?: boolean
+) => {
+  const orderFields = [sortFields[0]];
+  if (useSecondarySort && sortFields.length > 1)
+    orderFields.push(sortFields[1]);
+
+  return _.orderBy(
+    rows,
+    sortFields.map((s) => {
+      return s.sortValue || s.value;
+    }),
+    orderFields.map((_, index) => {
+      // Always sort secondary sort values in the ascending order.
+      const sortOrders =
+        reverseSort && (!useSecondarySort || index != 1) ? "desc" : "asc";
+
+      return sortOrders;
+    })
+  );
+};

--- a/ui/components/DataTable/helpers.ts
+++ b/ui/components/DataTable/helpers.ts
@@ -168,8 +168,13 @@ export const sortByField = (
   rows: any[],
   reverseSort: boolean,
   sortFields: Field[],
-  useSecondarySort?: boolean
+  useSecondarySort?: boolean,
+  disableSort?: boolean
 ) => {
+  if (disableSort) {
+    return rows;
+  }
+
   const orderFields = [sortFields[0]];
   if (useSecondarySort && sortFields.length > 1)
     orderFields.push(sortFields[1]);

--- a/ui/components/DataTable/index.ts
+++ b/ui/components/DataTable/index.ts
@@ -1,0 +1,7 @@
+import DataTable from "./DataTable";
+import { filterByStatusCallback, filterConfig } from "./helpers";
+import { Field } from "./types";
+
+export default DataTable;
+
+export { filterByStatusCallback, filterConfig, Field };

--- a/ui/components/DataTable/types.ts
+++ b/ui/components/DataTable/types.ts
@@ -1,0 +1,21 @@
+import { FilterConfig, FilterSelections } from "../FilterDialog";
+
+export type Field = {
+  label: string | number;
+  labelRenderer?: string | ((k: any) => string | JSX.Element);
+  value: string | ((k: any) => string | JSX.Element | null);
+  sortValue?: (k: any) => any;
+  textSearchable?: boolean;
+  minWidth?: number;
+  maxWidth?: number;
+  /** boolean for field to initially sort against. */
+  defaultSort?: boolean;
+  /** boolean for field to implement secondary sort against. */
+  secondarySort?: boolean;
+};
+
+export type FilterState = {
+  filters: FilterConfig;
+  formState: FilterSelections;
+  textFilters: string[];
+};

--- a/ui/components/__tests__/FilterDialog.test.tsx
+++ b/ui/components/__tests__/FilterDialog.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import "jest-styled-components";
 import React from "react";
 import { withTheme } from "../../lib/test-utils";
-import { initialFormState } from "../DataTable";
+import { initialFormState } from "../DataTable/helpers";
 import FilterDialog, { filterSeparator } from "../FilterDialog";
 
 describe("FilterDialog", () => {


### PR DESCRIPTION
Part of https://github.com/weaveworks/weave-gitops-enterprise/issues/2609

**Save until after the release**

Breaks up the `DataTable` component without affecting the modules that import it. Also adds some sort skipping logic for when we want to sort elsewhere.

I had originally intended to break up `DataTable` further but it was too high-risk.

