### PR TITLE
Fix Suspend button width on Source details pages with short status message

### DIFF
--- a/ui/components/SyncActions.tsx
+++ b/ui/components/SyncActions.tsx
@@ -75,4 +75,5 @@ const SyncActions = ({
 
 export default styled(SyncActions)`
   width: 50%;
+  min-width: fit-content;
 `;

--- a/ui/components/__tests__/__snapshots__/SyncActions.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/SyncActions.test.tsx.snap
@@ -70,6 +70,9 @@ exports[`SyncActions snapshots hideDropdown 1`] = `
 
 .c1 {
   width: 50%;
+  min-width: -webkit-fit-content;
+  min-width: -moz-fit-content;
+  min-width: fit-content;
 }
 
 <div
@@ -340,6 +343,9 @@ exports[`SyncActions snapshots non-suspended 1`] = `
 
 .c1 {
   width: 50%;
+  min-width: -webkit-fit-content;
+  min-width: -moz-fit-content;
+  min-width: fit-content;
 }
 
 <div
@@ -647,6 +653,9 @@ exports[`SyncActions snapshots suspended 1`] = `
 
 .c1 {
   width: 50%;
+  min-width: -webkit-fit-content;
+  min-width: -moz-fit-content;
+  min-width: fit-content;
 }
 
 <div


### PR DESCRIPTION
Closes https://github.com/weaveworks/weave-gitops/issues/4001

- Added `min-width: fit-content` to the `SyncActions` component to prevent Suspend button being to narrow on Source details pages in the status message is too short.

Notes:
- The padding on the Suspend button stays the same, but the button's with is forced to be too narrow because of the `width: 50%` specified in the `SyncActions` component. As discussed with @joshri, this width setting was added to make  the buttons play nicely with Applied Revision and Last Updated elements on Application details pages.

Testing:

- The original issue can be seen in staging on a HelmChart page with a short status message:
https://gitops.euw1.wego-gke.weave.works/helm_chart/details?clusterName=Default&name=dex-dex&namespace=flux-system

At least on my laptop's screen:
<img width="1532" alt="Screenshot 2023-09-20 at 11 40 49" src="https://github.com/weaveworks/weave-gitops/assets/8824708/611efb01-2ed7-481c-a41f-378a659660a9">

To reproduce the original issue in the main branch, just go to a Source details page and change the object status message to smth. short (HelmChart have shorter message than other sources thats why this issue was visible on HelmChart pages):

<img width="1532" alt="Screenshot 2023-09-20 at 11 30 49" src="https://github.com/weaveworks/weave-gitops/assets/8824708/381b112f-4764-46ab-a1c5-52ce35055829">


In the current branch with the fix, the Suspend button should look as expected:

<img width="1535" alt="Screenshot 2023-09-20 at 11 20 15" src="https://github.com/weaveworks/weave-gitops/assets/8824708/165b384f-2cdc-4478-892e-d09b8b88e750">

You can also check that the fix does not change the layout of Application details page (the issue with Suspend button was not happening on the Application details pages, but I would not like to introduce any changes to the elements' layout with the fix) and Applied Revision and Last Updated elements look like before on wide and narrow screens:

<img width="1530" alt="Screenshot 2023-09-20 at 11 21 11" src="https://github.com/weaveworks/weave-gitops/assets/8824708/e0413ad7-ee8f-468b-94ef-e697301960a0">

<img width="840" alt="Screenshot 2023-09-20 at 11 21 24" src="https://github.com/weaveworks/weave-gitops/assets/8824708/5c6090e8-ae04-4d1a-9dbd-b5652c8ae167">

