### PR TITLE
Add sync and suspend for image update automations

### DIFF
--- a/core/server/suspend_test.go
+++ b/core/server/suspend_test.go
@@ -68,7 +68,7 @@ func TestSuspend_Suspend(t *testing.T) {
 		},
 		{
 			kind: imgautomationv1.ImageUpdateAutomationKind,
-			obj:  makeImageUpdateAutomation("iua-1", *ns, gr),
+			obj:  makeImageUpdateAutomation("iua-1", *ns),
 		},
 	}
 

--- a/core/server/suspend_test.go
+++ b/core/server/suspend_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	helmv2 "github.com/fluxcd/helm-controller/api/v2beta1"
+	imgautomationv1 "github.com/fluxcd/image-automation-controller/api/v1beta1"
+	reflectorv1 "github.com/fluxcd/image-reflector-controller/api/v1beta2"
 	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1beta2"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1beta2"
 	. "github.com/onsi/gomega"
@@ -32,17 +34,21 @@ func TestSuspend_Suspend(t *testing.T) {
 
 	ns := newNamespace(ctx, k, g)
 
+	gr := makeGitRepo("git-repo-1", *ns)
+
+	hr := makeHelmRepo("repo-1", *ns)
+
 	tests := []struct {
 		kind string
 		obj  client.Object
 	}{
 		{
 			kind: sourcev1.GitRepositoryKind,
-			obj:  makeGitRepo("git-repo-1", *ns),
+			obj:  gr,
 		},
 		{
 			kind: sourcev1.HelmRepositoryKind,
-			obj:  makeHelmRepo("repo-1", *ns),
+			obj:  hr,
 		},
 		{
 			kind: sourcev1.BucketKind,
@@ -50,11 +56,19 @@ func TestSuspend_Suspend(t *testing.T) {
 		},
 		{
 			kind: kustomizev1.KustomizationKind,
-			obj:  makeKustomization("kust-1", *ns, makeGitRepo("somerepo", *ns)),
+			obj:  makeKustomization("kust-1", *ns, gr),
 		},
 		{
 			kind: helmv2.HelmReleaseKind,
-			obj:  makeHelmRelease("hr-1", *ns, makeHelmRepo("somerepo", *ns), makeHelmChart("somechart", *ns)),
+			obj:  makeHelmRelease("hr-1", *ns, hr, makeHelmChart("somechart", *ns)),
+		},
+		{
+			kind: reflectorv1.ImageRepositoryKind,
+			obj:  makeImageRepository("ir-1", *ns),
+		},
+		{
+			kind: imgautomationv1.ImageUpdateAutomationKind,
+			obj:  makeImageUpdateAutomation("iua-1", *ns, gr),
 		},
 	}
 
@@ -157,13 +171,23 @@ func checkSpec(t *testing.T, k client.Client, name types.NamespacedName, obj cli
 		}
 
 		return v.Spec.Suspend
+
+	case *reflectorv1.ImageRepository:
+		if err := k.Get(context.Background(), name, v); err != nil {
+			t.Error(err)
+		}
+
+		return v.Spec.Suspend
+
+	case *imgautomationv1.ImageUpdateAutomation:
+		if err := k.Get(context.Background(), name, v); err != nil {
+			t.Error(err)
+		}
+
+		return v.Spec.Suspend
 	}
 
 	t.Errorf("unsupported object %T", obj)
 
 	return false
-}
-
-func TestSuspend_Resume(t *testing.T) {
-
 }

--- a/core/server/sync.go
+++ b/core/server/sync.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	helmv2 "github.com/fluxcd/helm-controller/api/v2beta1"
+	imgautomationv1 "github.com/fluxcd/image-automation-controller/api/v1beta1"
 	reflectorv1 "github.com/fluxcd/image-reflector-controller/api/v1beta2"
 	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1beta2"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1beta2"
@@ -124,7 +125,6 @@ func getFluxObject(kind string) (fluxsync.Reconcilable, error) {
 		return &fluxsync.KustomizationAdapter{Kustomization: &kustomizev1.Kustomization{}}, nil
 	case helmv2.HelmReleaseKind:
 		return &fluxsync.HelmReleaseAdapter{HelmRelease: &helmv2.HelmRelease{}}, nil
-
 	case sourcev1.GitRepositoryKind:
 		return &fluxsync.GitRepositoryAdapter{GitRepository: &sourcev1.GitRepository{}}, nil
 	case sourcev1.BucketKind:
@@ -137,6 +137,8 @@ func getFluxObject(kind string) (fluxsync.Reconcilable, error) {
 		return &fluxsync.OCIRepositoryAdapter{OCIRepository: &sourcev1.OCIRepository{}}, nil
 	case reflectorv1.ImageRepositoryKind:
 		return &fluxsync.ImageRepositoryAdapter{ImageRepository: &reflectorv1.ImageRepository{}}, nil
+	case imgautomationv1.ImageUpdateAutomationKind:
+		return &fluxsync.ImageUpdateAutomationAdapter{ImageUpdateAutomation: &imgautomationv1.ImageUpdateAutomation{}}, nil
 	}
 
 	return nil, fmt.Errorf("not supported kind: %s", kind)

--- a/core/server/sync_test.go
+++ b/core/server/sync_test.go
@@ -474,7 +474,7 @@ func makeImageUpdateAutomation(name string, ns corev1.Namespace) *imgautomationv
 			Name:      name,
 			Namespace: ns.Name,
 		},
-		Spec: imgautomationv1.ImageUpdateAutomationSpec{},
+		Spec: imgautomationv1.ImageUpdateAutomationSpec{SourceRef: imgautomationv1.CrossNamespaceSourceReference{Kind: sourcev1.GitRepositoryKind}},
 		Status: imgautomationv1.ImageUpdateAutomationStatus{
 			ReconcileRequestStatus: meta.ReconcileRequestStatus{
 				LastHandledReconcileAt: time.Now().Format(time.RFC3339Nano),

--- a/core/server/sync_test.go
+++ b/core/server/sync_test.go
@@ -54,7 +54,7 @@ func TestSync(t *testing.T) {
 	ociRepo := makeOCIRepo(name, *ns)
 
 	ir := makeImageRepository(name, *ns)
-	iua := makeImageUpdateAutomation(name, *ns, gitRepo)
+	iua := makeImageUpdateAutomation(name, *ns)
 
 	g.Expect(k.Create(ctx, kust)).Should(Succeed())
 	g.Expect(k.Create(ctx, hr)).Should(Succeed())
@@ -161,15 +161,6 @@ func TestSync(t *testing.T) {
 			WithSource: false,
 		},
 		reconcilable: fluxsync.ImageUpdateAutomationAdapter{ImageUpdateAutomation: iua},
-	}, {
-		name: "image update automation with source",
-		msg: &pb.SyncFluxObjectRequest{
-			Objects: []*pb.ObjectRef{{ClusterName: "Default",
-				Kind: imgautomationv1.ImageUpdateAutomationKind}},
-			WithSource: true,
-		},
-		reconcilable: fluxsync.ImageUpdateAutomationAdapter{ImageUpdateAutomation: iua},
-		source:       fluxsync.NewReconcileable(gitRepo),
 	}, {
 		name: "multiple objects",
 		msg: &pb.SyncFluxObjectRequest{
@@ -477,7 +468,7 @@ func makeImageRepository(name string, ns corev1.Namespace) *reflectorv1.ImageRep
 	}
 }
 
-func makeImageUpdateAutomation(name string, ns corev1.Namespace, source *sourcev1.GitRepository) *imgautomationv1.ImageUpdateAutomation {
+func makeImageUpdateAutomation(name string, ns corev1.Namespace) *imgautomationv1.ImageUpdateAutomation {
 	iua := &imgautomationv1.ImageUpdateAutomation{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -489,14 +480,6 @@ func makeImageUpdateAutomation(name string, ns corev1.Namespace, source *sourcev
 				LastHandledReconcileAt: time.Now().Format(time.RFC3339Nano),
 			},
 		},
-	}
-
-	if source != nil {
-		iua.Spec.SourceRef = imgautomationv1.CrossNamespaceSourceReference{
-			Kind:      sourcev1.GitRepositoryKind,
-			Name:      name,
-			Namespace: ns.Name,
-		}
 	}
 
 	return iua

--- a/core/server/sync_test.go
+++ b/core/server/sync_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	helmv2 "github.com/fluxcd/helm-controller/api/v2beta1"
+	imgautomationv1 "github.com/fluxcd/image-automation-controller/api/v1beta1"
 	reflectorv1 "github.com/fluxcd/image-reflector-controller/api/v1beta2"
 	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1beta2"
 	"github.com/fluxcd/pkg/apis/meta"
@@ -53,16 +54,17 @@ func TestSync(t *testing.T) {
 	ociRepo := makeOCIRepo(name, *ns)
 
 	ir := makeImageRepository(name, *ns)
+	iua := makeImageUpdateAutomation(name, *ns, gitRepo)
 
 	g.Expect(k.Create(ctx, kust)).Should(Succeed())
 	g.Expect(k.Create(ctx, hr)).Should(Succeed())
-	g.Expect(k.Create(ctx, ir)).Should(Succeed())
-
 	g.Expect(k.Create(ctx, bucket)).Should(Succeed())
 	g.Expect(k.Create(ctx, chart)).Should(Succeed())
 	g.Expect(k.Create(ctx, helmRepo)).Should(Succeed())
 	g.Expect(k.Create(ctx, gitRepo)).Should(Succeed())
 	g.Expect(k.Create(ctx, ociRepo)).Should(Succeed())
+	g.Expect(k.Create(ctx, ir)).Should(Succeed())
+	g.Expect(k.Create(ctx, iua)).Should(Succeed())
 
 	tests := []struct {
 		name         string
@@ -151,6 +153,23 @@ func TestSync(t *testing.T) {
 			WithSource: false,
 		},
 		reconcilable: fluxsync.ImageRepositoryAdapter{ImageRepository: ir},
+	}, {
+		name: "image update automation no source",
+		msg: &pb.SyncFluxObjectRequest{
+			Objects: []*pb.ObjectRef{{ClusterName: "Default",
+				Kind: imgautomationv1.ImageUpdateAutomationKind}},
+			WithSource: false,
+		},
+		reconcilable: fluxsync.ImageUpdateAutomationAdapter{ImageUpdateAutomation: iua},
+	}, {
+		name: "image update automation with source",
+		msg: &pb.SyncFluxObjectRequest{
+			Objects: []*pb.ObjectRef{{ClusterName: "Default",
+				Kind: imgautomationv1.ImageUpdateAutomationKind}},
+			WithSource: true,
+		},
+		reconcilable: fluxsync.ImageUpdateAutomationAdapter{ImageUpdateAutomation: iua},
+		source:       fluxsync.NewReconcileable(gitRepo),
 	}, {
 		name: "multiple objects",
 		msg: &pb.SyncFluxObjectRequest{
@@ -282,6 +301,15 @@ func simulateReconcile(ctx context.Context, k client.Client, name types.Namespac
 		return k.Status().Update(ctx, obj)
 
 	case *reflectorv1.ImageRepository:
+		if err := k.Get(ctx, name, obj); err != nil {
+			return err
+		}
+
+		obj.Status.SetLastHandledReconcileRequest(time.Now().Format(time.RFC3339Nano))
+
+		return k.Status().Update(ctx, obj)
+
+	case *imgautomationv1.ImageUpdateAutomation:
 		if err := k.Get(ctx, name, obj); err != nil {
 			return err
 		}
@@ -447,4 +475,29 @@ func makeImageRepository(name string, ns corev1.Namespace) *reflectorv1.ImageRep
 			},
 		},
 	}
+}
+
+func makeImageUpdateAutomation(name string, ns corev1.Namespace, source *sourcev1.GitRepository) *imgautomationv1.ImageUpdateAutomation {
+	iua := &imgautomationv1.ImageUpdateAutomation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns.Name,
+		},
+		Spec: imgautomationv1.ImageUpdateAutomationSpec{},
+		Status: imgautomationv1.ImageUpdateAutomationStatus{
+			ReconcileRequestStatus: meta.ReconcileRequestStatus{
+				LastHandledReconcileAt: time.Now().Format(time.RFC3339Nano),
+			},
+		},
+	}
+
+	if source != nil {
+		iua.Spec.SourceRef = imgautomationv1.CrossNamespaceSourceReference{
+			Kind:      sourcev1.GitRepositoryKind,
+			Name:      name,
+			Namespace: ns.Name,
+		}
+	}
+
+	return iua
 }

--- a/core/server/sync_test.go
+++ b/core/server/sync_test.go
@@ -154,7 +154,7 @@ func TestSync(t *testing.T) {
 		},
 		reconcilable: fluxsync.ImageRepositoryAdapter{ImageRepository: ir},
 	}, {
-		name: "image update automation no source",
+		name: "image update automation",
 		msg: &pb.SyncFluxObjectRequest{
 			Objects: []*pb.ObjectRef{{ClusterName: "Default",
 				Kind: imgautomationv1.ImageUpdateAutomationKind}},

--- a/pkg/kube/kubehttp.go
+++ b/pkg/kube/kubehttp.go
@@ -10,7 +10,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	helmv2 "github.com/fluxcd/helm-controller/api/v2beta1"
-	automationv1 "github.com/fluxcd/image-automation-controller/api/v1beta1"
+	imgautomationv1 "github.com/fluxcd/image-automation-controller/api/v1beta1"
 	reflectorv1 "github.com/fluxcd/image-reflector-controller/api/v1beta2"
 	kustomizev2 "github.com/fluxcd/kustomize-controller/api/v1beta2"
 	notificationv2 "github.com/fluxcd/notification-controller/api/v1beta1"
@@ -37,9 +37,9 @@ func CreateScheme() (*apiruntime.Scheme, error) {
 		rbacv1.AddToScheme,
 		authv1.AddToScheme,
 		notificationv2.AddToScheme,
-		automationv1.AddToScheme,
 		pacv2beta2.AddToScheme,
 		reflectorv1.AddToScheme,
+		imgautomationv1.AddToScheme,
 	}
 
 	err := builder.AddToScheme(scheme)

--- a/tools/testcrds/image.toolkit.fluxcd.io_imageupdateautomations.yaml
+++ b/tools/testcrds/image.toolkit.fluxcd.io_imageupdateautomations.yaml
@@ -1,0 +1,303 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.12.0
+  name: imageupdateautomations.image.toolkit.fluxcd.io
+spec:
+  group: image.toolkit.fluxcd.io
+  names:
+    kind: ImageUpdateAutomation
+    listKind: ImageUpdateAutomationList
+    plural: imageupdateautomations
+    singular: imageupdateautomation
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.lastAutomationRunTime
+      name: Last run
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: ImageUpdateAutomation is the Schema for the imageupdateautomations
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ImageUpdateAutomationSpec defines the desired state of ImageUpdateAutomation
+            properties:
+              git:
+                description: GitSpec contains all the git-specific definitions. This
+                  is technically optional, but in practice mandatory until there are
+                  other kinds of source allowed.
+                properties:
+                  checkout:
+                    description: Checkout gives the parameters for cloning the git
+                      repository, ready to make changes. If not present, the `spec.ref`
+                      field from the referenced `GitRepository` or its default will
+                      be used.
+                    properties:
+                      ref:
+                        description: Reference gives a branch, tag or commit to clone
+                          from the Git repository.
+                        properties:
+                          branch:
+                            description: Branch to check out, defaults to 'master'
+                              if no other field is defined.
+                            type: string
+                          commit:
+                            description: "Commit SHA to check out, takes precedence
+                              over all reference fields. \n This can be combined with
+                              Branch to shallow clone the branch, in which the commit
+                              is expected to exist."
+                            type: string
+                          name:
+                            description: "Name of the reference to check out; takes
+                              precedence over Branch, Tag and SemVer. \n It must be
+                              a valid Git reference: https://git-scm.com/docs/git-check-ref-format#_description
+                              Examples: \"refs/heads/main\", \"refs/tags/v0.1.0\",
+                              \"refs/pull/420/head\", \"refs/merge-requests/1/head\""
+                            type: string
+                          semver:
+                            description: SemVer tag expression to check out, takes
+                              precedence over Tag.
+                            type: string
+                          tag:
+                            description: Tag to check out, takes precedence over Branch.
+                            type: string
+                        type: object
+                    required:
+                    - ref
+                    type: object
+                  commit:
+                    description: Commit specifies how to commit to the git repository.
+                    properties:
+                      author:
+                        description: Author gives the email and optionally the name
+                          to use as the author of commits.
+                        properties:
+                          email:
+                            description: Email gives the email to provide when making
+                              a commit.
+                            type: string
+                          name:
+                            description: Name gives the name to provide when making
+                              a commit.
+                            type: string
+                        required:
+                        - email
+                        type: object
+                      messageTemplate:
+                        description: MessageTemplate provides a template for the commit
+                          message, into which will be interpolated the details of
+                          the change made.
+                        type: string
+                      signingKey:
+                        description: SigningKey provides the option to sign commits
+                          with a GPG key
+                        properties:
+                          secretRef:
+                            description: SecretRef holds the name to a secret that
+                              contains a 'git.asc' key corresponding to the ASCII
+                              Armored file containing the GPG signing keypair as the
+                              value. It must be in the same namespace as the ImageUpdateAutomation.
+                            properties:
+                              name:
+                                description: Name of the referent.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                        type: object
+                    required:
+                    - author
+                    type: object
+                  push:
+                    description: Push specifies how and where to push commits made
+                      by the automation. If missing, commits are pushed (back) to
+                      `.spec.checkout.branch` or its default.
+                    properties:
+                      branch:
+                        description: Branch specifies that commits should be pushed
+                          to the branch named. The branch is created using `.spec.checkout.branch`
+                          as the starting point, if it doesn't already exist.
+                        type: string
+                    required:
+                    - branch
+                    type: object
+                required:
+                - commit
+                type: object
+              interval:
+                description: Interval gives an lower bound for how often the automation
+                  run should be attempted.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                type: string
+              sourceRef:
+                description: SourceRef refers to the resource giving access details
+                  to a git repository.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  kind:
+                    default: GitRepository
+                    description: Kind of the referent.
+                    enum:
+                    - GitRepository
+                    type: string
+                  name:
+                    description: Name of the referent.
+                    type: string
+                  namespace:
+                    description: Namespace of the referent, defaults to the namespace
+                      of the Kubernetes resource object that contains the reference.
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              suspend:
+                description: Suspend tells the controller to not run this automation,
+                  until it is unset (or set to false). Defaults to false.
+                type: boolean
+              update:
+                default:
+                  strategy: Setters
+                description: Update gives the specification for how to update the
+                  files in the repository. This can be left empty, to use the default
+                  value.
+                properties:
+                  path:
+                    description: Path to the directory containing the manifests to
+                      be updated. Defaults to 'None', which translates to the root
+                      path of the GitRepositoryRef.
+                    type: string
+                  strategy:
+                    default: Setters
+                    description: Strategy names the strategy to be used.
+                    enum:
+                    - Setters
+                    type: string
+                required:
+                - strategy
+                type: object
+            required:
+            - interval
+            - sourceRef
+            type: object
+          status:
+            default:
+              observedGeneration: -1
+            description: ImageUpdateAutomationStatus defines the observed state of
+              ImageUpdateAutomation
+            properties:
+              conditions:
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              lastAutomationRunTime:
+                description: LastAutomationRunTime records the last time the controller
+                  ran this automation through to completion (even if no updates were
+                  made).
+                format: date-time
+                type: string
+              lastHandledReconcileAt:
+                description: LastHandledReconcileAt holds the value of the most recent
+                  reconcile request value, so a change of the annotation value can
+                  be detected.
+                type: string
+              lastPushCommit:
+                description: LastPushCommit records the SHA1 of the last commit made
+                  by the controller, for this automation object
+                type: string
+              lastPushTime:
+                description: LastPushTime records the time of the last pushed change.
+                format: date-time
+                type: string
+              observedGeneration:
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/ui/components/CheckboxActions.tsx
+++ b/ui/components/CheckboxActions.tsx
@@ -95,10 +95,10 @@ type Props = {
 
 function CheckboxActions({ className, checked = [], rows = [] }: Props) {
   const [reqObjects, setReqObjects] = React.useState([]);
-  const hasChecked = checked.length > 0;
 
   React.useEffect(() => {
-    if (hasChecked && rows.length) setReqObjects(makeObjects(checked, rows));
+    if (checked.length > 0 && rows.length)
+      setReqObjects(makeObjects(checked, rows));
     else setReqObjects([]);
   }, [checked, rows]);
 

--- a/ui/components/CheckboxActions.tsx
+++ b/ui/components/CheckboxActions.tsx
@@ -35,6 +35,7 @@ const DefaultSync: React.FC<{ reqObjects: ObjectRef[] }> = ({ reqObjects }) => {
   const noSource = {
     [V2Routes.Sources]: true,
     [V2Routes.ImageRepositories]: true,
+    [V2Routes.ImageUpdates]: true,
   };
   return (
     <SyncButton

--- a/ui/components/ImageAutomation/ImageAutomationDetails.tsx
+++ b/ui/components/ImageAutomation/ImageAutomationDetails.tsx
@@ -36,7 +36,7 @@ const ImageAutomationDetails = ({
         {name}
       </Text>
       <PageStatus conditions={conditions} suspended={suspended} />
-      {kind == Kind.ImageRepository && (
+      {kind !== Kind.ImagePolicy && (
         <SyncActions
           name={name}
           namespace={namespace}
@@ -44,7 +44,7 @@ const ImageAutomationDetails = ({
           kind={kind}
           suspended={suspended}
           wide
-          hideDropdown
+          hideDropdown={kind === Kind.ImageRepository ? true : false}
         />
       )}
 

--- a/ui/components/ImageAutomation/ImageAutomationDetails.tsx
+++ b/ui/components/ImageAutomation/ImageAutomationDetails.tsx
@@ -44,7 +44,7 @@ const ImageAutomationDetails = ({
           kind={kind}
           suspended={suspended}
           wide
-          hideDropdown={kind === Kind.ImageRepository ? true : false}
+          hideDropdown
         />
       )}
 

--- a/ui/components/ImageAutomation/updates/ImageAutomationUpdatesTable.tsx
+++ b/ui/components/ImageAutomation/updates/ImageAutomationUpdatesTable.tsx
@@ -21,6 +21,7 @@ const ImageAutomationUpdatesTable = () => {
   return (
     <RequestStateHandler loading={isLoading} error={error}>
       <DataTable
+        hasCheckboxes
         filters={initialFilterState}
         rows={data?.objects}
         fields={[


### PR DESCRIPTION
Allows sync and suspend for image update automations + fixes a bug where buttons were not disabled when un-checking the last checked button (having variable outside of useEffect prevented update -> see CheckboxActions component)

https://github.com/weaveworks/weave-gitops/assets/65822698/abdb7cc5-1670-45f7-a535-ae51955837a3

