### PR TITLE
Update docs for explorer v22 configuration on `useQueryServiceBackend`

### DIFF
--- a/website/docs/explorer/configuration.mdx
+++ b/website/docs/explorer/configuration.mdx
@@ -180,7 +180,7 @@ rules:
     resources: [ "serviceaccounts" ]
     verbs: [ "impersonate" ]
     resourceNames:
-      - "collector" # should match .spec.values.explorer.collector.serviceAccount.name
+      - "collector"
 ```
 </details>
 

--- a/website/docs/explorer/configuration.mdx
+++ b/website/docs/explorer/configuration.mdx
@@ -14,12 +14,20 @@ This page helps you to understand the options available to configure Explorer
 
 ## Prerequisites
 Before using Explorer, please ensure that:
-- You have Weave Gitops Enterprise [v0.21.2](../../releases)
+- You have Weave Gitops Enterprise [v0.23.0](../../releases)
 
 ## Setup
 
-Explorer is enabled via configuration through the feature flag  `enableExplorer` that you could
-configure in your Weave Gitops Enterprise helm release values file
+The following configuration options are available for you to setup Explorer.
+
+- `.spec.values.enableExplorer`: feature flag to control whether Explorer is enabled.
+- `.spec.values.useQueryServiceBackend`: feature flag to control whether you want to leverage Explorer backend capabilities for
+other UI experiences like [Applications](../getting-started/ui/#applications-view) or [Sources](../getting-started/ui/#the-sources-view)
+- `.spec.values.explorer.collector.serviceAccount`: ServiceAccount `name` and `namespace` that explorer collector will use to impersonate
+in leaf clusters. Make sure you read [authz for collector](#Authentication_and_Authorization_for_collecting) before setting it. Default
+values are `name: collector`, `namespace: flux-system`.
+
+You should specify them in your HelmRelease values:
 
 ```yaml
 ---
@@ -31,7 +39,13 @@ metadata:
 spec:
   # ... other spec components
   values:
-    enableExplorer: true
+    enableExplorer: true # feature flag to enable explorer
+    useQueryServiceBackend: true # uses explorer query backend in collection UIs
+    explorer:
+      collector:
+        serviceAccount: # service account that collector will impersonate in leaf clusters
+          name: collector
+          namespace: flux-system
 ```
 
 ## Configuration
@@ -85,7 +99,7 @@ in [setup RBAC](../configuration/service-account-permissions.mdx), the GitopsClu
 
 To configure collection, you would need to extend this configuration with the following:
 
-1. Create a ServiceAccount `collector` in `flux-system` namespace for any leaf cluster that you want to watch.
+1. Create a ServiceAccount for the one that you specified in your [setup](#setup) `.spec.values.explorer.collector.serviceAccount`.
 
 <details><summary>Expand to see an example</summary>
 
@@ -93,14 +107,14 @@ To configure collection, you would need to extend this configuration with the fo
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: collector
-  namespace: flux-system
+  name: collector # should match .spec.values.explorer.collector.serviceAccount.name
+  namespace: flux-system # should match .spec.values.explorer.collector.serviceAccount.namespace
 ```
 
 </details>
 
 
-2. Create a ClusterRole `collector` with the permissions to watch the supported resources.
+2. Create a ClusterRole with the permissions to watch the supported resources.
 
 <details><summary>Expand to see an example</summary>
 
@@ -108,7 +122,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: collector
+  name: collector # could be .spec.values.explorer.collector.serviceAccount.name
 rules:
   - apiGroups: [ "rbac.authorization.k8s.io" ]
     resources: [ "roles", "clusterroles", "rolebindings", "clusterrolebindings" ]
@@ -126,7 +140,7 @@ rules:
 
 </details>
 
-3. Create a ClusterRolebinding `collector` to assign permissions to `collector` ServiceAccount.
+3. Create a ClusterRolebinding to assign previous ClusterRole to the created collector `ServiceAccount`.
 
 <details><summary>Expand to see an example</summary>
 
@@ -134,14 +148,14 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: collector
+  name: collector # could be .spec.values.explorer.collector.serviceAccount.name
 subjects:
   - kind: ServiceAccount
-    name: collector
-    namespace: flux-system
+    name: collector # should match .spec.values.explorer.collector.serviceAccount.name
+    namespace: flux-system # should match .spec.values.explorer.collector.serviceAccount.namespace
 roleRef:
   kind: ClusterRole
-  name: collector
+  name: collector # name of the cluster role created earlier
   apiGroup: rbac.authorization.k8s.io
 ```
 
@@ -166,7 +180,7 @@ rules:
     resources: [ "serviceaccounts" ]
     verbs: [ "impersonate" ]
     resourceNames:
-      - "collector"
+      - "collector" # should match .spec.values.explorer.collector.serviceAccount.name
 ```
 </details>
 

--- a/website/docs/explorer/configuration.mdx
+++ b/website/docs/explorer/configuration.mdx
@@ -14,7 +14,7 @@ This page helps you to understand the options available to configure Explorer
 
 ## Prerequisites
 Before using Explorer, please ensure that:
-- You have Weave Gitops Enterprise [v0.23.0](../../releases)
+- You have Weave Gitops Enterprise [v0.22.0](../../releases)
 
 ## Setup
 
@@ -23,9 +23,6 @@ The following configuration options are available for you to setup Explorer.
 - `.spec.values.enableExplorer`: feature flag to control whether Explorer is enabled.
 - `.spec.values.useQueryServiceBackend`: feature flag to control whether you want to leverage Explorer backend capabilities for
 other UI experiences like [Applications](../getting-started/ui/#applications-view) or [Sources](../getting-started/ui/#the-sources-view)
-- `.spec.values.explorer.collector.serviceAccount`: ServiceAccount `name` and `namespace` that explorer collector will use to impersonate
-in leaf clusters. Make sure you read [authz for collector](#Authentication_and_Authorization_for_collecting) before setting it. Default
-values are `name: collector`, `namespace: flux-system`.
 
 You should specify them in your HelmRelease values:
 
@@ -41,11 +38,6 @@ spec:
   values:
     enableExplorer: true # feature flag to enable explorer
     useQueryServiceBackend: true # uses explorer query backend in collection UIs
-    explorer:
-      collector:
-        serviceAccount: # service account that collector will impersonate in leaf clusters
-          name: collector
-          namespace: flux-system
 ```
 
 ## Configuration
@@ -97,9 +89,17 @@ Query results are filtered honouring the access determined via RBAC.
 define the connection and security context that Explorer leverages to collect data from leaf clusters. Given that you have followed the indications
 in [setup RBAC](../configuration/service-account-permissions.mdx), the GitopsCluster service account is able to impersonate any user or group.
 
+:::tip
+
+Collector RBAC resources are part of your leaf clusters common RBAC configuration. It is commonly
+located in your  `clusters/bases` folder, as described in [Getting started](./getting-started.mdx).
+
+:::
+
+
 To configure collection, you would need to extend this configuration with the following:
 
-1. Create a ServiceAccount for the one that you specified in your [setup](#setup) `.spec.values.explorer.collector.serviceAccount`.
+1. Create a ServiceAccount `collector` in `flux-system` namespace for any leaf cluster that you want to watch.
 
 <details><summary>Expand to see an example</summary>
 
@@ -107,14 +107,14 @@ To configure collection, you would need to extend this configuration with the fo
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: collector # should match .spec.values.explorer.collector.serviceAccount.name
-  namespace: flux-system # should match .spec.values.explorer.collector.serviceAccount.namespace
+  name: collector
+  namespace: flux-system
 ```
 
 </details>
 
 
-2. Create a ClusterRole with the permissions to watch the supported resources.
+2. Create a ClusterRole `collector` with the permissions to watch the supported resources.
 
 <details><summary>Expand to see an example</summary>
 
@@ -122,7 +122,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: collector # could be .spec.values.explorer.collector.serviceAccount.name
+  name: collector
 rules:
   - apiGroups: [ "rbac.authorization.k8s.io" ]
     resources: [ "roles", "clusterroles", "rolebindings", "clusterrolebindings" ]
@@ -140,7 +140,7 @@ rules:
 
 </details>
 
-3. Create a ClusterRolebinding to assign previous ClusterRole to the created collector `ServiceAccount`.
+3. Create a ClusterRolebinding `collector` to assign permissions to `collector` ServiceAccount.
 
 <details><summary>Expand to see an example</summary>
 
@@ -148,14 +148,14 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: collector # could be .spec.values.explorer.collector.serviceAccount.name
+  name: collector
 subjects:
   - kind: ServiceAccount
-    name: collector # should match .spec.values.explorer.collector.serviceAccount.name
-    namespace: flux-system # should match .spec.values.explorer.collector.serviceAccount.namespace
+    name: collector
+    namespace: flux-system
 roleRef:
   kind: ClusterRole
-  name: collector # name of the cluster role created earlier
+  name: collector
   apiGroup: rbac.authorization.k8s.io
 ```
 

--- a/website/docs/explorer/configuration.mdx
+++ b/website/docs/explorer/configuration.mdx
@@ -22,7 +22,7 @@ The following configuration options are available for you to setup Explorer.
 
 - `.spec.values.enableExplorer`: feature flag to control whether Explorer is enabled.
 - `.spec.values.useQueryServiceBackend`: feature flag to control whether you want to leverage Explorer backend capabilities for
-other UI experiences like [Applications](../getting-started/ui/#applications-view) or [Sources](../getting-started/ui/#the-sources-view)
+other UI experiences like [Applications](../../getting-started/ui#applications-view) or [Sources](../../getting-started/ui#the-sources-view)
 
 You should specify them in your HelmRelease values:
 

--- a/website/docs/releases.mdx
+++ b/website/docs/releases.mdx
@@ -30,6 +30,10 @@ This page details the changes for Weave GitOps Enterprise and its associated com
 
 - Don't wait for ControlPlane readiness to sync secrets, this allows secrets to be sync'd related to CNI or other early stage processes
 
+### Upgrade Notes (from the previous release)
+
+- Explorer: you should configure [collector service account](https://docs.gitops.weave.works/docs/explorer/configuration/#authentication-and-authorization-for-collecting) in your leaf clusters.
+
 ### Known issues
 
 - Clusters page horizontally scrolls too much and status becomes unreadable for some fields

--- a/website/docs/releases.mdx
+++ b/website/docs/releases.mdx
@@ -20,6 +20,7 @@ This page details the changes for Weave GitOps Enterprise and its associated com
 
 - Explorer supports now Flux sources.
 - Applications UI and Sources UI could be configured to use Explorer backend to improve UI experience.
+- Explorer collector uses impersonation. Ensure you [configure collector](../explorer/configuration/#authentication-and-authorization-for-collecting) for your leaf clusters.
 
 #### GitopsSets
 

--- a/website/versioned_docs/version-0.22.0/explorer/configuration.mdx
+++ b/website/versioned_docs/version-0.22.0/explorer/configuration.mdx
@@ -180,7 +180,7 @@ rules:
     resources: [ "serviceaccounts" ]
     verbs: [ "impersonate" ]
     resourceNames:
-      - "collector" # should match .spec.values.explorer.collector.serviceAccount.name
+      - "collector"
 ```
 </details>
 

--- a/website/versioned_docs/version-0.22.0/explorer/configuration.mdx
+++ b/website/versioned_docs/version-0.22.0/explorer/configuration.mdx
@@ -14,12 +14,17 @@ This page helps you to understand the options available to configure Explorer
 
 ## Prerequisites
 Before using Explorer, please ensure that:
-- You have Weave Gitops Enterprise [v0.21.2](../../releases)
+- You have Weave Gitops Enterprise [v0.22.0](../../releases)
 
 ## Setup
 
-Explorer is enabled via configuration through the feature flag  `enableExplorer` that you could
-configure in your Weave Gitops Enterprise helm release values file
+The following configuration options are available for you to setup Explorer.
+
+- `.spec.values.enableExplorer`: feature flag to control whether Explorer is enabled.
+- `.spec.values.useQueryServiceBackend`: feature flag to control whether you want to leverage Explorer backend capabilities for
+other UI experiences like [Applications](../getting-started/ui/#applications-view) or [Sources](../getting-started/ui/#the-sources-view)
+
+You should specify them in your HelmRelease values:
 
 ```yaml
 ---
@@ -31,7 +36,8 @@ metadata:
 spec:
   # ... other spec components
   values:
-    enableExplorer: true
+    enableExplorer: true # feature flag to enable explorer
+    useQueryServiceBackend: true # uses explorer query backend in collection UIs
 ```
 
 ## Configuration
@@ -82,6 +88,14 @@ Query results are filtered honouring the access determined via RBAC.
 [GitopsClusters](../cluster-management/managing-existing-clusters.mdx#connect-a-cluster)
 define the connection and security context that Explorer leverages to collect data from leaf clusters. Given that you have followed the indications
 in [setup RBAC](../configuration/service-account-permissions.mdx), the GitopsCluster service account is able to impersonate any user or group.
+
+:::tip
+
+Collector RBAC resources are part of your leaf clusters common RBAC configuration. It is commonly
+located in your  `clusters/bases` folder, as described in [Getting started](./getting-started.mdx).
+
+:::
+
 
 To configure collection, you would need to extend this configuration with the following:
 
@@ -166,7 +180,7 @@ rules:
     resources: [ "serviceaccounts" ]
     verbs: [ "impersonate" ]
     resourceNames:
-      - "collector"
+      - "collector" # should match .spec.values.explorer.collector.serviceAccount.name
 ```
 </details>
 

--- a/website/versioned_docs/version-0.22.0/explorer/configuration.mdx
+++ b/website/versioned_docs/version-0.22.0/explorer/configuration.mdx
@@ -22,7 +22,7 @@ The following configuration options are available for you to setup Explorer.
 
 - `.spec.values.enableExplorer`: feature flag to control whether Explorer is enabled.
 - `.spec.values.useQueryServiceBackend`: feature flag to control whether you want to leverage Explorer backend capabilities for
-other UI experiences like [Applications](../getting-started/ui/#applications-view) or [Sources](../getting-started/ui/#the-sources-view)
+other UI experiences like [Applications](../../getting-started/ui#applications-view) or [Sources](../../getting-started/ui#the-sources-view)
 
 You should specify them in your HelmRelease values:
 

--- a/website/versioned_docs/version-0.22.0/releases.mdx
+++ b/website/versioned_docs/version-0.22.0/releases.mdx
@@ -20,7 +20,7 @@ This page details the changes for Weave GitOps Enterprise and its associated com
 
 - Explorer supports now Flux sources.
 - Applications UI and Sources UI could be configured to use Explorer backend to improve UI experience.
-- Explorer collector uses impersonation. Ensure you [configure collector](../explorer/configuration/#authentication-and-authorization-for-collecting) for your leaf clusters.
+- Explorer collector uses impersonation.
 
 #### GitopsSets
 
@@ -29,6 +29,10 @@ This page details the changes for Weave GitOps Enterprise and its associated com
 #### Cluster Bootstrapping
 
 - Don't wait for ControlPlane readiness to sync secrets, this allows secrets to be sync'd related to CNI or other early stage processes
+
+### Upgrade Notes (from the previous release)
+
+- Explorer: you should configure [collector service account](https://docs.gitops.weave.works/docs/explorer/configuration/#authentication-and-authorization-for-collecting) in your leaf clusters.
 
 ### Known issues
 

--- a/website/versioned_docs/version-0.22.0/releases.mdx
+++ b/website/versioned_docs/version-0.22.0/releases.mdx
@@ -20,6 +20,7 @@ This page details the changes for Weave GitOps Enterprise and its associated com
 
 - Explorer supports now Flux sources.
 - Applications UI and Sources UI could be configured to use Explorer backend to improve UI experience.
+- Explorer collector uses impersonation. Ensure you [configure collector](../explorer/configuration/#authentication-and-authorization-for-collecting) for your leaf clusters.
 
 #### GitopsSets
 


### PR DESCRIPTION
We have released https://github.com/weaveworks/weave-gitops-enterprise/releases/tag/v0.22.0 
but there was no documentation for `useQueryServiceBackend`

This PR adds it and updates release notes too.
