### PR TITLE
Fix the error could not not resolve module "node:os" from cosmiconfig preventing to build the UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,5 +117,8 @@
   },
   "alias": {
     "yaml": "yaml/browser/dist/index.js"
+  },
+  "resolutions": {
+    "htmlnano": "2.0.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1630,6 +1630,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.13.tgz#5ed7ed7c662948335fcad6c412bb42d99ea754e3"
   integrity sha512-Y86MAxASe25hNzlDbsviXl8jQHb0RDvKt4c40ZJQ1Don0AAL0STLZSs4N+6gLEO55pedy7r2cLwS+ZDxPm/2Bw==
 
+"@types/parse-json@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
+  integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
+
 "@types/prettier@^2.1.5":
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.6.0.tgz#efcbd41937f9ae7434c714ab698604822d890759"
@@ -2422,15 +2427,16 @@ core-js-pure@^3.20.2:
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.20.3.tgz#6cc4f36da06c61d95254efc54024fe4797fd5d02"
   integrity sha512-Q2H6tQ5MtPtcC7f3HxJ48i4Q7T9ybPKgvWyuH7JXIoNa2pm0KuBnycsET/qw1SLLZYfbsbrZQNMeIOClb+6WIA==
 
-cosmiconfig@^8.0.0:
-  version "8.1.3"
-  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-8.1.3.tgz#0e614a118fcc2d9e5afc2f87d53cd09931015689"
-  integrity sha512-/UkO2JKI18b5jVMJUp0lvKFMpa/Gye+ZgZjKD+DGEN9y7NRcf/nK1A0sp67ONmKtnDCNMS44E6jrk0Yc3bDuUw==
+cosmiconfig@^7.0.1:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-7.1.0.tgz#1443b9afa596b670082ea46cbd8f6a62b84635f6"
+  integrity sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==
   dependencies:
+    "@types/parse-json" "^4.0.0"
     import-fresh "^3.2.1"
-    js-yaml "^4.1.0"
     parse-json "^5.0.0"
     path-type "^4.0.0"
+    yaml "^1.10.0"
 
 cross-spawn@^5.1.0:
   version "5.1.0"
@@ -3679,12 +3685,12 @@ html-escaper@^2.0.0:
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
   integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
 
-htmlnano@^2.0.0:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/htmlnano/-/htmlnano-2.0.4.tgz#315108063ed0bb6a16ccb53ad1b601f02d3fe721"
-  integrity sha512-WGCkyGFwjKW1GeCBsPYacMvaMnZtFJ0zIRnC2NCddkA+IOEhTqskXrS7lep+3yYZw/nQ3dW1UAX4yA/GJyR8BA==
+htmlnano@2.0.3, htmlnano@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/htmlnano/-/htmlnano-2.0.3.tgz#50ee639ed63357d4a6c01309f52a35892e4edc2e"
+  integrity sha512-S4PGGj9RbdgW8LhbILNK7W9JhmYP8zmDY7KDV/8eCiJBQJlbmltp5I0gv8c5ntLljfdxxfmJ+UJVSqyH4mb41A==
   dependencies:
-    cosmiconfig "^8.0.0"
+    cosmiconfig "^7.0.1"
     posthtml "^0.16.5"
     timsort "^0.3.0"
 
@@ -7106,6 +7112,11 @@ yallist@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
+
+yaml@^1.10.0:
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
+  integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
 yaml@^2.2.2:
   version "2.2.2"


### PR DESCRIPTION
Closes #3986

Fixes the following error preventing to build the UI:
```
[go-build 13/13] RUN --mount=type=cache,target=/root/.cache/go-build LDFLAGS=${LDFLAGS##-X localbuild=true} GIT_COMMIT=$GIT_COMMIT make gitops-server [cached]
       → yarn build
       → yarn run v1.22.19
       → warning package.json: No license field
       → $ parcel build --target default
       → Building...
       → Bundling...
       → Packaging & Optimizing...
       → 🚨 Build failed.
       → 
       → @parcel/optimizer-htmlnano: Could not resolve module "node:os" from 
       → "/home/app/node_modules/cosmiconfig/dist/index.js"
       → 
       → 
       →   Error: Could not resolve module "node:os" from 
       →   "/home/app/node_modules/cosmiconfig/dist/index.js"
       →       at NodePackageManager.resolveInternal 
       →   (/home/app/node_modules/@parcel/package-manager/lib/index.js:3672:21)
       →       at NodePackageManager.resolveSync 
       →   (/home/app/node_modules/@parcel/package-manager/lib/index.js:3567:29)
       →       at NodePackageManager.requireSync 
       →   (/home/app/node_modules/@parcel/package-manager/lib/index.js:3394:33)
       →       at Module.m.require 
       →   (/home/app/node_modules/@parcel/package-manager/lib/index.js:3410:25)
       →       at require (node:internal/modules/cjs/helpers:119:18)
       →       at Object.<anonymous> 
       →   (/home/app/node_modules/cosmiconfig/dist/index.js:23:35)
       →       at Module._compile (node:internal/modules/cjs/loader:1198:14)
       →       at Object.Module._extensions..js 
       →   (node:internal/modules/cjs/loader:1252:10)
       →       at Module.load (node:internal/modules/cjs/loader:1076:32)
       →       at NodePackageManager.load 
       →   (/home/app/node_modules/@parcel/package-manager/lib/index.js:3423:15)
       → info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
       → error Command failed with exit code 1.
       → make: *** [Makefile:165: ui] Error 1
     
     ERROR IN: [ui 12/12] RUN --mount=type=cache,target=/home/app/ui/.parcel-cache make ui

Build Failed: ImageBuild: executor failed running [/bin/sh -c make ui]: exit code: 2
```

based on a suggestion from the following issue:
https://github.com/parcel-bundler/parcel/issues/9224