### PR TITLE
dashboard helmrepository apiVersion should be v1beta2 not v1

### DIFF
--- a/pkg/run/install/install_dashboard.go
+++ b/pkg/run/install/install_dashboard.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	sourcev1b2 "github.com/fluxcd/source-controller/api/v1beta2"
 	"strings"
 	"time"
 
+	sourcev1b2 "github.com/fluxcd/source-controller/api/v1beta2"
+
 	helmv2 "github.com/fluxcd/helm-controller/api/v2beta1"
-	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 	coretypes "github.com/weaveworks/weave-gitops/core/server/types"
 	"github.com/weaveworks/weave-gitops/pkg/config"
 	"github.com/weaveworks/weave-gitops/pkg/logger"
@@ -301,7 +301,7 @@ func makeHelmRepository(name, namespace string) *sourcev1b2.HelmRepository {
 	helmRepository := &sourcev1b2.HelmRepository{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       sourcev1b2.HelmRepositoryKind,
-			APIVersion: sourcev1.GroupVersion.Identifier(),
+			APIVersion: sourcev1b2.GroupVersion.Identifier(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,

--- a/pkg/run/install/install_dashboard_test.go
+++ b/pkg/run/install/install_dashboard_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	helmv2 "github.com/fluxcd/helm-controller/api/v2beta1"
-	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 	sourcev1b2 "github.com/fluxcd/source-controller/api/v1beta2"
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
@@ -397,7 +396,7 @@ var _ = Describe("makeHelmRepository", func() {
 	It("creates helmrepository", func() {
 		actual := makeHelmRepository(testDashboardName, testNamespace)
 		Expect(actual.Kind).To(Equal(sourcev1b2.HelmRepositoryKind))
-		Expect(actual.APIVersion).To(Equal(sourcev1.GroupVersion.Identifier()))
+		Expect(actual.APIVersion).To(Equal(sourcev1b2.GroupVersion.Identifier()))
 		Expect(actual.Name).To(Equal(testDashboardName))
 		Expect(actual.Namespace).To(Equal(testNamespace))
 


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes https://github.com/weaveworks/weave-gitops/issues/3957

<!-- Describe what has changed in this PR -->
**What changed?**

Changes generated dashboard helmrepository apiVersion from v1 to v1beta2


<!-- Tell your future self why have you made these changes -->
**Why was this change made?**

HelmRepository still not yet in v1 so creating in v1 will end in the resource not been created

<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**

- Adjusted unit test expectation 
- Executed the command [too](https://github.com/weaveworks/weave-gitops/issues/3957#issuecomment-1687693817)

<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**
No

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
No