### PR TITLE
Add prop to hide dark mode switch

### DIFF
--- a/ui/components/Logo.tsx
+++ b/ui/components/Logo.tsx
@@ -13,15 +13,15 @@ type Props = {
   link?: string;
 };
 
-function Logo({ className, link, collapsed }: Props) {
+function Logo({ className, link = V2Routes.Automations, collapsed }: Props) {
   const dark = useInDarkMode();
   return (
     <Flex className={className} wide>
-      <Link to={link || V2Routes.Automations}>
+      <Link to={link}>
         <img src={dark ? images.logoDark : images.logoLight} />
       </Link>
       <Fade fade={collapsed}>
-        <Link to={link || V2Routes.Automations}>
+        <Link to={link}>
           <img src={dark ? images.logotypeLight : images.logotype} />
         </Link>
       </Fade>

--- a/ui/components/Logo.tsx
+++ b/ui/components/Logo.tsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 import styled from "styled-components";
 import { useInDarkMode } from "../hooks/theme";
 import images from "../lib/images";
+import { V2Routes } from "../lib/types";
 import { Fade } from "../lib/utils";
 import Flex from "./Flex";
 
@@ -16,11 +17,11 @@ function Logo({ className, link, collapsed }: Props) {
   const dark = useInDarkMode();
   return (
     <Flex className={className} wide>
-      <Link to={link}>
+      <Link to={link || V2Routes.Automations}>
         <img src={dark ? images.logoDark : images.logoLight} />
       </Link>
       <Fade fade={collapsed}>
-        <Link to={link}>
+        <Link to={link || V2Routes.Automations}>
           <img src={dark ? images.logotypeLight : images.logotype} />
         </Link>
       </Fade>

--- a/ui/components/UserSettings.tsx
+++ b/ui/components/UserSettings.tsx
@@ -46,7 +46,12 @@ const PersonButton = styled(IconButton)<{ open: boolean }>`
   }
 `;
 
-function UserSettings({ className }: { className?: string }) {
+type Props = {
+  className?: string;
+  darkModeEnabled?: boolean;
+};
+
+function UserSettings({ className, darkModeEnabled = true }: Props) {
   const history = useHistory();
   const [anchorEl, setAnchorEl] = React.useState(null);
   const { userInfo, logOut } = React.useContext(Auth);
@@ -62,11 +67,13 @@ function UserSettings({ className }: { className?: string }) {
 
   return (
     <div className={className}>
-      <Switch
-        onChange={() => toggleDarkMode()}
-        checked={settings.theme === ThemeTypes.Dark}
-        color="primary"
-      />
+      {darkModeEnabled && (
+        <Switch
+          onChange={() => toggleDarkMode()}
+          checked={settings.theme === ThemeTypes.Dark}
+          color="primary"
+        />
+      )}
       <Tooltip title="Account settings" enterDelay={500} enterNextDelay={500}>
         <PersonButton
           onClick={handleClick}

--- a/ui/components/__tests__/__snapshots__/Logo.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/Logo.test.tsx.snap
@@ -68,7 +68,7 @@ exports[`Logo snapshots renders collapsed view 1`] = `
   className="c0 c1"
 >
   <a
-    href=""
+    href="/applications"
     onClick={[Function]}
   >
     <img
@@ -79,7 +79,7 @@ exports[`Logo snapshots renders collapsed view 1`] = `
     className="c2 c3"
   >
     <a
-      href=""
+      href="/applications"
       onClick={[Function]}
     >
       <img
@@ -157,7 +157,7 @@ exports[`Logo snapshots renders open view 1`] = `
   className="c0 c1"
 >
   <a
-    href=""
+    href="/applications"
     onClick={[Function]}
   >
     <img
@@ -168,7 +168,7 @@ exports[`Logo snapshots renders open view 1`] = `
     className="c2 c3"
   >
     <a
-      href=""
+      href="/applications"
       onClick={[Function]}
     >
       <img


### PR DESCRIPTION
Enterprise imports UserSettings from OSS, and needs to be able to disable the dark mode switch for now.

When running tests, I found a random console error where the `to` prop on Link was undefined in the Logo component, so I fixed that as well