### PR TITLE
Tweaking dependabot to just raise PRs for security updates. 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,8 @@ updates:
       - "weaveworks/pesto"
       - "weaveworks/wild-watermelon"
       - "weaveworks/tangerine"
+    # Only do security updates not version updates.
+    open-pull-requests-limit: 0
 
   # Maintain dependencies for backend
   - package-ecosystem: "gomod"
@@ -21,6 +23,8 @@ updates:
       - "weaveworks/pesto"
       - "weaveworks/wild-watermelon"
       - "weaveworks/tangerine"
+    # Only do security updates not version updates.
+    open-pull-requests-limit: 0
 
   # Maintain dependencies for website
   - package-ecosystem: "npm"
@@ -32,4 +36,5 @@ updates:
       - "weaveworks/pesto"
       - "weaveworks/wild-watermelon"
       - "weaveworks/tangerine"
-
+    # Only do security updates not version updates.
+    open-pull-requests-limit: 0


### PR DESCRIPTION
Tweaking dependabot to just raise PRs for security updates not version updates. 

To have version updates managed by dependabot was not in scope so it is an unintended consequence. This PR tries to revert this behaviour as the documentation [suggests](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit)


