### PR TITLE
Add docs for using a private helm repository in wge-profiles

### DIFF
--- a/website/docs/cluster-management/getting-started.mdx
+++ b/website/docs/cluster-management/getting-started.mdx
@@ -175,6 +175,8 @@ Download the profile repository below to your config repository path then commit
   {ProfileRepo}
 </CodeBlock>
 
+For more information about profiles, see [profiles from private helm repositories](./profiles.mdx/#optional-using-a-helm-chart-from-a-remote-publicprivate-repository), [policy profiles](../policy/weave-policy-profile.mdx), and [eso secrets profiles](../secrets/setup-eso.mdx).
+
 #### Add a cluster bootstrap config
 
 Create a cluster bootstrap config as follows:

--- a/website/docs/cluster-management/profiles.mdx
+++ b/website/docs/cluster-management/profiles.mdx
@@ -90,10 +90,10 @@ metadata:
   namespace: flux-system
 spec:
   interval: 1m
-  url: https://raw.githubusercontent.com/weaveworks/weave-gitops-profile-examples/gh-pages
+  url: https://weaveworks.github.io/weave-gitops-profile-examples/
 ```
 
-To be able to use private repositories with restricted access, a secret can be used and synced to the target leaf cluster using `SecretSync`. 
+To be able to use private repositories with restricted access, a secret can be used and synced to the target leaf cluster using [SecretSync](../secrets/bootstraping-secrets.mdx). 
 
 The secret is referenced in the SecretSync as `spec.secretRef` and the labels of the target leaf cluster are added for the syncer to match clusters against those labels using  `spec.clusterSelector.matchLabels`.
 ```yaml title="SecretSync.yaml"
@@ -108,7 +108,7 @@ spec:
       weave.works/capi: bootstrap
   secretRef:
     name: weave-gitops-enterprise-credentials
-  targetNamespace: my-namespace
+  targetNamespace: flux-system
 ```
 
 Once the SecretSync and Secret are available, the secret can be directly referenced in the HelmRepsitory object directly

--- a/website/docs/cluster-management/profiles.mdx
+++ b/website/docs/cluster-management/profiles.mdx
@@ -78,6 +78,54 @@ spec:
 ...
 ```
 
+#### (Optional) Using a helm chart from a remote public/private repository
+The helm releases with the profiles can be added in a remote repository which can be referenced using a HelmRepository resource.The repository can be either public or private, although extra steps are required to use the private repo.
+
+In this example a public repo and branch is referenced directly where the helm releases are
+```yaml title="HelmRepository.yaml"
+apiVersion: source.toolkit.fluxcd.io/v1beta1
+kind: HelmRepository
+metadata:
+  name: weaveworks-charts
+  namespace: flux-system
+spec:
+  interval: 1m
+  url: https://raw.githubusercontent.com/weaveworks/weave-gitops-profile-examples/gh-pages
+```
+
+To be able to use private repositories with restricted access, a secret can be used and synced to the target leaf cluster using `SecretSync`. 
+
+The secret is referenced in the SecretSync as `spec.secretRef` and the labels of the target leaf cluster are added for the syncer to match clusters against those labels using  `spec.clusterSelector.matchLabels`.
+```yaml title="SecretSync.yaml"
+apiVersion: capi.weave.works/v1alpha1
+kind: SecretSync
+metadata:
+  name: my-dev-secret-syncer
+  namespace: flux-system
+spec:
+  clusterSelector:
+    matchLabels:
+      weave.works/capi: bootstrap
+  secretRef:
+    name: weave-gitops-enterprise-credentials
+  targetNamespace: my-namespace
+```
+
+Once the SecretSync and Secret are available, the secret can be directly referenced in the HelmRepsitory object directly
+```yaml title="PrivateHelmRepository.yaml"
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: weaveworks-charts
+  namespace: flux-system
+spec:
+  interval: 60m
+  secretRef:
+    name: weave-gitops-enterprise-credentials
+  url: https://charts.dev.wkp.weave.works/releases/charts-v3
+  ```
+**note**: The `HelmRepoSecret`, `SecretSync`, and the `GitopsCluster` should all be in the same namespace.
+
 ### 2. Select which profiles you want installed when creating a cluster
 
 Currently WGE inspects the current namespace that it is deployed in (in the management cluster) for a `HelmRepository` object named `weaveworks-charts`. This Kubernetes object should be pointing to a Helm chart repository that includes the profiles that are available for installation.


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes https://github.com/weaveworks/weave-gitops-enterprise/issues/2649

<!-- Describe what has changed in this PR -->
**What changed?**
Documentation for using private helm repository to retrieve profiles. SecretSync is to be used to sync the secret.

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**
Document the steps regarding the ability to use private helm repositories as the current usage assumption is of public repos only.

<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**
N/A

<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**
N/A

<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**
N/A

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
