### PR TITLE
Allow for custom actions for data table checkboxes

### DIFF
--- a/ui/components/CheckboxActions.tsx
+++ b/ui/components/CheckboxActions.tsx
@@ -4,13 +4,13 @@ import * as React from "react";
 import styled from "styled-components";
 import { useSyncFluxObject } from "../hooks/automations";
 import { useToggleSuspend } from "../hooks/flux";
+import { ObjectRef } from "../lib/api/core/types.pb";
 import Button from "./Button";
 import Flex from "./Flex";
 import Icon, { IconType } from "./Icon";
-import Spacer from "./Spacer";
 import SyncButton from "./SyncButton";
 
-export const makeObjects = (checked: string[], rows: any[]) => {
+export const makeObjects = (checked: string[], rows: any[]): ObjectRef[] => {
   const objects = [];
   checked.forEach((uid) => {
     const row = _.find(rows, (row) => {
@@ -27,21 +27,25 @@ export const makeObjects = (checked: string[], rows: any[]) => {
   return objects;
 };
 
-type Props = {
-  className?: string;
-  checked?: string[];
-  rows?: any[];
+const DefaultSync: React.FC<{ reqObjects: ObjectRef[] }> = ({ reqObjects }) => {
+  const defaultSync = useSyncFluxObject(reqObjects);
+  return (
+    <SyncButton
+      disabled={reqObjects[0] ? false : true}
+      loading={defaultSync.isLoading}
+      onClick={(opts) => defaultSync.mutateAsync(opts)}
+    />
+  );
 };
 
-function CheckboxActions({ className, checked = [], rows = [] }: Props) {
-  const [reqObjects, setReqObjects] = React.useState([]);
-  const hasChecked = checked.length > 0;
-
-  React.useEffect(() => {
-    if (hasChecked && rows.length) setReqObjects(makeObjects(checked, rows));
-  }, [checked, rows]);
-
-  function createSuspendHandler(suspend: boolean) {
+const DefaultSuspend: React.FC<{
+  reqObjects: ObjectRef[];
+  suspend: boolean;
+}> = ({ reqObjects, suspend }) => {
+  function createDefaultSuspendHandler(
+    reqObjects: ObjectRef[],
+    suspend: boolean
+  ) {
     const result = useToggleSuspend(
       {
         objects: reqObjects,
@@ -52,40 +56,75 @@ function CheckboxActions({ className, checked = [], rows = [] }: Props) {
         ? "automations"
         : "sources"
     );
-
     return () => result.mutateAsync();
   }
 
-  const sync = useSyncFluxObject(reqObjects);
+  return (
+    <Tooltip
+      title={suspend ? "Suspend Selected" : "Resume Selected"}
+      placement="top"
+    >
+      <div>
+        <Button
+          disabled={reqObjects[0] ? false : true}
+          onClick={createDefaultSuspendHandler(reqObjects, suspend)}
+        >
+          <Icon
+            type={suspend ? IconType.PauseIcon : IconType.PlayIcon}
+            size="medium"
+          />
+        </Button>
+      </div>
+    </Tooltip>
+  );
+};
+
+type Action = {
+  element: React.ReactElement;
+  additionalProps?: { [key: string]: any };
+};
+
+type Props = {
+  className?: string;
+  checked?: string[];
+  rows?: any[];
+  actions?: Action[];
+};
+
+function CheckboxActions({
+  className,
+  checked = [],
+  rows = [],
+  actions,
+}: Props) {
+  const [reqObjects, setReqObjects] = React.useState([]);
+  const hasChecked = checked.length > 0;
+
+  React.useEffect(() => {
+    if (hasChecked && rows.length) setReqObjects(makeObjects(checked, rows));
+  }, [checked, rows]);
+
+  const defaultActions = [
+    { element: DefaultSync },
+    { element: DefaultSuspend, additionalProps: { suspend: true } },
+    { element: DefaultSuspend, additionalProps: { suspend: false } },
+  ];
+  const hasActions = actions || defaultActions;
 
   return (
-    <Flex start align className={className}>
-      <SyncButton
-        onClick={(opts) => sync.mutateAsync(opts)}
-        loading={sync.isLoading}
-        disabled={!hasChecked}
-      />
-      <Spacer padding="xxs" />
-      <Tooltip title="Suspend Selected" placement="top">
-        <div>
-          <Button disabled={!hasChecked} onClick={createSuspendHandler(true)}>
-            <Icon type={IconType.PauseIcon} size="medium" />
-          </Button>
-        </div>
-      </Tooltip>
-      <Spacer padding="xxs" />
-      <Tooltip title="Resume Selected" placement="top">
-        <div>
-          <Button disabled={!hasChecked} onClick={createSuspendHandler(false)}>
-            <Icon type={IconType.PlayIcon} size="medium" />
-          </Button>
-        </div>
-      </Tooltip>
-      <Spacer padding="xxs" />
+    <Flex start align className={className} gap="8">
+      {hasActions.map((action) => {
+        return React.createElement(action.element, {
+          ...action.additionalProps,
+          reqObjects: reqObjects,
+        });
+      })}
     </Flex>
   );
 }
 
 export default styled(CheckboxActions).attrs({
   className: CheckboxActions.name,
-})``;
+})`
+  margin-right: 8px;
+`;

--- a/ui/components/CheckboxActions.tsx
+++ b/ui/components/CheckboxActions.tsx
@@ -79,7 +79,7 @@ const DefaultSuspend: React.FC<{
   );
 };
 
-type Action = {
+export type Action = {
   element: React.ReactElement;
   additionalProps?: { [key: string]: any };
 };

--- a/ui/components/DataTable/DataTable.tsx
+++ b/ui/components/DataTable/DataTable.tsx
@@ -14,7 +14,7 @@ import { useHistory, useLocation } from "react-router-dom";
 import styled from "styled-components";
 import { ThemeTypes } from "../../contexts/AppContext";
 import { IconButton } from "../Button";
-import CheckboxActions from "../CheckboxActions";
+import CheckboxActions, { Action } from "../CheckboxActions";
 import ChipGroup from "../ChipGroup";
 import FilterDialog, {
   FilterConfig,
@@ -37,7 +37,6 @@ import {
   toPairs,
 } from "./helpers";
 import { Field, FilterState } from "./types";
-
 /** DataTable Properties  */
 export interface Props {
   /** The ID of the table. */
@@ -50,7 +49,7 @@ export interface Props {
   rows?: any[];
   filters?: FilterConfig;
   dialogOpen?: boolean;
-  hasCheckboxes?: boolean;
+  hasCheckboxes?: Action[] | boolean;
   hideSearchAndFilters?: boolean;
   emptyMessagePlaceholder?: React.ReactNode;
   onColumnHeaderClick?: (field: Field) => void;
@@ -252,7 +251,13 @@ function UnstyledDataTable({
   return (
     <Flex wide tall column className={className}>
       <TopBar wide align end>
-        {checkboxes && <CheckboxActions checked={checked} rows={filtered} />}
+        {checkboxes && (
+          <CheckboxActions
+            checked={checked}
+            rows={filtered}
+            actions={typeof checkboxes !== "boolean" && checkboxes}
+          />
+        )}
         {filters && !hideSearchAndFilters && (
           <>
             <ChipGroup

--- a/ui/components/SyncButton.tsx
+++ b/ui/components/SyncButton.tsx
@@ -14,10 +14,7 @@ type Props = {
 
 export const ArrowDropDown = styled(IconButton)`
   &.MuiButton-outlined {
-    border-color: ${(props) => props.theme.colors.neutral20};
-    &:disabled {
-      border-left: none;
-    }
+    border-color: ${(props) => props.theme.colors.grayToPrimary};
     //2px = MUI radius
     border-radius: 0 2px 2px 0;
   }

--- a/ui/hooks/automations.ts
+++ b/ui/hooks/automations.ts
@@ -6,14 +6,13 @@ import {
   SyncFluxObjectRequest,
   SyncFluxObjectResponse,
 } from "../lib/api/core/core.pb";
-import { Kind } from "../lib/api/core/types.pb";
+import { Kind, ObjectRef } from "../lib/api/core/types.pb";
 import { Automation } from "../lib/objects";
 import {
   MultiRequestError,
   NoNamespace,
   ReactQueryOptions,
   RequestError,
-  Syncable,
 } from "../lib/types";
 import { notifyError, notifySuccess } from "../lib/utils";
 import { convertResponse } from "./objects";
@@ -61,7 +60,7 @@ export function useListAutomations(
   );
 }
 
-export function useSyncFluxObject(objs: Syncable[]) {
+export function useSyncFluxObject(objs: ObjectRef[]) {
   const { api } = useContext(CoreClientContext);
   const mutation = useMutation<
     SyncFluxObjectResponse,

--- a/ui/lib/types.ts
+++ b/ui/lib/types.ts
@@ -66,13 +66,6 @@ export interface Source {
   lastUpdatedAt?: string;
 }
 
-export interface Syncable {
-  name?: string;
-  kind?: Kind;
-  namespace?: string;
-  clusterName?: string;
-}
-
 export type MultiRequestError = ListError & {
   kind?: Kind;
 };


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Part of: [#3034](https://github.com/weaveworks/weave-gitops-enterprise/issues/3034)

Draft because I want to make sure this does not conflict with @opudrovs current image automation work
