### PR TITLE
Adding missing namespace in sops doc command

### DIFF
--- a/website/docs/secrets/setup-sops.mdx
+++ b/website/docs/secrets/setup-sops.mdx
@@ -194,7 +194,7 @@ flux create kustomization age-secrets \
 6- Annotate the kustomization object created in the previous step with the name and namespace of the public key created in step 4.
 
 ```bash
-kubectl annotate kustomization secrets \
+kubectl annotate kustomization age-secrets \
 sops-public-key/name=sops-age-public-key \
 sops-public-key/namespace=flux-system \
 -n flux-system

--- a/website/docs/secrets/setup-sops.mdx
+++ b/website/docs/secrets/setup-sops.mdx
@@ -90,7 +90,7 @@ gpg --delete-secret-keys "${KEY_FP}"
 
 ```bash
 flux create kustomization gpg-secrets \
---source=secrets \
+--source=secrets \ # the git source to reconcile the secrets from
 --path=./secrets/gpg \
 --prune=true \
 --interval=10m \
@@ -103,7 +103,8 @@ flux create kustomization gpg-secrets \
 ```bash
 kubectl annotate kustomization gpg-secrets \
 sops-public-key/name=sops-gpg-public-key \
-sops-public-key/namespace=flux-system
+sops-public-key/namespace=flux-system \
+-n flux-system
 ```
 
 <details><summary>Expand to see the expected kustomization object</summary>
@@ -195,7 +196,8 @@ flux create kustomization age-secrets \
 ```bash
 kubectl annotate kustomization secrets \
 sops-public-key/name=sops-age-public-key \
-sops-public-key/namespace=flux-system
+sops-public-key/namespace=flux-system \
+-n flux-system
 ```
 
 <details><summary>Expand to see the expected kustomization object</summary>
@@ -253,7 +255,7 @@ The following example is using GPG encryption to install SOPS and generate keys 
 >
   {SopsBootstrapJob}
 </CodeBlock>
-    
+
 </details>
 
 #### Cluster template updates

--- a/website/versioned_docs/version-0.20.0/secrets/setup-sops.mdx
+++ b/website/versioned_docs/version-0.20.0/secrets/setup-sops.mdx
@@ -3,11 +3,12 @@ title: Setup SOPS
 hide_title: true
 ---
 
+import TierLabel from "./../_components/TierLabel";
+import CodeBlock from "@theme/CodeBlock";
+
 import SopsBootstrapJob from "!!raw-loader!./assets/sops-bootstrap-job.yaml";
 import TemplateParams from "!!raw-loader!./assets/template-params.yaml";
 import TemplateAnnotations from "!!raw-loader!./assets/template-annotations.yaml";
-
-import TierLabel from "./../_components/TierLabel";
 
 <h1>
   {frontMatter.title} <TierLabel tiers="Enterprise" />
@@ -89,7 +90,7 @@ gpg --delete-secret-keys "${KEY_FP}"
 
 ```bash
 flux create kustomization gpg-secrets \
---source=secrets \
+--source=secrets \ # the git source to reconcile the secrets from
 --path=./secrets/gpg \
 --prune=true \
 --interval=10m \
@@ -102,7 +103,8 @@ flux create kustomization gpg-secrets \
 ```bash
 kubectl annotate kustomization gpg-secrets \
 sops-public-key/name=sops-gpg-public-key \
-sops-public-key/namespace=flux-system
+sops-public-key/namespace=flux-system \
+-n flux-system
 ```
 
 <details><summary>Expand to see the expected kustomization object</summary>
@@ -194,7 +196,8 @@ flux create kustomization age-secrets \
 ```bash
 kubectl annotate kustomization secrets \
 sops-public-key/name=sops-age-public-key \
-sops-public-key/namespace=flux-system
+sops-public-key/namespace=flux-system \
+-n flux-system
 ```
 
 <details><summary>Expand to see the expected kustomization object</summary>
@@ -245,12 +248,14 @@ As well as an option to push the public key to the git repository via a PR (to b
 The following example is using GPG encryption to install SOPS and generate keys when bootstrapping leaf clusters. Create the following `ClusterBootstrapConfig` CR and push it to your fleet repo.
 
 <details><summary>Expand to view </summary>
-    <CodeBlock
-    title="clusters/management/capi/boostrap/sops-bootstrap-job.yaml"
-    className="language-yaml"
-    >
-        {SopsBootstrapJob}
-    </CodeBlock>
+
+<CodeBlock
+  title="clusters/management/capi/boostrap/sops-bootstrap-job.yaml"
+  className="language-yaml"
+>
+  {SopsBootstrapJob}
+</CodeBlock>
+
 </details>
 
 #### Cluster template updates
@@ -267,23 +272,27 @@ templates.weave.works/sops-enabled: "true"
 The template should have the following parameters that are needed for the Kustomization
 
 <details><summary>Expand to view </summary>
-    <CodeBlock
-    title="clusters/management/capi/templates/template.yaml"
-    className="language-yaml"
-    >
-    {TemplateParams}
-    </CodeBlock>
+
+<CodeBlock
+  title="clusters/management/capi/templates/template.yaml"
+  className="language-yaml"
+>
+  {TemplateParams}
+</CodeBlock>
+
 </details>
 
 The template should have the following annotations under `GitOpsCluster` to be used in the bootstrap job
 
 <details><summary>Expand to view </summary>
-    <CodeBlock
-    title="clusters/management/capi/templates/template.yaml"
-    className="language-yaml"
-    >
-    {TemplateAnnotations}
-    </CodeBlock>
+
+<CodeBlock
+  title="clusters/management/capi/templates/template.yaml"
+  className="language-yaml"
+>
+  {TemplateAnnotations}
+</CodeBlock>
+
 </details>
 
 ### Installation Steps

--- a/website/versioned_docs/version-0.20.0/secrets/setup-sops.mdx
+++ b/website/versioned_docs/version-0.20.0/secrets/setup-sops.mdx
@@ -3,12 +3,11 @@ title: Setup SOPS
 hide_title: true
 ---
 
-import TierLabel from "./../_components/TierLabel";
-import CodeBlock from "@theme/CodeBlock";
-
 import SopsBootstrapJob from "!!raw-loader!./assets/sops-bootstrap-job.yaml";
 import TemplateParams from "!!raw-loader!./assets/template-params.yaml";
 import TemplateAnnotations from "!!raw-loader!./assets/template-annotations.yaml";
+
+import TierLabel from "./../_components/TierLabel";
 
 <h1>
   {frontMatter.title} <TierLabel tiers="Enterprise" />
@@ -248,14 +247,12 @@ As well as an option to push the public key to the git repository via a PR (to b
 The following example is using GPG encryption to install SOPS and generate keys when bootstrapping leaf clusters. Create the following `ClusterBootstrapConfig` CR and push it to your fleet repo.
 
 <details><summary>Expand to view </summary>
-
-<CodeBlock
-  title="clusters/management/capi/boostrap/sops-bootstrap-job.yaml"
-  className="language-yaml"
->
-  {SopsBootstrapJob}
-</CodeBlock>
-
+    <CodeBlock
+    title="clusters/management/capi/boostrap/sops-bootstrap-job.yaml"
+    className="language-yaml"
+    >
+        {SopsBootstrapJob}
+    </CodeBlock>
 </details>
 
 #### Cluster template updates
@@ -272,27 +269,23 @@ templates.weave.works/sops-enabled: "true"
 The template should have the following parameters that are needed for the Kustomization
 
 <details><summary>Expand to view </summary>
-
-<CodeBlock
-  title="clusters/management/capi/templates/template.yaml"
-  className="language-yaml"
->
-  {TemplateParams}
-</CodeBlock>
-
+    <CodeBlock
+    title="clusters/management/capi/templates/template.yaml"
+    className="language-yaml"
+    >
+    {TemplateParams}
+    </CodeBlock>
 </details>
 
 The template should have the following annotations under `GitOpsCluster` to be used in the bootstrap job
 
 <details><summary>Expand to view </summary>
-
-<CodeBlock
-  title="clusters/management/capi/templates/template.yaml"
-  className="language-yaml"
->
-  {TemplateAnnotations}
-</CodeBlock>
-
+    <CodeBlock
+    title="clusters/management/capi/templates/template.yaml"
+    className="language-yaml"
+    >
+    {TemplateAnnotations}
+    </CodeBlock>
 </details>
 
 ### Installation Steps

--- a/website/versioned_docs/version-0.20.0/secrets/setup-sops.mdx
+++ b/website/versioned_docs/version-0.20.0/secrets/setup-sops.mdx
@@ -193,7 +193,7 @@ flux create kustomization age-secrets \
 6- Annotate the kustomization object created in the previous step with the name and namespace of the public key created in step 4.
 
 ```bash
-kubectl annotate kustomization secrets \
+kubectl annotate kustomization age-secrets \
 sops-public-key/name=sops-age-public-key \
 sops-public-key/namespace=flux-system \
 -n flux-system

--- a/website/versioned_docs/version-0.21.1/secrets/setup-sops.mdx
+++ b/website/versioned_docs/version-0.21.1/secrets/setup-sops.mdx
@@ -3,11 +3,12 @@ title: Setup SOPS
 hide_title: true
 ---
 
+import TierLabel from "./../_components/TierLabel";
+import CodeBlock from "@theme/CodeBlock";
+
 import SopsBootstrapJob from "!!raw-loader!./assets/sops-bootstrap-job.yaml";
 import TemplateParams from "!!raw-loader!./assets/template-params.yaml";
 import TemplateAnnotations from "!!raw-loader!./assets/template-annotations.yaml";
-
-import TierLabel from "./../_components/TierLabel";
 
 <h1>
   {frontMatter.title} <TierLabel tiers="Enterprise" />
@@ -89,7 +90,7 @@ gpg --delete-secret-keys "${KEY_FP}"
 
 ```bash
 flux create kustomization gpg-secrets \
---source=secrets \
+--source=secrets \ # the git source to reconcile the secrets from
 --path=./secrets/gpg \
 --prune=true \
 --interval=10m \
@@ -102,7 +103,8 @@ flux create kustomization gpg-secrets \
 ```bash
 kubectl annotate kustomization gpg-secrets \
 sops-public-key/name=sops-gpg-public-key \
-sops-public-key/namespace=flux-system
+sops-public-key/namespace=flux-system \
+-n flux-system
 ```
 
 <details><summary>Expand to see the expected kustomization object</summary>
@@ -194,7 +196,8 @@ flux create kustomization age-secrets \
 ```bash
 kubectl annotate kustomization secrets \
 sops-public-key/name=sops-age-public-key \
-sops-public-key/namespace=flux-system
+sops-public-key/namespace=flux-system \
+-n flux-system
 ```
 
 <details><summary>Expand to see the expected kustomization object</summary>
@@ -245,12 +248,14 @@ As well as an option to push the public key to the git repository via a PR (to b
 The following example is using GPG encryption to install SOPS and generate keys when bootstrapping leaf clusters. Create the following `ClusterBootstrapConfig` CR and push it to your fleet repo.
 
 <details><summary>Expand to view </summary>
-    <CodeBlock
-    title="clusters/management/capi/boostrap/sops-bootstrap-job.yaml"
-    className="language-yaml"
-    >
-        {SopsBootstrapJob}
-    </CodeBlock>
+
+<CodeBlock
+  title="clusters/management/capi/boostrap/sops-bootstrap-job.yaml"
+  className="language-yaml"
+>
+  {SopsBootstrapJob}
+</CodeBlock>
+
 </details>
 
 #### Cluster template updates
@@ -267,23 +272,27 @@ templates.weave.works/sops-enabled: "true"
 The template should have the following parameters that are needed for the Kustomization
 
 <details><summary>Expand to view </summary>
-    <CodeBlock
-    title="clusters/management/capi/templates/template.yaml"
-    className="language-yaml"
-    >
-    {TemplateParams}
-    </CodeBlock>
+
+<CodeBlock
+  title="clusters/management/capi/templates/template.yaml"
+  className="language-yaml"
+>
+  {TemplateParams}
+</CodeBlock>
+
 </details>
 
 The template should have the following annotations under `GitOpsCluster` to be used in the bootstrap job
 
 <details><summary>Expand to view </summary>
-    <CodeBlock
-    title="clusters/management/capi/templates/template.yaml"
-    className="language-yaml"
-    >
-    {TemplateAnnotations}
-    </CodeBlock>
+
+<CodeBlock
+  title="clusters/management/capi/templates/template.yaml"
+  className="language-yaml"
+>
+  {TemplateAnnotations}
+</CodeBlock>
+
 </details>
 
 ### Installation Steps

--- a/website/versioned_docs/version-0.21.1/secrets/setup-sops.mdx
+++ b/website/versioned_docs/version-0.21.1/secrets/setup-sops.mdx
@@ -3,12 +3,11 @@ title: Setup SOPS
 hide_title: true
 ---
 
-import TierLabel from "./../_components/TierLabel";
-import CodeBlock from "@theme/CodeBlock";
-
 import SopsBootstrapJob from "!!raw-loader!./assets/sops-bootstrap-job.yaml";
 import TemplateParams from "!!raw-loader!./assets/template-params.yaml";
 import TemplateAnnotations from "!!raw-loader!./assets/template-annotations.yaml";
+
+import TierLabel from "./../_components/TierLabel";
 
 <h1>
   {frontMatter.title} <TierLabel tiers="Enterprise" />
@@ -248,14 +247,12 @@ As well as an option to push the public key to the git repository via a PR (to b
 The following example is using GPG encryption to install SOPS and generate keys when bootstrapping leaf clusters. Create the following `ClusterBootstrapConfig` CR and push it to your fleet repo.
 
 <details><summary>Expand to view </summary>
-
-<CodeBlock
-  title="clusters/management/capi/boostrap/sops-bootstrap-job.yaml"
-  className="language-yaml"
->
-  {SopsBootstrapJob}
-</CodeBlock>
-
+    <CodeBlock
+    title="clusters/management/capi/boostrap/sops-bootstrap-job.yaml"
+    className="language-yaml"
+    >
+        {SopsBootstrapJob}
+    </CodeBlock>
 </details>
 
 #### Cluster template updates
@@ -272,27 +269,23 @@ templates.weave.works/sops-enabled: "true"
 The template should have the following parameters that are needed for the Kustomization
 
 <details><summary>Expand to view </summary>
-
-<CodeBlock
-  title="clusters/management/capi/templates/template.yaml"
-  className="language-yaml"
->
-  {TemplateParams}
-</CodeBlock>
-
+    <CodeBlock
+    title="clusters/management/capi/templates/template.yaml"
+    className="language-yaml"
+    >
+    {TemplateParams}
+    </CodeBlock>
 </details>
 
 The template should have the following annotations under `GitOpsCluster` to be used in the bootstrap job
 
 <details><summary>Expand to view </summary>
-
-<CodeBlock
-  title="clusters/management/capi/templates/template.yaml"
-  className="language-yaml"
->
-  {TemplateAnnotations}
-</CodeBlock>
-
+    <CodeBlock
+    title="clusters/management/capi/templates/template.yaml"
+    className="language-yaml"
+    >
+    {TemplateAnnotations}
+    </CodeBlock>
 </details>
 
 ### Installation Steps

--- a/website/versioned_docs/version-0.21.1/secrets/setup-sops.mdx
+++ b/website/versioned_docs/version-0.21.1/secrets/setup-sops.mdx
@@ -193,7 +193,7 @@ flux create kustomization age-secrets \
 6- Annotate the kustomization object created in the previous step with the name and namespace of the public key created in step 4.
 
 ```bash
-kubectl annotate kustomization secrets \
+kubectl annotate kustomization age-secrets \
 sops-public-key/name=sops-age-public-key \
 sops-public-key/namespace=flux-system \
 -n flux-system

--- a/website/versioned_docs/version-0.21.2/secrets/setup-sops.mdx
+++ b/website/versioned_docs/version-0.21.2/secrets/setup-sops.mdx
@@ -194,7 +194,7 @@ flux create kustomization age-secrets \
 6- Annotate the kustomization object created in the previous step with the name and namespace of the public key created in step 4.
 
 ```bash
-kubectl annotate kustomization secrets \
+kubectl annotate kustomization age-secrets \
 sops-public-key/name=sops-age-public-key \
 sops-public-key/namespace=flux-system \
 -n flux-system

--- a/website/versioned_docs/version-0.21.2/secrets/setup-sops.mdx
+++ b/website/versioned_docs/version-0.21.2/secrets/setup-sops.mdx
@@ -90,7 +90,7 @@ gpg --delete-secret-keys "${KEY_FP}"
 
 ```bash
 flux create kustomization gpg-secrets \
---source=secrets \
+--source=secrets \ # the git source to reconcile the secrets from
 --path=./secrets/gpg \
 --prune=true \
 --interval=10m \
@@ -103,7 +103,8 @@ flux create kustomization gpg-secrets \
 ```bash
 kubectl annotate kustomization gpg-secrets \
 sops-public-key/name=sops-gpg-public-key \
-sops-public-key/namespace=flux-system
+sops-public-key/namespace=flux-system \
+-n flux-system
 ```
 
 <details><summary>Expand to see the expected kustomization object</summary>
@@ -195,7 +196,8 @@ flux create kustomization age-secrets \
 ```bash
 kubectl annotate kustomization secrets \
 sops-public-key/name=sops-age-public-key \
-sops-public-key/namespace=flux-system
+sops-public-key/namespace=flux-system \
+-n flux-system
 ```
 
 <details><summary>Expand to see the expected kustomization object</summary>
@@ -253,7 +255,7 @@ The following example is using GPG encryption to install SOPS and generate keys 
 >
   {SopsBootstrapJob}
 </CodeBlock>
-    
+
 </details>
 
 #### Cluster template updates

--- a/website/versioned_docs/version-0.22.0/secrets/setup-sops.mdx
+++ b/website/versioned_docs/version-0.22.0/secrets/setup-sops.mdx
@@ -194,7 +194,7 @@ flux create kustomization age-secrets \
 6- Annotate the kustomization object created in the previous step with the name and namespace of the public key created in step 4.
 
 ```bash
-kubectl annotate kustomization secrets \
+kubectl annotate kustomization age-secrets \
 sops-public-key/name=sops-age-public-key \
 sops-public-key/namespace=flux-system \
 -n flux-system

--- a/website/versioned_docs/version-0.22.0/secrets/setup-sops.mdx
+++ b/website/versioned_docs/version-0.22.0/secrets/setup-sops.mdx
@@ -90,7 +90,7 @@ gpg --delete-secret-keys "${KEY_FP}"
 
 ```bash
 flux create kustomization gpg-secrets \
---source=secrets \
+--source=secrets \ # the git source to reconcile the secrets from
 --path=./secrets/gpg \
 --prune=true \
 --interval=10m \
@@ -103,7 +103,8 @@ flux create kustomization gpg-secrets \
 ```bash
 kubectl annotate kustomization gpg-secrets \
 sops-public-key/name=sops-gpg-public-key \
-sops-public-key/namespace=flux-system
+sops-public-key/namespace=flux-system \
+-n flux-system
 ```
 
 <details><summary>Expand to see the expected kustomization object</summary>
@@ -195,7 +196,8 @@ flux create kustomization age-secrets \
 ```bash
 kubectl annotate kustomization secrets \
 sops-public-key/name=sops-age-public-key \
-sops-public-key/namespace=flux-system
+sops-public-key/namespace=flux-system \
+-n flux-system
 ```
 
 <details><summary>Expand to see the expected kustomization object</summary>
@@ -253,7 +255,7 @@ The following example is using GPG encryption to install SOPS and generate keys 
 >
   {SopsBootstrapJob}
 </CodeBlock>
-    
+
 </details>
 
 #### Cluster template updates

--- a/website/versioned_docs/version-0.23.0/secrets/setup-sops.mdx
+++ b/website/versioned_docs/version-0.23.0/secrets/setup-sops.mdx
@@ -194,7 +194,7 @@ flux create kustomization age-secrets \
 6- Annotate the kustomization object created in the previous step with the name and namespace of the public key created in step 4.
 
 ```bash
-kubectl annotate kustomization secrets \
+kubectl annotate kustomization age-secrets \
 sops-public-key/name=sops-age-public-key \
 sops-public-key/namespace=flux-system \
 -n flux-system

--- a/website/versioned_docs/version-0.23.0/secrets/setup-sops.mdx
+++ b/website/versioned_docs/version-0.23.0/secrets/setup-sops.mdx
@@ -90,7 +90,7 @@ gpg --delete-secret-keys "${KEY_FP}"
 
 ```bash
 flux create kustomization gpg-secrets \
---source=secrets \
+--source=secrets \ # the git source to reconcile the secrets from
 --path=./secrets/gpg \
 --prune=true \
 --interval=10m \
@@ -103,7 +103,8 @@ flux create kustomization gpg-secrets \
 ```bash
 kubectl annotate kustomization gpg-secrets \
 sops-public-key/name=sops-gpg-public-key \
-sops-public-key/namespace=flux-system
+sops-public-key/namespace=flux-system \
+-n flux-system
 ```
 
 <details><summary>Expand to see the expected kustomization object</summary>
@@ -195,7 +196,8 @@ flux create kustomization age-secrets \
 ```bash
 kubectl annotate kustomization secrets \
 sops-public-key/name=sops-age-public-key \
-sops-public-key/namespace=flux-system
+sops-public-key/namespace=flux-system \
+-n flux-system
 ```
 
 <details><summary>Expand to see the expected kustomization object</summary>
@@ -253,7 +255,7 @@ The following example is using GPG encryption to install SOPS and generate keys 
 >
   {SopsBootstrapJob}
 </CodeBlock>
-    
+
 </details>
 
 #### Cluster template updates


### PR DESCRIPTION
One of the commands in the Setup SOPS website doc was missing the namespace which would make it crash for the user. This PR adds it in all versions.