### PR TITLE
Added a redirect for getting started page

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -41,6 +41,7 @@ jobs:
           fi
           sed -i 's#url:.*$#url: "https://staging.docs.gitops.weave.works",#' docusaurus.config.js
           sed -i 's#baseUrl:.*$#baseUrl: "/${{ github.head_ref }}/",#' docusaurus.config.js
+          yarn clear
           npm run build
       - id: auth
         uses: google-github-actions/auth@v0.4.0
@@ -97,6 +98,7 @@ jobs:
           else
           npm i
           fi
+          yarn clear
           npm run build
       - id: auth
         uses: google-github-actions/auth@v0.4.0

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ brew tap weaveworks/tap
 brew install weaveworks/tap/gitops
 ```
 
-Please see the [getting started guide](https://docs.gitops.weave.works/docs/getting-started).
+Please see the [getting started guide](https://docs.gitops.weave.works/docs/getting-started/intro).
 
 ## CLI Reference
 
@@ -117,7 +117,7 @@ Please see our Weave GitOps OSS [FAQ](https://www.weave.works/faqs-for-weave-git
 Need help or want to contribute? Please see the links below.
 
 - Getting Started?
-    - Follow our [Get Started guide](https://docs.gitops.weave.works/docs/getting-started) and give us feedback
+    - Follow our [Get Started guide](https://docs.gitops.weave.works/docs/getting-started/intro) and give us feedback
 - Need help?
     - Talk to us in
       the [#weave-gitops channel](https://app.slack.com/client/T2NDH1D9D/C0248LVC719/thread/C2ND76PAA-1621532937.019800)

--- a/ui/pages/SignIn.tsx
+++ b/ui/pages/SignIn.tsx
@@ -198,7 +198,7 @@ function SignIn() {
           <DocsWrapper center align>
             Need help? Have a look at the&nbsp;
             <a
-              href="https://docs.gitops.weave.works/docs/getting-started"
+              href="https://docs.gitops.weave.works/docs/getting-started/intro"
               target="_blank"
               rel="noopener noreferrer"
             >

--- a/website/docs/installation/aws-marketplace.mdx
+++ b/website/docs/installation/aws-marketplace.mdx
@@ -19,7 +19,6 @@ the [Helm S3 Plugin](https://github.com/hypnoglow/helm-s3).
 ### Step 1: Subscribe to Weave GitOps on the AWS Marketplace
 
 To deploy the managed Weave GitOps solution, first subscribe to the product on [AWS Marketplace](https://aws.amazon.com/marketplace/pp/prodview-vkn2wejad2ix4).
-**This subscription is only available for deployment on EKS versions 1.17-1.21.**
 
 _Note: it may take ~20 minutes for your Subscription to become live and deployable._
 

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -40,7 +40,7 @@ module.exports = {
           // /docs/oldDoc -> /docs/newDoc
           {
             to: '/docs/getting-started/intro/',
-            from: ['/docs/gitops-dashboard/index.html', '/docs/gitops-dashboard/index'],
+            from: ['/docs/getting-started/', '/docs/getting-started'],
           },
         ],
       },

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -32,6 +32,19 @@ module.exports = {
         };
       },
     }),
+    [
+        '@docusaurus/plugin-client-redirects',
+      {
+        fromExtensions: ['html', 'htm'], // /myPage.html -> /myPage
+        redirects: [
+          // /docs/oldDoc -> /docs/newDoc
+          {
+            to: '/docs/getting-started/intro/',
+            from: ['/docs/gitops-dashboard/index.html', '/docs/gitops-dashboard/index'],
+          },
+        ],
+      },
+    ],
   ],
   themeConfig: {
     navbar: {
@@ -185,6 +198,12 @@ module.exports = {
           trackingID: process.env.GA_KEY,
           // Optional fields.
           anonymizeIP: true, // Should IPs be anonymized?
+        },
+        sitemap: {
+            changefreq: 'weekly',
+            priority: 0.5,
+            ignorePatterns: ['/tags/**'],
+            filename: 'sitemap.xml',
         },
       },
     ],

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -40,7 +40,7 @@ module.exports = {
           // /docs/oldDoc -> /docs/newDoc
           {
             to: '/docs/getting-started/intro/',
-            from: ['/docs/getting-started/', '/docs/getting-started'],
+            from: ['/docs/getting-started'],
           },
         ],
       },

--- a/website/package.json
+++ b/website/package.json
@@ -15,8 +15,10 @@
   },
   "dependencies": {
     "@docusaurus/core": "^2.4.0",
+    "@docusaurus/plugin-client-redirects": "^2.4.0",
     "@docusaurus/plugin-google-analytics": "^2.4.0",
     "@docusaurus/plugin-google-gtag": "^2.4.0",
+    "@docusaurus/plugin-sitemap": "^2.4.0",
     "@docusaurus/preset-classic": "^2.4.0",
     "@docusaurus/theme-search-algolia": "^2.4.0",
     "@fortawesome/fontawesome-svg-core": "^6.3.0",

--- a/website/versioned_docs/version-0.22.0/installation/aws-marketplace.mdx
+++ b/website/versioned_docs/version-0.22.0/installation/aws-marketplace.mdx
@@ -19,7 +19,6 @@ the [Helm S3 Plugin](https://github.com/hypnoglow/helm-s3).
 ### Step 1: Subscribe to Weave GitOps on the AWS Marketplace
 
 To deploy the managed Weave GitOps solution, first subscribe to the product on [AWS Marketplace](https://aws.amazon.com/marketplace/pp/prodview-vkn2wejad2ix4).
-**This subscription is only available for deployment on EKS versions 1.17-1.21.**
 
 _Note: it may take ~20 minutes for your Subscription to become live and deployable._
 

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -1331,6 +1331,21 @@
     react-helmet-async "*"
     react-loadable "npm:@docusaurus/react-loadable@5.5.2"
 
+"@docusaurus/plugin-client-redirects@^2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-2.4.0.tgz#53117d112ac9cc191deda053af4335e0381b4125"
+  integrity sha512-HsS+Dc2ZLWhfpjYJ5LIrOB/XfXZcElcC7o1iA4yIVtiFz+LHhwP863fhqbwSJ1c6tNDOYBH3HwbskHrc/PIn7Q==
+  dependencies:
+    "@docusaurus/core" "2.4.0"
+    "@docusaurus/logger" "2.4.0"
+    "@docusaurus/utils" "2.4.0"
+    "@docusaurus/utils-common" "2.4.0"
+    "@docusaurus/utils-validation" "2.4.0"
+    eta "^2.0.0"
+    fs-extra "^10.1.0"
+    lodash "^4.17.21"
+    tslib "^2.4.0"
+
 "@docusaurus/plugin-content-blog@2.4.0":
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.4.0.tgz#50dbfbc7b51f152ae660385fd8b34076713374c3"
@@ -1431,7 +1446,7 @@
     "@docusaurus/utils-validation" "2.4.0"
     tslib "^2.4.0"
 
-"@docusaurus/plugin-sitemap@2.4.0":
+"@docusaurus/plugin-sitemap@2.4.0", "@docusaurus/plugin-sitemap@^2.4.0":
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.4.0.tgz#ba0eb43565039fe011bdd874b5c5d7252b19d709"
   integrity sha512-pZxh+ygfnI657sN8a/FkYVIAmVv0CGk71QMKqJBOfMmDHNN1FeDeFkBjWP49ejBqpqAhjufkv5UWq3UOu2soCw==


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Fixes https://github.com/weaveworks/weave-gitops-interlock/issues/414

<!-- Describe what has changed in this PR -->
**What changed?**
This pr adds a redirect for old page which no longer exists. Also removed redundant info from marketplace docs.


<!-- Tell your future self why have you made these changes -->
**Why was this change made?**
The page link https://docs.gitops.weave.works/docs/getting-started/ currently goes to older versions of docs with outdated information causing confusion. 

When the new getting started page was introduced https://docs.gitops.weave.works/docs/getting-started/intro we must have missed updating outdated links.

<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**
Adding a redirect plugin https://docusaurus.io/docs/using-plugins

<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**
Staging build and local testing

<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**


<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
This pr adds a redirect for the old page which no longer exists. Also removed redundant info from marketplace docs.
Added two plugins - 1 for redirect and 1 for generating a sitemap for our documentation site so crawlers have up to date info on our website