### PR TITLE
Add noText prop to kubeStatusIndicator

### DIFF
--- a/ui/components/AutomationsTable.tsx
+++ b/ui/components/AutomationsTable.tsx
@@ -139,7 +139,7 @@ function AutomationsTable({
       value: (a: Automation) =>
         a.conditions.length > 0 ? (
           <KubeStatusIndicator
-            short
+            noText
             conditions={a.conditions}
             suspended={a.suspended}
           />

--- a/ui/components/AutomationsTable.tsx
+++ b/ui/components/AutomationsTable.tsx
@@ -139,7 +139,7 @@ function AutomationsTable({
       value: (a: Automation) =>
         a.conditions.length > 0 ? (
           <KubeStatusIndicator
-            noText
+            short
             conditions={a.conditions}
             suspended={a.suspended}
           />

--- a/ui/components/KubeStatusIndicator.tsx
+++ b/ui/components/KubeStatusIndicator.tsx
@@ -12,6 +12,7 @@ type Props = {
   conditions: Condition[];
   short?: boolean;
   suspended?: boolean;
+  noText?: boolean;
 };
 
 export enum ReadyType {
@@ -190,11 +191,14 @@ function KubeStatusIndicator({
   conditions,
   short,
   suspended,
+  noText,
 }: Props) {
   const { type, color, icon } = getIndicatorInfo(suspended, conditions);
 
-  let text = computeMessage(conditions);
-  if (short || suspended) text = type;
+  let text;
+  if (noText) text = null;
+  else if (short || suspended) text = type;
+  else text = computeMessage(conditions);
 
   return (
     <Flex start className={className} align>

--- a/ui/components/__tests__/KubeStatusIndicator.test.tsx
+++ b/ui/components/__tests__/KubeStatusIndicator.test.tsx
@@ -108,7 +108,7 @@ describe("KubeStatusIndicator", () => {
     ];
 
     render(
-      withTheme(<KubeStatusIndicator conditions={conditions} suspended short />)
+      withTheme(<KubeStatusIndicator conditions={conditions} suspended />)
     );
     const msg = screen.getByText("Suspended");
     expect(msg).toBeTruthy();
@@ -224,6 +224,23 @@ describe("KubeStatusIndicator", () => {
       const tree = renderer
         .create(
           withTheme(<KubeStatusIndicator conditions={conditions} short />)
+        )
+        .toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+    it("renders with noText prop", () => {
+      const conditions = [
+        {
+          type: "Ready",
+          status: "False",
+          reason: "BigTrouble",
+          message: "There was a problem",
+          timestamp: "2022-03-03 17:00:38 +0000 UTC",
+        },
+      ];
+      const tree = renderer
+        .create(
+          withTheme(<KubeStatusIndicator conditions={conditions} noText />)
         )
         .toJSON();
       expect(tree).toMatchSnapshot();

--- a/ui/components/__tests__/__snapshots__/KubeStatusIndicator.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/KubeStatusIndicator.test.tsx.snap
@@ -255,3 +255,105 @@ exports[`KubeStatusIndicator snapshots renders success 1`] = `
   </div>
 </div>
 `;
+
+exports[`KubeStatusIndicator snapshots renders with noText prop 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c2 svg {
+  fill: #BC3B1D;
+  height: 16px;
+  width: 16px;
+}
+
+.c2 svg path.path-fill,
+.c2 svg line.path-fill,
+.c2 svg polygon.path-fill,
+.c2 svg rect.path-fill,
+.c2 svg circle.path-fill,
+.c2 svg polyline.path-fill {
+  fill: #BC3B1D !important;
+  -webkit-transition: fill 200ms cubic-bezier(0.4,0,0.2,1) 0ms;
+  transition: fill 200ms cubic-bezier(0.4,0,0.2,1) 0ms;
+}
+
+.c2 svg path.stroke-fill,
+.c2 svg line.stroke-fill,
+.c2 svg polygon.stroke-fill,
+.c2 svg rect.stroke-fill,
+.c2 svg circle.stroke-fill,
+.c2 svg polyline.stroke-fill {
+  stroke: #BC3B1D !important;
+  -webkit-transition: stroke 200ms cubic-bezier(0.4,0,0.2,1) 0ms;
+  transition: stroke 200ms cubic-bezier(0.4,0,0.2,1) 0ms;
+}
+
+.c2 svg rect.rect-height {
+  height: 16px;
+  width: 16px;
+}
+
+.c2.downward {
+  -webkit-transform: rotate(180deg);
+  -ms-transform: rotate(180deg);
+  transform: rotate(180deg);
+}
+
+.c2.upward {
+  -webkit-transform: initial;
+  -ms-transform: initial;
+  transform: initial;
+}
+
+.c2 img {
+  width: 16px;
+}
+
+<div
+  className="c0 KubeStatusIndicator"
+>
+  <div
+    className="c1 c2"
+  >
+    <svg
+      aria-hidden={true}
+      className="MuiSvgIcon-root"
+      focusable="false"
+      viewBox="0 0 24 24"
+    >
+      <path
+        d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"
+      />
+    </svg>
+  </div>
+</div>
+`;


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Related: https://github.com/weaveworks/weave-gitops-enterprise/issues/3309

There is a case in EE where we'd like the `KubeStatusIndicator` component to render the correct status icon without text - right now there's a bit of a hack in place to set `display: none` to the `span` in the component, but I think this functionality is worth having in the component itself. I also changed the code a bit so we don't run `computeMessage` unless we have to. 

