### PR TITLE
Add redirects for orphaned website pages

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -41,6 +41,18 @@ module.exports = {
             to: '/docs/intro-weave-gitops/',
             from: ['/docs/getting-started'],
           },
+          {
+            to: '/docs/intro-weave-gitops/',
+            from: '/docs/0.6.2/getting-started'
+          },
+          {
+            to: '/docs/intro-weave-gitops/',
+            from: '/docs/releases'
+          },
+          {
+            to: '/docs/enterprise/getting-started/releases-enterprise/',
+            from: ['/docs/enterprise/releases/']
+          }
         ],
       },
     ],


### PR DESCRIPTION
closes weaveworks/weave-gitops-enterprise#3192

Redirects added:

- https://staging.docs.gitops.weave.works/3192-redirects/docs/intro-weave-gitops
- https://staging.docs.gitops.weave.works/3192-redirects/docs/releases
- https://staging.docs.gitops.weave.works/3192-redirects/docs/enterprise/releases