### PR TITLE
predictable resolution for gitrepository gvk when v1 and v1beta2 exist

### DIFF
--- a/core/server/primarykinds.go
+++ b/core/server/primarykinds.go
@@ -25,7 +25,7 @@ const (
 	// It's multiplied with the digit following the "beta" suffix.
 	// Beta versions are more stable than alpha versions but might still contain bugs.
 	// They are given a higher weight than alpha versions.
-	betaWeight = 500
+	betaWeight = 50
 
 	// stableWeight is a weight assigned to stable versions (those without an "alpha" or "beta" suffix).
 	// Stable versions are the final, production-ready releases of software, hence they have the highest weight.

--- a/core/server/primarykinds_test.go
+++ b/core/server/primarykinds_test.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
 
@@ -18,8 +17,11 @@ func TestVersionRank(t *testing.T) {
 		gvk2     schema.GroupVersionKind
 		expected int
 	}{
+
 		{schema.GroupVersionKind{Version: "v1"}, schema.GroupVersionKind{Version: "v1alpha1"}, 1},
 		{schema.GroupVersionKind{Version: "v1"}, schema.GroupVersionKind{Version: "v1beta1"}, 1},
+		{schema.GroupVersionKind{Version: "v1"}, schema.GroupVersionKind{Version: "v1beta2"}, 1},
+		{schema.GroupVersionKind{Version: "v1"}, schema.GroupVersionKind{Version: "v1beta10"}, 1},
 		{schema.GroupVersionKind{Version: "v2"}, schema.GroupVersionKind{Version: "v1"}, 1},
 		{schema.GroupVersionKind{Version: "v2beta1"}, schema.GroupVersionKind{Version: "v1beta1"}, 1},
 		// Additional test cases
@@ -80,27 +82,14 @@ func TestGetPrimaryKinds(t *testing.T) {
 		g.Expect(primaryKinds.kinds["Pod"]).To(Equal(schema.GroupVersionKind{Group: "core", Version: "v2", Kind: "Pod"}))
 		g.Expect(primaryKinds.kinds["Node"]).To(Equal(schema.GroupVersionKind{Group: "core", Version: "v1beta2", Kind: "Node"}))
 	})
-
-	t.Run("should return v1 for gitrepositories", func(t *testing.T) {
-		primaryKinds, err := DefaultPrimaryKinds()
-
-		g.Expect(err).NotTo(HaveOccurred())
-
-		// Expect the highest version of each kind to be returned
-		g.Expect(primaryKinds.kinds["GitRepository"]).To(Equal(schema.GroupVersionKind{Group: "source.toolkit.fluxcd.io", Version: "v1", Kind: "GitRepository"}))
-	})
 }
 
 func TestDefaultPrimaryKinds(t *testing.T) {
 	g := NewGomegaWithT(t)
-	for i := 0; i < 100; i++ {
-		primaryKinds, err := DefaultPrimaryKinds()
-		g.Expect(err).NotTo(HaveOccurred())
+	primaryKinds, err := DefaultPrimaryKinds()
+	g.Expect(err).NotTo(HaveOccurred())
 
-		t.Run("should return v1 for gitrepositories", func(t *testing.T) {
-			// Expect the highest version of each kind to be returned
-			g.Expect(primaryKinds.kinds["GitRepository"]).To(Equal(schema.GroupVersionKind{Group: "source.toolkit.fluxcd.io", Version: "v1", Kind: "GitRepository"}))
-			fmt.Printf("iteration: %d", i)
-		})
-	}
+	t.Run("should return v1 GitRepository", func(t *testing.T) {
+		g.Expect(primaryKinds.kinds["GitRepository"]).To(Equal(schema.GroupVersionKind{Group: "source.toolkit.fluxcd.io", Version: "v1", Kind: "GitRepository"}))
+	})
 }

--- a/core/server/primarykinds_test.go
+++ b/core/server/primarykinds_test.go
@@ -1,9 +1,11 @@
 package server
 
 import (
-	. "github.com/onsi/gomega"
+	"fmt"
 	"reflect"
 	"testing"
+
+	. "github.com/onsi/gomega"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -78,4 +80,27 @@ func TestGetPrimaryKinds(t *testing.T) {
 		g.Expect(primaryKinds.kinds["Pod"]).To(Equal(schema.GroupVersionKind{Group: "core", Version: "v2", Kind: "Pod"}))
 		g.Expect(primaryKinds.kinds["Node"]).To(Equal(schema.GroupVersionKind{Group: "core", Version: "v1beta2", Kind: "Node"}))
 	})
+
+	t.Run("should return v1 for gitrepositories", func(t *testing.T) {
+		primaryKinds, err := DefaultPrimaryKinds()
+
+		g.Expect(err).NotTo(HaveOccurred())
+
+		// Expect the highest version of each kind to be returned
+		g.Expect(primaryKinds.kinds["GitRepository"]).To(Equal(schema.GroupVersionKind{Group: "source.toolkit.fluxcd.io", Version: "v1", Kind: "GitRepository"}))
+	})
+}
+
+func TestDefaultPrimaryKinds(t *testing.T) {
+	g := NewGomegaWithT(t)
+	for i := 0; i < 100; i++ {
+		primaryKinds, err := DefaultPrimaryKinds()
+		g.Expect(err).NotTo(HaveOccurred())
+
+		t.Run("should return v1 for gitrepositories", func(t *testing.T) {
+			// Expect the highest version of each kind to be returned
+			g.Expect(primaryKinds.kinds["GitRepository"]).To(Equal(schema.GroupVersionKind{Group: "source.toolkit.fluxcd.io", Version: "v1", Kind: "GitRepository"}))
+			fmt.Printf("iteration: %d", i)
+		})
+	}
 }


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes https://github.com/weaveworks/weave-gitops/issues/3626

<!-- Describe what has changed in this PR -->
**What changed?**

Adjusted weights to avoid the ranking function computes v1 and v1beta2 with the same value.

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**

We noticed that sometimes gvk resolution for gitrepositories was returning `v1beta2` instead of `v1` which was expected. The reason was that both `v1` and `v1beta2` level had the same ranking value. 

Therefore v1 or v1beta2 was returned depending on which one was first introduced in primaryKinds. Given  `AllKnownTypes ` was randomly returning either of them, we got to that unpredictable behavior.

<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**

Adjusted weights to avoid the ranking function computes v1 and v1beta2 with the same value.

<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**

Added test case for supporting the specific case and for the gitRepository from primaryKinds.

Also tested e2e 

<img width="963" alt="Screenshot 2023-09-01 at 12 00 11" src="https://github.com/weaveworks/weave-gitops/assets/12957664/83cedc8b-312d-41aa-83ba-2f65619b2539">

