### PR TITLE
docs: Bump dex chart version

### DIFF
--- a/website/docs/enterprise/getting-started/install-enterprise.mdx
+++ b/website/docs/enterprise/getting-started/install-enterprise.mdx
@@ -271,15 +271,13 @@ spec:
   chart:
     spec:
       chart: dex
-      version: 0.6.5
+      version: 0.15.3
       sourceRef:
         kind: HelmRepository
         name: dex
         namespace: dex
       interval: 1m
   values:
-    image:
-      tag: v2.31.0
     envVars:
     - name: GITHUB_CLIENT_ID
       valueFrom:
@@ -300,7 +298,7 @@ spec:
         type: memory
 
       staticClients:
-      - name: 'Weave GitOps Core'
+      - name: 'Weave GitOps'
         id: weave-gitops
         secret: AiAImuXKhoI5ApvKWF988txjZ+6rG3S7o6X5En
         redirectURIs:


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Fixed #4040

<!-- Describe what has changed in this PR -->
**What changed?**
Updated the chart version of Dex that was referenced in our docs to 0.15.3. Also removed hard-coded image version to defer instead to the chart values (currently pulls in v2.37.0 which is the latest as of now).
Note that this was also tested on a GKE cluster along with these chart versions:
- cert-manager 1.13.1
- ingress-ngix 4.8.0
- Weave GitOps 0.33.0

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**
The previous version (0.6.5) was too old.

<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**
N/A

<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**
N/A

<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**
N/A

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
N/A