### PR TITLE
Remove titles from detail pages for consistency 

### DIFF
--- a/ui/components/AutomationDetail.tsx
+++ b/ui/components/AutomationDetail.tsx
@@ -245,9 +245,6 @@ export default styled(AutomationDetail).attrs({
   ${Collapsible} {
     width: 100%;
   }
-  ${PageStatus} {
-    padding: ${(props) => props.theme.spacing.small} 0px;
-  }
   .collapse-wrapper {
     padding: 16px 44px;
     width: 100%;

--- a/ui/components/ImageAutomation/ImageAutomationDetails.tsx
+++ b/ui/components/ImageAutomation/ImageAutomationDetails.tsx
@@ -8,7 +8,6 @@ import PageStatus from "../PageStatus";
 import Spacer from "../Spacer";
 import SubRouterTabs, { RouterTab } from "../SubRouterTabs";
 import SyncActions from "../SyncActions";
-import Text from "../Text";
 import YamlView from "../YamlView";
 
 interface Props {
@@ -32,9 +31,6 @@ const ImageAutomationDetails = ({
 
   return (
     <Flex wide tall column className={className}>
-      <Text size="large" semiBold titleHeight>
-        {name}
-      </Text>
       <PageStatus conditions={conditions} suspended={suspended} />
       {kind !== Kind.ImagePolicy && (
         <SyncActions
@@ -85,9 +81,6 @@ const ImageAutomationDetails = ({
 export default styled(ImageAutomationDetails).attrs({
   className: ImageAutomationDetails.name,
 })`
-  ${PageStatus} {
-    padding: ${(props) => props.theme.spacing.small} 0px;
-  }
   ${SubRouterTabs} {
     margin-top: ${(props) => props.theme.spacing.medium};
   }

--- a/ui/components/PageStatus.tsx
+++ b/ui/components/PageStatus.tsx
@@ -71,6 +71,7 @@ function PageStatus({
   );
 }
 export default styled(PageStatus).attrs({ className: PageStatus.name })`
+  padding-bottom: ${(props) => props.theme.spacing.small};
   transition-property: max-height;
   transition-duration: 0.5s;
   transition-timing-function: ease-in-out;

--- a/ui/components/PodDetail.tsx
+++ b/ui/components/PodDetail.tsx
@@ -182,7 +182,7 @@ function PodDetail({ className, pod }: Props) {
 
 export default styled(PodDetail).attrs({ className: PodDetail.name })`
   height: 100%;
-  ${PageStatus}, ${NoDialogDataTable} {
+  ${NoDialogDataTable} {
     margin-bottom: ${(props) => props.theme.spacing.small};
   }
 `;

--- a/ui/components/SourceDetail.tsx
+++ b/ui/components/SourceDetail.tsx
@@ -15,7 +15,6 @@ import Metadata from "./Metadata";
 import PageStatus from "./PageStatus";
 import SubRouterTabs, { RouterTab } from "./SubRouterTabs";
 import SyncActions from "./SyncActions";
-import Text from "./Text";
 import YamlView from "./YamlView";
 
 type Props = {
@@ -65,9 +64,6 @@ function SourceDetail({ className, source, info, type, customActions }: Props) {
 
   return (
     <Flex wide tall column className={className}>
-      <Text size="large" semiBold titleHeight>
-        {source.name}
-      </Text>
       <PageStatus conditions={source.conditions} suspended={source.suspended} />
       <SyncActions
         name={name}
@@ -115,9 +111,6 @@ function SourceDetail({ className, source, info, type, customActions }: Props) {
 }
 
 export default styled(SourceDetail).attrs({ className: SourceDetail.name })`
-  ${PageStatus} {
-    padding: ${(props) => props.theme.spacing.small} 0px;
-  }
   ${SubRouterTabs} {
     margin-top: ${(props) => props.theme.spacing.medium};
   }


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Part of: #3890 

Checked detail pages in OSS and removed detail page titles accordingly - also adjusted a common override on PageStatus to be the default. This does not close the titles issue, as I'd like to check EE as well
