### PR TITLE
Remove the `yaml` package from direct website dependencies.

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -30,8 +30,7 @@
     "react-player": "^2.11.0",
     "trim": "^1.0.1",
     "url-loader": "^4.1.1",
-    "webpack": "^5.76.0",
-    "yaml": "^2.2.2"
+    "webpack": "^5.76.0"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
Follow-up to https://github.com/weaveworks/weave-gitops/pull/3640

The `yaml` package was added to direct dependencies of the website because the `resolutions` example was found had the package in direct dependencies.

So, I tested removing it now and it works fine when keeping the `yaml` package only in resolutions (similar to the `ua-parser-js` package which was already there). 

The behavior of code stays the same. I tested running the documentation locally.