### PR TITLE
ad docs and dashboard for indexer RED metrics

### DIFF
--- a/website/docs/assets/dashboards/explorer.json
+++ b/website/docs/assets/dashboards/explorer.json
@@ -25,7 +25,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 31,
+  "id": 3,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -43,10 +43,7 @@
       "type": "row"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "datasource": {},
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -90,7 +87,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.5.2",
+      "pluginVersion": "10.0.2",
       "targets": [
         {
           "datasource": {
@@ -127,7 +124,7 @@
       "dashes": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "f6557ad8-98c0-4dc2-a6a8-6e44be0ea97a"
       },
       "fill": 1,
       "fillGradient": 0,
@@ -157,7 +154,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "9.5.2",
+      "pluginVersion": "10.0.2",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -172,7 +169,7 @@
             "uid": "P1809F7CD0C75ACF3"
           },
           "editorMode": "code",
-          "expr": "sum(rate(http_request_duration_seconds_count{handler=\"/v1/query\"}[1m]))",
+          "expr": "sum(rate(http_request_duration_seconds_count{handler=\"/v1/query\"}[2m]))",
           "legendFormat": "total",
           "range": true,
           "refId": "A"
@@ -183,7 +180,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(rate(http_request_duration_seconds_count{handler=\"/v1/query\",code!~\"2..\"}[1m]))",
+          "expr": "sum(rate(http_request_duration_seconds_count{handler=\"/v1/query\",code!~\"2..\"}[2m]))",
           "hide": false,
           "legendFormat": "errors",
           "range": true,
@@ -228,7 +225,7 @@
       "dashes": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "f6557ad8-98c0-4dc2-a6a8-6e44be0ea97a"
       },
       "fill": 1,
       "fillGradient": 0,
@@ -258,7 +255,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "9.5.2",
+      "pluginVersion": "10.0.2",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -273,7 +270,7 @@
             "uid": "P1809F7CD0C75ACF3"
           },
           "editorMode": "code",
-          "expr": "sum(rate(http_request_duration_seconds_sum{code=\"200\",handler=\"/v1/query\",method=\"POST\"}[1m])) / sum(rate(http_request_duration_seconds_count{code=\"200\",handler=\"/v1/query\",method=\"POST\"}[1m]))",
+          "expr": "sum(rate(http_request_duration_seconds_sum{code=\"200\",handler=\"/v1/query\",method=\"POST\"}[2m])) / sum(rate(http_request_duration_seconds_count{code=\"200\",handler=\"/v1/query\",method=\"POST\"}[2m]))",
           "legendFormat": "200s",
           "range": true,
           "refId": "A"
@@ -316,7 +313,7 @@
       "dashes": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "f6557ad8-98c0-4dc2-a6a8-6e44be0ea97a"
       },
       "fill": 1,
       "fillGradient": 0,
@@ -346,7 +343,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "9.5.2",
+      "pluginVersion": "10.0.2",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -361,7 +358,7 @@
             "uid": "P1809F7CD0C75ACF3"
           },
           "editorMode": "code",
-          "expr": "sum(rate(datastore_latency_seconds_count{action=~\"Get.*\"}[1m])) by (action)",
+          "expr": "sum(rate(datastore_latency_seconds_count{action=~\"Get.*\"}[2m])) by (action)",
           "legendFormat": "{{action}}",
           "range": true,
           "refId": "A"
@@ -400,7 +397,7 @@
       "dashes": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "f6557ad8-98c0-4dc2-a6a8-6e44be0ea97a"
       },
       "fill": 1,
       "fillGradient": 0,
@@ -429,7 +426,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "9.5.2",
+      "pluginVersion": "10.0.2",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -444,7 +441,7 @@
             "uid": "P1809F7CD0C75ACF3"
           },
           "editorMode": "code",
-          "expr": "sum(rate(datastore_latency_seconds_sum{action=~\"Get.*\",status=\"success\"}[1m])) / sum(rate(datastore_latency_seconds_count{action=~\"Get.*\",status=\"success\"}[1m]))\n",
+          "expr": "sum(rate(datastore_latency_seconds_sum{action=~\"Get.*\",status=\"success\"}[2m])) / sum(rate(datastore_latency_seconds_count{action=~\"Get.*\",status=\"success\"}[2m]))\n",
           "legendFormat": "success",
           "range": true,
           "refId": "A"
@@ -487,7 +484,7 @@
       "dashes": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "f6557ad8-98c0-4dc2-a6a8-6e44be0ea97a"
       },
       "fill": 1,
       "fillGradient": 0,
@@ -517,7 +514,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "9.5.2",
+      "pluginVersion": "10.0.2",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -532,7 +529,7 @@
             "uid": "P1809F7CD0C75ACF3"
           },
           "editorMode": "code",
-          "expr": "sum(irate(indexer_latency_seconds_count[1m])) by (action)",
+          "expr": "sum(irate(indexer_latency_seconds_count[2m])) by (action)",
           "legendFormat": "{{action}}",
           "range": true,
           "refId": "A"
@@ -571,7 +568,7 @@
       "dashes": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "f6557ad8-98c0-4dc2-a6a8-6e44be0ea97a"
       },
       "fill": 1,
       "fillGradient": 0,
@@ -600,7 +597,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "9.5.2",
+      "pluginVersion": "10.0.2",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -615,7 +612,7 @@
             "uid": "P1809F7CD0C75ACF3"
           },
           "editorMode": "code",
-          "expr": "sum(rate(indexer_latency_seconds_sum{status=\"success\"}[1m])) / sum(rate(indexer_latency_seconds_count{status=\"success\"}[1m]))\n",
+          "expr": "sum(rate(indexer_latency_seconds_sum{status=\"success\"}[2m])) / sum(rate(indexer_latency_seconds_count{status=\"success\"}[2m]))\n",
           "legendFormat": "success",
           "range": true,
           "refId": "A"
@@ -671,7 +668,7 @@
       "dashes": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "f6557ad8-98c0-4dc2-a6a8-6e44be0ea97a"
       },
       "fill": 1,
       "fillGradient": 0,
@@ -701,7 +698,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "9.5.2",
+      "pluginVersion": "10.0.2",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -758,10 +755,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "datasource": {},
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -790,7 +784,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "9.5.2",
+      "pluginVersion": "10.0.2",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -849,7 +843,7 @@
       "dashes": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "f6557ad8-98c0-4dc2-a6a8-6e44be0ea97a"
       },
       "fill": 1,
       "fillGradient": 0,
@@ -877,7 +871,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "9.5.2",
+      "pluginVersion": "10.0.2",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -892,7 +886,7 @@
             "uid": "P1809F7CD0C75ACF3"
           },
           "editorMode": "code",
-          "expr": "sum(irate(datastore_latency_seconds_count{action=~\"Store.*\"}[1m])) by (action)",
+          "expr": "sum(irate(datastore_latency_seconds_count{action=~\"Store.*\"}[2m])) by (action)",
           "legendFormat": "{{action}}",
           "range": true,
           "refId": "A"
@@ -933,7 +927,7 @@
       "dashes": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "f6557ad8-98c0-4dc2-a6a8-6e44be0ea97a"
       },
       "fill": 1,
       "fillGradient": 0,
@@ -961,7 +955,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "9.5.2",
+      "pluginVersion": "10.0.2",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -976,7 +970,7 @@
             "uid": "P1809F7CD0C75ACF3"
           },
           "editorMode": "code",
-          "expr": "sum(rate(datastore_latency_seconds_sum{action=~\"Store.*\",status=\"success\"}[1m])) / sum(rate(datastore_latency_seconds_count{action=~\"Store.*\",status=\"success\"}[1m]))\n",
+          "expr": "sum(rate(datastore_latency_seconds_sum{action=~\"Store.*\",status=\"success\"}[2m])) / sum(rate(datastore_latency_seconds_count{action=~\"Store.*\",status=\"success\"}[2m]))\n",
           "legendFormat": "success",
           "range": true,
           "refId": "A"
@@ -985,6 +979,176 @@
       "thresholds": [],
       "timeRegions": [],
       "title": "Datastore Write Requests Duration",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:725",
+          "format": "s",
+          "label": "Latency",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:726",
+          "format": "short"
+        }
+      ],
+      "yaxis": {
+        "align": true
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "f6557ad8-98c0-4dc2-a6a8-6e44be0ea97a"
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 5,
+        "w": 12,
+        "x": 0,
+        "y": 33
+      },
+      "hiddenSeries": false,
+      "id": 22,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "10.0.2",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "editorMode": "code",
+          "expr": "sum(irate(indexer_latency_seconds_count{action=~\"Add|Remove.*\"}[2m])) by (action)",
+          "legendFormat": "{{action}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Indexer Write Request Rate",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:384",
+          "format": "short"
+        },
+        {
+          "$$hashKey": "object:385",
+          "format": "short"
+        }
+      ],
+      "yaxis": {
+        "align": true
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "f6557ad8-98c0-4dc2-a6a8-6e44be0ea97a"
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 5,
+        "w": 12,
+        "x": 12,
+        "y": 33
+      },
+      "hiddenSeries": false,
+      "id": 23,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "10.0.2",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(indexer_latency_seconds_sum{action=~\"Add|Remove.*\",status=\"success\"}[2m])) / sum(rate(indexer_latency_seconds_count{action=~\"Add|Remove.*\",status=\"success\"}[2m]))\n",
+          "legendFormat": "success",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Indexer Write Requests Duration",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -1021,13 +1185,13 @@
     "list": []
   },
   "time": {
-    "from": "now-5m",
+    "from": "now-15m",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "",
   "title": "Explorer",
   "uid": "Lp7_c9UVk",
-  "version": 14,
+  "version": 2,
   "weekStart": ""
 }

--- a/website/docs/assets/dashboards/explorer.json
+++ b/website/docs/assets/dashboards/explorer.json
@@ -43,7 +43,10 @@
       "type": "row"
     },
     {
-      "datasource": {},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -124,7 +127,7 @@
       "dashes": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "f6557ad8-98c0-4dc2-a6a8-6e44be0ea97a"
+        "uid": "prometheus"
       },
       "fill": 1,
       "fillGradient": 0,
@@ -225,7 +228,7 @@
       "dashes": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "f6557ad8-98c0-4dc2-a6a8-6e44be0ea97a"
+        "uid": "prometheus"
       },
       "fill": 1,
       "fillGradient": 0,
@@ -313,7 +316,7 @@
       "dashes": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "f6557ad8-98c0-4dc2-a6a8-6e44be0ea97a"
+        "uid": "prometheus"
       },
       "fill": 1,
       "fillGradient": 0,
@@ -397,7 +400,7 @@
       "dashes": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "f6557ad8-98c0-4dc2-a6a8-6e44be0ea97a"
+        "uid": "prometheus"
       },
       "fill": 1,
       "fillGradient": 0,
@@ -484,7 +487,7 @@
       "dashes": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "f6557ad8-98c0-4dc2-a6a8-6e44be0ea97a"
+        "uid": "prometheus"
       },
       "fill": 1,
       "fillGradient": 0,
@@ -568,7 +571,7 @@
       "dashes": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "f6557ad8-98c0-4dc2-a6a8-6e44be0ea97a"
+        "uid": "prometheus"
       },
       "fill": 1,
       "fillGradient": 0,
@@ -668,7 +671,7 @@
       "dashes": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "f6557ad8-98c0-4dc2-a6a8-6e44be0ea97a"
+        "uid": "prometheus"
       },
       "fill": 1,
       "fillGradient": 0,
@@ -843,7 +846,7 @@
       "dashes": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "f6557ad8-98c0-4dc2-a6a8-6e44be0ea97a"
+        "uid": "prometheus"
       },
       "fill": 1,
       "fillGradient": 0,
@@ -927,7 +930,7 @@
       "dashes": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "f6557ad8-98c0-4dc2-a6a8-6e44be0ea97a"
+        "uid": "prometheus"
       },
       "fill": 1,
       "fillGradient": 0,
@@ -1013,7 +1016,7 @@
       "dashes": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "f6557ad8-98c0-4dc2-a6a8-6e44be0ea97a"
+        "uid": "prometheus"
       },
       "fill": 1,
       "fillGradient": 0,
@@ -1097,7 +1100,7 @@
       "dashes": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "f6557ad8-98c0-4dc2-a6a8-6e44be0ea97a"
+        "uid": "prometheus"
       },
       "fill": 1,
       "fillGradient": 0,

--- a/website/docs/explorer/operations.mdx
+++ b/website/docs/explorer/operations.mdx
@@ -221,9 +221,9 @@ datastore_inflight_requests{action="DeleteAllRoleBindings"} 0
 
 ##### Indexer Writes
 
-**Request Latency:** histogram with the latency of the indexer read requests.
+**Request Latency:** histogram with the latency of the indexer write requests.
 
-- `action` is the index read operation that could be either `Add`, `Remove` or `RemoveByQuery`
+- `action` is the index write operation that could be either `Add`, `Remove` or `RemoveByQuery`
 - `status` is the result of the operation. It could be either `success` or `error`
 
 ```
@@ -241,7 +241,7 @@ indexer_latency_seconds_count{action="Remove",status="success"} 3
 
 **Requests In Flight:** gauge with the number of inflight requests being handled at the same time.
 
-- `action` is the index read operation that could be either `Add`, `Remove` or `RemoveByQuery`
+- `action` is the index write operation that could be either `Add`, `Remove` or `RemoveByQuery`
 
 ```
 indexer_inflight_requests{action="Add"} 0

--- a/website/docs/explorer/operations.mdx
+++ b/website/docs/explorer/operations.mdx
@@ -219,6 +219,34 @@ datastore_inflight_requests{action="StoreRoleBindings"} 0
 datastore_inflight_requests{action="DeleteAllRoleBindings"} 0
 ```
 
+##### Indexer Writes
+
+**Request Latency:** histogram with the latency of the indexer read requests.
+
+- `action` is the index read operation that could be either `Add`, `Remove` or `RemoveByQuery`
+- `status` is the result of the operation. It could be either `success` or `error`
+
+```
+indexer_latency_seconds_bucket{action="Add",status="success",le="+Inf"} 109
+indexer_latency_seconds_bucket{action="Remove",status="success",le="+Inf"} 3
+```
+```
+indexer_latency_seconds_sum{action="Add",status="success"} 8.393912168
+indexer_latency_seconds_sum{action="Remove",status="success"} 0.012298476
+```
+```
+indexer_latency_seconds_count{action="Add",status="success"} 109
+indexer_latency_seconds_count{action="Remove",status="success"} 3
+```
+
+**Requests In Flight:** gauge with the number of inflight requests being handled at the same time.
+
+- `action` is the index read operation that could be either `Add`, `Remove` or `RemoveByQuery`
+
+```
+indexer_inflight_requests{action="Add"} 0
+indexer_inflight_requests{action="Remove"} 0
+```
 
 ### Dashboard
 


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Docs for 
https://github.com/weaveworks/weave-gitops-enterprise/pull/3134

<!-- Describe what has changed in this PR -->
**What changed?**
Collecting:
Explorer monitoring documentation extended with indexer write metrics

Dashboard:
Added indexer writes panels to explorer grafana dashboard

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**
Increase observability for datastore and monitor RED metrics for write operations

<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**
Manual test

<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**
added docs for indexer write metrics

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
