### PR TITLE
Fix missing key prop in checkbox actions, and provide "-" default text for large info

### DIFF
--- a/ui/components/LargeInfo.tsx
+++ b/ui/components/LargeInfo.tsx
@@ -19,7 +19,7 @@ function LargeInfo({ className, title, info, component }: Props) {
       </Text>
       <Tooltip title={info || ""} placement="top">
         <Text size="large" color="neutral40">
-          {component ? component : info || ""}
+          {component ? component : info || "-"}
         </Text>
       </Tooltip>
     </Flex>


### PR DESCRIPTION
- Fixes a console error in tests on a missing key prop in checkbox actions
- Fixes a case in EE where the new large info component could be empty when tf objects have no last updated time - now a hyphen will be displayed by default without extra code in EE + causing the tooltip to render a hyphen
