### PR TITLE
Dark Mode UI bug follow ups

### DIFF
--- a/ui/components/DataTable/DataTable.tsx
+++ b/ui/components/DataTable/DataTable.tsx
@@ -387,10 +387,14 @@ export const DataTable = styled(UnstyledDataTable)`
   th {
     padding: 0;
     background: ${(props) => props.theme.colors.neutralGray};
-    border-top-left-radius: 4px;
-    border-top-right-radius: 4px;
     .MuiCheckbox-root {
       padding: 4px 9px;
+    }
+    :first-child {
+      border-top-left-radius: ${(props) => props.theme.spacing.xxs};
+    }
+    :last-child {
+      border-top-right-radius: ${(props) => props.theme.spacing.xxs};
     }
   }
   td {

--- a/ui/components/DataTable/__tests__/__snapshots__/DataTable.test.tsx.snap
+++ b/ui/components/DataTable/__tests__/__snapshots__/DataTable.test.tsx.snap
@@ -298,12 +298,18 @@ exports[`DataTable snapshots renders 1`] = `
 .c1 th {
   padding: 0;
   background: #F6F7F9;
-  border-top-left-radius: 4px;
-  border-top-right-radius: 4px;
 }
 
 .c1 th .MuiCheckbox-root {
   padding: 4px 9px;
+}
+
+.c1 th:first-child {
+  border-top-left-radius: 4px;
+}
+
+.c1 th:last-child {
+  border-top-right-radius: 4px;
 }
 
 .c1 td {

--- a/ui/components/SyncButton.tsx
+++ b/ui/components/SyncButton.tsx
@@ -15,15 +15,29 @@ type Props = {
 export const ArrowDropDown = styled(IconButton)`
   &.MuiButton-outlined {
     border-color: ${(props) => props.theme.colors.grayToPrimary};
+    border-left: none;
+    &:hover {
+      border-left: none;
+    }
+    //2px = MUI radius
+    border-radius: 0 2px 2px 0;
   }
   &.MuiButton-root {
-    border-radius: 0;
     min-width: 0;
-    height: initial;
-    padding: 7px 0px;
+    height: 32px;
+    padding: 8px 4px;
   }
   &.MuiButton-text {
     padding: 0;
+  }
+`;
+
+const Sync = styled(Button)<{ hideDropdown: boolean }>`
+  &.MuiButton-outlined {
+    margin-right: 0;
+    ${(props) =>
+      !props.hideDropdown &&
+      `border-radius: 2px 0 0 2px; border-right: none; &:hover {border-right: none;};`}
   }
 `;
 
@@ -66,15 +80,15 @@ function SyncButton({
       style={{ position: "relative", display: open ? "block" : "inline-block" }}
     >
       <Flex>
-        <Button
+        <Sync
           disabled={disabled}
           loading={loading}
           variant="outlined"
           onClick={() => onClick({ withSource: true })}
-          style={{ marginRight: 0 }}
+          hideDropdown={hideDropdown}
         >
           Sync
-        </Button>
+        </Sync>
         {arrowDropDown}
       </Flex>
       <DropDown open={open} absolute={true}>

--- a/ui/components/SyncButton.tsx
+++ b/ui/components/SyncButton.tsx
@@ -32,11 +32,11 @@ export const ArrowDropDown = styled(IconButton)`
   }
 `;
 
-const Sync = styled(Button)<{ hideDropdown: boolean }>`
+const Sync = styled(Button)<{ $hideDropdown: boolean }>`
   &.MuiButton-outlined {
     margin-right: 0;
     ${(props) =>
-      !props.hideDropdown &&
+      !props.$hideDropdown &&
       `border-radius: 2px 0 0 2px; border-right: none; &:hover {border-right: none;};`}
   }
 `;
@@ -85,7 +85,8 @@ function SyncButton({
           loading={loading}
           variant="outlined"
           onClick={() => onClick({ withSource: true })}
-          hideDropdown={hideDropdown}
+          //$ - transient prop that is not passed to DOM https://styled-components.com/docs/api#transient-props
+          $hideDropdown={hideDropdown}
         >
           Sync
         </Sync>

--- a/ui/components/SyncButton.tsx
+++ b/ui/components/SyncButton.tsx
@@ -16,7 +16,8 @@ export const ArrowDropDown = styled(IconButton)`
   &.MuiButton-outlined {
     border-color: ${(props) => props.theme.colors.grayToPrimary};
     border-left: none;
-    &:hover {
+    &:hover,
+    &:disabled {
       border-left: none;
     }
     //2px = MUI radius
@@ -37,7 +38,7 @@ const Sync = styled(Button)<{ $hideDropdown: boolean }>`
     margin-right: 0;
     ${(props) =>
       !props.$hideDropdown &&
-      `border-radius: 2px 0 0 2px; border-right: none; &:hover {border-right: none;};`}
+      `border-radius: 2px 0 0 2px; border-right: none; &:hover, &:disabled {border-right: none;};`}
   }
 `;
 


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes #3682 
Closes #3683

This PR fixes two requests made during the Dark Mode work:

https://github.com/weaveworks/weave-gitops/assets/65822698/e8906d6e-c1b7-495a-8618-3038eb533d9b

- Sync and ArrowDropDown buttons are now the same height, with their right and left borders removed respectively. 
- Border radius was being applied to each `th` cell - now it's only the first and last as intended.

