### PR TITLE
enabled dependabot with daily schedule and eng teams as reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,35 @@
+version: 2
+updates:
+  # Maintain dependencies for frontend
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    reviewers:
+      - "weaveworks/timber-wolf"
+      - "weaveworks/pesto"
+      - "weaveworks/wild-watermelon"
+      - "weaveworks/tangerine"
+
+  # Maintain dependencies for backend
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    reviewers:
+      - "weaveworks/timber-wolf"
+      - "weaveworks/pesto"
+      - "weaveworks/wild-watermelon"
+      - "weaveworks/tangerine"
+
+  # Maintain dependencies for website
+  - package-ecosystem: "npm"
+    directory: "/website"
+    schedule:
+      interval: "daily"
+    reviewers:
+      - "weaveworks/timber-wolf"
+      - "weaveworks/pesto"
+      - "weaveworks/wild-watermelon"
+      - "weaveworks/tangerine"
+


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Part of https://github.com/weaveworks/corp/issues/3627 

<!-- Describe what has changed in this PR -->
**What changed?**

This PR adds a baseline configuration file for Dependabot to setup both interval to daily (as starting point) and reviewers to prod-eng teams as maintainers

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**

As part of our switch to [Dependabot](https://github.com/weaveworks/corp/issues/3627 ) we have enabled it in the repo.It gives us vulnerability detection and remediation however PRs are not assigned so could be missed. 

<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**
Validated with another repo but it would be needed to validate the whole flow once merged

<!--
Is it notable for release? e.g. schema updates or configuration required? If so, please mention it.
-->
**Release notes**

Using dependabot for vulnerability management

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**

Not required