### PR TITLE
Fix 'cluster not found' error when requesting source from automation `sourceRef`

### DIFF
--- a/ui/components/AutomationsTable.tsx
+++ b/ui/components/AutomationsTable.tsx
@@ -129,6 +129,7 @@ function AutomationsTable({
       label: "Verified",
       value: (a: Automation) => (
         <SourceIsVerifiedStatus
+          automation={a}
           sourceRef={getSourceRefForAutomation(a) || {}}
         />
       ),

--- a/ui/components/UserSettings.tsx
+++ b/ui/components/UserSettings.tsx
@@ -68,7 +68,12 @@ function UserSettings({ className, darkModeEnabled = true }: Props) {
     <Flex className={className} gap="8" align>
       <DarkModeSwitch darkModeEnabled={darkModeEnabled} />
       <Tooltip title="Docs" enterDelay={500} enterNextDelay={500}>
-        <Link as={PersonButton} href="https://docs.gitops.weave.works/" newTab>
+        <Link
+          as={PersonButton}
+          href="https://docs.gitops.weave.works/"
+          target="_blank"
+          rel="noreferrer"
+        >
           <Icon size="medium" type={IconType.FindInPage} />
         </Link>
       </Tooltip>

--- a/ui/components/VerifiedStatus.tsx
+++ b/ui/components/VerifiedStatus.tsx
@@ -2,7 +2,12 @@ import { Tooltip } from "@material-ui/core";
 import React from "react";
 import { useGetObject } from "../hooks/objects";
 import { Condition, Kind, ObjectRef } from "../lib/api/core/types.pb";
-import { GitRepository, OCIRepository, Source } from "../lib/objects";
+import {
+  Automation,
+  GitRepository,
+  OCIRepository,
+  Source,
+} from "../lib/objects";
 import Flex from "./Flex";
 import Icon, { IconType } from "./Icon";
 
@@ -53,9 +58,10 @@ const VerifiedStatus = ({
 };
 
 export const SourceIsVerifiedStatus: React.FC<{
+  automation?: Automation;
   sourceRef?: ObjectRef;
   source?: Source;
-}> = ({ sourceRef, source }): JSX.Element => {
+}> = ({ automation, sourceRef, source }): JSX.Element => {
   const isVerifiable = source
     ? checkVerifiable({
         name: source.name,
@@ -69,9 +75,9 @@ export const SourceIsVerifiedStatus: React.FC<{
   if (source) return <VerifiedStatus source={source as VerifiableSource} />;
   const {
     name = "",
-    namespace = "",
+    namespace = automation.namespace,
     kind = "",
-    clusterName = "",
+    clusterName = automation.clusterName,
   } = sourceRef || {};
   const { data: verifiable } = useGetObject<VerifiableSource>(
     name,

--- a/ui/components/__tests__/__snapshots__/Page.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/Page.test.tsx.snap
@@ -325,7 +325,6 @@ exports[`Page snapshots default 1`] = `
         aria-disabled={false}
         className="MuiButtonBase-root MuiIconButton-root c10 c11 Link"
         href="https://docs.gitops.weave.works/"
-        newTab={true}
         onBlur={[Function]}
         onDragLeave={[Function]}
         onFocus={[Function]}
@@ -338,7 +337,9 @@ exports[`Page snapshots default 1`] = `
         onTouchEnd={[Function]}
         onTouchMove={[Function]}
         onTouchStart={[Function]}
+        rel="noreferrer"
         tabIndex={0}
+        target="_blank"
         title="Docs"
       >
         <span


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes #4019 

The request for an automation's source was using the `sourceRef` field, which doesn't have a namespace if the source is in the same one as an automation, and NEVER has a cluster name. This PR uses the automation's namespace and cluster name to actually get the source back on these requests. 

Also fixes not actually opening a new tab on the new docs button - careful when using the `as` prop for styles with a styled component, because it actually changed the `a` element into a button as well
