### PR TITLE
Add redirect for another orphaned docs page

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -52,6 +52,10 @@ module.exports = {
           {
             to: '/docs/enterprise/getting-started/releases-enterprise/',
             from: ['/docs/enterprise/releases/']
+          },
+          {
+            to: '/docs/intro-weave-gitops/',
+            from: '/docs/intro'
           }
         ],
       },


### PR DESCRIPTION
This page is being linked to from some publicly available Weaveworks presentations so we better have that one covered.

Affected page: https://staging.docs.gitops.weave.works/3192-redirects/docs/intro should redirect to https://staging.docs.gitops.weave.works/3192-redirects/docs/intro-weave-gitops

refs weaveworks/weave-gitops-enterprise#3192
