### PR TITLE
Update docs for weave-gitops-enterprise 0.27.0 release

### DIFF
--- a/website/docs/enterprise/getting-started/install-enterprise.mdx
+++ b/website/docs/enterprise/getting-started/install-enterprise.mdx
@@ -377,7 +377,7 @@ brew install weaveworks/tap/gitops-ee
 <TabItem value="curl" label="curl">
 
 ```bash
-curl --silent --location "https://artifacts.wge.dev.weave.works/releases/bin/0.22.0/gitops-$(uname | tr '[:upper:]' '[:lower:]')-$(uname -m).tar.gz" | tar xz -C /tmp
+curl --silent --location "https://artifacts.wge.dev.weave.works/releases/bin/0.27.0/gitops-$(uname)-$(uname -m).tar.gz" | tar xz -C /tmp
 sudo mv /tmp/gitops /usr/local/bin
 gitops version
 ```

--- a/website/docs/enterprise/getting-started/releases-enterprise.mdx
+++ b/website/docs/enterprise/getting-started/releases-enterprise.mdx
@@ -22,7 +22,7 @@ This page details the changes for Weave GitOps Enterprise and its associated com
 
 #### GitOpsSets
 
-- Config generator enabled by default! Include values from ConfigMaps in your GitOpsSets
+- Config generator enabled by default! Include values from ConfigMaps and Secrets in your GitOpsSets
 
 #### UI
 

--- a/website/docs/enterprise/getting-started/releases-enterprise.mdx
+++ b/website/docs/enterprise/getting-started/releases-enterprise.mdx
@@ -10,6 +10,61 @@ import TierLabel from "../../_components/TierLabel";
 This page details the changes for Weave GitOps Enterprise and its associated components. For Weave GitOps OSS - please see the release notes on [GitHub](https://github.com/weaveworks/weave-gitops/releases).
 :::
 
+## v0.27.0
+2023-07-7
+
+## Highlights
+
+- Dark Mode is now available in WGE.
+- Added Prometheus metrics for all API endpoints.
+
+## Breaking Changes
+
+(none)
+
+## Dependency versions
+
+- weave-gitops v0.26.0
+- cluster-controller v1.5.2
+- cluster-bootstrap-controller v0.6.0
+- templates-controller v0.2.0
+- (optional) pipeline-controller v0.21.0
+- (optional) policy-agent v2.5.0
+- (optional) gitopssets-controller v0.13.4
+
+## v0.26.0
+2023-06-22
+
+### Highlights
+
+- Dark Mode is now available in WGE.
+- Added Prometheus metrics for all API endpoints.
+
+### Dependency versions
+
+- weave-gitops v0.26.0
+- cluster-controller v1.5.2
+- cluster-bootstrap-controller v0.6.0
+- templates-controller v0.2.0
+- (optional) pipeline-controller v0.21.0
+- (optional) policy-agent v2.5.0
+- (optional) gitopssets-controller v0.13.2
+
+## v0.25.0
+2023-06-08
+
+_Bug fixes_
+
+### Dependency versions
+
+- weave-gitops v0.25.1-rc.1
+- cluster-controller v1.5.2
+- cluster-bootstrap-controller v0.6.0
+- templates-controller v0.2.0
+- (optional) pipeline-controller v0.21.0
+- (optional) policy-agent v2.4.0
+- (optional) gitopssets-controller v0.12.0
+
 ## v0.24.0
 2023-05-25
 

--- a/website/docs/enterprise/getting-started/releases-enterprise.mdx
+++ b/website/docs/enterprise/getting-started/releases-enterprise.mdx
@@ -13,16 +13,23 @@ This page details the changes for Weave GitOps Enterprise and its associated com
 ## v0.27.0
 2023-07-7
 
-## Highlights
+### Highlights
 
-- Dark Mode is now available in WGE.
-- Added Prometheus metrics for all API endpoints.
+#### Explorer
 
-## Breaking Changes
+- Retries to make sure we're showing you the freshest data
+- Exports more metrics to enhance observability
 
-(none)
+#### GitOpsSets
 
-## Dependency versions
+- Config generator enabled by default! Include values from ConfigMaps in your GitOpsSets
+
+#### UI
+
+- Dark mode enhancements
+- Consistent form styling
+
+### Dependency versions
 
 - weave-gitops v0.26.0
 - cluster-controller v1.5.2

--- a/website/docs/gitopssets/_api-toc.json
+++ b/website/docs/gitopssets/_api-toc.json
@@ -5,6 +5,8 @@
 ,
 { "level": 3, "value": "ClusterGenerator", "id": "templates.weave.works/v1alpha1.ClusterGenerator" }
 ,
+{ "level": 3, "value": "ConfigGenerator", "id": "templates.weave.works/v1alpha1.ConfigGenerator" }
+,
 { "level": 3, "value": "GitOpsSetGenerator", "id": "templates.weave.works/v1alpha1.GitOpsSetGenerator" }
 ,
 { "level": 3, "value": "GitOpsSetNestedGenerator", "id": "templates.weave.works/v1alpha1.GitOpsSetNestedGenerator" }

--- a/website/docs/gitopssets/_api.mdx
+++ b/website/docs/gitopssets/_api.mdx
@@ -288,6 +288,47 @@ Kubernetes meta/v1.LabelSelector
 </tr>
 </tbody>
 </table>
+<h3 id="templates.weave.works/v1alpha1.ConfigGenerator">ConfigGenerator
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#templates.weave.works/v1alpha1.GitOpsSetGenerator">GitOpsSetGenerator</a>, 
+<a href="#templates.weave.works/v1alpha1.GitOpsSetNestedGenerator">GitOpsSetNestedGenerator</a>)
+</p>
+<p>ConfigGenerator loads a referenced ConfigMap or
+Secret from the Cluster and makes it available as a resource.</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>kind</code><br />
+<em>
+string
+</em>
+</td>
+<td>
+<p>Kind of the referent.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>name</code><br />
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name of the referent.</p>
+</td>
+</tr>
+</tbody>
+</table>
 <h3 id="templates.weave.works/v1alpha1.GitOpsSetGenerator">GitOpsSetGenerator
 </h3>
 <p>
@@ -381,6 +422,18 @@ APIClientGenerator
 <em>
 <a href="#templates.weave.works/v1alpha1.ImagePolicyGenerator">
 ImagePolicyGenerator
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>config</code><br />
+<em>
+<a href="#templates.weave.works/v1alpha1.ConfigGenerator">
+ConfigGenerator
 </a>
 </em>
 </td>
@@ -485,6 +538,18 @@ APIClientGenerator
 <em>
 <a href="#templates.weave.works/v1alpha1.ImagePolicyGenerator">
 ImagePolicyGenerator
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>config</code><br />
+<em>
+<a href="#templates.weave.works/v1alpha1.ConfigGenerator">
+ConfigGenerator
 </a>
 </em>
 </td>

--- a/website/docs/gitopssets/guide.mdx
+++ b/website/docs/gitopssets/guide.mdx
@@ -9,6 +9,16 @@ Currently rendering templates operates in two phases:
 
 Please read the [security information](#security) below before using this.
 
+## General behaviour
+
+GitOpsSets can be suspended, by setting the `spec.suspend` flag to be true.
+
+When this is the case, updates will not be applied, no resources created _or_
+deleted.
+
+In addition, a manual reconciliation can be requested by annotating a GitOpsSet
+with the `reconcile.fluxcd.io/requestedAt` annotation.
+
 ## Generation
 
 The simplest generator is the `List` generator.
@@ -208,6 +218,7 @@ We currently provide these generators:
 - [apiClient](#apiclient-generator)
 - [cluster](#cluster-generator)
 - [imagepolicy](#imagepolicy-generator)
+- [config](#config-generator)
 
 ### List generator
 
@@ -543,7 +554,7 @@ spec:
                 - path: examples/generation/production.yaml
                 - path: examples/generation/staging.yaml
           - name: gen2
-          - list:
+            list:
               elements:
                 - cluster: dev-cluster
                   version: 1.0.0
@@ -566,7 +577,6 @@ spec:
           sourceRef:
             kind: GitRepository
             name: go-demo-repo
-
 ```
 The name value is used as a key in the generated results.
 
@@ -864,6 +874,12 @@ The `ImagePolicy` generator works with the [Flux Image Automation](https://fluxc
 
 When an `ImagePolicy` is updated, this will trigger a regeneration of templates.
 
+The generated elements have the following fields:
+
+* latestImage - the latest image from the status field on the `ImagePolicy`
+* latestTag - only the tag part of the latestImage, e.g. will be v0.1 for an image of "testing/image:v0.1"
+* previousImage - the previous image from the status field on the `ImagePolicy`
+
 This can be used simply, to create a deployment with an image...or, combined with a Matrix generator, to manage multiple workloads with the same image.
 
 ```yaml
@@ -952,6 +968,118 @@ metadata:
 data:
   cluster: prod-cluster
   image: stefanprodan/podinfo:5.1.4
+  version: 1.0.0
+```
+
+### Config generator
+
+The `Config` generator with Kubernetes [ConfigMaps](https://kubernetes.io/docs/concepts/configuration/configmap/) and [Secrets](https://kubernetes.io/docs/concepts/configuration/secret/).
+
+When an `ConfigMap` or `Secret` is updated, this will trigger a regeneration of templates.
+
+This can be used simply, to create a resource with an config variable...or, combined with a Matrix generator, to manage multiple workloads with the same values.
+
+With the existing `ConfigMap`
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-cm
+data:
+  name: test-config
+  demo: test-value
+```
+And the GitOpsSet below
+```yaml
+apiVersion: templates.weave.works/v1alpha1
+kind: GitOpsSet
+metadata:
+  name: config-sample
+spec:
+  generators:
+    - config:
+        kind: ConfigMap
+        name: test-cm
+  templates:
+    - content:
+        kind: ConfigMap
+        apiVersion: v1
+        metadata:
+          name: "{{ .Element.name }}-demo"
+          labels:
+            app.kubernetes.io/name: go-demo
+            app.kubernetes.io/instance: "{{ .Element.name }}"
+        data:
+          generatedValue: "{{ .Element.demo }}"
+```
+In this example, a new `ConfigMap` is generated containing the value of the "demo" field from the existing `ConfigMap` _test-cm_.
+
+As with the other generators, the `Config` generator can be combined with other generators:
+
+This will generate two `ConfigMaps` with the values.
+```yaml
+apiVersion: templates.weave.works/v1alpha1
+kind: GitOpsSet
+metadata:
+  name: imagepolicy-matrix-example
+  namespace: default
+spec:
+  generators:
+    - matrix:
+        generators:
+          - config:
+              kind: ConfigMap
+              name: test-cm
+          - list:
+              elements:
+                - cluster: dev-cluster
+                  version: 1.0.0
+                - cluster: prod-cluster
+                  version: 1.0.0
+  templates:
+    - content:
+        kind: ConfigMap
+        apiVersion: v1
+        metadata:
+          name: "demo-configmap-{{ .Element.cluster }}"
+        data:
+          generatedValue: "{{ .Element.demo }}"
+          cluster: "{{ .Element.cluster }}"
+          version: "{{ .Element.version }}"
+```
+
+The resulting ConfigMaps look like this:
+
+```shell
+$ kubectl get configmaps
+NAME                          DATA   AGE
+demo-configmap-dev-cluster    3      3m19s
+demo-configmap-prod-cluster   3      3m19s
+```
+
+With the templated fields like this:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: demo-configmap-dev-cluster
+  namespace: default
+data:
+  cluster: dev-cluster
+  generatedValue: test-value
+  version: 1.0.0
+```
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: demo-configmap-prod-cluster
+  namespace: default
+data:
+  cluster: prod-cluster
+  generatedValue: test-value
   version: 1.0.0
 ```
 


### PR DESCRIPTION
Update the user-guide for the v0.27.0 weave-gitops-enterprise release

Also
- Update some older releases that were missing
- Update gitopssets-controller guide and api for the Config generator