### PR TITLE
Fix kubeconfig script

### DIFF
--- a/website/docs/cluster-management/managing-clusters-without-capi.mdx
+++ b/website/docs/cluster-management/managing-clusters-without-capi.mdx
@@ -106,49 +106,49 @@ Here's how to create a kubeconfig secret.
 	<details><summary>Expand to see script</summary>
 
 	```bash title="static-kubeconfig.sh"
-#!/bin/bash
+    #!/bin/bash
 
-if [[ -z "$CLUSTER_NAME" ]]; then
-    echo "Ensure CLUSTER_NAME has been set"
-    exit 1
-fi
+    if [[ -z "$CLUSTER_NAME" ]]; then
+        echo "Ensure CLUSTER_NAME has been set"
+        exit 1
+    fi
 
-if [[ -z "$CA_CERTIFICATE" ]]; then
-    echo "Ensure CA_CERTIFICATE has been set to the path of the CA certificate"
-    exit 1
-fi
+    if [[ -z "$CA_CERTIFICATE" ]]; then
+        echo "Ensure CA_CERTIFICATE has been set to the path of the CA certificate"
+        exit 1
+    fi
 
-if [[ -z "$ENDPOINT" ]]; then
-    echo "Ensure ENDPOINT has been set"
-    exit 1
-fi
+    if [[ -z "$ENDPOINT" ]]; then
+        echo "Ensure ENDPOINT has been set"
+        exit 1
+    fi
 
-if [[ -z "$TOKEN" ]]; then
-    echo "Ensure TOKEN has been set"
-    exit 1
-fi
+    if [[ -z "$TOKEN" ]]; then
+        echo "Ensure TOKEN has been set"
+        exit 1
+    fi
 
-export CLUSTER_CA_CERTIFICATE=$(cat "$CA_CERTIFICATE" | base64)
+    export CLUSTER_CA_CERTIFICATE=$(cat "$CA_CERTIFICATE" | base64)
 
-envsubst <<EOF
-apiVersion: v1
-kind: Config
-current-context: $CLUSTER_NAME
-clusters:
-- name: $CLUSTER_NAME
-  cluster:
-    server: https://$ENDPOINT
-    certificate-authority-data: $CLUSTER_CA_CERTIFICATE
-users:
-- name: $CLUSTER_NAME
-  user:
-    token: $TOKEN
-contexts:
-- name: $CLUSTER_NAME
-  context:
-    cluster: $CLUSTER_NAME
-    user: $CLUSTER_NAME
-EOF
+    envsubst <<EOF
+    apiVersion: v1
+    kind: Config
+    current-context: $CLUSTER_NAME
+    clusters:
+    - name: $CLUSTER_NAME
+      cluster:
+        server: https://$ENDPOINT
+        certificate-authority-data: $CLUSTER_CA_CERTIFICATE
+    users:
+    - name: $CLUSTER_NAME
+      user:
+        token: $TOKEN
+    contexts:
+    - name: $CLUSTER_NAME
+      context:
+        cluster: $CLUSTER_NAME
+        user: $CLUSTER_NAME
+    EOF
 	```
 
 	</details>

--- a/website/docs/cluster-management/managing-clusters-without-capi.mdx
+++ b/website/docs/cluster-management/managing-clusters-without-capi.mdx
@@ -106,50 +106,49 @@ Here's how to create a kubeconfig secret.
 	<details><summary>Expand to see script</summary>
 
 	```bash title="static-kubeconfig.sh"
-	#!/bin/bash
+#!/bin/bash
 
-	if [[ -z "$CLUSTER_NAME" ]]; then
-			echo "Ensure CLUSTER_NAME has been set"
-			exit 1
-	fi
+if [[ -z "$CLUSTER_NAME" ]]; then
+    echo "Ensure CLUSTER_NAME has been set"
+    exit 1
+fi
 
-	if [[ -z "$CA_CERTIFICATE" ]]; then
-			echo "Ensure CA_CERTIFICATE has been set to the path of the CA certificate"
-			exit 1
-	fi
+if [[ -z "$CA_CERTIFICATE" ]]; then
+    echo "Ensure CA_CERTIFICATE has been set to the path of the CA certificate"
+    exit 1
+fi
 
-	if [[ -z "$ENDPOINT" ]]; then
-			echo "Ensure ENDPOINT has been set"
-			exit 1
-	fi
+if [[ -z "$ENDPOINT" ]]; then
+    echo "Ensure ENDPOINT has been set"
+    exit 1
+fi
 
-	if [[ -z "$TOKEN" ]]; then
-			echo "Ensure TOKEN has been set"
-			exit 1
-	fi
+if [[ -z "$TOKEN" ]]; then
+    echo "Ensure TOKEN has been set"
+    exit 1
+fi
 
-	export CLUSTER_CA_CERTIFICATE=$(cat "$CA_CERTIFICATE" | base64)
+export CLUSTER_CA_CERTIFICATE=$(cat "$CA_CERTIFICATE" | base64)
 
-	envsubst <<EOF
-	apiVersion: v1
-	kind: Config
-	clusters:
-	- name: $CLUSTER_NAME
-		cluster:
-			server: https://$ENDPOINT
-			certificate-authority-data: $CLUSTER_CA_CERTIFICATE
-	users:
-	- name: $CLUSTER_NAME
-		user:
-			token: $TOKEN
-	contexts:
-	- name: $CLUSTER_NAME
-		context:
-			cluster: $CLUSTER_NAME
-			user: $CLUSTER_NAME
-	current-context: $CLUSTER_NAME
-
-	EOF
+envsubst <<EOF
+apiVersion: v1
+kind: Config
+current-context: $CLUSTER_NAME
+clusters:
+- name: $CLUSTER_NAME
+  cluster:
+    server: https://$ENDPOINT
+    certificate-authority-data: $CLUSTER_CA_CERTIFICATE
+users:
+- name: $CLUSTER_NAME
+  user:
+    token: $TOKEN
+contexts:
+- name: $CLUSTER_NAME
+  context:
+    cluster: $CLUSTER_NAME
+    user: $CLUSTER_NAME
+EOF
 	```
 
 	</details>

--- a/website/versioned_docs/version-0.16.0/cluster-management/managing-existing-clusters.mdx
+++ b/website/versioned_docs/version-0.16.0/cluster-management/managing-existing-clusters.mdx
@@ -100,51 +100,50 @@ TOKEN=$(kubectl get secret demo-01-token-gqz7p -o jsonpath={.data.token} | base6
 
 We'll use a helper script to generate the kubeconfig, save this into `static-kubeconfig.sh`:
 
-```bash title="static-kubeconfig.sh"
-#!/bin/bash
+    ```bash title="static-kubeconfig.sh"
+    #!/bin/bash
 
-if [[ -z "$CLUSTER_NAME" ]]; then
-    echo "Ensure CLUSTER_NAME has been set"
-    exit 1
-fi
+    if [[ -z "$CLUSTER_NAME" ]]; then
+        echo "Ensure CLUSTER_NAME has been set"
+        exit 1
+    fi
 
-if [[ -z "$CA_CERTIFICATE" ]]; then
-    echo "Ensure CA_CERTIFICATE has been set to the path of the CA certificate"
-    exit 1
-fi
+    if [[ -z "$CA_CERTIFICATE" ]]; then
+        echo "Ensure CA_CERTIFICATE has been set to the path of the CA certificate"
+        exit 1
+    fi
 
-if [[ -z "$ENDPOINT" ]]; then
-    echo "Ensure ENDPOINT has been set"
-    exit 1
-fi
+    if [[ -z "$ENDPOINT" ]]; then
+        echo "Ensure ENDPOINT has been set"
+        exit 1
+    fi
 
-if [[ -z "$TOKEN" ]]; then
-    echo "Ensure TOKEN has been set"
-    exit 1
-fi
+    if [[ -z "$TOKEN" ]]; then
+        echo "Ensure TOKEN has been set"
+        exit 1
+    fi
 
-export CLUSTER_CA_CERTIFICATE=$(cat "$CA_CERTIFICATE" | base64)
+    export CLUSTER_CA_CERTIFICATE=$(cat "$CA_CERTIFICATE" | base64)
 
-envsubst <<EOF
-apiVersion: v1
-kind: Config
-clusters:
-- name: $CLUSTER_NAME
-  cluster:
-    server: https://$ENDPOINT
-    certificate-authority-data: $CLUSTER_CA_CERTIFICATE
-users:
-- name: $CLUSTER_NAME
-  user:
-    token: $TOKEN
-contexts:
-- name: $CLUSTER_NAME
-  context:
-    cluster: $CLUSTER_NAME
-    user: $CLUSTER_NAME
-current-context: $CLUSTER_NAME
-
-EOF
+    envsubst <<EOF
+    apiVersion: v1
+    kind: Config
+    current-context: $CLUSTER_NAME
+    clusters:
+    - name: $CLUSTER_NAME
+      cluster:
+        server: https://$ENDPOINT
+        certificate-authority-data: $CLUSTER_CA_CERTIFICATE
+    users:
+    - name: $CLUSTER_NAME
+      user:
+        token: $TOKEN
+    contexts:
+    - name: $CLUSTER_NAME
+      context:
+        cluster: $CLUSTER_NAME
+        user: $CLUSTER_NAME
+    EOF
 ```
 
 For the next step, the cluster certificate (CA) is needed. How you get hold of the certificate depends on the cluster. For GKE you can view it on the GCP Console: Cluster->Details->Endpoint->”Show cluster certificate”. You will need to copy the contents of the certificate into the `ca.crt` file used below.

--- a/website/versioned_docs/version-0.17.0/cluster-management/managing-existing-clusters.mdx
+++ b/website/versioned_docs/version-0.17.0/cluster-management/managing-existing-clusters.mdx
@@ -100,51 +100,50 @@ TOKEN=$(kubectl get secret demo-01-token-gqz7p -o jsonpath={.data.token} | base6
 
 We'll use a helper script to generate the kubeconfig, save this into `static-kubeconfig.sh`:
 
-```bash title="static-kubeconfig.sh"
-#!/bin/bash
+	```bash title="static-kubeconfig.sh"
+    #!/bin/bash
 
-if [[ -z "$CLUSTER_NAME" ]]; then
-    echo "Ensure CLUSTER_NAME has been set"
-    exit 1
-fi
+    if [[ -z "$CLUSTER_NAME" ]]; then
+        echo "Ensure CLUSTER_NAME has been set"
+        exit 1
+    fi
 
-if [[ -z "$CA_CERTIFICATE" ]]; then
-    echo "Ensure CA_CERTIFICATE has been set to the path of the CA certificate"
-    exit 1
-fi
+    if [[ -z "$CA_CERTIFICATE" ]]; then
+        echo "Ensure CA_CERTIFICATE has been set to the path of the CA certificate"
+        exit 1
+    fi
 
-if [[ -z "$ENDPOINT" ]]; then
-    echo "Ensure ENDPOINT has been set"
-    exit 1
-fi
+    if [[ -z "$ENDPOINT" ]]; then
+        echo "Ensure ENDPOINT has been set"
+        exit 1
+    fi
 
-if [[ -z "$TOKEN" ]]; then
-    echo "Ensure TOKEN has been set"
-    exit 1
-fi
+    if [[ -z "$TOKEN" ]]; then
+        echo "Ensure TOKEN has been set"
+        exit 1
+    fi
 
-export CLUSTER_CA_CERTIFICATE=$(cat "$CA_CERTIFICATE" | base64)
+    export CLUSTER_CA_CERTIFICATE=$(cat "$CA_CERTIFICATE" | base64)
 
-envsubst <<EOF
-apiVersion: v1
-kind: Config
-clusters:
-- name: $CLUSTER_NAME
-  cluster:
-    server: https://$ENDPOINT
-    certificate-authority-data: $CLUSTER_CA_CERTIFICATE
-users:
-- name: $CLUSTER_NAME
-  user:
-    token: $TOKEN
-contexts:
-- name: $CLUSTER_NAME
-  context:
-    cluster: $CLUSTER_NAME
-    user: $CLUSTER_NAME
-current-context: $CLUSTER_NAME
-
-EOF
+    envsubst <<EOF
+    apiVersion: v1
+    kind: Config
+    clusters:
+    - name: $CLUSTER_NAME
+      cluster:
+        server: https://$ENDPOINT
+        certificate-authority-data: $CLUSTER_CA_CERTIFICATE
+    users:
+    - name: $CLUSTER_NAME
+      user:
+        token: $TOKEN
+    contexts:
+    - name: $CLUSTER_NAME
+      context:
+        cluster: $CLUSTER_NAME
+        user: $CLUSTER_NAME
+    current-context: $CLUSTER_NAME
+    EOF
 ```
 
 For the next step, the cluster certificate (CA) is needed. How you get hold of the certificate depends on the cluster. For GKE you can view it on the GCP Console: Cluster->Details->Endpoint->”Show cluster certificate”. You will need to copy the contents of the certificate into the `ca.crt` file used below.

--- a/website/versioned_docs/version-0.18.0/cluster-management/managing-existing-clusters.mdx
+++ b/website/versioned_docs/version-0.18.0/cluster-management/managing-existing-clusters.mdx
@@ -108,50 +108,49 @@ kubectl create secret generic demo-01-kubeconfig \
 	<details><summary>Expand to see script</summary>
 
 	```bash title="static-kubeconfig.sh"
-	#!/bin/bash
+    #!/bin/bash
 
-	if [[ -z "$CLUSTER_NAME" ]]; then
-			echo "Ensure CLUSTER_NAME has been set"
-			exit 1
-	fi
+    if [[ -z "$CLUSTER_NAME" ]]; then
+        echo "Ensure CLUSTER_NAME has been set"
+        exit 1
+    fi
 
-	if [[ -z "$CA_CERTIFICATE" ]]; then
-			echo "Ensure CA_CERTIFICATE has been set to the path of the CA certificate"
-			exit 1
-	fi
+    if [[ -z "$CA_CERTIFICATE" ]]; then
+        echo "Ensure CA_CERTIFICATE has been set to the path of the CA certificate"
+        exit 1
+    fi
 
-	if [[ -z "$ENDPOINT" ]]; then
-			echo "Ensure ENDPOINT has been set"
-			exit 1
-	fi
+    if [[ -z "$ENDPOINT" ]]; then
+        echo "Ensure ENDPOINT has been set"
+        exit 1
+    fi
 
-	if [[ -z "$TOKEN" ]]; then
-			echo "Ensure TOKEN has been set"
-			exit 1
-	fi
+    if [[ -z "$TOKEN" ]]; then
+        echo "Ensure TOKEN has been set"
+        exit 1
+    fi
 
-	export CLUSTER_CA_CERTIFICATE=$(cat "$CA_CERTIFICATE" | base64)
+    export CLUSTER_CA_CERTIFICATE=$(cat "$CA_CERTIFICATE" | base64)
 
-	envsubst <<EOF
-	apiVersion: v1
-	kind: Config
-	clusters:
-	- name: $CLUSTER_NAME
-		cluster:
-			server: https://$ENDPOINT
-			certificate-authority-data: $CLUSTER_CA_CERTIFICATE
-	users:
-	- name: $CLUSTER_NAME
-		user:
-			token: $TOKEN
-	contexts:
-	- name: $CLUSTER_NAME
-		context:
-			cluster: $CLUSTER_NAME
-			user: $CLUSTER_NAME
-	current-context: $CLUSTER_NAME
-
-	EOF
+    envsubst <<EOF
+    apiVersion: v1
+    kind: Config
+    current-context: $CLUSTER_NAME
+    clusters:
+    - name: $CLUSTER_NAME
+      cluster:
+        server: https://$ENDPOINT
+        certificate-authority-data: $CLUSTER_CA_CERTIFICATE
+    users:
+    - name: $CLUSTER_NAME
+      user:
+        token: $TOKEN
+    contexts:
+    - name: $CLUSTER_NAME
+      context:
+        cluster: $CLUSTER_NAME
+        user: $CLUSTER_NAME
+    EOF
 	```
 
 	</details>

--- a/website/versioned_docs/version-0.19.0/cluster-management/managing-existing-clusters.mdx
+++ b/website/versioned_docs/version-0.19.0/cluster-management/managing-existing-clusters.mdx
@@ -108,50 +108,49 @@ kubectl create secret generic demo-01-kubeconfig \
 	<details><summary>Expand to see script</summary>
 
 	```bash title="static-kubeconfig.sh"
-	#!/bin/bash
+    #!/bin/bash
 
-	if [[ -z "$CLUSTER_NAME" ]]; then
-			echo "Ensure CLUSTER_NAME has been set"
-			exit 1
-	fi
+    if [[ -z "$CLUSTER_NAME" ]]; then
+        echo "Ensure CLUSTER_NAME has been set"
+        exit 1
+    fi
 
-	if [[ -z "$CA_CERTIFICATE" ]]; then
-			echo "Ensure CA_CERTIFICATE has been set to the path of the CA certificate"
-			exit 1
-	fi
+    if [[ -z "$CA_CERTIFICATE" ]]; then
+        echo "Ensure CA_CERTIFICATE has been set to the path of the CA certificate"
+        exit 1
+    fi
 
-	if [[ -z "$ENDPOINT" ]]; then
-			echo "Ensure ENDPOINT has been set"
-			exit 1
-	fi
+    if [[ -z "$ENDPOINT" ]]; then
+        echo "Ensure ENDPOINT has been set"
+        exit 1
+    fi
 
-	if [[ -z "$TOKEN" ]]; then
-			echo "Ensure TOKEN has been set"
-			exit 1
-	fi
+    if [[ -z "$TOKEN" ]]; then
+        echo "Ensure TOKEN has been set"
+        exit 1
+    fi
 
-	export CLUSTER_CA_CERTIFICATE=$(cat "$CA_CERTIFICATE" | base64)
+    export CLUSTER_CA_CERTIFICATE=$(cat "$CA_CERTIFICATE" | base64)
 
-	envsubst <<EOF
-	apiVersion: v1
-	kind: Config
-	clusters:
-	- name: $CLUSTER_NAME
-		cluster:
-			server: https://$ENDPOINT
-			certificate-authority-data: $CLUSTER_CA_CERTIFICATE
-	users:
-	- name: $CLUSTER_NAME
-		user:
-			token: $TOKEN
-	contexts:
-	- name: $CLUSTER_NAME
-		context:
-			cluster: $CLUSTER_NAME
-			user: $CLUSTER_NAME
-	current-context: $CLUSTER_NAME
-
-	EOF
+    envsubst <<EOF
+    apiVersion: v1
+    kind: Config
+    current-context: $CLUSTER_NAME
+    clusters:
+    - name: $CLUSTER_NAME
+      cluster:
+        server: https://$ENDPOINT
+        certificate-authority-data: $CLUSTER_CA_CERTIFICATE
+    users:
+    - name: $CLUSTER_NAME
+      user:
+        token: $TOKEN
+    contexts:
+    - name: $CLUSTER_NAME
+      context:
+        cluster: $CLUSTER_NAME
+        user: $CLUSTER_NAME
+    EOF
 	```
 
 	</details>

--- a/website/versioned_docs/version-0.20.0/cluster-management/managing-existing-clusters.mdx
+++ b/website/versioned_docs/version-0.20.0/cluster-management/managing-existing-clusters.mdx
@@ -108,50 +108,49 @@ kubectl create secret generic demo-01-kubeconfig \
 	<details><summary>Expand to see script</summary>
 
 	```bash title="static-kubeconfig.sh"
-	#!/bin/bash
+    #!/bin/bash
 
-	if [[ -z "$CLUSTER_NAME" ]]; then
-			echo "Ensure CLUSTER_NAME has been set"
-			exit 1
-	fi
+    if [[ -z "$CLUSTER_NAME" ]]; then
+        echo "Ensure CLUSTER_NAME has been set"
+        exit 1
+    fi
 
-	if [[ -z "$CA_CERTIFICATE" ]]; then
-			echo "Ensure CA_CERTIFICATE has been set to the path of the CA certificate"
-			exit 1
-	fi
+    if [[ -z "$CA_CERTIFICATE" ]]; then
+        echo "Ensure CA_CERTIFICATE has been set to the path of the CA certificate"
+        exit 1
+    fi
 
-	if [[ -z "$ENDPOINT" ]]; then
-			echo "Ensure ENDPOINT has been set"
-			exit 1
-	fi
+    if [[ -z "$ENDPOINT" ]]; then
+        echo "Ensure ENDPOINT has been set"
+        exit 1
+    fi
 
-	if [[ -z "$TOKEN" ]]; then
-			echo "Ensure TOKEN has been set"
-			exit 1
-	fi
+    if [[ -z "$TOKEN" ]]; then
+        echo "Ensure TOKEN has been set"
+        exit 1
+    fi
 
-	export CLUSTER_CA_CERTIFICATE=$(cat "$CA_CERTIFICATE" | base64)
+    export CLUSTER_CA_CERTIFICATE=$(cat "$CA_CERTIFICATE" | base64)
 
-	envsubst <<EOF
-	apiVersion: v1
-	kind: Config
-	clusters:
-	- name: $CLUSTER_NAME
-		cluster:
-			server: https://$ENDPOINT
-			certificate-authority-data: $CLUSTER_CA_CERTIFICATE
-	users:
-	- name: $CLUSTER_NAME
-		user:
-			token: $TOKEN
-	contexts:
-	- name: $CLUSTER_NAME
-		context:
-			cluster: $CLUSTER_NAME
-			user: $CLUSTER_NAME
-	current-context: $CLUSTER_NAME
-
-	EOF
+    envsubst <<EOF
+    apiVersion: v1
+    kind: Config
+    current-context: $CLUSTER_NAME
+    clusters:
+    - name: $CLUSTER_NAME
+      cluster:
+        server: https://$ENDPOINT
+        certificate-authority-data: $CLUSTER_CA_CERTIFICATE
+    users:
+    - name: $CLUSTER_NAME
+      user:
+        token: $TOKEN
+    contexts:
+    - name: $CLUSTER_NAME
+      context:
+        cluster: $CLUSTER_NAME
+        user: $CLUSTER_NAME
+    EOF
 	```
 
 	</details>

--- a/website/versioned_docs/version-0.21.1/cluster-management/managing-existing-clusters.mdx
+++ b/website/versioned_docs/version-0.21.1/cluster-management/managing-existing-clusters.mdx
@@ -108,50 +108,49 @@ kubectl create secret generic demo-01-kubeconfig \
 	<details><summary>Expand to see script</summary>
 
 	```bash title="static-kubeconfig.sh"
-	#!/bin/bash
+    #!/bin/bash
 
-	if [[ -z "$CLUSTER_NAME" ]]; then
-			echo "Ensure CLUSTER_NAME has been set"
-			exit 1
-	fi
+    if [[ -z "$CLUSTER_NAME" ]]; then
+        echo "Ensure CLUSTER_NAME has been set"
+        exit 1
+    fi
 
-	if [[ -z "$CA_CERTIFICATE" ]]; then
-			echo "Ensure CA_CERTIFICATE has been set to the path of the CA certificate"
-			exit 1
-	fi
+    if [[ -z "$CA_CERTIFICATE" ]]; then
+        echo "Ensure CA_CERTIFICATE has been set to the path of the CA certificate"
+        exit 1
+    fi
 
-	if [[ -z "$ENDPOINT" ]]; then
-			echo "Ensure ENDPOINT has been set"
-			exit 1
-	fi
+    if [[ -z "$ENDPOINT" ]]; then
+        echo "Ensure ENDPOINT has been set"
+        exit 1
+    fi
 
-	if [[ -z "$TOKEN" ]]; then
-			echo "Ensure TOKEN has been set"
-			exit 1
-	fi
+    if [[ -z "$TOKEN" ]]; then
+        echo "Ensure TOKEN has been set"
+        exit 1
+    fi
 
-	export CLUSTER_CA_CERTIFICATE=$(cat "$CA_CERTIFICATE" | base64)
+    export CLUSTER_CA_CERTIFICATE=$(cat "$CA_CERTIFICATE" | base64)
 
-	envsubst <<EOF
-	apiVersion: v1
-	kind: Config
-	clusters:
-	- name: $CLUSTER_NAME
-		cluster:
-			server: https://$ENDPOINT
-			certificate-authority-data: $CLUSTER_CA_CERTIFICATE
-	users:
-	- name: $CLUSTER_NAME
-		user:
-			token: $TOKEN
-	contexts:
-	- name: $CLUSTER_NAME
-		context:
-			cluster: $CLUSTER_NAME
-			user: $CLUSTER_NAME
-	current-context: $CLUSTER_NAME
-
-	EOF
+    envsubst <<EOF
+    apiVersion: v1
+    kind: Config
+    current-context: $CLUSTER_NAME
+    clusters:
+    - name: $CLUSTER_NAME
+      cluster:
+        server: https://$ENDPOINT
+        certificate-authority-data: $CLUSTER_CA_CERTIFICATE
+    users:
+    - name: $CLUSTER_NAME
+      user:
+        token: $TOKEN
+    contexts:
+    - name: $CLUSTER_NAME
+      context:
+        cluster: $CLUSTER_NAME
+        user: $CLUSTER_NAME
+    EOF
 	```
 
 	</details>

--- a/website/versioned_docs/version-0.21.2/cluster-management/managing-existing-clusters.mdx
+++ b/website/versioned_docs/version-0.21.2/cluster-management/managing-existing-clusters.mdx
@@ -108,50 +108,49 @@ kubectl create secret generic demo-01-kubeconfig \
 	<details><summary>Expand to see script</summary>
 
 	```bash title="static-kubeconfig.sh"
-	#!/bin/bash
+    #!/bin/bash
 
-	if [[ -z "$CLUSTER_NAME" ]]; then
-			echo "Ensure CLUSTER_NAME has been set"
-			exit 1
-	fi
+    if [[ -z "$CLUSTER_NAME" ]]; then
+        echo "Ensure CLUSTER_NAME has been set"
+        exit 1
+    fi
 
-	if [[ -z "$CA_CERTIFICATE" ]]; then
-			echo "Ensure CA_CERTIFICATE has been set to the path of the CA certificate"
-			exit 1
-	fi
+    if [[ -z "$CA_CERTIFICATE" ]]; then
+        echo "Ensure CA_CERTIFICATE has been set to the path of the CA certificate"
+        exit 1
+    fi
 
-	if [[ -z "$ENDPOINT" ]]; then
-			echo "Ensure ENDPOINT has been set"
-			exit 1
-	fi
+    if [[ -z "$ENDPOINT" ]]; then
+        echo "Ensure ENDPOINT has been set"
+        exit 1
+    fi
 
-	if [[ -z "$TOKEN" ]]; then
-			echo "Ensure TOKEN has been set"
-			exit 1
-	fi
+    if [[ -z "$TOKEN" ]]; then
+        echo "Ensure TOKEN has been set"
+        exit 1
+    fi
 
-	export CLUSTER_CA_CERTIFICATE=$(cat "$CA_CERTIFICATE" | base64)
+    export CLUSTER_CA_CERTIFICATE=$(cat "$CA_CERTIFICATE" | base64)
 
-	envsubst <<EOF
-	apiVersion: v1
-	kind: Config
-	clusters:
-	- name: $CLUSTER_NAME
-		cluster:
-			server: https://$ENDPOINT
-			certificate-authority-data: $CLUSTER_CA_CERTIFICATE
-	users:
-	- name: $CLUSTER_NAME
-		user:
-			token: $TOKEN
-	contexts:
-	- name: $CLUSTER_NAME
-		context:
-			cluster: $CLUSTER_NAME
-			user: $CLUSTER_NAME
-	current-context: $CLUSTER_NAME
-
-	EOF
+    envsubst <<EOF
+    apiVersion: v1
+    kind: Config
+    current-context: $CLUSTER_NAME
+    clusters:
+    - name: $CLUSTER_NAME
+      cluster:
+        server: https://$ENDPOINT
+        certificate-authority-data: $CLUSTER_CA_CERTIFICATE
+    users:
+    - name: $CLUSTER_NAME
+      user:
+        token: $TOKEN
+    contexts:
+    - name: $CLUSTER_NAME
+      context:
+        cluster: $CLUSTER_NAME
+        user: $CLUSTER_NAME
+    EOF
 	```
 
 	</details>

--- a/website/versioned_docs/version-0.22.0/cluster-management/managing-existing-clusters.mdx
+++ b/website/versioned_docs/version-0.22.0/cluster-management/managing-existing-clusters.mdx
@@ -108,50 +108,49 @@ kubectl create secret generic demo-01-kubeconfig \
 	<details><summary>Expand to see script</summary>
 
 	```bash title="static-kubeconfig.sh"
-	#!/bin/bash
+    #!/bin/bash
 
-	if [[ -z "$CLUSTER_NAME" ]]; then
-			echo "Ensure CLUSTER_NAME has been set"
-			exit 1
-	fi
+    if [[ -z "$CLUSTER_NAME" ]]; then
+        echo "Ensure CLUSTER_NAME has been set"
+        exit 1
+    fi
 
-	if [[ -z "$CA_CERTIFICATE" ]]; then
-			echo "Ensure CA_CERTIFICATE has been set to the path of the CA certificate"
-			exit 1
-	fi
+    if [[ -z "$CA_CERTIFICATE" ]]; then
+        echo "Ensure CA_CERTIFICATE has been set to the path of the CA certificate"
+        exit 1
+    fi
 
-	if [[ -z "$ENDPOINT" ]]; then
-			echo "Ensure ENDPOINT has been set"
-			exit 1
-	fi
+    if [[ -z "$ENDPOINT" ]]; then
+        echo "Ensure ENDPOINT has been set"
+        exit 1
+    fi
 
-	if [[ -z "$TOKEN" ]]; then
-			echo "Ensure TOKEN has been set"
-			exit 1
-	fi
+    if [[ -z "$TOKEN" ]]; then
+        echo "Ensure TOKEN has been set"
+        exit 1
+    fi
 
-	export CLUSTER_CA_CERTIFICATE=$(cat "$CA_CERTIFICATE" | base64)
+    export CLUSTER_CA_CERTIFICATE=$(cat "$CA_CERTIFICATE" | base64)
 
-	envsubst <<EOF
-	apiVersion: v1
-	kind: Config
-	clusters:
-	- name: $CLUSTER_NAME
-		cluster:
-			server: https://$ENDPOINT
-			certificate-authority-data: $CLUSTER_CA_CERTIFICATE
-	users:
-	- name: $CLUSTER_NAME
-		user:
-			token: $TOKEN
-	contexts:
-	- name: $CLUSTER_NAME
-		context:
-			cluster: $CLUSTER_NAME
-			user: $CLUSTER_NAME
-	current-context: $CLUSTER_NAME
-
-	EOF
+    envsubst <<EOF
+    apiVersion: v1
+    kind: Config
+    current-context: $CLUSTER_NAME
+    clusters:
+    - name: $CLUSTER_NAME
+      cluster:
+        server: https://$ENDPOINT
+        certificate-authority-data: $CLUSTER_CA_CERTIFICATE
+    users:
+    - name: $CLUSTER_NAME
+      user:
+        token: $TOKEN
+    contexts:
+    - name: $CLUSTER_NAME
+      context:
+        cluster: $CLUSTER_NAME
+        user: $CLUSTER_NAME
+    EOF
 	```
 
 	</details>

--- a/website/versioned_docs/version-0.23.0/cluster-management/managing-existing-clusters.mdx
+++ b/website/versioned_docs/version-0.23.0/cluster-management/managing-existing-clusters.mdx
@@ -108,50 +108,49 @@ kubectl create secret generic demo-01-kubeconfig \
 	<details><summary>Expand to see script</summary>
 
 	```bash title="static-kubeconfig.sh"
-	#!/bin/bash
+    #!/bin/bash
 
-	if [[ -z "$CLUSTER_NAME" ]]; then
-			echo "Ensure CLUSTER_NAME has been set"
-			exit 1
-	fi
+    if [[ -z "$CLUSTER_NAME" ]]; then
+        echo "Ensure CLUSTER_NAME has been set"
+        exit 1
+    fi
 
-	if [[ -z "$CA_CERTIFICATE" ]]; then
-			echo "Ensure CA_CERTIFICATE has been set to the path of the CA certificate"
-			exit 1
-	fi
+    if [[ -z "$CA_CERTIFICATE" ]]; then
+        echo "Ensure CA_CERTIFICATE has been set to the path of the CA certificate"
+        exit 1
+    fi
 
-	if [[ -z "$ENDPOINT" ]]; then
-			echo "Ensure ENDPOINT has been set"
-			exit 1
-	fi
+    if [[ -z "$ENDPOINT" ]]; then
+        echo "Ensure ENDPOINT has been set"
+        exit 1
+    fi
 
-	if [[ -z "$TOKEN" ]]; then
-			echo "Ensure TOKEN has been set"
-			exit 1
-	fi
+    if [[ -z "$TOKEN" ]]; then
+        echo "Ensure TOKEN has been set"
+        exit 1
+    fi
 
-	export CLUSTER_CA_CERTIFICATE=$(cat "$CA_CERTIFICATE" | base64)
+    export CLUSTER_CA_CERTIFICATE=$(cat "$CA_CERTIFICATE" | base64)
 
-	envsubst <<EOF
-	apiVersion: v1
-	kind: Config
-	clusters:
-	- name: $CLUSTER_NAME
-		cluster:
-			server: https://$ENDPOINT
-			certificate-authority-data: $CLUSTER_CA_CERTIFICATE
-	users:
-	- name: $CLUSTER_NAME
-		user:
-			token: $TOKEN
-	contexts:
-	- name: $CLUSTER_NAME
-		context:
-			cluster: $CLUSTER_NAME
-			user: $CLUSTER_NAME
-	current-context: $CLUSTER_NAME
-
-	EOF
+    envsubst <<EOF
+    apiVersion: v1
+    kind: Config
+    current-context: $CLUSTER_NAME
+    clusters:
+    - name: $CLUSTER_NAME
+      cluster:
+        server: https://$ENDPOINT
+        certificate-authority-data: $CLUSTER_CA_CERTIFICATE
+    users:
+    - name: $CLUSTER_NAME
+      user:
+        token: $TOKEN
+    contexts:
+    - name: $CLUSTER_NAME
+      context:
+        cluster: $CLUSTER_NAME
+        user: $CLUSTER_NAME
+    EOF
 	```
 
 	</details>

--- a/website/versioned_docs/version-0.24.0/cluster-management/managing-existing-clusters.mdx
+++ b/website/versioned_docs/version-0.24.0/cluster-management/managing-existing-clusters.mdx
@@ -108,50 +108,49 @@ kubectl create secret generic demo-01-kubeconfig \
 	<details><summary>Expand to see script</summary>
 
 	```bash title="static-kubeconfig.sh"
-	#!/bin/bash
+    #!/bin/bash
 
-	if [[ -z "$CLUSTER_NAME" ]]; then
-			echo "Ensure CLUSTER_NAME has been set"
-			exit 1
-	fi
+    if [[ -z "$CLUSTER_NAME" ]]; then
+        echo "Ensure CLUSTER_NAME has been set"
+        exit 1
+    fi
 
-	if [[ -z "$CA_CERTIFICATE" ]]; then
-			echo "Ensure CA_CERTIFICATE has been set to the path of the CA certificate"
-			exit 1
-	fi
+    if [[ -z "$CA_CERTIFICATE" ]]; then
+        echo "Ensure CA_CERTIFICATE has been set to the path of the CA certificate"
+        exit 1
+    fi
 
-	if [[ -z "$ENDPOINT" ]]; then
-			echo "Ensure ENDPOINT has been set"
-			exit 1
-	fi
+    if [[ -z "$ENDPOINT" ]]; then
+        echo "Ensure ENDPOINT has been set"
+        exit 1
+    fi
 
-	if [[ -z "$TOKEN" ]]; then
-			echo "Ensure TOKEN has been set"
-			exit 1
-	fi
+    if [[ -z "$TOKEN" ]]; then
+        echo "Ensure TOKEN has been set"
+        exit 1
+    fi
 
-	export CLUSTER_CA_CERTIFICATE=$(cat "$CA_CERTIFICATE" | base64)
+    export CLUSTER_CA_CERTIFICATE=$(cat "$CA_CERTIFICATE" | base64)
 
-	envsubst <<EOF
-	apiVersion: v1
-	kind: Config
-	clusters:
-	- name: $CLUSTER_NAME
-		cluster:
-			server: https://$ENDPOINT
-			certificate-authority-data: $CLUSTER_CA_CERTIFICATE
-	users:
-	- name: $CLUSTER_NAME
-		user:
-			token: $TOKEN
-	contexts:
-	- name: $CLUSTER_NAME
-		context:
-			cluster: $CLUSTER_NAME
-			user: $CLUSTER_NAME
-	current-context: $CLUSTER_NAME
-
-	EOF
+    envsubst <<EOF
+    apiVersion: v1
+    kind: Config
+    current-context: $CLUSTER_NAME
+    clusters:
+    - name: $CLUSTER_NAME
+      cluster:
+        server: https://$ENDPOINT
+        certificate-authority-data: $CLUSTER_CA_CERTIFICATE
+    users:
+    - name: $CLUSTER_NAME
+      user:
+        token: $TOKEN
+    contexts:
+    - name: $CLUSTER_NAME
+      context:
+        cluster: $CLUSTER_NAME
+        user: $CLUSTER_NAME
+    EOF
 	```
 
 	</details>

--- a/website/versioned_docs/version-0.25.0/cluster-management/managing-existing-clusters.mdx
+++ b/website/versioned_docs/version-0.25.0/cluster-management/managing-existing-clusters.mdx
@@ -108,50 +108,49 @@ kubectl create secret generic demo-01-kubeconfig \
 	<details><summary>Expand to see script</summary>
 
 	```bash title="static-kubeconfig.sh"
-	#!/bin/bash
+    #!/bin/bash
 
-	if [[ -z "$CLUSTER_NAME" ]]; then
-			echo "Ensure CLUSTER_NAME has been set"
-			exit 1
-	fi
+    if [[ -z "$CLUSTER_NAME" ]]; then
+        echo "Ensure CLUSTER_NAME has been set"
+        exit 1
+    fi
 
-	if [[ -z "$CA_CERTIFICATE" ]]; then
-			echo "Ensure CA_CERTIFICATE has been set to the path of the CA certificate"
-			exit 1
-	fi
+    if [[ -z "$CA_CERTIFICATE" ]]; then
+        echo "Ensure CA_CERTIFICATE has been set to the path of the CA certificate"
+        exit 1
+    fi
 
-	if [[ -z "$ENDPOINT" ]]; then
-			echo "Ensure ENDPOINT has been set"
-			exit 1
-	fi
+    if [[ -z "$ENDPOINT" ]]; then
+        echo "Ensure ENDPOINT has been set"
+        exit 1
+    fi
 
-	if [[ -z "$TOKEN" ]]; then
-			echo "Ensure TOKEN has been set"
-			exit 1
-	fi
+    if [[ -z "$TOKEN" ]]; then
+        echo "Ensure TOKEN has been set"
+        exit 1
+    fi
 
-	export CLUSTER_CA_CERTIFICATE=$(cat "$CA_CERTIFICATE" | base64)
+    export CLUSTER_CA_CERTIFICATE=$(cat "$CA_CERTIFICATE" | base64)
 
-	envsubst <<EOF
-	apiVersion: v1
-	kind: Config
-	clusters:
-	- name: $CLUSTER_NAME
-		cluster:
-			server: https://$ENDPOINT
-			certificate-authority-data: $CLUSTER_CA_CERTIFICATE
-	users:
-	- name: $CLUSTER_NAME
-		user:
-			token: $TOKEN
-	contexts:
-	- name: $CLUSTER_NAME
-		context:
-			cluster: $CLUSTER_NAME
-			user: $CLUSTER_NAME
-	current-context: $CLUSTER_NAME
-
-	EOF
+    envsubst <<EOF
+    apiVersion: v1
+    kind: Config
+    current-context: $CLUSTER_NAME
+    clusters:
+    - name: $CLUSTER_NAME
+      cluster:
+        server: https://$ENDPOINT
+        certificate-authority-data: $CLUSTER_CA_CERTIFICATE
+    users:
+    - name: $CLUSTER_NAME
+      user:
+        token: $TOKEN
+    contexts:
+    - name: $CLUSTER_NAME
+      context:
+        cluster: $CLUSTER_NAME
+        user: $CLUSTER_NAME
+    EOF
 	```
 
 	</details>

--- a/website/versioned_docs/version-0.26.0/cluster-management/managing-existing-clusters.mdx
+++ b/website/versioned_docs/version-0.26.0/cluster-management/managing-existing-clusters.mdx
@@ -108,52 +108,50 @@ kubectl create secret generic demo-01-kubeconfig \
 	<details><summary>Expand to see script</summary>
 
 	```bash title="static-kubeconfig.sh"
-	#!/bin/bash
+    #!/bin/bash
 
-	if [[ -z "$CLUSTER_NAME" ]]; then
-			echo "Ensure CLUSTER_NAME has been set"
-			exit 1
-	fi
+    if [[ -z "$CLUSTER_NAME" ]]; then
+        echo "Ensure CLUSTER_NAME has been set"
+        exit 1
+    fi
 
-	if [[ -z "$CA_CERTIFICATE" ]]; then
-			echo "Ensure CA_CERTIFICATE has been set to the path of the CA certificate"
-			exit 1
-	fi
+    if [[ -z "$CA_CERTIFICATE" ]]; then
+        echo "Ensure CA_CERTIFICATE has been set to the path of the CA certificate"
+        exit 1
+    fi
 
-	if [[ -z "$ENDPOINT" ]]; then
-			echo "Ensure ENDPOINT has been set"
-			exit 1
-	fi
+    if [[ -z "$ENDPOINT" ]]; then
+        echo "Ensure ENDPOINT has been set"
+        exit 1
+    fi
 
-	if [[ -z "$TOKEN" ]]; then
-			echo "Ensure TOKEN has been set"
-			exit 1
-	fi
+    if [[ -z "$TOKEN" ]]; then
+        echo "Ensure TOKEN has been set"
+        exit 1
+    fi
 
-	export CLUSTER_CA_CERTIFICATE=$(cat "$CA_CERTIFICATE" | base64)
+    export CLUSTER_CA_CERTIFICATE=$(cat "$CA_CERTIFICATE" | base64)
 
-	envsubst <<EOF
-	apiVersion: v1
-	kind: Config
-	clusters:
-	- name: $CLUSTER_NAME
-		cluster:
-			server: https://$ENDPOINT
-			certificate-authority-data: $CLUSTER_CA_CERTIFICATE
-	users:
-	- name: $CLUSTER_NAME
-		user:
-			token: $TOKEN
-	contexts:
-	- name: $CLUSTER_NAME
-		context:
-			cluster: $CLUSTER_NAME
-			user: $CLUSTER_NAME
-	current-context: $CLUSTER_NAME
-
-	EOF
-	```
-
+    envsubst <<EOF
+    apiVersion: v1
+    kind: Config
+    current-context: $CLUSTER_NAME
+    clusters:
+    - name: $CLUSTER_NAME
+      cluster:
+        server: https://$ENDPOINT
+        certificate-authority-data: $CLUSTER_CA_CERTIFICATE
+    users:
+    - name: $CLUSTER_NAME
+      user:
+        token: $TOKEN
+    contexts:
+    - name: $CLUSTER_NAME
+      context:
+        cluster: $CLUSTER_NAME
+        user: $CLUSTER_NAME
+    EOF
+    ```
 	</details>
 
 	For the next step, the cluster certificate (CA) is needed. How you get hold of the certificate depends on the cluster. For GKE you can view it on the GCP Console: Cluster->Details->Endpoint->”Show cluster certificate”. You will need to copy the contents of the certificate into the `ca.crt` file used below.

--- a/website/versioned_docs/version-0.27.0/cluster-management/managing-clusters-without-capi.mdx
+++ b/website/versioned_docs/version-0.27.0/cluster-management/managing-clusters-without-capi.mdx
@@ -106,50 +106,49 @@ Here's how to create a kubeconfig secret.
 	<details><summary>Expand to see script</summary>
 
 	```bash title="static-kubeconfig.sh"
-	#!/bin/bash
+    #!/bin/bash
 
-	if [[ -z "$CLUSTER_NAME" ]]; then
-			echo "Ensure CLUSTER_NAME has been set"
-			exit 1
-	fi
+    if [[ -z "$CLUSTER_NAME" ]]; then
+        echo "Ensure CLUSTER_NAME has been set"
+        exit 1
+    fi
 
-	if [[ -z "$CA_CERTIFICATE" ]]; then
-			echo "Ensure CA_CERTIFICATE has been set to the path of the CA certificate"
-			exit 1
-	fi
+    if [[ -z "$CA_CERTIFICATE" ]]; then
+        echo "Ensure CA_CERTIFICATE has been set to the path of the CA certificate"
+        exit 1
+    fi
 
-	if [[ -z "$ENDPOINT" ]]; then
-			echo "Ensure ENDPOINT has been set"
-			exit 1
-	fi
+    if [[ -z "$ENDPOINT" ]]; then
+        echo "Ensure ENDPOINT has been set"
+        exit 1
+    fi
 
-	if [[ -z "$TOKEN" ]]; then
-			echo "Ensure TOKEN has been set"
-			exit 1
-	fi
+    if [[ -z "$TOKEN" ]]; then
+        echo "Ensure TOKEN has been set"
+        exit 1
+    fi
 
-	export CLUSTER_CA_CERTIFICATE=$(cat "$CA_CERTIFICATE" | base64)
+    export CLUSTER_CA_CERTIFICATE=$(cat "$CA_CERTIFICATE" | base64)
 
-	envsubst <<EOF
-	apiVersion: v1
-	kind: Config
-	clusters:
-	- name: $CLUSTER_NAME
-		cluster:
-			server: https://$ENDPOINT
-			certificate-authority-data: $CLUSTER_CA_CERTIFICATE
-	users:
-	- name: $CLUSTER_NAME
-		user:
-			token: $TOKEN
-	contexts:
-	- name: $CLUSTER_NAME
-		context:
-			cluster: $CLUSTER_NAME
-			user: $CLUSTER_NAME
-	current-context: $CLUSTER_NAME
-
-	EOF
+    envsubst <<EOF
+    apiVersion: v1
+    kind: Config
+    current-context: $CLUSTER_NAME
+    clusters:
+    - name: $CLUSTER_NAME
+      cluster:
+        server: https://$ENDPOINT
+        certificate-authority-data: $CLUSTER_CA_CERTIFICATE
+    users:
+    - name: $CLUSTER_NAME
+      user:
+        token: $TOKEN
+    contexts:
+    - name: $CLUSTER_NAME
+      context:
+        cluster: $CLUSTER_NAME
+        user: $CLUSTER_NAME
+    EOF
 	```
 
 	</details>

--- a/website/versioned_docs/version-0.28.0/cluster-management/managing-clusters-without-capi.mdx
+++ b/website/versioned_docs/version-0.28.0/cluster-management/managing-clusters-without-capi.mdx
@@ -106,50 +106,49 @@ Here's how to create a kubeconfig secret.
 	<details><summary>Expand to see script</summary>
 
 	```bash title="static-kubeconfig.sh"
-	#!/bin/bash
+    #!/bin/bash
 
-	if [[ -z "$CLUSTER_NAME" ]]; then
-			echo "Ensure CLUSTER_NAME has been set"
-			exit 1
-	fi
+    if [[ -z "$CLUSTER_NAME" ]]; then
+        echo "Ensure CLUSTER_NAME has been set"
+        exit 1
+    fi
 
-	if [[ -z "$CA_CERTIFICATE" ]]; then
-			echo "Ensure CA_CERTIFICATE has been set to the path of the CA certificate"
-			exit 1
-	fi
+    if [[ -z "$CA_CERTIFICATE" ]]; then
+        echo "Ensure CA_CERTIFICATE has been set to the path of the CA certificate"
+        exit 1
+    fi
 
-	if [[ -z "$ENDPOINT" ]]; then
-			echo "Ensure ENDPOINT has been set"
-			exit 1
-	fi
+    if [[ -z "$ENDPOINT" ]]; then
+        echo "Ensure ENDPOINT has been set"
+        exit 1
+    fi
 
-	if [[ -z "$TOKEN" ]]; then
-			echo "Ensure TOKEN has been set"
-			exit 1
-	fi
+    if [[ -z "$TOKEN" ]]; then
+        echo "Ensure TOKEN has been set"
+        exit 1
+    fi
 
-	export CLUSTER_CA_CERTIFICATE=$(cat "$CA_CERTIFICATE" | base64)
+    export CLUSTER_CA_CERTIFICATE=$(cat "$CA_CERTIFICATE" | base64)
 
-	envsubst <<EOF
-	apiVersion: v1
-	kind: Config
-	clusters:
-	- name: $CLUSTER_NAME
-		cluster:
-			server: https://$ENDPOINT
-			certificate-authority-data: $CLUSTER_CA_CERTIFICATE
-	users:
-	- name: $CLUSTER_NAME
-		user:
-			token: $TOKEN
-	contexts:
-	- name: $CLUSTER_NAME
-		context:
-			cluster: $CLUSTER_NAME
-			user: $CLUSTER_NAME
-	current-context: $CLUSTER_NAME
-
-	EOF
+    envsubst <<EOF
+    apiVersion: v1
+    kind: Config
+    current-context: $CLUSTER_NAME
+    clusters:
+    - name: $CLUSTER_NAME
+      cluster:
+        server: https://$ENDPOINT
+        certificate-authority-data: $CLUSTER_CA_CERTIFICATE
+    users:
+    - name: $CLUSTER_NAME
+      user:
+        token: $TOKEN
+    contexts:
+    - name: $CLUSTER_NAME
+      context:
+        cluster: $CLUSTER_NAME
+        user: $CLUSTER_NAME
+    EOF
 	```
 
 	</details>


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes

<!-- Describe what has changed in this PR -->
**What changed?**
Fixes the indentation in the `static-kubeconfig.sh` to generate valid YAML.

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**
The script was generating invalid YAML

<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**


<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**
Running the recommend command from the docs with the old version creates an invalid YAML that fails with `kubectl --kubeconfig` with invalid YAML on line 5, running it with a file generated using this command it works.

<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**
No

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
