### PR TITLE
fix url checking reg exp and make it readable

### DIFF
--- a/ui/lib/__tests__/utils.test.ts
+++ b/ui/lib/__tests__/utils.test.ts
@@ -20,7 +20,25 @@ describe("utils lib", () => {
   describe("isHTTP", () => {
     it("detects HTTP", () => {
       expect(isHTTP("http://www.google.com")).toEqual(true);
-      expect(isHTTP("http://www.google.com/")).toEqual(true);
+      expect(isHTTP("https://www.google.com/")).toEqual(true);
+      expect(isHTTP("http://10.0.0.1/")).toEqual(true);
+      expect(isHTTP("http://127.0.0.1/")).toEqual(true);
+      expect(isHTTP("https://192.168.0.1/")).toEqual(true);
+      expect(isHTTP("http://192.168.0.2/")).toEqual(true);
+      expect(isHTTP("https://169.254.0.1/")).toEqual(true);
+      expect(isHTTP("http://169.254.0.2/")).toEqual(true);
+      expect(isHTTP("https://172.31.0.1/")).toEqual(true);
+      expect(isHTTP("http://172.31.0.2/")).toEqual(true);
+      expect(
+        isHTTP(
+          "http://localhost:8080/applications/argocd/fsa-installation?view=tree"
+        )
+      ).toEqual(true);
+      expect(
+        isHTTP(
+          "https://localhost:8080/applications/argocd/fsa-installation?view=tree"
+        )
+      ).toEqual(true);
       expect(
         isHTTP("http://github.com/weaveworks/weave-gitops-clusters")
       ).toEqual(true);

--- a/ui/lib/utils.ts
+++ b/ui/lib/utils.ts
@@ -33,7 +33,44 @@ export function isHTTP(uri: string): boolean {
   // Regex from Diego Perini's gist: https://gist.github.com/dperini/729294
   // It works better than other regular expressions for validating HTTP and HTTPS URLs.
   const regex = new RegExp(
-    /^(?:(?:(?:https?):)?\/\/)(?:\S+(?::\S*)?@)?(?:(?!(?:10|127)(?:\.\d{1,3}){3})(?!(?:169\.254|192\.168)(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z0-9\u00a1-\uffff][a-z0-9\u00a1-\uffff_-]{0,62})?[a-z0-9\u00a1-\uffff]\.)+(?:[a-z\u00a1-\uffff]{2,}\.?))(?::\d{2,5})?(?:[/?#]\S*)?$/i
+    "^" +
+      // protocol identifier (optional)
+      // short syntax // still required
+      "(?:(?:(?:https?):)?\\/\\/)" +
+      // user:pass BasicAuth (optional)
+      "(?:\\S+(?::\\S*)?@)?" +
+      "(?:" +
+      // IP address dotted notation octets
+      // excludes loopback network 0.0.0.0
+      // excludes reserved space >= 224.0.0.0
+      // excludes network & broadcast addresses
+      // (first & last IP address of each class)
+      "(?:[1-9]\\d?|1\\d\\d|2[01]\\d|22[0-3])" +
+      "(?:\\.(?:1?\\d{1,2}|2[0-4]\\d|25[0-5])){2}" +
+      "(?:\\.(?:[1-9]\\d?|1\\d\\d|2[0-4]\\d|25[0-4]))" +
+      "|" +
+      // host & domain names, may end with dot
+      // can be replaced by a shortest alternative
+      // (?![-_])(?:[-\\w\\u00a1-\\uffff]{0,63}[^-_]\\.)+
+      "(?:" +
+      "(?:" +
+      "[a-z0-9\\u00a1-\\uffff]" +
+      "[a-z0-9\\u00a1-\\uffff_-]{0,62}" +
+      ")?" +
+      "[a-z0-9\\u00a1-\\uffff]\\." +
+      ")+" +
+      // TLD identifier name, may end with dot
+      "(?:[a-z\\u00a1-\\uffff]{2,}\\.?)" +
+      ")" +
+      // locahost is the only name allowed without TLD
+      "|" +
+      "localhost" +
+      // port number (optional)
+      "(?::\\d{2,5})?" +
+      // resource path (optional)
+      "(?:[/?#]\\S*)?" +
+      "$",
+    "i"
   );
 
   return regex.test(uri);


### PR DESCRIPTION
Fixes #3601

- In file `ui/lib/__tests__/utils.test.ts`, this PR adds more test cases to the `isHTTP` function to accurately distinguish between HTTP and HTTPS URLs, improving the reliability and functionality of the function.
  - The added test cases cover scenarios that were previously uncovered, including localhost and private IPs.

- In file `ui/lib/utils.ts`, this PR updates the regular expression used for validating HTTP and HTTPS URIs.
  - The regular expression is now multiline, uses double quotes for consistency, and uses `\\` to escape special characters.
  - The regular expression has been simplified and organized to improve readability, understandability, and maintainability.