### PR TITLE
Allow group claim to be string, not only []string

### DIFF
--- a/pkg/server/auth/claims.go
+++ b/pkg/server/auth/claims.go
@@ -45,7 +45,7 @@ func (c *ClaimsConfig) PrincipalFromClaims(token claimsToken) (*UserPrincipal, e
 	groups := []string{}
 
 	if v, ok := claims[groupsKey]; ok {
-		
+
 		gv, ok := v.([]interface{})
 
 		if ok {
@@ -57,7 +57,7 @@ func (c *ClaimsConfig) PrincipalFromClaims(token claimsToken) (*UserPrincipal, e
 				groups = append(groups, s)
 			}
 		} else {
-			if s, ok := v.(string); ok && len(s) > 0{
+			if s, ok := v.(string); ok && len(s) > 0 {
 				groups = append(groups, s)
 			} else {
 				return nil, fmt.Errorf("the groups claim %q is an empty value", groupsKey)

--- a/pkg/server/auth/claims.go
+++ b/pkg/server/auth/claims.go
@@ -45,16 +45,22 @@ func (c *ClaimsConfig) PrincipalFromClaims(token claimsToken) (*UserPrincipal, e
 	groups := []string{}
 
 	if v, ok := claims[groupsKey]; ok {
+		
 		gv, ok := v.([]interface{})
-		if !ok {
-			return nil, fmt.Errorf("invalid groups claim %q in response %v", groupsKey, v)
-		}
 
-		for _, v := range gv {
-			if s, ok := v.(string); !ok {
-				return nil, fmt.Errorf("invalid groups claim %q in response %v", groupsKey, v)
-			} else {
+		if ok {
+			for _, v := range gv {
+				if s, ok := v.(string); !ok {
+					return nil, fmt.Errorf("invalid groups claim %q in response %v", groupsKey, v)
+				} else {
+					groups = append(groups, s)
+				}
+			}
+		} else {
+			if s, ok := v.(string); ok && len(s) > 0{
 				groups = append(groups, s)
+			} else {
+				return nil, fmt.Errorf("the groups claim %q is an empty value", groupsKey)
 			}
 		}
 	}

--- a/pkg/server/auth/claims.go
+++ b/pkg/server/auth/claims.go
@@ -50,11 +50,11 @@ func (c *ClaimsConfig) PrincipalFromClaims(token claimsToken) (*UserPrincipal, e
 
 		if ok {
 			for _, v := range gv {
-				if s, ok := v.(string); !ok {
+				s, ok := v.(string)
+				if !ok {
 					return nil, fmt.Errorf("invalid groups claim %q in response %v", groupsKey, v)
-				} else {
-					groups = append(groups, s)
 				}
+				groups = append(groups, s)
 			}
 		} else {
 			if s, ok := v.(string); ok && len(s) > 0{

--- a/pkg/server/auth/claims_test.go
+++ b/pkg/server/auth/claims_test.go
@@ -42,6 +42,14 @@ func TestPrincipalFromClaims(t *testing.T) {
 			config: &auth.ClaimsConfig{Groups: "test_groups"},
 			want:   &auth.UserPrincipal{ID: "example@example.com", Groups: []string{"new-group1", "new-group2"}},
 		},
+		{
+			name: "single string custom group claim",
+			token: testutils.MakeJWToken(t, privKey, "example@example.com", func(m map[string]any) {
+				m["test_groups"] = "single-group"
+			}),
+			config: &auth.ClaimsConfig{Groups: "test_groups"},
+			want:   &auth.UserPrincipal{ID: "example@example.com", Groups: []string{"single-group"}},
+		},
 	}
 
 	srv := testutils.MakeKeysetServer(t, privKey)


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes
No open issue exists for this PR.

<!-- Describe what has changed in this PR -->
**What changed?**
When using an OIDC Provider that filters the groups associated with the user principal,
for instance Jumpcloud, it is possible for the groups claim* to have a single string value, and not a list of strings or a list of one string, i.e:
claims[groupsKey] = ["group1"]
claims[groupsKey] = "group1"

This can occur when the user is only assigned to a single group in the OIDC Directory relevant to the Weave Gitops OIDC Application.

\* no matter the attribute name [groups | memberOf | other custom key]

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**
I encountered this issue with the error message:
`failed to query user info endpoint: invalid groups claim "groups" in response Flux-Admins`

and so, in order to tix the issue, I have changed it so that when the type assertion for v.([]interface{}) fails, 
it is assumed that v might be a string, and is then type asserted that it is, and it is appended to groups as a single item.

<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**
it took me a while to get a hang on some of the golang idiom used in the code,
but I think that the end result is quite clean.

<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**
I was developing the change while debugging the tests,
and so I was able to:
- manufacture a new test for the new code
- locally test using a real actual JWT token from my OIDC (had to skip a few JWT  validations, but that's a given)
- make sure all everything works as expected with various inputs with my debugging sessions

<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**
Adds support for OIDC providers that may send a string value for groups instead of a single element list.

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**

Edits by maintainers are welcome