### PR TITLE
Weave Gitops Enterprise 0.28.0 release notes

### DIFF
--- a/website/docs/enterprise/getting-started/releases-enterprise.mdx
+++ b/website/docs/enterprise/getting-started/releases-enterprise.mdx
@@ -10,6 +10,27 @@ import TierLabel from "../../_components/TierLabel";
 This page details the changes for Weave GitOps Enterprise and its associated components. For Weave GitOps OSS - please see the release notes on [GitHub](https://github.com/weaveworks/weave-gitops/releases).
 :::
 
+## v0.28.0
+2023-07-20
+
+### Highlights
+
+TDB
+
+### Breaking Changes
+
+- This version of Weave Gitops Enterprise drops support for `v1alpha1` of the `CAPITemplate` and `GitopsTemplate` CRDs. Please migrate to `v1alpha2` of these CRDs. See the [migration guide](../../gitops-templates/versions.mdx)
+
+### Dependency versions
+
+- weave-gitops v0.28.0
+- cluster-controller v1.5.2
+- cluster-bootstrap-controller v0.6.0
+- templates-controller v0.2.0
+- (optional) pipeline-controller v0.21.0
+- (optional) policy-agent v2.5.0
+- (optional) gitopssets-controller v0.14.0
+
 ## v0.27.0
 2023-07-7
 

--- a/website/docs/gitops-templates/versions.mdx
+++ b/website/docs/gitops-templates/versions.mdx
@@ -14,8 +14,10 @@ There are now multiple published versions of the template CRD.
 ### `v1alpha1` to `v1alpha2`
 
 When manually migrating a template from `v1alpha1` to `v1alpha2` (for example in git) you will need to:
-1. Update the `apiVersion` to `templates.weave.works/v1alpha2`
-1. Move the `spec.resourcetemplates` field to `spec.resourcetemplates[0].contents`
+1. Update the `apiVersion` to either:
+  1. `GitopsTemplate`: `templates.weave.works/v1alpha2`
+  1. `CAPITemplate`: `capi.weave.works/v1alpha2`
+1. Move the `spec.resourcetemplates` field to `spec.resourcetemplates[0].content`
 1. Either leave the `spec.resourcetemplates[0].path` field empty or give it a sensible value.
 
 If you experience issues with the path not being recognised when Flux reconciles
@@ -25,24 +27,20 @@ the new template versions, try manually applying the new template to the cluster
 
 ## Conversion Webhook
 
-A conversion webhook is hosted by the `flux-system/templates-controller-webhook-service` service.
-`v1alpha1` templates are automatically converted to `v1alpha2` when they are loaded into the cluster.
+As of Weave Gitops Enterprise 0.28.0 the conversion webhook has been removed.
 
-### v1alpha1 to v1alpha2 conversion
-
-The `spec.resourcetemplates` field is moved to `spec.resourcetemplates[0].contents` and the `spec.resourcetemplates[0].path` is left empty.
-When the tempalte is rendered the `spec.resourcetemplates[0].path` field has a default value calculated.
+This removed the need for cert-manager to be installed, but you will now have to convert any `v1alpha1` templates to `v1alpha2` manually in git.
 
 ## `v1alpha2` (default) notes
 
-This version changes the type of `spec.resourcetemplates` from a list of objects to a list of files with a `path` and `contents`:
+This version changes the type of `spec.resourcetemplates` from a list of objects to a list of files with a `path` and `content`:
 
 Example:
 ```yaml
 spec:
   resourcetemplates:
     - path: "clusters/{{ .params.CLUSTER_NAME }}.yaml"
-      contents:
+      content:
         - apiVersion: cluster.x-k8s.io/v1alpha3
           kind: Cluster
           metadata:

--- a/website/docs/gitops-templates/versions.mdx
+++ b/website/docs/gitops-templates/versions.mdx
@@ -50,7 +50,7 @@ spec:
 
 ## `v1alpha1` notes
 
-The original version of the template. This version is no longer works with Weave Gitops Enterprise 0.28.0 and above.
+The original version of the template. This version no longer works with Weave Gitops Enterprise 0.28.0 and above.
 
 It uses `spec.resourcetemplates` as a list of resources to render.
 

--- a/website/docs/gitops-templates/versions.mdx
+++ b/website/docs/gitops-templates/versions.mdx
@@ -14,9 +14,9 @@ There are now multiple published versions of the template CRD.
 ### `v1alpha1` to `v1alpha2`
 
 When manually migrating a template from `v1alpha1` to `v1alpha2` (for example in git) you will need to:
-1. Update the `apiVersion` to either:
-  1. `GitopsTemplate`: `templates.weave.works/v1alpha2`
-  1. `CAPITemplate`: `capi.weave.works/v1alpha2`
+1. Update the `apiVersion`:
+    1. for `GitopsTemplate` update the apiVersion to `templates.weave.works/v1alpha2`
+    1. for `CAPITemplate` update the apiVersion to `capi.weave.works/v1alpha2`
 1. Move the `spec.resourcetemplates` field to `spec.resourcetemplates[0].content`
 1. Either leave the `spec.resourcetemplates[0].path` field empty or give it a sensible value.
 
@@ -50,7 +50,7 @@ spec:
 
 ## `v1alpha1` notes
 
-The original version of the template. This version is deprecated and will be removed in a future release.
+The original version of the template. This version is no longer works with Weave Gitops Enterprise 0.28.0 and above.
 
 It uses `spec.resourcetemplates` as a list of resources to render.
 

--- a/website/docs/gitopssets/installation.mdx
+++ b/website/docs/gitopssets/installation.mdx
@@ -30,14 +30,15 @@ kind: Namespace
 metadata:
   name: gitopssets-system
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmRepository
 metadata:
-  name: weaveworks-artifacts-charts
+  name: weaveworks-oci-charts
   namespace: gitopssets-system
 spec:
   interval: 1m
-  url: https://artifacts.wge.dev.weave.works/dev/charts
+  type: oci
+  url: oci://ghcr.io/weaveworks/charts
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease
@@ -51,9 +52,9 @@ spec:
       chart: gitopssets-controller
       sourceRef:
         kind: HelmRepository
-        name: weaveworks-artifacts-charts
+        name: weaveworks-oci-charts
         namespace: gitopssets-system
-      version: 0.6.1
+      version: 0.14.0
   install:
     crds: CreateReplace
   upgrade:


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Adds release notes for Weave Gitops Enterprise 0.28.0

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**

Keep docs up to date with latest changes in WGE. Of note in this release:

- Gitopssets-controller chart has moved
- templates-controller deployment and webhook has been removed, if you still have old `v1alpha1` templates then you need to migrate them to `v1alpha2` now.