### PR TITLE
implement remove run for non-session mode

### DIFF
--- a/cmd/gitops/remove/run/cmd.go
+++ b/cmd/gitops/remove/run/cmd.go
@@ -1,6 +1,7 @@
 package run
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -10,13 +11,16 @@ import (
 	"github.com/weaveworks/weave-gitops/pkg/kube"
 	"github.com/weaveworks/weave-gitops/pkg/logger"
 	"github.com/weaveworks/weave-gitops/pkg/run"
+	"github.com/weaveworks/weave-gitops/pkg/run/install"
 	"github.com/weaveworks/weave-gitops/pkg/run/session"
+	"github.com/weaveworks/weave-gitops/pkg/run/watch"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/rest"
 )
 
 type RunCommandFlags struct {
 	AllSessions bool
+	NoSession   bool
 
 	// Global flags.
 	Namespace  string
@@ -44,6 +48,9 @@ gitops remove run --all-sessions
 
 # Remove all GitOps Run sessions from the dev namespace
 gitops remove run -n dev --all-sessions
+
+# Clean up resources from a failed GitOps Run in no session mode
+gitops remove run --no-session
 `,
 		PreRunE: removeRunPreRunE(opts),
 		RunE:    removeRunRunE(opts),
@@ -56,6 +63,7 @@ gitops remove run -n dev --all-sessions
 	cmdFlags := cmd.Flags()
 
 	cmdFlags.BoolVar(&flags.AllSessions, "all-sessions", false, "Remove all GitOps Run sessions")
+	cmdFlags.BoolVar(&flags.NoSession, "no-session", false, "Remove all GitOps Run sessions")
 
 	kubeConfigArgs = run.GetKubeConfigArgs()
 
@@ -122,8 +130,11 @@ func getKubeClient(cmd *cobra.Command) (*kube.KubeHTTP, *rest.Config, error) {
 
 func removeRunPreRunE(opts *config.Options) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
-		numArgs := len(args)
+		if flags.NoSession {
+			return nil
+		}
 
+		numArgs := len(args)
 		if numArgs == 0 && !flags.AllSessions {
 			return cmderrors.ErrSessionNameIsRequired
 		}
@@ -140,8 +151,25 @@ func removeRunRunE(opts *config.Options) func(cmd *cobra.Command, args []string)
 		}
 
 		log := logger.NewCLILogger(os.Stdout)
+		ctx := context.Background()
 
-		if flags.AllSessions {
+		if flags.NoSession {
+			if err := watch.CleanupBucketSourceAndHelm(ctx, log, kubeClient, flags.Namespace); err != nil {
+				return err
+			}
+
+			if err := watch.CleanupBucketSourceAndKS(ctx, log, kubeClient, flags.Namespace); err != nil {
+				return err
+			}
+
+			if err := watch.UninstallDevBucketServer(ctx, log, kubeClient); err != nil {
+				return err
+			}
+
+			if err := install.UninstallFluentBit(ctx, log, kubeClient, flags.Namespace, install.FluentBitHRName); err != nil {
+				return err
+			}
+		} else if flags.AllSessions {
 			internalSessions, listErr := session.List(kubeClient, flags.Namespace)
 			if listErr != nil {
 				return listErr

--- a/pkg/run/watch/install_dev_bucket_server.go
+++ b/pkg/run/watch/install_dev_bucket_server.go
@@ -315,8 +315,12 @@ func UninstallDevBucketServer(ctx context.Context, log logger.Logger, kubeClient
 	log.Actionf("Removing namespace %s ...", constants.GitOpsRunNamespace)
 
 	if err := kubeClient.Delete(ctx, &devBucketNamespace); err != nil {
-		log.Failuref("Cannot remove namespace %s", constants.GitOpsRunNamespace)
-		return err
+		if !apierrors.IsNotFound(err) {
+			log.Failuref("Cannot remove namespace %s", constants.GitOpsRunNamespace)
+			return err
+		} else {
+			return nil
+		}
 	}
 
 	log.Actionf("Waiting for namespace %s to be terminated ...", constants.GitOpsRunNamespace)

--- a/pkg/run/watch/setup_bucket_source.go
+++ b/pkg/run/watch/setup_bucket_source.go
@@ -102,7 +102,9 @@ func cleanupBucketAndSecretObjects(ctx context.Context, log logger.Logger, kubeC
 	log.Actionf("Deleting secret %s ...", secret.Name)
 
 	if err := kubeClient.Delete(ctx, &secret); err != nil {
-		log.Failuref("Error deleting secret %s: %v", secret.Name, err.Error())
+		if !apierrors.IsNotFound(err) {
+			log.Failuref("Error deleting secret %s: %v", secret.Name, err.Error())
+		}
 	} else {
 		log.Successf("Deleted secret %s", secret.Name)
 	}
@@ -118,7 +120,9 @@ func cleanupBucketAndSecretObjects(ctx context.Context, log logger.Logger, kubeC
 	log.Actionf("Deleting source %s ...", source.Name)
 
 	if err := kubeClient.Delete(ctx, &source); err != nil {
-		log.Failuref("Error deleting source %s: %v", source.Name, err.Error())
+		if !apierrors.IsNotFound(err) {
+			log.Failuref("Error deleting source %s: %v", source.Name, err.Error())
+		}
 	} else {
 		log.Successf("Deleted source %s", source.Name)
 	}

--- a/pkg/run/watch/setup_dev_helm.go
+++ b/pkg/run/watch/setup_dev_helm.go
@@ -90,7 +90,9 @@ func CleanupBucketSourceAndHelm(ctx context.Context, log logger.Logger, kubeClie
 	log.Actionf("Deleting HelmRelease %s ...", helm.Name)
 
 	if err := kubeClient.Delete(ctx, &helm); err != nil {
-		log.Failuref("Error deleting HelmRelease %s: %v", helm.Name, err.Error())
+		if !apierrors.IsNotFound(err) {
+			log.Failuref("Error deleting HelmRelease %s: %v", helm.Name, err.Error())
+		}
 	} else {
 		log.Successf("Deleted HelmRelease %s", helm.Name)
 	}

--- a/pkg/run/watch/setup_dev_ks.go
+++ b/pkg/run/watch/setup_dev_ks.go
@@ -230,7 +230,9 @@ func CleanupBucketSourceAndKS(ctx context.Context, log logger.Logger, kubeClient
 	log.Actionf("Deleting Kustomization %s ...", ks.Name)
 
 	if err := kubeClient.Delete(ctx, &ks); err != nil {
-		log.Failuref("Error deleting Kustomization %s: %v", ks.Name, err.Error())
+		if !apierrors.IsNotFound(err) {
+			log.Failuref("Error deleting Kustomization %s: %v", ks.Name, err.Error())
+		}
 	} else {
 		log.Successf("Deleted Kustomization %s", ks.Name)
 	}


### PR DESCRIPTION
Fixes #3545 

- In file `cmd/gitops/remove/run/cmd.go`, this PR adds support for a new command line flag to remove all resources from a failed GitOps Run when running in no session mode, enhancing usability by improving the user experience.
  - The `--no-session` flag is added to the `RunCommandFlags` struct, and if the flag is set, session name or `--all-sessions` flag is ignored.
  - The `removeRunPreRunE` function is updated to return early if the `--no-session` flag is set.
  - The `removeRunRunE` function is updated to remove all resources related to a failed GitOps Run in no session mode if the `--no-session` flag is set.

- In file `setup_bucket_source.go`, this PR changes to the `cleanupBucketAndSecretObjects()` function to log errors only if the error is caused by something other than the object not existing, making error logging more efficient.

- In file `setup_bucket_source.go`, this PR updates the `cleanupBucketAndSecretObjects()` function to handle errors during deletion of the source objects more efficiently.

- In file `setup_dev_ks.go`, this PR changes the behavior of `CleanupBucketSourceAndKS` function when deleting a Kustomization in Kubernetes to improve the reliability and accuracy of error logging.

- In file `setup_dev_helm.go`, this PR updates the error handling block of `CleanupBucketSourceAndHelm` function with a new conditional to avoid spamming the console with "not found" error messages, making the logs cleaner and easier to read.

To test this PR
```
gitops run ./manifests --no-session
# press Ctrl + C randomly
gitops remove run --no-session
```
and it should clean everything except
- the dashboard
- the Flux installation