### PR TITLE
Enhance types in checkbox actions for EE terraform sync/suspend all

### DIFF
--- a/ui/components/CheckboxActions.tsx
+++ b/ui/components/CheckboxActions.tsx
@@ -80,7 +80,7 @@ const DefaultSuspend: React.FC<{
 };
 
 export type Action = {
-  element: React.ReactElement;
+  element: React.FC;
   additionalProps?: { [key: string]: any };
 };
 
@@ -113,10 +113,13 @@ function CheckboxActions({
 
   return (
     <Flex start align className={className} gap="8">
-      {hasActions.map((action) => {
-        return React.createElement(action.element, {
+      {hasActions.map((action: Action) => {
+        const elementProps: any = {
           ...action.additionalProps,
           reqObjects: reqObjects,
+        };
+        return React.createElement(action.element, {
+          ...elementProps,
         });
       })}
     </Flex>

--- a/ui/components/CheckboxActions.tsx
+++ b/ui/components/CheckboxActions.tsx
@@ -79,7 +79,7 @@ const DefaultSuspend: React.FC<{
   );
 };
 
-export type Action = {
+type Action = {
   element: React.ReactElement;
   additionalProps?: { [key: string]: any };
 };

--- a/ui/components/CheckboxActions.tsx
+++ b/ui/components/CheckboxActions.tsx
@@ -79,7 +79,7 @@ const DefaultSuspend: React.FC<{
   );
 };
 
-type Action = {
+export type Action = {
   element: React.ReactElement;
   additionalProps?: { [key: string]: any };
 };

--- a/ui/components/CheckboxActions.tsx
+++ b/ui/components/CheckboxActions.tsx
@@ -80,7 +80,7 @@ const DefaultSuspend: React.FC<{
 };
 
 export type Action = {
-  element: React.FC;
+  component: React.FC;
   additionalProps?: { [key: string]: any };
 };
 
@@ -105,9 +105,9 @@ function CheckboxActions({
   }, [checked, rows]);
 
   const defaultActions = [
-    { element: DefaultSync },
-    { element: DefaultSuspend, additionalProps: { suspend: true } },
-    { element: DefaultSuspend, additionalProps: { suspend: false } },
+    { component: DefaultSync },
+    { component: DefaultSuspend, additionalProps: { suspend: true } },
+    { component: DefaultSuspend, additionalProps: { suspend: false } },
   ];
   const hasActions = actions || defaultActions;
 
@@ -118,7 +118,7 @@ function CheckboxActions({
           ...action.additionalProps,
           reqObjects: reqObjects,
         };
-        return React.createElement(action.element, {
+        return React.createElement(action.component, {
           ...elementProps,
         });
       })}


### PR DESCRIPTION
Follow up to: #3829 

Getting Typescript errors when actually trying to apply these changes in EE.

The props in `createElement` have to be typed otherwise whatever you're passing down is going to conflict - in this case since we want them to be custom I've given it the sad `any` type. But at least now we know that it's `any`. 