### PR TITLE
ci: Pin GitHub Actions versions

### DIFF
--- a/.github/workflows/chart.yaml
+++ b/.github/workflows/chart.yaml
@@ -105,7 +105,7 @@ jobs:
           destination: helm.gitops.weave.works
           parent: false
       - name: Log in to the Container registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -63,7 +63,7 @@ jobs:
         with:
           go-version: ${{ matrix.go-version }}
       - name: Setup Flux CLI
-        uses: fluxcd/flux2/action@main
+        uses: fluxcd/flux2/action@709b17ce59d184427c1395bc70f496ba528d3bee # main
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - run: make unit-tests

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -120,7 +120,7 @@ jobs:
           echo "LDFLAGS=$(make echo-ldflags)" >> $GITHUB_ENV
           echo "FLUX_VERSION=$(make echo-flux-version)" >> $GITHUB_ENV
       - name: Build and export
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
         with:
           tags: "${{ env.CI_CONTAINER_REPOSITORY }}/${{ matrix.docker-image }}:${{ needs.ci-generate-tag.outputs.tag }}"
           outputs: type=docker,dest=/tmp/${{ matrix.docker-image }}.tar

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -114,7 +114,7 @@ jobs:
           - gitops-server
     steps:
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
-      - uses: docker/setup-buildx-action@v2
+      - uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
       - name: Set build-time flags
         run: |
           echo "LDFLAGS=$(make echo-ldflags)" >> $GITHUB_ENV
@@ -152,7 +152,7 @@ jobs:
           - gitops
           - gitops-server
     steps:
-      - uses: docker/setup-buildx-action@v2
+      - uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
       - uses: google-github-actions/setup-gcloud@e30db14379863a8c79331b04a9969f4c1e225e0b # v1.1.1
       - name: Download cached docker image
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2

--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -88,7 +88,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create Pull Request
         id: create-pull-request
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38 # v5.0.2
         with:
           author: weave-gitops-bot <weave-gitops-bot@weave.works>
           signoff: true

--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Build Changelog
         id: github_release
-        uses: mikepenz/release-changelog-builder-action@v3
+        uses: mikepenz/release-changelog-builder-action@713885393e391b4ce984457280aba0d24fbf0c87 # v4.0.0
         with:
           configuration: "${{ github.workspace }}/.github/changelog/changelog_configuration.json"
           ignorePreReleases: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -67,7 +67,7 @@ jobs:
           git fetch --prune --unshallow
           git fetch --tags -f
       - name: Log in to the Container registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -89,7 +89,7 @@ jobs:
       - name: setup qemu
         uses: docker/setup-qemu-action@v2
       - name: setup docker buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
       - name: Build and push Docker image
         uses: docker/build-push-action@v3
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -87,7 +87,7 @@ jobs:
           flavor: |
             latest=true
       - name: setup qemu
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3.0.0
       - name: setup docker buildx
         uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
       - name: Build and push Docker image

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -78,7 +78,7 @@ jobs:
           echo "FLUX_VERSION=$(make echo-flux-version)" >> $GITHUB_ENV
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934 # v5.0.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -91,7 +91,7 @@ jobs:
       - name: setup docker buildx
         uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
       - name: Build and push Docker image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -151,7 +151,7 @@ jobs:
           $GITHUB_EVENT_PULL_REQUEST_BODY
           END_OF_CHANGELOG
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v3
+        uses: goreleaser/goreleaser-action@7ec5c2b0c6cdda6e8bbb49444bc797dd33d74dd8 # v5.0.0
         with:
           version: latest
           args: release --rm-dist --skip-validate --release-notes=${{ runner.temp }}/changelog.md

--- a/.github/workflows/repostats.yaml
+++ b/.github/workflows/repostats.yaml
@@ -1,9 +1,14 @@
+name: repo-stats
+
 on:
   schedule:
     # Run this once per day, towards the end of the day for keeping the most
     # recent data point most meaningful (hours are interpreted in UTC).
     - cron: "0 23 * * *"
   workflow_dispatch: # Allow for running this manually.
+
+permissions:
+  contents: none
 
 jobs:
   j1:

--- a/.github/workflows/trigger.yaml
+++ b/.github/workflows/trigger.yaml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: none
+
 jobs:
   trigger-enterprise-workflow:
     runs-on: ubuntu-latest

--- a/.github/workflows/trigger.yaml
+++ b/.github/workflows/trigger.yaml
@@ -14,7 +14,7 @@ jobs:
    # if: github.event_name == 'pull_request' && github.event.pull_request.merged == true
     steps:
       - name: Trigger Workflow
-        uses: peter-evans/repository-dispatch@v1
+        uses: peter-evans/repository-dispatch@bf47d102fdb849e755b0b0023ea3e81a44b6f570 # v2.1.2
         with:
           token: ${{ secrets.WKS_CI_TEST_BOT_PR_TOKEN }}
           repository: weaveworks/weave-gitops-enterprise

--- a/.github/workflows/upgrade-flux.yaml
+++ b/.github/workflows/upgrade-flux.yaml
@@ -43,7 +43,7 @@ jobs:
           go get -u github.com/fluxcd/flux2
           go mod tidy
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38 # v5.0.2
         with:
           author: weave-gitops-bot <weave-gitops-bot@weave.works>
           signoff: true
@@ -53,5 +53,5 @@ jobs:
           title: "Upgrade flux to ${{ needs.has-new-flux.outputs.version }}"
           token: ${{ secrets.WEAVE_GITOPS_BOT_ACCESS_TOKEN }}
           body: |
-            Upgrade the flux version used by gitops run, the package
-            dependencies, and the supported flux version in the manual.
+            Upgrade the flux version used by gitops run and the package
+            dependencies.


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes https://github.com/weaveworks/weave-gitops/issues/4023

<!-- Describe what has changed in this PR -->
**What changed?**
To ensure we use a specific version of each GitHub Action. 

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**
This is a follow-up PR to https://github.com/weaveworks/weave-gitops/pull/4044 to ensure all GitHub Actions are pinned to a commit SHA.

<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**
N/A

<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**
N/A

<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**
N/A

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
N/A