### PR TITLE
Add a hardcoded secret name for the Tilt auth

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -43,7 +43,7 @@ if advanced_go_dev_mode:
             './bin',
         ],
         dockerfile="dev.dockerfile",
-        entrypoint="/app/build/gitops-server --log-level=debug --insecure",
+        entrypoint="/app/build/gitops-server --log-level=debug --insecure --admin-secret=dev-weave-gitops-user-auth",
         live_update=[
             sync('./bin', '/app/build'),
         ],


### PR DESCRIPTION
Closes #3604

The fix is based on @foot 's suggestion ✨ 

Test it locally in the following mode `FAST_AND_FURIOUSER=1 SKIP_UI_BUILD=1 tilt up`. Works as expected.
