### PR TITLE
Allow renaming the default cluster.

### DIFF
--- a/charts/gitops-server/templates/deployment.yaml
+++ b/charts/gitops-server/templates/deployment.yaml
@@ -59,6 +59,9 @@ spec:
             - "--enable-metrics"
             - "--metrics-address=:{{ .Values.metrics.service.port }}"
             {{- end }}
+          {{- if .Values.clusterName }}
+            - "--cluster-name={{ .Values.clusterName }}"
+          {{- end }}
           {{- with .Values.additionalArgs }}
             {{- range . }}
             - {{ . | quote }}

--- a/charts/gitops-server/values.yaml
+++ b/charts/gitops-server/values.yaml
@@ -194,3 +194,7 @@ metrics:
       prometheus.io/scrape: "true"
       prometheus.io/path: "/metrics"
       prometheus.io/port: "{{ .Values.metrics.service.port }}"
+
+# You do not need to set this unless you want to change the name that this
+# cluster responds to.  The default is Default.
+# clusterName: Default

--- a/cmd/gitops-server/cmd/cmd.go
+++ b/cmd/gitops-server/cmd/cmd.go
@@ -152,7 +152,6 @@ func runCmd(cmd *cobra.Command, args []string) error {
 	assetFS := getAssets()
 	assetHandler := http.FileServer(http.FS(assetFS))
 	redirector := createRedirector(assetFS, log)
-	clusterName := kube.InClusterConfigClusterName()
 
 	rest, err := config.GetConfig()
 	if err != nil {
@@ -209,6 +208,8 @@ func runCmd(cmd *cobra.Command, args []string) error {
 		oidcPrefixes.GroupsPrefix = authServer.AuthConfig.OIDCConfig.GroupsPrefix
 	}
 
+	log.Info("Single cluster", "name", options.ClusterName)
+
 	cl, err := cluster.NewSingleCluster(options.ClusterName, rest, scheme, oidcPrefixes, cluster.DefaultKubeConfigOptions...)
 	if err != nil {
 		return fmt.Errorf("failed to create cluster client; %w", err)
@@ -236,7 +237,7 @@ func runCmd(cmd *cobra.Command, args []string) error {
 
 	healthChecker := health.NewHealthChecker()
 
-	coreConfig, err := core.NewCoreConfig(log, rest, clusterName, clustersManager, healthChecker)
+	coreConfig, err := core.NewCoreConfig(log, rest, options.ClusterName, clustersManager, healthChecker)
 	if err != nil {
 		return fmt.Errorf("could not create core config: %w", err)
 	}

--- a/cmd/gitops-server/cmd/cmd.go
+++ b/cmd/gitops-server/cmd/cmd.go
@@ -75,6 +75,8 @@ type Options struct {
 	EnableMetrics  bool
 	MetricsAddress string
 
+	ClusterName string
+
 	UseK8sCachedClients bool
 }
 
@@ -98,6 +100,7 @@ func NewCommand() *cobra.Command {
 	cmd.Flags().StringVar(&options.NotificationControllerAddress, "notification-controller-address", "", "the address of the notification-controller running in the cluster")
 	cmd.Flags().StringVar(&options.Path, "path", "", "Path url")
 	cmd.Flags().StringVar(&options.Port, "port", server.DefaultPort, "UI port")
+	cmd.Flags().StringVar(&options.ClusterName, "cluster-name", cluster.DefaultCluster, "Internal name of the cluster")
 	cmd.Flags().StringSliceVar(&options.AuthMethods, "auth-methods", auth.DefaultAuthMethodStrings(), fmt.Sprintf("Which auth methods to use, valid values are %s", strings.Join(auth.DefaultAuthMethodStrings(), ",")))
 	cmd.Flags().BoolVar(&options.UseK8sCachedClients, "use-k8s-cached-clients", false, "Enables the use of cached clients")
 	//  TLS
@@ -206,7 +209,7 @@ func runCmd(cmd *cobra.Command, args []string) error {
 		oidcPrefixes.GroupsPrefix = authServer.AuthConfig.OIDCConfig.GroupsPrefix
 	}
 
-	cl, err := cluster.NewSingleCluster(cluster.DefaultCluster, rest, scheme, oidcPrefixes, cluster.DefaultKubeConfigOptions...)
+	cl, err := cluster.NewSingleCluster(options.ClusterName, rest, scheme, oidcPrefixes, cluster.DefaultKubeConfigOptions...)
 	if err != nil {
 		return fmt.Errorf("failed to create cluster client; %w", err)
 	}

--- a/cmd/gitops-server/main.go
+++ b/cmd/gitops-server/main.go
@@ -1,15 +1,10 @@
 package main
 
 import (
-	"fmt"
-	"os"
-
+	"github.com/spf13/cobra"
 	"github.com/weaveworks/weave-gitops/cmd/gitops-server/cmd"
 )
 
 func main() {
-	if err := cmd.NewCommand().Execute(); err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-		os.Exit(1)
-	}
+	cobra.CheckErr(cmd.NewCommand().Execute())
 }

--- a/core/server/server.go
+++ b/core/server/server.go
@@ -38,12 +38,13 @@ type coreServer struct {
 	primaryKinds    *PrimaryKinds
 	crd             crd.Fetcher
 	healthChecker   health.HealthChecker
+	ClusterName     string
 }
 
 type CoreServerConfig struct {
-	log             logr.Logger
+	Log             logr.Logger
 	RestCfg         *rest.Config
-	clusterName     string
+	ClusterName     string
 	NSAccess        nsaccess.Checker
 	ClustersManager clustersmngr.ClustersManager
 	PrimaryKinds    *PrimaryKinds
@@ -58,9 +59,9 @@ func NewCoreConfig(log logr.Logger, cfg *rest.Config, clusterName string, cluste
 	}
 
 	return CoreServerConfig{
-		log:             log.WithName("core-server"),
+		Log:             log.WithName("core-server"),
 		RestCfg:         cfg,
-		clusterName:     clusterName,
+		ClusterName:     clusterName,
 		NSAccess:        nsaccess.NewChecker(nsaccess.DefautltWegoAppRules),
 		ClustersManager: clustersManager,
 		PrimaryKinds:    kinds,
@@ -70,15 +71,16 @@ func NewCoreConfig(log logr.Logger, cfg *rest.Config, clusterName string, cluste
 
 func NewCoreServer(cfg CoreServerConfig) (pb.CoreServer, error) {
 	if cfg.CRDService == nil {
-		cfg.CRDService = crd.NewFetcher(cfg.log, cfg.ClustersManager)
+		cfg.CRDService = crd.NewFetcher(cfg.Log, cfg.ClustersManager)
 	}
 
 	return &coreServer{
-		logger:          cfg.log,
+		logger:          cfg.Log,
 		nsChecker:       cfg.NSAccess,
 		clustersManager: cfg.ClustersManager,
 		primaryKinds:    cfg.PrimaryKinds,
 		crd:             cfg.CRDService,
 		healthChecker:   cfg.HealthChecker,
+		ClusterName:     cfg.ClusterName,
 	}, nil
 }

--- a/core/server/version.go
+++ b/core/server/version.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/weaveworks/weave-gitops/core/clustersmngr/cluster"
 	pb "github.com/weaveworks/weave-gitops/pkg/api/core"
 	"github.com/weaveworks/weave-gitops/pkg/server/auth"
 )
@@ -22,7 +21,7 @@ const (
 )
 
 func (cs *coreServer) getKubeVersion(ctx context.Context) (string, error) {
-	dc, err := cs.clustersManager.GetImpersonatedDiscoveryClient(ctx, auth.Principal(ctx), cluster.DefaultCluster)
+	dc, err := cs.clustersManager.GetImpersonatedDiscoveryClient(ctx, auth.Principal(ctx), cs.ClusterName)
 	if err != nil {
 		return "", fmt.Errorf("error creating discovery client: %w", err)
 	}

--- a/ui/hooks/flux.ts
+++ b/ui/hooks/flux.ts
@@ -10,15 +10,10 @@ import {
 import { GroupVersionKind, Kind } from "../lib/api/core/types.pb";
 import { getChildren } from "../lib/graph";
 import { FluxObject } from "../lib/objects";
-import {
-  DefaultCluster,
-  NoNamespace,
-  ReactQueryOptions,
-  RequestError,
-} from "../lib/types";
+import { NoNamespace, ReactQueryOptions, RequestError } from "../lib/types";
 import { notifyError, notifySuccess } from "../lib/utils";
 export function useListFluxRuntimeObjects(
-  clusterName = DefaultCluster,
+  clusterName: string,
   namespace = NoNamespace,
   opts: ReactQueryOptions<ListFluxRuntimeObjectsResponse, RequestError> = {
     retry: false,
@@ -34,7 +29,7 @@ export function useListFluxRuntimeObjects(
   );
 }
 
-export function useListFluxCrds(clusterName = DefaultCluster) {
+export function useListFluxCrds(clusterName: string) {
   const { api } = useContext(CoreClientContext);
 
   return useQuery<ListFluxCrdsResponse, RequestError>(
@@ -55,7 +50,7 @@ export function useGetReconciledObjects(
   namespace: string,
   type: Kind,
   kinds: GroupVersionKind[],
-  clusterName = DefaultCluster,
+  clusterName: string,
   opts: ReactQueryOptions<FluxObject[], RequestError> = {
     retry: false,
     refetchInterval: 5000,
@@ -80,7 +75,7 @@ export function useGetReconciledTree(
   namespace: string,
   type: Kind,
   kinds: GroupVersionKind[],
-  clusterName = DefaultCluster,
+  clusterName: string,
   opts: ReactQueryOptions<FluxObject[], RequestError> = {
     retry: false,
     refetchInterval: 5000,

--- a/ui/hooks/flux.ts
+++ b/ui/hooks/flux.ts
@@ -10,11 +10,9 @@ import {
 import { GroupVersionKind, Kind } from "../lib/api/core/types.pb";
 import { getChildren } from "../lib/graph";
 import { FluxObject } from "../lib/objects";
-import { NoNamespace, ReactQueryOptions, RequestError } from "../lib/types";
+import { ReactQueryOptions, RequestError } from "../lib/types";
 import { notifyError, notifySuccess } from "../lib/utils";
 export function useListFluxRuntimeObjects(
-  clusterName: string,
-  namespace = NoNamespace,
   opts: ReactQueryOptions<ListFluxRuntimeObjectsResponse, RequestError> = {
     retry: false,
     refetchInterval: 5000,
@@ -24,17 +22,17 @@ export function useListFluxRuntimeObjects(
 
   return useQuery<ListFluxRuntimeObjectsResponse, RequestError>(
     "flux_runtime_objects",
-    () => api.ListFluxRuntimeObjects({ namespace, clusterName }),
+    () => api.ListFluxRuntimeObjects({}),
     opts
   );
 }
 
-export function useListFluxCrds(clusterName: string) {
+export function useListFluxCrds() {
   const { api } = useContext(CoreClientContext);
 
   return useQuery<ListFluxCrdsResponse, RequestError>(
     "flux_crds",
-    () => api.ListFluxCrds({ clusterName }),
+    () => api.ListFluxCrds({}),
     { retry: false, refetchInterval: 5000 }
   );
 }

--- a/ui/lib/types.ts
+++ b/ui/lib/types.ts
@@ -52,7 +52,6 @@ export enum V2Routes {
   NotImplemented = "/not_implemented",
 }
 
-export const DefaultCluster = "Default";
 export const NoNamespace = "";
 
 export interface Source {


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes

<!-- Describe what has changed in this PR -->
**What changed?**
This provides functionality for renaming the default cluster in Weave GitOps from "Default" to a custom name.

Simple command-line rename, chart entry for setting it when required.

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**
To allow us to pass in names from the Backstage plugin.

<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**


<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
Tweak the helm values in `tools/helm-values-dev.yaml`:

```diff
+clusterName: testing
+
```

The new cluster name will be visible in the URL bar and queries to the backend will include the new name.

**How did you validate the change?**
See above

<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**
Nothing

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
This will be addressed in the Backstage docs.