### PR TITLE
Fix url for enterprise intro page

### DIFF
--- a/website/docs/policy/policy.mdx
+++ b/website/docs/policy/policy.mdx
@@ -25,7 +25,7 @@ Enterprise customers should have access to fork policy library repo into their l
 
 ## Tenant Policy
 
-Tenant policies are special policies that are used by the [Multi Tenancy](https://docs.gitops.weave.works/docs/enterprise/multi-tenancy/) feature in [Weave GitOps Enterprise](https://docs.gitops.weave.works/docs/enterprise/intro/)
+Tenant policies are special policies that are used by the [Multi Tenancy](https://docs.gitops.weave.works/docs/enterprise/multi-tenancy/) feature in [Weave GitOps Enterprise](https://docs.gitops.weave.works/docs/intro-ee/)
 
 Tenant policies have a special tag `tenancy`.
 

--- a/website/versioned_docs/version-0.22.0/policy/policy.mdx
+++ b/website/versioned_docs/version-0.22.0/policy/policy.mdx
@@ -25,7 +25,7 @@ Enterprise customers should have access to fork policy library repo into their l
 
 ## Tenant Policy
 
-Tenant policies are special policies that are used by the [Multi Tenancy](https://docs.gitops.weave.works/docs/enterprise/multi-tenancy/) feature in [Weave GitOps Enterprise](https://docs.gitops.weave.works/docs/enterprise/intro/)
+Tenant policies are special policies that are used by the [Multi Tenancy](https://docs.gitops.weave.works/docs/enterprise/multi-tenancy/) feature in [Weave GitOps Enterprise](https://docs.gitops.weave.works/docs/intro-ee/)
 
 Tenant policies have a special tag `tenancy`.
 

--- a/website/versioned_docs/version-0.23.0/policy/policy.mdx
+++ b/website/versioned_docs/version-0.23.0/policy/policy.mdx
@@ -25,7 +25,7 @@ Enterprise customers should have access to fork policy library repo into their l
 
 ## Tenant Policy
 
-Tenant policies are special policies that are used by the [Multi Tenancy](https://docs.gitops.weave.works/docs/enterprise/multi-tenancy/) feature in [Weave GitOps Enterprise](https://docs.gitops.weave.works/docs/enterprise/intro/)
+Tenant policies are special policies that are used by the [Multi Tenancy](https://docs.gitops.weave.works/docs/enterprise/multi-tenancy/) feature in [Weave GitOps Enterprise](https://docs.gitops.weave.works/docs/intro-ee/)
 
 Tenant policies have a special tag `tenancy`.
 


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes https://github.com/weaveworks/weave-gitops-interlock/issues/414

<!-- Describe what has changed in this PR -->
**What changed?**
Fixed old enterprise urls with new ones.

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**
Old url https://docs.gitops.weave.works/docs/enterprise/intro/ goes to the wrong version `0.12.0`


<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**
Local testing

<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**


<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
Fixed old enterprise urls with new ones.