### PR TITLE
Trick bundler into correctly building D3

### DIFF
--- a/ui/components/ReconciliationGraph.tsx
+++ b/ui/components/ReconciliationGraph.tsx
@@ -10,6 +10,12 @@ import Flex from "./Flex";
 import RequestStateHandler from "./RequestStateHandler";
 import Spacer from "./Spacer";
 
+// This is working around a parcel build error.
+// https://github.com/parcel-bundler/parcel/issues/8792
+// https://github.com/weaveworks/weave-gitops/issues/3672
+// Theory: this is tricking parcel into correctly importing d3. :shrug:
+d3;
+
 interface Props {
   className?: string;
   reconciledObjectsAutomation: ReconciledObjectsAutomation;


### PR DESCRIPTION
Closes #3672 

It appears that this is tricking `parcel` into correctly importing `d3` by including a reference to the library in the module syntax-tree (I guess).

The library is referenced, but no calls are made. 