### PR TITLE
Consistent use of topBarHeight variable

### DIFF
--- a/ui/components/Logo.tsx
+++ b/ui/components/Logo.tsx
@@ -6,6 +6,7 @@ import images from "../lib/images";
 import { V2Routes } from "../lib/types";
 import { Fade } from "../lib/utils";
 import Flex from "./Flex";
+import { topBarHeight } from "./Page";
 
 type Props = {
   className?: string;
@@ -41,8 +42,8 @@ export default styled(Logo)`
     width: auto;
     height: 32px;
   }
-  padding-left: 12px;
-  height: 65px;
+  padding-left: 16px;
+  height: ${topBarHeight};
   width: ${(props) => (props.collapsed ? "36px" : "180px")};
   transition: width 0.5s;
 `;

--- a/ui/components/Nav.tsx
+++ b/ui/components/Nav.tsx
@@ -12,6 +12,7 @@ import { colors } from "../typedefs/styled";
 import Flex from "./Flex";
 import Icon, { IconType } from "./Icon";
 import Link from "./Link";
+import { topBarHeight } from "./Page";
 import Spacer from "./Spacer";
 import Text from "./Text";
 
@@ -36,6 +37,7 @@ const NavContainer = styled.div<{ collapsed: boolean }>`
   width: ${(props) => (props.collapsed ? collapsedWidth : fullWidth)};
   min-width: ${(props) => (props.collapsed ? collapsedWidth : fullWidth)};
   height: 100%;
+  max-height: calc(100% - ${topBarHeight});
   transition: all 0.5s;
 `;
 

--- a/ui/components/Page.tsx
+++ b/ui/components/Page.tsx
@@ -18,7 +18,7 @@ export type PageProps = {
   error?: RequestError | RequestError[] | MultiRequestError[];
 };
 
-const topBarHeight = "60px";
+export const topBarHeight = "60px";
 
 const ContentContainer = styled.div`
   height: 100%;

--- a/ui/components/__tests__/__snapshots__/Logo.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/Logo.test.tsx.snap
@@ -37,8 +37,8 @@ exports[`Logo snapshots renders collapsed view 1`] = `
 }
 
 .c1 {
-  padding-left: 12px;
-  height: 65px;
+  padding-left: 16px;
+  height: 60px;
   width: 36px;
   -webkit-transition: width 0.5s;
   transition: width 0.5s;
@@ -126,8 +126,8 @@ exports[`Logo snapshots renders open view 1`] = `
 }
 
 .c1 {
-  padding-left: 12px;
-  height: 65px;
+  padding-left: 16px;
+  height: 60px;
   width: 180px;
   -webkit-transition: width 0.5s;
   transition: width 0.5s;


### PR DESCRIPTION
Somewhere along the way, the nav and content stopped lining up. I've exported the `topBarHeight` variable and made sure that the nav container stops shrinking the logo component height. Also lines up logo with nav icons

This branch (aka good) -
<img width="319" alt="image" src="https://github.com/weaveworks/weave-gitops/assets/65822698/f7c7f762-cef8-45c1-843c-2a1341e58445">

<img width="362" alt="image" src="https://github.com/weaveworks/weave-gitops/assets/65822698/7fe873c6-fff9-414e-99bc-5544bbefacd8">

Main (aka bad) -
<img width="304" alt="image" src="https://github.com/weaveworks/weave-gitops/assets/65822698/e799d714-a905-493f-a3a7-3f16908f5f98">

<img width="346" alt="image" src="https://github.com/weaveworks/weave-gitops/assets/65822698/daee08be-1325-4c16-9c29-b70c51645d85">

