### PR TITLE
Fixes staging-docs

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -45,9 +45,9 @@ jobs:
           npm i
           fi
           sed -i 's#url:.*$#url: "https://staging.docs.gitops.weave.works",#' docusaurus.config.js
-          sed -i 's#baseUrl:.*$#baseUrl: "/$GITHUB_HEAD_REF/",#' docusaurus.config.js
+          sed -i "s#baseUrl:.*\$#baseUrl: \"/$GITHUB_HEAD_REF/\",#" docusaurus.config.js
           yarn clear
-          npm run build
+          DISABLE_VERSIONING=true npm run build
       - id: auth
         uses: google-github-actions/auth@35b0e87d162680511bf346c299f71c9c5c379033 # v1.1.1
         with:
@@ -64,15 +64,21 @@ jobs:
         env:
           GITHUB_HEAD_REF: ${{ github.head_ref }}
         run: |
+          # Pull this out to a heredoc so we can easily interpolate variables
+          PAYLOAD=$(cat <<EOF
+          {
+            "state": "success",
+            "context": "Doc site preview",
+            "target_url": "https://staging.docs.gitops.weave.works/$GITHUB_HEAD_REF"
+          }
+          EOF
+          )
+
           curl --request POST \
             --url https://api.github.com/repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha }} \
             --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
             --header 'content-type: application/json' \
-            --data '{
-              "state": "success",
-              "context": "Doc site preview",
-              "target_url": "https://staging.docs.gitops.weave.works/$GITHUB_HEAD_REF"
-              }' \
+            --data "$PAYLOAD" \
             --fail
 
   prod-release:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -47,7 +47,7 @@ jobs:
           sed -i 's#url:.*$#url: "https://staging.docs.gitops.weave.works",#' docusaurus.config.js
           sed -i "s#baseUrl:.*\$#baseUrl: \"/$GITHUB_HEAD_REF/\",#" docusaurus.config.js
           yarn clear
-          DISABLE_VERSIONING=true npm run build
+          npm run build
       - id: auth
         uses: google-github-actions/auth@35b0e87d162680511bf346c299f71c9c5c379033 # v1.1.1
         with:

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -187,6 +187,7 @@ module.exports = {
           id: 'default',
           sidebarPath: require.resolve("./sidebars.js"),
           editUrl: "https://github.com/weaveworks/weave-gitops/edit/main/website",
+          disableVersioning: process.env.DISABLE_VERSIONING === "true",
         },
         blog: {
           showReadingTime: true,


### PR DESCRIPTION
- var interpolation wasn't working with single quotes
- also introduce env var into docusaurus so you can optionally disable versioning (`DISABLE_VERSIONING=true yarn build` to dramatically speed up builds when testing things..)

<!-- Describe what has changed in this PR -->
**What changed?**

Some of the github action code, switch from single `''` to double `""` quoted strings so we can do the var interpolation

Switch to env vars which relied on the variable expansion made in https://github.com/weaveworks/weave-gitops/pull/4046

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**

So staging docs works


<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**

- Use heredoc for JSON payloads.. seems to work okay and avoids having to escape all the double quoted key names in JSON..

<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**

Checked that the staging docs now works
