### PR TITLE
Properly set up Link styled-component

### DIFF
--- a/ui/components/Link.tsx
+++ b/ui/components/Link.tsx
@@ -40,7 +40,11 @@ function Link({
   ...props
 }: Props) {
   if ((href && !isAllowedLink(href)) || (!href && !to)) {
-    return <Text {...textProps}>{children}</Text>;
+    return (
+      <Text className={className} {...textProps}>
+        {children}
+      </Text>
+    );
   }
 
   const txt = (
@@ -80,6 +84,6 @@ function Link({
   );
 }
 
-export default styled(Link)`
+export default styled(Link).attrs({ className: Link.name })`
   text-decoration: none;
 `;

--- a/ui/components/__tests__/__snapshots__/Breadcrumbs.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/Breadcrumbs.test.tsx.snap
@@ -33,7 +33,7 @@ exports[`Breadcrumbs snapshots renders 1`] = `
   className="c0"
 >
   <a
-    className="c1"
+    className="c1 Link"
     href="/applications"
     onClick={[Function]}
   >
@@ -144,7 +144,7 @@ exports[`Breadcrumbs snapshots renders child route 1`] = `
   className="c0"
 >
   <a
-    className="c1"
+    className="c1 Link"
     href="/applications"
     onClick={[Function]}
   >
@@ -171,7 +171,7 @@ exports[`Breadcrumbs snapshots renders child route 1`] = `
     </svg>
   </div>
   <a
-    className="c1"
+    className="c1 Link"
     href="/kustomization?name=flux"
     onClick={[Function]}
   >
@@ -210,11 +210,16 @@ exports[`Breadcrumbs snapshots renders on the root page 1`] = `
   color: #1a1a1a;
 }
 
+.c2 {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
 <div
   className="c0"
 >
   <span
-    className="c1"
+    className="c1 c2 Link"
     color="neutral40"
     size="large"
   />

--- a/ui/components/__tests__/__snapshots__/Footer.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/Footer.test.tsx.snap
@@ -115,7 +115,7 @@ exports[`Footer snapshots default 1`] = `
       class="c4"
     />
     <a
-      class="c5"
+      class="c5 Link"
       href="mailto:sales@weave.works"
       rel="noreferrer"
       target="_blank"
@@ -189,7 +189,7 @@ exports[`Footer snapshots default 1`] = `
         class="c4"
       />
       <a
-        class="c5"
+        class="c5 Link"
         href="https://github.com/weaveworks/weave-gitops/commit/123abcd"
         rel="noreferrer"
         target="_blank"
@@ -335,7 +335,7 @@ exports[`Footer snapshots no api version 1`] = `
       class="c4"
     />
     <a
-      class="c5"
+      class="c5 Link"
       href="mailto:sales@weave.works"
       rel="noreferrer"
       target="_blank"
@@ -409,8 +409,13 @@ exports[`Footer snapshots no api version 1`] = `
         class="c4"
       />
       <a
+<<<<<<< HEAD
         class="c5"
         href="https://github.com/weaveworks/weave-gitops/releases/tag/v0.24.0-rc.1"
+=======
+        class="c5 Link"
+        href="https://github.com/weaveworks/weave-gitops/releases/tag/v0.23.0"
+>>>>>>> 29107af9c (update snaps)
         rel="noreferrer"
         target="_blank"
       >

--- a/ui/components/__tests__/__snapshots__/Footer.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/Footer.test.tsx.snap
@@ -409,13 +409,8 @@ exports[`Footer snapshots no api version 1`] = `
         class="c4"
       />
       <a
-<<<<<<< HEAD
-        class="c5"
-        href="https://github.com/weaveworks/weave-gitops/releases/tag/v0.24.0-rc.1"
-=======
         class="c5 Link"
-        href="https://github.com/weaveworks/weave-gitops/releases/tag/v0.23.0"
->>>>>>> 29107af9c (update snaps)
+        href="https://github.com/weaveworks/weave-gitops/releases/tag/v0.24.0-rc.1"
         rel="noreferrer"
         target="_blank"
       >

--- a/ui/components/__tests__/__snapshots__/Metadata.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/Metadata.test.tsx.snap
@@ -242,7 +242,7 @@ exports[`Metadata snapshots renders with data 1`] = `
         </td>
         <td>
           <a
-            className="c5"
+            className="c5 Link"
             href="https://google.com"
             rel="noreferrer"
             target="_blank"

--- a/ui/components/__tests__/__snapshots__/Page.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/Page.test.tsx.snap
@@ -159,7 +159,7 @@ exports[`Page snapshots default 1`] = `
         className="c9"
       />
       <a
-        className="c10"
+        className="c10 Link"
         href="mailto:sales@weave.works"
         rel="noreferrer"
         target="_blank"

--- a/ui/components/__tests__/__snapshots__/Version.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/Version.test.tsx.snap
@@ -180,7 +180,7 @@ exports[`Version snapshots renders a link with version text and version href 1`]
     className="c2"
   />
   <a
-    className="c3"
+    className="c3 Link"
     href="https://github.com/weaveworks/weave-gitops"
     rel="noreferrer"
     target="_blank"


### PR DESCRIPTION
Some usage of the Link component in Enterprise (see Breadcrumbs) had to create a lot of custom styling when the url passed was invalid. I'd like to delete those styles and allow the use of `${Link} {...}` inside another styled component.
