### PR TITLE
Add dark mode switch to sign in page

### DIFF
--- a/ui/App.tsx
+++ b/ui/App.tsx
@@ -17,6 +17,7 @@ import ImageAutomationRepoDetails from "./components/ImageAutomation/repositorie
 import ImageAutomationUpdatesDetails from "./components/ImageAutomation/updates/ImageAutomationUpdatesDetails";
 import Layout from "./components/Layout";
 import PendoContainer from "./components/PendoContainer";
+import PolicyViolationPage from "./components/Policies/PolicyViolations/PolicyViolationPage";
 import AppContextProvider, {
   AppContext,
   ThemeTypes,
@@ -41,12 +42,11 @@ import ImageAutomationPage from "./pages/v2/ImageAutomationPage";
 import KustomizationPage from "./pages/v2/KustomizationPage";
 import Notifications from "./pages/v2/Notifications";
 import OCIRepositoryPage from "./pages/v2/OCIRepositoryPage";
+import PoliciesList from "./pages/v2/PoliciesList";
+import PolicyDetailsPage from "./pages/v2/PolicyDetailsPage";
 import ProviderPage from "./pages/v2/ProviderPage";
 import Sources from "./pages/v2/Sources";
 import UserInfo from "./pages/v2/UserInfo";
-import PoliciesList from "./pages/v2/PoliciesList";
-import PolicyDetailsPage from "./pages/v2/PolicyDetailsPage";
-import PolicyViolationPage from "./components/Policies/PolicyViolations/PolicyViolationPage";
 
 const queryClient = new QueryClient();
 

--- a/ui/components/DarkModeSwitch.tsx
+++ b/ui/components/DarkModeSwitch.tsx
@@ -1,0 +1,37 @@
+import { Switch } from "@material-ui/core";
+import * as React from "react";
+import styled from "styled-components";
+import { AppContext, ThemeTypes } from "../contexts/AppContext";
+import images from "../lib/images";
+
+type Props = {
+  className?: string;
+  darkModeEnabled?: boolean;
+};
+
+function DarkModeSwitch({ className, darkModeEnabled }: Props) {
+  const { toggleDarkMode, settings } = React.useContext(AppContext);
+  if (!darkModeEnabled) return null;
+  return (
+    <Switch
+      className={className}
+      onChange={() => toggleDarkMode()}
+      checked={settings.theme === ThemeTypes.Dark}
+      color="primary"
+    />
+  );
+}
+
+export default styled(DarkModeSwitch).attrs({
+  className: DarkModeSwitch.name,
+})`
+.MuiSwitch-thumb {
+    color: #fff;
+    background-image: url(${(props) =>
+      props.theme.mode === ThemeTypes.Dark
+        ? images.darkModeIcon
+        : images.lightModeIcon});
+  }
+  .MuiSwitch-track {
+    background-color: ${(props) => props.theme.colors.primary};
+`;

--- a/ui/components/UserSettings.tsx
+++ b/ui/components/UserSettings.tsx
@@ -3,16 +3,14 @@ import {
   ListItemIcon,
   Menu,
   MenuItem,
-  Switch,
   Tooltip,
 } from "@material-ui/core";
 import * as React from "react";
 import { useHistory } from "react-router-dom";
 import styled from "styled-components";
-import { AppContext, ThemeTypes } from "../contexts/AppContext";
 import { Auth } from "../contexts/AuthContext";
-import images from "../lib/images";
 import { V2Routes } from "../lib/types";
+import DarkModeSwitch from "./DarkModeSwitch";
 import Icon, { IconType } from "./Icon";
 const SettingsMenu = styled(Menu)`
   .MuiPaper-root {
@@ -55,7 +53,6 @@ function UserSettings({ className, darkModeEnabled = true }: Props) {
   const history = useHistory();
   const [anchorEl, setAnchorEl] = React.useState(null);
   const { userInfo, logOut } = React.useContext(Auth);
-  const { toggleDarkMode, settings } = React.useContext(AppContext);
 
   const open = Boolean(anchorEl);
   const handleClick = (event) => {
@@ -67,13 +64,7 @@ function UserSettings({ className, darkModeEnabled = true }: Props) {
 
   return (
     <div className={className}>
-      {darkModeEnabled && (
-        <Switch
-          onChange={() => toggleDarkMode()}
-          checked={settings.theme === ThemeTypes.Dark}
-          color="primary"
-        />
-      )}
+      <DarkModeSwitch darkModeEnabled={darkModeEnabled} />
       <Tooltip title="Account settings" enterDelay={500} enterNextDelay={500}>
         <PersonButton
           onClick={handleClick}
@@ -107,14 +98,4 @@ function UserSettings({ className, darkModeEnabled = true }: Props) {
   );
 }
 
-export default styled(UserSettings)`
-  .MuiSwitch-thumb {
-    color: #fff;
-    background-image: url(${(props) =>
-      props.theme.mode === ThemeTypes.Dark
-        ? images.darkModeIcon
-        : images.lightModeIcon});
-  }
-  .MuiSwitch-track {
-    background-color: ${(props) => props.theme.colors.primary};
-`;
+export default styled(UserSettings)``;

--- a/ui/components/__tests__/__snapshots__/Page.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/Page.test.tsx.snap
@@ -234,6 +234,15 @@ exports[`Page snapshots default 1`] = `
   border-radius: 0 0 8px 8px;
 }
 
+.c8 .MuiSwitch-thumb {
+  color: #fff;
+  background-image: url();
+}
+
+.c8 .MuiSwitch-track {
+  background-color: #00b3ec;
+}
+
 .c9 {
   height: 40px;
   width: 40px;
@@ -247,15 +256,6 @@ exports[`Page snapshots default 1`] = `
 .c9.MuiIconButton-root:hover {
   background-color: #fff;
   color: #009CCC;
-}
-
-.c8 .MuiSwitch-thumb {
-  color: #fff;
-  background-image: url();
-}
-
-.c8 .MuiSwitch-track {
-  background-color: #00b3ec;
 }
 
 .c11 {
@@ -334,10 +334,10 @@ exports[`Page snapshots default 1`] = `
       </div>
     </div>
     <div
-      className="c8"
+      className=""
     >
       <span
-        className="MuiSwitch-root"
+        className="MuiSwitch-root c8 DarkModeSwitch"
       >
         <span
           aria-disabled={false}

--- a/ui/pages/SignIn.tsx
+++ b/ui/pages/SignIn.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 import styled from "styled-components";
 import Alert from "../components/Alert";
 import Button from "../components/Button";
+import DarkModeSwitch from "../components/DarkModeSwitch";
 import Flex from "../components/Flex";
 import LoadingPage from "../components/LoadingPage";
 import { Auth } from "../contexts/AuthContext";
@@ -15,7 +16,6 @@ export const FormWrapper = styled(Flex)`
   background-color: ${(props) => props.theme.colors.white};
   border-radius: ${(props) => props.theme.borderRadius.soft};
   width: 500px;
-  padding-top: 40px;
   align-content: space-between;
   .MuiButton-label {
     width: 250px;
@@ -63,13 +63,20 @@ const DocsWrapper = styled(Flex)`
   }
 `;
 
+const SwitchFlex = styled(Flex)`
+  padding: ${(props) => props.theme.spacing.small};
+  box-sizing: border-box;
+`;
+
 const MarginButton = styled(Button)`
   &.MuiButtonBase-root {
     margin-top: ${(props) => props.theme.spacing.medium};
   }
 `;
-
-function SignIn() {
+type Props = {
+  darkModeEnabled?: boolean;
+};
+function SignIn({ darkModeEnabled = true }: Props) {
   const { isFlagEnabled, flags } = useFeatureFlags();
 
   const formRef = React.useRef<HTMLFormElement>();
@@ -125,6 +132,9 @@ function SignIn() {
           zIndex: 999,
         }}
       >
+        <SwitchFlex wide align end>
+          <DarkModeSwitch darkModeEnabled={darkModeEnabled} />
+        </SwitchFlex>
         <Logo wide align center>
           <img
             src={dark ? images.logoDark : images.logoLight}


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes #3737 

Separates out dark mode switch into separate component for reuse in sign in page - will need immediate followup in enterprise to set prop to disable dark mode for now

https://github.com/weaveworks/weave-gitops/assets/65822698/4057c39f-e00a-4910-963d-e7a08fba8c2d
