### PR TITLE
Fix version in tf getting started guide

### DIFF
--- a/website/docs/terraform/get-started-terraform.mdx
+++ b/website/docs/terraform/get-started-terraform.mdx
@@ -148,7 +148,7 @@ spec:
 In this mode, Terraform resources will be planned and automatically applied for you. Enable it by setting `.spec.approvePlan=auto`: 
 
 ```yaml
-apiVersion: infra.contrib.fluxcd.io/v1alpha1
+apiVersion: infra.contrib.fluxcd.io/v1alpha2
 kind: Terraform
 metadata:
   name: helloworld


### PR DESCRIPTION
the getting started guide currently leads to an error where the Terraform crd isn't found due to a version mismatch where v1alpha1 should really be v1alpha2 - FIXED IT
