### PR TITLE
Remove 'with source' option from Sources Sync

### DIFF
--- a/ui/components/CheckboxActions.tsx
+++ b/ui/components/CheckboxActions.tsx
@@ -1,10 +1,12 @@
 import { Tooltip } from "@material-ui/core";
 import _ from "lodash";
 import * as React from "react";
+import { useLocation } from "react-router-dom";
 import styled from "styled-components";
 import { useSyncFluxObject } from "../hooks/automations";
 import { useToggleSuspend } from "../hooks/flux";
 import { ObjectRef } from "../lib/api/core/types.pb";
+import { V2Routes } from "../lib/types";
 import Button from "./Button";
 import Flex from "./Flex";
 import Icon, { IconType } from "./Icon";
@@ -29,11 +31,16 @@ export const makeObjects = (checked: string[], rows: any[]): ObjectRef[] => {
 
 const DefaultSync: React.FC<{ reqObjects: ObjectRef[] }> = ({ reqObjects }) => {
   const defaultSync = useSyncFluxObject(reqObjects);
+  const location = useLocation();
+  const noSource = {
+    [V2Routes.Sources]: true,
+  };
   return (
     <SyncButton
       disabled={reqObjects[0] ? false : true}
       loading={defaultSync.isLoading}
       onClick={(opts) => defaultSync.mutateAsync(opts)}
+      hideDropdown={noSource[location.pathname]}
     />
   );
 };


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes #3853 

Adds an object where you can add any Routes that should have the `hideDropdown` prop enabled on their DataTable, in this case for the SourcesTable.

<img width="600" alt="image" src="https://github.com/weaveworks/weave-gitops/assets/65822698/c35bcb20-d367-40bd-99d3-5f3d2efc9428">
