### PR TITLE
Add batch error handling to Notifications page

### DIFF
--- a/ui/components/Alert.tsx
+++ b/ui/components/Alert.tsx
@@ -1,7 +1,8 @@
-import { AlertTitle, Alert as MaterialAlert } from "@material-ui/lab";
+import { Alert as MaterialAlert, AlertTitle } from "@material-ui/lab";
 import * as React from "react";
 import styled from "styled-components";
 import Flex from "./Flex";
+import Icon, { IconType } from "./Icon";
 import Text from "./Text";
 
 /** Alert Properties */
@@ -21,7 +22,12 @@ export interface Props {
 function UnstyledAlert({ center, title, message, severity, className }: Props) {
   return (
     <Flex wide start={!center} className={className}>
-      <MaterialAlert severity={severity}>
+      <MaterialAlert
+        icon={
+          <Icon type={IconType.ErrorIcon} size="medium" color="alertDark" />
+        }
+        severity={severity}
+      >
         <AlertTitle>{title}</AlertTitle>
         <Text color="black">{message}</Text>
       </MaterialAlert>

--- a/ui/components/ErrorList.tsx
+++ b/ui/components/ErrorList.tsx
@@ -1,0 +1,128 @@
+import { Box, Collapse } from "@material-ui/core";
+import { Alert } from "@material-ui/lab";
+import { sortBy, uniqBy } from "lodash";
+import * as React from "react";
+import styled from "styled-components";
+import Button from "./Button";
+import Flex from "./Flex";
+import Icon, { IconType } from "./Icon";
+import Text from "./Text";
+
+interface Error {
+  clusterName?: string;
+  namespace?: string;
+  message?: string;
+}
+
+type Props = {
+  className?: string;
+  errors?: Error[];
+};
+
+const BoxWrapper = styled(Box)`
+  .MuiAlert-root {
+    width: auto;
+    margin-bottom: ${(props) => props.theme.spacing.base};
+    background: ${(props) => props.theme.colors.alertLight};
+    border-radius: ${(props) => props.theme.spacing.xs};
+  }
+  .MuiAlert-action {
+    display: inline;
+    color: ${(props) => props.theme.colors.alertMedium};
+  }
+  .MuiIconButton-root:hover {
+    background-color: ${(props) => props.theme.colors.alertLight};
+  }
+  .MuiAlert-icon {
+    .MuiSvgIcon-root {
+      display: none;
+    }
+  }
+  .MuiAlert-message {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+`;
+
+const ErrorText = styled(Text)`
+  margin-left: 8px;
+`;
+
+const NavButton = styled(Button)`
+  padding: 0;
+  min-width: auto;
+  margin: 0;
+`;
+
+const ErrorsCount = styled.span`
+  background: ${(props) => props.theme.colors.alertDark};
+  color: ${(props) => props.theme.colors.white};
+  padding: 4px;
+  border-radius: 4px;
+  margin: 0 4px;
+`;
+
+function ErrorList({ className, errors }: Props) {
+  const [expand, setExpand] = React.useState(true);
+  const [index, setIndex] = React.useState(0);
+
+  if (!errors || !errors.length) {
+    return null;
+  }
+
+  const uniq = uniqBy(errors, (error) =>
+    [error.clusterName, error.message].join()
+  );
+
+  const sorted = sortBy(uniq, "clusterName", "namespace", "message");
+  const currentError = sorted[index];
+
+  return (
+    <BoxWrapper className={className} id="alert-list-errors">
+      <Collapse in={expand}>
+        <Alert severity="error" onClose={() => setExpand(false)}>
+          <Flex align center>
+            <Icon size="medium" type={IconType.ErrorIcon} color="alertDark" />
+            <ErrorText size="medium" data-testid="error-message" color="black">
+              {currentError.clusterName}:&nbsp;
+              {currentError.message}
+            </ErrorText>
+          </Flex>
+          <Flex align center>
+            <NavButton
+              disabled={index === 0}
+              data-testid="prevError"
+              onClick={() => setIndex((currIndex) => currIndex - 1)}
+            >
+              <Icon
+                type={IconType.NavigateBeforeIcon}
+                color="alertMedium"
+                size="medium"
+              />
+            </NavButton>
+            <ErrorsCount data-testid="errorsCount">
+              {index + 1} / {sorted.length}
+            </ErrorsCount>
+            <NavButton
+              disabled={sorted.length === index + 1}
+              id="nextError"
+              data-testid="nextError"
+              onClick={() => setIndex((currIndex) => currIndex + 1)}
+            >
+              <Icon
+                type={IconType.NavigateNextIcon}
+                color="alertMedium"
+                size="medium"
+              />
+            </NavButton>
+          </Flex>
+        </Alert>
+      </Collapse>
+    </BoxWrapper>
+  );
+}
+
+export default styled(ErrorList).attrs({ className: ErrorList.name })`
+  width: 100%;
+`;

--- a/ui/index.ts
+++ b/ui/index.ts
@@ -13,6 +13,7 @@ import DataTable, {
 import DependenciesView from "./components/DependenciesView";
 import DetailModal from "./components/DetailModal";
 import DirectedGraph from "./components/DirectedGraph";
+import ErrorList from "./components/ErrorList";
 import EventsTable from "./components/EventsTable";
 import Flex from "./components/Flex";
 import FluxObjectsTable from "./components/FluxObjectsTable";
@@ -145,6 +146,7 @@ export {
   DialogYamlView,
   DirectedGraph,
   EventsTable,
+  ErrorList,
   Flex,
   FluxObject,
   FluxObjectsTable,

--- a/ui/pages/v2/Notifications.tsx
+++ b/ui/pages/v2/Notifications.tsx
@@ -1,5 +1,7 @@
 import * as React from "react";
 import styled from "styled-components";
+import Alert from "../../components/Alert";
+import ErrorList from "../../components/ErrorList";
 import NotificationsTable from "../../components/NotificationsTable";
 import Page from "../../components/Page";
 import { useListProviders } from "../../hooks/notifications";
@@ -13,9 +15,12 @@ function Notifications({ className }: Props) {
     <Page
       className={className}
       loading={isLoading}
-      error={data?.errors || error}
       path={[{ label: "Notifications" }]}
     >
+      {error && (
+        <Alert severity="error" title="Request Error" message={error.message} />
+      )}
+      <ErrorList errors={data?.errors} />
       <NotificationsTable rows={data?.objects} />
     </Page>
   );


### PR DESCRIPTION
Closes #3634 

Adds an `ErrorList` component to Core, heavily inspired by the one used in EE. This also exports the `ErrorList` component so that it may be imported in EE and eventually subsume the `AlertListErrors` component (there is nothing wrong with that component currently, but this will enforce Consistency:tm:).

There are now two error "classes" on the page:

Error when we can't reach the backend:
![Screenshot from 2023-08-09 12-40-04](https://github.com/weaveworks/weave-gitops/assets/2802257/1a4704b6-c877-4ba7-abfc-7e3a1df858f2)

Batched errors from various clusters (backend returns lots of errors):
![Screenshot from 2023-08-09 12-40-22](https://github.com/weaveworks/weave-gitops/assets/2802257/545d3f65-14df-46ec-9113-0ff1ebdabdba)

Simulated the error state using this:

```diff
 core/server/objects.go | 10 ++++++++++
 1 file changed, 10 insertions(+)

diff --git a/core/server/objects.go b/core/server/objects.go
index 0bb6e26d5..f99290bbc 100644
--- a/core/server/objects.go
+++ b/core/server/objects.go
@@ -14,6 +14,7 @@ import (
 	pb "github.com/weaveworks/weave-gitops/pkg/api/core"
 	"github.com/weaveworks/weave-gitops/pkg/run/constants"
 	"github.com/weaveworks/weave-gitops/pkg/server/auth"
+	"github.com/weaveworks/weave-gitops/pkg/utils"
 	v1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -148,6 +149,15 @@ func (cs *coreServer) ListObjects(ctx context.Context, msg *pb.ListObjectsReques
 		}
 	}
 
+	if msg.Kind == "Provider" {
+
+		for i := 0; i < 50; i++ {
+			msg, _ := utils.GenerateRandomString(5, 10)
+			respErrors = append(respErrors, &pb.ListError{ClusterName: "provider", Message: fmt.Sprintf("such and such is forbidden in namespace: %v", msg)})
+		}
+
+	}
+
 	return &pb.ListObjectsResponse{
 		Objects: results,
 		Errors:  respErrors,
```