### PR TITLE
Add helm 'values' flags to create dashboard

### DIFF
--- a/cmd/gitops/beta/run/cmd.go
+++ b/cmd/gitops/beta/run/cmd.go
@@ -153,7 +153,7 @@ gitops beta run ./charts/podinfo --timeout 3m --port-forward namespace=flux-syst
 	cmdFlags.BoolVar(&flags.SkipResourceCleanup, "skip-resource-cleanup", false, "Skip resource cleanup. If not specified, the GitOps Run resources will be deleted by default.")
 	cmdFlags.StringVar(&flags.DecryptionKeyFile, "decryption-key-file", "", "Path to an age key file used for decrypting Secrets using SOPS.")
 
-	cmdFlags.StringSliceVar(&flags.DashboardValuesFiles, "values", nil, "local path to values.yaml files for HelmRelease, also accepts comma-separated values")
+	cmdFlags.StringSliceVar(&flags.DashboardValuesFiles, "values", nil, "Local path to values.yaml files for HelmRelease, also accepts comma-separated values.")
 	cmdFlags.StringVar(&flags.DashboardImage, "dashboard-image", "", "Override GitOps Dashboard image")
 	_ = cmdFlags.MarkHidden("dashboard-image")
 

--- a/cmd/gitops/create/dashboard/cmd.go
+++ b/cmd/gitops/create/dashboard/cmd.go
@@ -25,8 +25,9 @@ const (
 
 type DashboardCommandFlags struct {
 	// Create command flags.
-	Export  bool
-	Timeout time.Duration
+	Export      bool
+	Timeout     time.Duration
+	valuesFiles []string
 	// Overridden global flags.
 	Username string
 	Password string
@@ -63,6 +64,7 @@ gitops create dashboard ww-gitops \
 
 	cmdFlags.StringVar(&flags.Username, "username", "admin", "The username of the dashboard admin user.")
 	cmdFlags.StringVar(&flags.Password, "password", "", "The password of the dashboard admin user.")
+	cmdFlags.StringSliceVar(&flags.valuesFiles, "values", nil, "local path to values.yaml files for HelmRelease, also accepts comma-separated values")
 
 	kubeConfigArgs = run.GetKubeConfigArgs()
 
@@ -118,6 +120,10 @@ func createDashboardCommandRunE(opts *config.Options) func(*cobra.Command, []str
 			return err
 		}
 
+		if flags.valuesFiles, err = cmd.Flags().GetStringSlice("values"); err != nil {
+			return err
+		}
+
 		var output io.Writer
 
 		if flags.Export {
@@ -147,7 +153,7 @@ func createDashboardCommandRunE(opts *config.Options) func(*cobra.Command, []str
 			adminUsername = defaultAdminUsername
 		}
 
-		dashboardObjects, err := install.CreateDashboardObjects(log, dashboardName, flags.Namespace, adminUsername, passwordHash, "", "")
+		dashboardObjects, err := install.CreateDashboardObjects(log, dashboardName, flags.Namespace, adminUsername, passwordHash, "", "", flags.valuesFiles)
 		if err != nil {
 			return fmt.Errorf("error creating dashboard objects: %w", err)
 		}

--- a/cmd/gitops/create/dashboard/cmd.go
+++ b/cmd/gitops/create/dashboard/cmd.go
@@ -27,7 +27,7 @@ type DashboardCommandFlags struct {
 	// Create command flags.
 	Export      bool
 	Timeout     time.Duration
-	valuesFiles []string
+	ValuesFiles []string
 	// Overridden global flags.
 	Username string
 	Password string
@@ -64,7 +64,7 @@ gitops create dashboard ww-gitops \
 
 	cmdFlags.StringVar(&flags.Username, "username", "admin", "The username of the dashboard admin user.")
 	cmdFlags.StringVar(&flags.Password, "password", "", "The password of the dashboard admin user.")
-	cmdFlags.StringSliceVar(&flags.valuesFiles, "values", nil, "local path to values.yaml files for HelmRelease, also accepts comma-separated values")
+	cmdFlags.StringSliceVar(&flags.ValuesFiles, "values", nil, "Local path to values.yaml files for HelmRelease, also accepts comma-separated values.")
 
 	kubeConfigArgs = run.GetKubeConfigArgs()
 
@@ -120,7 +120,7 @@ func createDashboardCommandRunE(opts *config.Options) func(*cobra.Command, []str
 			return err
 		}
 
-		if flags.valuesFiles, err = cmd.Flags().GetStringSlice("values"); err != nil {
+		if flags.ValuesFiles, err = cmd.Flags().GetStringSlice("values"); err != nil {
 			return err
 		}
 
@@ -153,7 +153,7 @@ func createDashboardCommandRunE(opts *config.Options) func(*cobra.Command, []str
 			adminUsername = defaultAdminUsername
 		}
 
-		dashboardObjects, err := install.CreateDashboardObjects(log, dashboardName, flags.Namespace, adminUsername, passwordHash, "", "", flags.valuesFiles)
+		dashboardObjects, err := install.CreateDashboardObjects(log, dashboardName, flags.Namespace, adminUsername, passwordHash, "", "", flags.ValuesFiles)
 		if err != nil {
 			return fmt.Errorf("error creating dashboard objects: %w", err)
 		}

--- a/pkg/run/install/install_dashboard.go
+++ b/pkg/run/install/install_dashboard.go
@@ -82,9 +82,8 @@ type DashboardObjects struct {
 func CreateDashboardObjects(log logger.Logger, name, namespace, username, passwordHash, chartVersion, dashboardImage string, valuesFiles []string) (*DashboardObjects, error) {
 	log.Actionf("Creating GitOps Dashboard objects ...")
 
-	var valuesFromFiles map[string]interface{}
+	valuesFromFiles := make(map[string]interface{})
 	if len(valuesFiles) > 0 {
-		valuesMap := make(map[string]interface{})
 		for _, v := range valuesFiles {
 			data, err := os.ReadFile(v)
 			if err != nil {
@@ -101,7 +100,7 @@ func CreateDashboardObjects(log logger.Logger, name, namespace, username, passwo
 				return nil, fmt.Errorf("unmarshaling values from %s failed: %w", v, err)
 			}
 
-			valuesFromFiles = transform.MergeMaps(valuesMap, jsonMap)
+			valuesFromFiles = transform.MergeMaps(valuesFromFiles, jsonMap)
 		}
 	}
 

--- a/pkg/run/install/install_dashboard.go
+++ b/pkg/run/install/install_dashboard.go
@@ -8,10 +8,9 @@ import (
 	"strings"
 	"time"
 
+	helmv2 "github.com/fluxcd/helm-controller/api/v2beta1"
 	"github.com/fluxcd/pkg/runtime/transform"
 	sourcev1b2 "github.com/fluxcd/source-controller/api/v1beta2"
-
-	helmv2 "github.com/fluxcd/helm-controller/api/v2beta1"
 	coretypes "github.com/weaveworks/weave-gitops/core/server/types"
 	"github.com/weaveworks/weave-gitops/pkg/config"
 	"github.com/weaveworks/weave-gitops/pkg/logger"
@@ -83,25 +82,23 @@ func CreateDashboardObjects(log logger.Logger, name, namespace, username, passwo
 	log.Actionf("Creating GitOps Dashboard objects ...")
 
 	valuesFromFiles := make(map[string]interface{})
-	if len(valuesFiles) > 0 {
-		for _, v := range valuesFiles {
-			data, err := os.ReadFile(v)
-			if err != nil {
-				return nil, fmt.Errorf("reading values from %s failed: %w", v, err)
-			}
-
-			jsonBytes, err := yaml.YAMLToJSON(data)
-			if err != nil {
-				return nil, fmt.Errorf("converting values to JSON from %s failed: %w", v, err)
-			}
-
-			jsonMap := make(map[string]interface{})
-			if err := json.Unmarshal(jsonBytes, &jsonMap); err != nil {
-				return nil, fmt.Errorf("unmarshaling values from %s failed: %w", v, err)
-			}
-
-			valuesFromFiles = transform.MergeMaps(valuesFromFiles, jsonMap)
+	for _, v := range valuesFiles {
+		data, err := os.ReadFile(v)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read YAML values from %q: %w", v, err)
 		}
+
+		jsonBytes, err := yaml.YAMLToJSON(data)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert YAML values from %q to JSON values: %w", v, err)
+		}
+
+		jsonMap := make(map[string]interface{})
+		if err := json.Unmarshal(jsonBytes, &jsonMap); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal JSON values from %q: %w", v, err)
+		}
+
+		valuesFromFiles = transform.MergeMaps(valuesFromFiles, jsonMap)
 	}
 
 	helmRepository := makeHelmRepository(name, namespace)
@@ -353,7 +350,7 @@ func makeHelmRepository(name, namespace string) *sourcev1b2.HelmRepository {
 }
 
 // makeHelmRelease creates a HelmRelease object for installing the GitOps Dashboard.
-func makeHelmRelease(log logger.Logger, name, namespace, username, passwordHash, chartVersion, dashboardImage string, valuesFromFile map[string]interface{}) (*helmv2.HelmRelease, error) {
+func makeHelmRelease(log logger.Logger, name, namespace, username, passwordHash, chartVersion, dashboardImage string, valuesFromFiles map[string]interface{}) (*helmv2.HelmRelease, error) {
 	helmRelease := &helmv2.HelmRelease{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       helmv2.HelmReleaseKind,
@@ -386,7 +383,7 @@ func makeHelmRelease(log logger.Logger, name, namespace, username, passwordHash,
 		helmRelease.Spec.Chart.Spec.Version = chartVersion
 	}
 
-	values, err := makeValues(username, passwordHash, dashboardImage, valuesFromFile)
+	values, err := makeValues(username, passwordHash, dashboardImage, valuesFromFiles)
 	if err != nil {
 		log.Failuref("Error generating chart values")
 		return nil, err
@@ -442,7 +439,7 @@ func parseImageRepository(input string) (repository, image, tag string, err erro
 }
 
 // makeValues creates a values object for installing the GitOps Dashboard.
-func makeValues(username, passwordHash, dashboardImage string, valuesFromFile map[string]interface{}) ([]byte, error) {
+func makeValues(username, passwordHash, dashboardImage string, valuesFromFiles map[string]interface{}) ([]byte, error) {
 	valuesMap := make(map[string]interface{})
 	if username != "" && passwordHash != "" {
 		valuesMap["adminUser"] =
@@ -473,7 +470,7 @@ func makeValues(username, passwordHash, dashboardImage string, valuesFromFile ma
 		}
 	}
 
-	finalValues := transform.MergeMaps(valuesMap, valuesFromFile)
+	finalValues := transform.MergeMaps(valuesMap, valuesFromFiles)
 
 	if len(finalValues) > 0 {
 		jsonRaw, err := json.Marshal(finalValues)

--- a/pkg/run/install/install_dashboard_test.go
+++ b/pkg/run/install/install_dashboard_test.go
@@ -162,13 +162,13 @@ var _ = Describe("InstallDashboard", func() {
 		d, err := yaml.Marshal(testValues)
 		Expect(err).NotTo(HaveOccurred())
 
-		err = os.WriteFile(testValuesFiles[0], d, 0644)
+		err = os.WriteFile(testValuesFiles[0], d, 0o644)
 		Expect(err).NotTo(HaveOccurred())
 
 		d, err = yaml.Marshal(testValues2)
 		Expect(err).NotTo(HaveOccurred())
 
-		err = os.WriteFile(testValuesFiles[1], d, 0644)
+		err = os.WriteFile(testValuesFiles[1], d, 0o644)
 		Expect(err).NotTo(HaveOccurred())
 
 		manifests, err := CreateDashboardObjects(fakeLogger, testDashboardName, testNamespace, testAdminUser, testPasswordHash, helmChartVersion, "", testValuesFiles)

--- a/website/docs/open-source/getting-started/install-OSS.mdx
+++ b/website/docs/open-source/getting-started/install-OSS.mdx
@@ -181,6 +181,11 @@ Our docs on [securing access to the dashboard](../../enterprise/getting-started/
 
 You will use the password you've just created when you've finished Weave GitOps Open Source installation and are ready to login to the dashboard UI.
 
+:::tip
+If you need to customize the Weave GitOps Helm release, you can use the `--values` CLI flag to supply one or more values files.
+
+:::
+
 #### Commit and push the `weave-gitops-dashboard.yaml` to the `fleet-infra` repository
 
    ```


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->

<!-- Describe what has changed in this PR -->
**What changed?**
flags `--values` added to `create dashboard` and `beta run` so we can provide additional helm values  when generating HelmRelease from the `gitops`cli

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**
Didn't wanted to have to deal with editing the yaml HelmRelease file to add values 

<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**
This is has been inspired by how it is implemented in flux for creating HelmRelease

<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**
with this yaml
``` yaml
# cat weave-gitops-dashboard.yaml
  service:
    type: nodePort
    nodePort: 30000
```

we have this export from the below command
``` yaml
# go run cmd/gitops/main.go create dashboard ww-gitops --password=password --export --values="./weave-gitops-dashboard.yaml" | tail -25
apiVersion: helm.toolkit.fluxcd.io/v2beta1
kind: HelmRelease
metadata:
  annotations:
    metadata.weave.works/description: This is the Weave GitOps Dashboard.  It provides
      a simple way to get insights into your GitOps workloads.
  name: ww-gitops
  namespace: flux-system
spec:
  chart:
    spec:
      chart: weave-gitops
      sourceRef:
        kind: HelmRepository
        name: ww-gitops
  interval: 1h0m0s
  values:
    adminUser:
      create: true
      passwordHash: $2a$10$fUEMY4RTq4L6H3t2xkmiAOSGSmjxlOuepzoL.dzTDVTlbTtLWFT0S
      username: admin
    service:
      nodePort: 30000
      type: nodePort
```


<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**
N/A

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
cli is self documented