### PR TITLE
override default tabs min-width at (600px) media query

### DIFF
--- a/ui/components/SubRouterTabs.tsx
+++ b/ui/components/SubRouterTabs.tsx
@@ -111,6 +111,9 @@ export default styled(SubRouterTabs).attrs({ className: SubRouterTabs.name })`
         min-height: 32px;
         width: fit-content;
         @media (min-width: 600px) {
+          min-width: auto;
+        }
+        @media (min-width: 1440px) {
           min-width: 132px;
         }
       }


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes #[3392](https://github.com/weaveworks/weave-gitops-enterprise/issues/3392)

<!-- Describe what has changed in this PR -->
**What changed?**
- update the tab min-width to be auto and update the size on larger screen size.

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**
- This change made to make the tabs component being usable on smaller screen size.

<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**
- Tested locally