### PR TITLE
Fix code tag style of `react-syntax-highlighter`

### DIFF
--- a/ui/components/YamlView.tsx
+++ b/ui/components/YamlView.tsx
@@ -44,7 +44,9 @@ function UnstyledYamlView({ yaml, object, mode, className }: YamlViewProps) {
     },
 
     codeTagProps: {
-      wordBreak: "break-word",
+      style: {
+        wordBreak: "break-word",
+      },
     },
 
     lineProps: { style: { flexWrap: "wrap" } },

--- a/ui/components/__tests__/__snapshots__/YamlView.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/YamlView.test.tsx.snap
@@ -185,9 +185,9 @@ exports[`YamlView snapshots renders 1`] = `
       style={
         Object {
           "whiteSpace": "pre-wrap",
+          "wordBreak": "break-word",
         }
       }
-      wordBreak="break-word"
     >
       <span
         style={


### PR DESCRIPTION
Follow-up to https://github.com/weaveworks/weave-gitops/pull/3676