### PR TITLE
Clear filters on datatable destroy

### DIFF
--- a/ui/components/DataTable/DataTable.tsx
+++ b/ui/components/DataTable/DataTable.tsx
@@ -248,17 +248,6 @@ function UnstyledDataTable({
       </TableRow>
     );
   });
-
-  React.useEffect(() => {
-    return () => {
-      const url = qs.parse(location.search);
-      const clearFilters = _.omit(url, ["filters", "search"]);
-      history.replace({
-        ...history.location,
-        search: qs.stringify(clearFilters),
-      });
-    };
-  }, [history]);
   return (
     <Flex wide tall column className={className}>
       <TopBar wide align end>

--- a/ui/components/DataTable/DataTable.tsx
+++ b/ui/components/DataTable/DataTable.tsx
@@ -248,6 +248,17 @@ function UnstyledDataTable({
       </TableRow>
     );
   });
+
+  React.useEffect(() => {
+    return () => {
+      const url = qs.parse(location.search);
+      const clearFilters = _.omit(url, ["filters", "search"]);
+      history.replace({
+        ...history.location,
+        search: qs.stringify(clearFilters),
+      });
+    };
+  }, [history]);
   return (
     <Flex wide tall column className={className}>
       <TopBar wide align end>

--- a/ui/components/FilterDialog.tsx
+++ b/ui/components/FilterDialog.tsx
@@ -120,14 +120,14 @@ export function selectionsToFilters(
 
     if (v) {
       const el = out[key];
-
       if (el) {
         el.options.push(val);
       } else {
-        out[key] = {
-          options: [val],
-          transformFunc: filterList[key]?.transformFunc,
-        };
+        if (filterList)
+          out[key] = {
+            options: [val],
+            transformFunc: filterList[key]?.transformFunc,
+          };
       }
     }
   });


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes

<!-- Describe what has changed in this PR -->
**What changed?**
We've `Datatable`  component that deals with two different filters [_explorer filters_ & _normal filters_]  this will lead to an issue on switching between URLs "switching between tabs that includes table data that can be filtered" .

To fix the error that cause page to breaks we need to check if the filters is already exist before using it for now . 

https://github.com/weaveworks/weave-gitops/assets/4614360/87302338-e608-4115-8436-b88de0d79877


https://github.com/weaveworks/weave-gitops/assets/4614360/2b70c40e-d4b8-4cea-8f4b-62c8d8832f3e

