### PR TITLE
Add Artifact Metadata section to OCI Repository detail pages

### DIFF
--- a/ui/components/Metadata.tsx
+++ b/ui/components/Metadata.tsx
@@ -4,12 +4,12 @@ import { formatMetadataKey, isHTTP } from "../lib/utils";
 import Flex from "./Flex";
 import InfoList from "./InfoList";
 import Link from "./Link";
-import Spacer from "./Spacer";
 import Text from "./Text";
 
 type Props = {
   className?: string;
   metadata?: [string, string][];
+  artifactMetadata?: [string, string][];
   labels?: [string, string][];
 };
 
@@ -21,9 +21,8 @@ const Label = styled(Text)`
   background-color: ${(props) => props.theme.colors.neutralGray};
 `;
 
-function Metadata({ metadata = [], labels = [], className }: Props) {
+const makeMetadata = (metadata: [string, string][]): [string, any][] => {
   const metadataCopy = [];
-
   for (let i = 0; i < metadata.length; i++) {
     metadataCopy[i] = metadata[i].slice();
   }
@@ -41,16 +40,34 @@ function Metadata({ metadata = [], labels = [], className }: Props) {
         </Link>
       );
   });
+  return metadataCopy;
+};
+
+function Metadata({
+  metadata = [],
+  labels = [],
+  artifactMetadata = [],
+  className,
+}: Props) {
+  const metadataCopy = makeMetadata(metadata);
+  const artifactMetadataCopy = makeMetadata(artifactMetadata);
 
   return (
-    <Flex wide column className={className} gap="16">
+    <Flex wide column className={className} gap="12">
       {metadataCopy.length > 0 && (
         <Flex column gap="8">
           <Text size="large" color="neutral30">
             Metadata
           </Text>
           <InfoList items={metadataCopy} />
-          <Spacer padding="small" />
+        </Flex>
+      )}
+      {artifactMetadataCopy.length > 0 && (
+        <Flex column gap="8">
+          <Text size="large" color="neutral30">
+            Artifact Metadata
+          </Text>
+          <InfoList items={artifactMetadataCopy} />
         </Flex>
       )}
       {labels.length > 0 && (
@@ -76,5 +93,5 @@ function Metadata({ metadata = [], labels = [], className }: Props) {
 export default styled(Metadata).attrs({
   className: Metadata.name,
 })`
-  margin-top: ${(props) => props.theme.spacing.medium};
+  margin: ${(props) => props.theme.spacing.small} 0;
 `;

--- a/ui/components/Metadata.tsx
+++ b/ui/components/Metadata.tsx
@@ -43,10 +43,10 @@ const makeMetadata = (metadata: [string, string][]): [string, any][] => {
   return metadataCopy;
 };
 
-const MetadataSection: React.FC<{ title: string; items: [string, any][] }> = ({
-  title,
-  items,
-}) => {
+const MetadataSection: React.FC<{
+  title: string;
+  items: [string, string | JSX.Element][];
+}> = ({ title, items }) => {
   return (
     <Flex column gap="8">
       <Text size="large" color="neutral30">

--- a/ui/components/Metadata.tsx
+++ b/ui/components/Metadata.tsx
@@ -43,6 +43,30 @@ const makeMetadata = (metadata: [string, string][]): [string, any][] => {
   return metadataCopy;
 };
 
+const MetadataSection: React.FC<{ title: string; items: [string, any][] }> = ({
+  title,
+  items,
+}) => {
+  return (
+    <Flex column gap="8">
+      <Text size="large" color="neutral30">
+        {title}
+      </Text>
+      {title === "Labels" ? (
+        items.map((label, index) => {
+          return (
+            <Label key={index}>
+              {label[0]}: {label[1]}
+            </Label>
+          );
+        })
+      ) : (
+        <InfoList items={items} />
+      )}
+    </Flex>
+  );
+};
+
 function Metadata({
   metadata = [],
   labels = [],
@@ -55,37 +79,15 @@ function Metadata({
   return (
     <Flex wide column className={className} gap="12">
       {metadataCopy.length > 0 && (
-        <Flex column gap="8">
-          <Text size="large" color="neutral30">
-            Metadata
-          </Text>
-          <InfoList items={metadataCopy} />
-        </Flex>
+        <MetadataSection title="Metadata" items={metadataCopy} />
       )}
       {artifactMetadataCopy.length > 0 && (
-        <Flex column gap="8">
-          <Text size="large" color="neutral30">
-            Artifact Metadata
-          </Text>
-          <InfoList items={artifactMetadataCopy} />
-        </Flex>
+        <MetadataSection
+          title="Artifact Metadata"
+          items={artifactMetadataCopy}
+        />
       )}
-      {labels.length > 0 && (
-        <Flex column gap="8">
-          <Text size="large" color="neutral30">
-            Labels
-          </Text>
-          <Flex wide start wrap gap="4">
-            {labels.map((label, index) => {
-              return (
-                <Label key={index}>
-                  {label[0]}: {label[1]}
-                </Label>
-              );
-            })}
-          </Flex>
-        </Flex>
-      )}
+      {labels.length > 0 && <MetadataSection title="Labels" items={labels} />}
     </Flex>
   );
 }

--- a/ui/components/Metadata.tsx
+++ b/ui/components/Metadata.tsx
@@ -53,13 +53,15 @@ const MetadataSection: React.FC<{ title: string; items: [string, any][] }> = ({
         {title}
       </Text>
       {title === "Labels" ? (
-        items.map((label, index) => {
-          return (
-            <Label key={index}>
-              {label[0]}: {label[1]}
-            </Label>
-          );
-        })
+        <Flex wide start wrap gap="4">
+          {items.map((label, index) => {
+            return (
+              <Label key={index}>
+                {label[0]}: {label[1]}
+              </Label>
+            );
+          })}
+        </Flex>
       ) : (
         <InfoList items={items} />
       )}

--- a/ui/components/OCIRepositoryDetail.tsx
+++ b/ui/components/OCIRepositoryDetail.tsx
@@ -56,11 +56,6 @@ function OCIRepositoryDetail({
         ["Interval", <Interval interval={ociRepository.interval} />],
         ...clusterInfo,
         ["Namespace", ociRepository.namespace],
-        [
-          "Source",
-          <Link href={ociRepository.source}>{ociRepository.source}</Link>,
-        ],
-        ["Revision", ociRepository.revision],
         ...tenancyInfo,
       ]}
     />

--- a/ui/components/SourceDetail.tsx
+++ b/ui/components/SourceDetail.tsx
@@ -52,7 +52,7 @@ function SourceDetail({ className, source, info, type, customActions }: Props) {
   }
 
   const isNameRelevant = (expectedName) => {
-    return expectedName === name;
+    return expectedName == name;
   };
 
   const isRelevant = (expectedType, expectedName) => {

--- a/ui/components/SourceDetail.tsx
+++ b/ui/components/SourceDetail.tsx
@@ -4,7 +4,7 @@ import { useRouteMatch } from "react-router-dom";
 import styled from "styled-components";
 import { useListAutomations } from "../hooks/automations";
 import { Kind } from "../lib/api/core/types.pb";
-import { HelmRelease, Source } from "../lib/objects";
+import { HelmRelease, OCIRepository, Source } from "../lib/objects";
 import { getSourceRefForAutomation } from "../lib/utils";
 import AutomationsTable from "./AutomationsTable";
 import EventsTable from "./EventsTable";
@@ -17,6 +17,11 @@ import SubRouterTabs, { RouterTab } from "./SubRouterTabs";
 import SyncActions from "./SyncActions";
 import YamlView from "./YamlView";
 
+//must specify OCIRepository type, artifactMetadata causes errors on the Source type
+const getArtifactMetadata = (source: OCIRepository) => {
+  return source.artifactMetadata || null;
+};
+
 type Props = {
   className?: string;
   type: Kind;
@@ -27,7 +32,16 @@ type Props = {
 };
 
 function SourceDetail({ className, source, info, type, customActions }: Props) {
-  const { name, namespace, clusterName, suspended } = source;
+  const {
+    name,
+    namespace,
+    yaml,
+    clusterName,
+    conditions,
+    suspended,
+    metadata,
+    labels,
+  } = source;
 
   const { data: automations, isLoading: automationsLoading } =
     useListAutomations();
@@ -38,18 +52,18 @@ function SourceDetail({ className, source, info, type, customActions }: Props) {
   }
 
   const isNameRelevant = (expectedName) => {
-    return expectedName == source.name;
+    return expectedName === name;
   };
 
   const isRelevant = (expectedType, expectedName) => {
-    return expectedType == source.type && isNameRelevant(expectedName);
+    return expectedType == type && isNameRelevant(expectedName);
   };
 
   const relevantAutomations = _.filter(automations?.result, (a) => {
     if (!source) {
       return false;
     }
-    if (a.clusterName != source.clusterName) {
+    if (a.clusterName != clusterName) {
       return false;
     }
 
@@ -65,10 +79,7 @@ function SourceDetail({ className, source, info, type, customActions }: Props) {
   return (
     <Flex wide tall column className={className} gap="32">
       <Flex column gap="8">
-        <PageStatus
-          conditions={source.conditions}
-          suspended={source.suspended}
-        />
+        <PageStatus conditions={conditions} suspended={suspended} />
         <SyncActions
           name={name}
           namespace={namespace}
@@ -84,28 +95,35 @@ function SourceDetail({ className, source, info, type, customActions }: Props) {
         <RouterTab name="Details" path={`${path}/details`}>
           <>
             <InfoList items={info} />
-            <Metadata metadata={source.metadata} labels={source.labels} />
+            <Metadata
+              metadata={metadata}
+              labels={labels}
+              artifactMetadata={
+                type === Kind.OCIRepository &&
+                getArtifactMetadata(source as OCIRepository)
+              }
+            />
             <AutomationsTable automations={relevantAutomations} hideSource />
           </>
         </RouterTab>
         <RouterTab name="Events" path={`${path}/events`}>
           <EventsTable
-            namespace={source.namespace}
+            namespace={namespace}
             involvedObject={{
-              kind: source.type,
-              name: source.name,
-              namespace: source.namespace,
-              clusterName: source.clusterName,
+              kind: type,
+              name: name,
+              namespace: namespace,
+              clusterName: clusterName,
             }}
           />
         </RouterTab>
         <RouterTab name="yaml" path={`${path}/yaml`}>
           <YamlView
-            yaml={source.yaml}
+            yaml={yaml}
             object={{
-              kind: source.type,
-              name: source.name,
-              namespace: source.namespace,
+              kind: type,
+              name: name,
+              namespace: namespace,
             }}
           />
         </RouterTab>

--- a/ui/components/__tests__/Metadata.test.tsx
+++ b/ui/components/__tests__/Metadata.test.tsx
@@ -21,6 +21,11 @@ describe("Metadata", () => {
                 ["link-to-google", "https://google.com"],
                 ["multi-lines", "This is first line\nThis is second line\n"],
               ]}
+              artifactMetadata={[
+                ["description", "Value 1"],
+                ["html", "<p><b>html</b></p>"],
+                ["link-to-google", "https://google.com"],
+              ]}
               labels={[
                 ["label", "label"],
                 ["goose", "goose"],

--- a/ui/components/__tests__/__snapshots__/Metadata.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/Metadata.test.tsx.snap
@@ -13,12 +13,12 @@ exports[`Metadata snapshots renders nothing without data 1`] = `
   -webkit-box-align: start;
   -ms-flex-align: start;
   align-items: start;
-  gap: 16px;
+  gap: 12px;
   width: 100%;
 }
 
 .c1 {
-  margin-top: 24px;
+  margin: 12px 0;
 }
 
 <div
@@ -39,7 +39,7 @@ exports[`Metadata snapshots renders with data 1`] = `
   -webkit-box-align: start;
   -ms-flex-align: start;
   align-items: start;
-  gap: 16px;
+  gap: 12px;
   width: 100%;
 }
 
@@ -93,7 +93,7 @@ exports[`Metadata snapshots renders with data 1`] = `
   justify-content: center;
 }
 
-.c11 {
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -153,7 +153,7 @@ exports[`Metadata snapshots renders with data 1`] = `
   color: #00b3ec;
 }
 
-.c12 {
+.c11 {
   font-family: 'proxima-nova',Helvetica,Arial,sans-serif;
   font-size: 14px;
   font-weight: 400;
@@ -161,16 +161,12 @@ exports[`Metadata snapshots renders with data 1`] = `
   font-style: normal;
 }
 
-.c10 {
-  padding: 12px;
-}
-
 .c8 {
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c13 {
+.c12 {
   padding: 8px 12px;
   border-radius: 15px;
   white-space: nowrap;
@@ -178,7 +174,7 @@ exports[`Metadata snapshots renders with data 1`] = `
 }
 
 .c1 {
-  margin-top: 24px;
+  margin: 12px 0;
 }
 
 <div
@@ -373,9 +369,94 @@ This is second line
         </span>
       </div>
     </div>
+  </div>
+  <div
+    className="c2"
+  >
+    <span
+      className="c3"
+      color="neutral30"
+      size="large"
+    >
+      Artifact Metadata
+    </span>
     <div
-      className="c10"
-    />
+      className="c4"
+    >
+      <div
+        className="c5"
+        data-testid="Description"
+      >
+        <span
+          className="c6"
+          color="neutral30"
+          size="medium"
+        >
+          Description
+          :
+        </span>
+        <span
+          className="c7"
+          color="neutral40"
+          size="medium"
+        >
+          Value 1
+        </span>
+      </div>
+      <div
+        className="c5"
+        data-testid="Html"
+      >
+        <span
+          className="c6"
+          color="neutral30"
+          size="medium"
+        >
+          Html
+          :
+        </span>
+        <span
+          className="c7"
+          color="neutral40"
+          size="medium"
+        >
+          &lt;p&gt;&lt;b&gt;html&lt;/b&gt;&lt;/p&gt;
+        </span>
+      </div>
+      <div
+        className="c5"
+        data-testid="Link To Google"
+      >
+        <span
+          className="c6"
+          color="neutral30"
+          size="medium"
+        >
+          Link To Google
+          :
+        </span>
+        <span
+          className="c7"
+          color="neutral40"
+          size="medium"
+        >
+          <a
+            className="c8 Link"
+            href="https://google.com"
+            rel="noreferrer"
+            target="_blank"
+          >
+            <span
+              className="c9"
+              color="primary"
+              size="medium"
+            >
+              https://google.com
+            </span>
+          </a>
+        </span>
+      </div>
+    </div>
   </div>
   <div
     className="c2"
@@ -388,10 +469,10 @@ This is second line
       Labels
     </span>
     <div
-      className="c11"
+      className="c10"
     >
       <span
-        className="c12 c13"
+        className="c11 c12"
         size="medium"
       >
         label
@@ -399,7 +480,7 @@ This is second line
         label
       </span>
       <span
-        className="c12 c13"
+        className="c11 c12"
         size="medium"
       >
         goose

--- a/ui/lib/__tests__/objects.test.ts
+++ b/ui/lib/__tests__/objects.test.ts
@@ -259,14 +259,12 @@ describe("objects lib", () => {
 
     const obj = new OCIRepository(response.object);
 
-    it("extracts source", () => {
-      expect(obj.source).toEqual("https://github.com/stefanprodan/podinfo.git");
-    });
-
-    it("extracts revision", () => {
-      expect(obj.revision).toEqual(
-        "6.1.8/b3b00fe35424a45d373bf4c7214178bc36fd7872"
-      );
+    it("extracts artifact metadata", () => {
+      expect(obj.artifactMetadata).toEqual([
+        ["created", "2022-08-08T12:31:41+03:00"],
+        ["revision", "6.1.8/b3b00fe35424a45d373bf4c7214178bc36fd7872"],
+        ["source", "https://github.com/stefanprodan/podinfo.git"],
+      ]);
     });
   });
 
@@ -275,8 +273,7 @@ describe("objects lib", () => {
       payload: '{"status": {"artifact": {"metadata": {}}}}',
     });
     it("handles empty metadata", () => {
-      expect(obj.source).toEqual("");
-      expect(obj.revision).toEqual("");
+      expect(obj.artifactMetadata).toEqual([]);
     });
   });
 

--- a/ui/lib/objects.ts
+++ b/ui/lib/objects.ts
@@ -200,20 +200,12 @@ export class OCIRepository extends FluxObject {
     return this.obj.spec?.url || "";
   }
 
-  get source(): string {
-    const metadata = this.obj.status?.artifact?.metadata;
-    if (!metadata) {
-      return "";
-    }
-    return metadata["org.opencontainers.image.source"] || "";
-  }
-
-  get revision(): string {
-    const metadata = this.obj.status?.artifact?.metadata;
-    if (!metadata) {
-      return "";
-    }
-    return metadata["org.opencontainers.image.revision"] || "";
+  get artifactMetadata(): [string, string][] {
+    const metadata = this.obj.status?.artifact?.metadata || {};
+    const prefix = "org.opencontainers.image/";
+    return Object.keys(metadata).flatMap((key) => {
+      return [[key.slice(prefix.length), metadata[key] as string]];
+    });
   }
 
   get isVerifiable(): boolean {


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes: https://github.com/weaveworks/weave-gitops-enterprise/issues/3341

Adds a new section to the Metadata component for OCI Repositories for clarity - we were previously displaying revision and source in the info list, but folks were expecting to see it in Metadata (which only recognizes our metadata.weaveworks prefix).

<img width="997" alt="image" src="https://github.com/weaveworks/weave-gitops/assets/65822698/867eb0d9-9d36-4806-b873-55492be232bd">

