### PR TITLE
Fixes WGE username field in installation guide

### DIFF
--- a/website/docs/enterprise/getting-started/install-enterprise.mdx
+++ b/website/docs/enterprise/getting-started/install-enterprise.mdx
@@ -495,7 +495,7 @@ Now create a Kubernetes secret to store your chosen username and the password ha
 ```sh
 kubectl create secret generic cluster-user-auth \
   --namespace flux-system \
-  --from-literal=username=admin \
+  --from-literal=username=wego-admin \
   --from-literal=password='$2a$10$OS5NJmPNEb13UTOSKngMxOWlmS7mlxX77hv4yAiISvZ71Dc7IuN3q'
 ```
 


### PR DESCRIPTION
It should be `wego-admin` to align with hard coded rolebinding.subject
