### PR TITLE
Adds installation instructions for the gitopssets-controller

### DIFF
--- a/website/docs/gitopssets/installation.mdx
+++ b/website/docs/gitopssets/installation.mdx
@@ -1,0 +1,58 @@
+---
+title: Installation
+hide_title: true
+---
+
+import TierLabel from "../_components/TierLabel";
+
+# Installation <TierLabel tiers="enterprise" />
+
+The gitopssets-controller can be installed in two ways:
+
+- As part of the Weave Gitops Enterprise installation. (installed by default)
+- As a standalone installation using a Helm chart.
+
+The standalone installation can be useful for leaf clusters that don't have Weave Gitops Enterprise installed.
+
+## Prerequisites
+
+Before installing the gitopssets-controller, ensure that the following is installed:
+
+- flux
+
+## Installing the gitopssets-controller
+
+To install the gitopssets-controller using a Helm chart, use the following HelmRelease:
+
+```yaml
+apiVersion: source.toolkit.fluxcd.io/v1beta1
+kind: HelmRepository
+metadata:
+  name: weaveworks-artifacts-charts
+  namespace: gitopssets-system
+spec:
+  interval: 1m
+  url: https://artifacts.wge.dev.weave.works/dev/charts
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: gitopssets-controller
+  namespace: gitopssets-system
+spec:
+  interval: 10m
+  chart:
+    spec:
+      chart: gitopssets-controller
+      sourceRef:
+        kind: HelmRepository
+        name: weaveworks-artifacts-charts
+        namespace: gitopssets-system
+      version: 0.6.1
+  install:
+    crds: CreateReplace
+  upgrade:
+    crds: CreateReplace
+```
+
+After adding the HelmRepository and HelmRelease to a git repository synced by flux, commit the changes to complete the installation process.

--- a/website/docs/gitopssets/installation.mdx
+++ b/website/docs/gitopssets/installation.mdx
@@ -25,6 +25,11 @@ Before installing the gitopssets-controller, ensure that the following is instal
 To install the gitopssets-controller using a Helm chart, use the following HelmRelease:
 
 ```yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gitopssets-system
+---
 apiVersion: source.toolkit.fluxcd.io/v1beta1
 kind: HelmRepository
 metadata:
@@ -55,4 +60,4 @@ spec:
     crds: CreateReplace
 ```
 
-After adding the HelmRepository and HelmRelease to a git repository synced by flux, commit the changes to complete the installation process.
+After adding the Namespace, HelmRepository and HelmRelease to a git repository synced by flux, commit the changes to complete the installation process.

--- a/website/docs/gitopssets/releases.mdx
+++ b/website/docs/gitopssets/releases.mdx
@@ -1,0 +1,18 @@
+---
+title: Releases
+hide_title: true
+---
+
+import TierLabel from "../_components/TierLabel";
+
+# Gitopssets Controller Releases <TierLabel tiers="enterprise" />
+
+## v0.7.0
+2023-03-30
+
+- Implement custom delimiters.
+
+## v0.6.1
+2023-03-20
+
+- Implement optional list expansion

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -260,8 +260,10 @@
       label: 'GitOpsSets',
       items: [
         'gitopssets/intro',
+        'gitopssets/installation',
         'gitopssets/guide',
-        'gitopssets/api-reference'
+        'gitopssets/api-reference',
+        'gitopssets/releases'
       ],
     }
   ],

--- a/website/versioned_docs/version-0.20.0/gitopssets/installation.mdx
+++ b/website/versioned_docs/version-0.20.0/gitopssets/installation.mdx
@@ -1,0 +1,63 @@
+---
+title: Installation
+hide_title: true
+---
+
+import TierLabel from "../_components/TierLabel";
+
+# Installation <TierLabel tiers="enterprise" />
+
+The gitopssets-controller can be installed in two ways:
+
+- As part of the Weave Gitops Enterprise installation. (installed by default)
+- As a standalone installation using a Helm chart.
+
+The standalone installation can be useful for leaf clusters that don't have Weave Gitops Enterprise installed.
+
+## Prerequisites
+
+Before installing the gitopssets-controller, ensure that the following is installed:
+
+- flux
+
+## Installing the gitopssets-controller
+
+To install the gitopssets-controller using a Helm chart, use the following HelmRelease:
+
+```yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gitopssets-system
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta1
+kind: HelmRepository
+metadata:
+  name: weaveworks-artifacts-charts
+  namespace: gitopssets-system
+spec:
+  interval: 1m
+  url: https://artifacts.wge.dev.weave.works/dev/charts
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: gitopssets-controller
+  namespace: gitopssets-system
+spec:
+  interval: 10m
+  chart:
+    spec:
+      chart: gitopssets-controller
+      sourceRef:
+        kind: HelmRepository
+        name: weaveworks-artifacts-charts
+        namespace: gitopssets-system
+      version: 0.6.1
+  install:
+    crds: CreateReplace
+  upgrade:
+    crds: CreateReplace
+```
+
+After adding the Namespace, HelmRepository and HelmRelease to a git repository synced by flux, commit the changes to complete the installation process.

--- a/website/versioned_docs/version-0.20.0/gitopssets/releases.mdx
+++ b/website/versioned_docs/version-0.20.0/gitopssets/releases.mdx
@@ -1,0 +1,18 @@
+---
+title: Releases
+hide_title: true
+---
+
+import TierLabel from "../_components/TierLabel";
+
+# Gitopssets Controller Releases <TierLabel tiers="enterprise" />
+
+## v0.7.0
+2023-03-30
+
+- Implement custom delimiters.
+
+## v0.6.1
+2023-03-20
+
+- Implement optional list expansion

--- a/website/versioned_sidebars/version-0.20.0-sidebars.json
+++ b/website/versioned_sidebars/version-0.20.0-sidebars.json
@@ -249,8 +249,10 @@
       "label": "GitOpsSets",
       "items": [
         "gitopssets/intro",
+        "gitopssets/installation",
         "gitopssets/guide",
-        "gitopssets/api-reference"
+        "gitopssets/api-reference",
+        "gitopssets/releases"
       ]
     }
   ],


### PR DESCRIPTION
Now that we publish the gitopssets-controller as a standalone helm chart, we provide away to install it in a more standalone mode

- Also add a releases page to track new releases