### PR TITLE
disabled snyk checks for both PRs and main

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -93,32 +93,6 @@ jobs:
       - run: make fakes
       - name: Check that make fakes has been run
         run: git diff --no-ext-diff --exit-code
-      - uses: snyk/actions/setup@master
-      - name: Setup snyk prerequisities
-        run: |
-          npm install --global snyk-delta
-      - name: Look for new insecure dependencies or bad licenses
-        run: |
-          snyk test --org=product-engineering-ly9 --json --file=go.mod | snyk-delta
-          snyk test --org=product-engineering-ly9 --json --file=package-lock.json | snyk-delta
-          snyk test --org=product-engineering-ly9 --json --file=website/yarn.lock | snyk-delta
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_API_TOKEN }}
-        if: github.event_name == 'pull_request' && github.repository_owner == 'weaveworks'
-      - name: Monitor dependencies & license problems with Snyk
-        # Throw an error if the error is "snyk couldn't run".
-        # Don't throw an error on "there are vulnerabilities", those
-        # are notified separately
-        run: |
-          exit_code=0
-          snyk monitor --all-projects --org=product-engineering-ly9 || exit_code=$?
-          if [ $exit_code -gt 1 ]; then
-            exit $exit_code
-          fi
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_API_TOKEN }}
-        if: github.event_name == 'push'
-
 
   ci-generate-tag:
     name: CI Generate Image Tag


### PR DESCRIPTION
Part of https://github.com/weaveworks/corp/issues/3627

Given our Snyk subscription ends today, 
This PR disables Snyk checks to avoid CI builds to fail. 

Dependabot will be enabled next

See more info in the ticket 