### PR TITLE
updating explorer kind docs to reflect latest changes

### DIFF
--- a/website/docs/explorer/configuration.mdx
+++ b/website/docs/explorer/configuration.mdx
@@ -70,6 +70,10 @@ Explorer watches for the following kind resources out of the box:
   - [HelmCharts](https://fluxcd.io/flux/components/source/helmcharts/)
   - [Buckets](https://fluxcd.io/flux/components/source/buckets/)
 
+[Weave Gitops](https://docs.gitops.weave.works/)
+- [GitopsSets](../../gitopssets/gitopssets-intro/)
+- [Policy Audit Violations](../../policy/getting-started)
+
 ## Data Layer
 
 Explorer take a simple approach to manage resource views. It leverages a Data Store for caching the views and query them.


### PR DESCRIPTION
updating explorer kind docs to reflect latest changes: added gitopssets and policy audit violations

![Screenshot 2023-09-19 at 16 28 56](https://github.com/weaveworks/weave-gitops/assets/12957664/0095998e-abea-4ef6-b350-d49b3f81ef15)
