### PR TITLE
adjusted link to enterprise install

### DIFF
--- a/website/versioned_docs/version-0.24.0/guides/deploying-capa.mdx
+++ b/website/versioned_docs/version-0.24.0/guides/deploying-capa.mdx
@@ -31,7 +31,8 @@ The `AWS_ACCESS_KEY_ID`and `AWS_SECRET_ACCESS_KEY` of a user should be configure
 The `GITHUB_TOKEN` should be set as an environment variable in the current shell. It should have permissions to create Pull Requests against the cluster config repo.
 :::
 
-If you've followed the [Installation guide](installation/weave-gitops-enterprise/index.mdx) you should have a management cluster ready to roll.
+If you've followed the [Installation guide](../enterprise/getting-started/install-enterprise.mdx) you should have a management cluster ready to roll.
+
 
 ### 1. Configure a capi provider
 


### PR DESCRIPTION
before the change capa warning

```bash
✔ Client
  Compiled successfully in 57.12s

[WARNING] Docs markdown link couldn't be resolved: (installation/weave-gitops-enterprise/index.mdx) in "/Users/enekofb/projects/github.com/weaveworks/weave-gitops/website/versioned_docs/version-0.24.0/guides/deploying-capa.mdx" for version 0.24.0
...
```

after the warning is fixed



