### PR TITLE
Set static height on signin footer

### DIFF
--- a/ui/pages/SignIn.tsx
+++ b/ui/pages/SignIn.tsx
@@ -44,6 +44,7 @@ const OidcFlex = styled(Flex)`
 const Footer = styled(Flex)`
   & img {
     width: 500px;
+    height: 300px;
   }
 `;
 


### PR DESCRIPTION
Closes #3210 

Sets a static height on the footer to ignore the "wheel" image height. I chose `300px` because it was roughly what both images were resolving to naturally.