### PR TITLE
Implement release locking to avoid publishing helm chart before container image 

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -274,7 +274,7 @@ jobs:
     steps:
       - name: Release
         run: |
-          curl --request POST \
+          curl --fail --request POST \
             --url https://api.github.com/repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha }} \
             --header 'authorization: Bearer ${{ secrets.WEAVE_GITOPS_BOT_ACCESS_TOKEN }}' \
             --header 'content-type: application/json' \

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -267,6 +267,22 @@ jobs:
     steps:
       - run: echo "All done"
 
+  release:
+    if: ${{ !startsWith(github.event.pull_request.head.ref, 'releases/') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Release
+        run: |
+          curl --request POST \
+            --url https://api.github.com/repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha }} \
+            --header 'authorization: Bearer ${{ secrets.WEAVE_GITOPS_BOT_ACCESS_TOKEN }}' \
+            --header 'content-type: application/json' \
+            --data '{
+                "state":"success",
+                "description":"release not required",
+                "context":"release"
+              }'
+
   notify-failure:
     name: Notify Slack on Failure
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -267,8 +267,9 @@ jobs:
     steps:
       - run: echo "All done"
 
+  #  release step updates 'release' status check for non releases branches. See ../../doc/incidents/issues-3907 for full context.
   release:
-    if: ${{ !startsWith(github.event.pull_request.head.ref, 'releases/') }}
+    if: ${{ github.event_name == 'pull_request' && !startsWith(github.event.pull_request.head.ref, 'releases/') }}
     runs-on: ubuntu-latest
     steps:
       - name: Release

--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -115,6 +115,17 @@ jobs:
            ${{ steps.github_release.outputs.changelog }}
           token: ${{ secrets.WEAVE_GITOPS_BOT_ACCESS_TOKEN }}
           labels: "exclude from release notes"
+      - name: Lock Release PR Merge
+        run: |
+          curl --request POST \
+            --url https://api.github.com/repos/${{ github.repository }}/statuses/${{ steps.create-pull-request.outputs.pull-request-head-sha }} \
+            --header 'authorization: Bearer ${{ secrets.WEAVE_GITOPS_BOT_ACCESS_TOKEN }}' \
+            --header 'content-type: application/json' \
+            --data '{
+                "state":"pending",
+                "description":"execute the release to pass this check",
+                "context":"release"
+              }'
       - name: "Comment on pull request"
         run: |
           curl --request POST \

--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -115,9 +115,10 @@ jobs:
            ${{ steps.github_release.outputs.changelog }}
           token: ${{ secrets.WEAVE_GITOPS_BOT_ACCESS_TOKEN }}
           labels: "exclude from release notes"
-      - name: Lock Release PR Merge
+      #  'Lock Release PR Merge' sets 'release' status check with pending state to avoid accidentally merging the release PR. See ../../doc/incidents/issues-3907 for full context.
+      - name: Lock Release PR
         run: |
-          curl --request POST \
+          curl --fail --request POST \
             --url https://api.github.com/repos/${{ github.repository }}/statuses/${{ steps.create-pull-request.outputs.pull-request-head-sha }} \
             --header 'authorization: Bearer ${{ secrets.WEAVE_GITOPS_BOT_ACCESS_TOKEN }}' \
             --header 'content-type: application/json' \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -168,9 +168,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+      #  'Unlock Release PR Merge' sets 'release' status check state to success to unlock merging the release PR. See ../../doc/incidents/issues-3907 for full context.
       - name: Unlock Release PR Merge
         run: |
-          curl --request POST \
+          curl --fail --request POST \
             --url https://api.github.com/repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha }} \
             --header 'authorization: Bearer ${{ secrets.WEAVE_GITOPS_BOT_ACCESS_TOKEN }}' \
             --header 'content-type: application/json' \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -168,6 +168,17 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+      - name: Unlock Release PR Merge
+        run: |
+          curl --request POST \
+            --url https://api.github.com/repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha }} \
+            --header 'authorization: Bearer ${{ secrets.WEAVE_GITOPS_BOT_ACCESS_TOKEN }}' \
+            --header 'content-type: application/json' \
+            --data '{
+                "state":"success",
+                "description":"release happened. PR ready to merge",
+                "context":"release"
+              }'
       - name: "Merge release"
         run: |
           curl --request PUT \

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -48,9 +48,7 @@ To release a new version of Weave Gitops, you need to:
     called "Doc site preview")
 - The PR cover message contains draft release notes. Edit the cover
   message to fill in or delete blocks as appropriate. In case of making a fix release because of regressions, add a message about the regression to the release notes. Move as many PRs out of "Uncategorized" as you possibly can.
-- If everything looks good, approve the PR - do *not* merge or things
-  won't be published in the right order. This immediately kicks off the
-  release job.
+- If everything looks good, approve the PR to trigger the [release](../.github/workflows/release.yaml) workflow.
 - Wait for the action to finish, at which point the PR will be merged automatically.
 - Notify weave-gitops-dev channel that PRs are now safe to merge.
 


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes https://github.com/weaveworks/weave-gitops/issues/3907

<!-- Describe what has changed in this PR -->
**What changed?**

Implements locking action as suggested [here](https://github.com/weaveworks/weave-gitops/tree/main/doc/incidents/issues-3907#prevention)


<!-- Tell your future self why have you made these changes -->
**Why was this change made?**

To reduce chances of release incident happened in [v0.29](https://github.com/weaveworks/weave-gitops/tree/main/doc/incidents/issues-3907) to happen in future release and simplify the releaser job.


<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**

Added status check called 'release' with locking semantics around release and non-release workflows. It also includes 
other enhancements from the original proposal like error prograpation while doing status checks update in github actions steps. 

<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**

The following scenarios has been tested in the context of the development repo. It will require to be validated for this repo once the code is merged.


**for a non-release PR** 

1) A [push into main](https://github.com/enekofb/weave-gitops/commit/07333862ee9a163bc1e0a5c10dc5ec5f04e17a6e
) does not require release status check 

2) A [PR to main](https://github.com/enekofb/weave-gitops/pull/12/checks) does passes without any intervention  

3) A PR to main that [might fails](https://github.com/enekofb/weave-gitops/pull/12/commits) the api endpoint call is stable and could be retried

<img width="1526" alt="Screenshot 2023-08-15 at 09 31 04" src="https://github.com/weaveworks/weave-gitops/assets/12957664/c614e33d-0356-4d55-ba35-cd8e00868274">

**for a release PR** 

2) A [release PR to main](https://github.com/enekofb/weave-gitops/pull/13) merges without any intervention

3) A release PR to main that [fails](https://github.com/enekofb/weave-gitops/actions/runs/5865309730/job/15901979520) cannot be merged until the status check is not unlocked

<img width="1194" alt="Screenshot 2023-08-15 at 09 46 49" src="https://github.com/weaveworks/weave-gitops/assets/12957664/6d05628a-46f5-4c37-9c13-bdac55d7943d">

<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**

No


<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**

No
