### PR TITLE
Prevent white background on input autofill in dark mode

### DIFF
--- a/ui/lib/theme.ts
+++ b/ui/lib/theme.ts
@@ -221,6 +221,15 @@ export const GlobalStyle = createGlobalStyle`
       background-color: ${(props) => props.theme.colors.primary};
     }
   }
+//prevents white autofill background in dark mode
+input:-webkit-autofill,
+input:-webkit-autofill:hover, 
+input:-webkit-autofill:focus {
+    ${(props) =>
+      props.theme.mode === ThemeTypes.Dark &&
+      `background-color: ${props.theme.colors.blueWithOpacity};`}
+  }
+
 `;
 
 export const muiTheme = (colors, mode) =>


### PR DESCRIPTION
Closes: #3805 

If no autofill styles are set by extensions or browser, we will set it so it doesn't come out while in dark mode. 

Extensions like 1password have their own stylesheets with `!important` set on attributes like this, which helps users understand that their autofill worked as expected. Screenshot is from firefox with a saved login

<img width="763" alt="image" src="https://github.com/weaveworks/weave-gitops/assets/65822698/2fe70d28-11a6-4b80-be6e-897e145e5a80">

