### PR TITLE
fix: Only run npm publish job on weave-gitops repo

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -212,6 +212,7 @@ jobs:
   ci-publish-js-lib:
     name: Publish js library
     runs-on: ubuntu-latest
+    if: github.repository == 'weaveworks/weave-gitops'
     needs: [ci-js]
     permissions:
       packages: write


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
There's a step in our CI process that pushes an npm package to the GitHub npm registry. This step fails when executed in forks of the repo. This change attempts to only run this step for PRs within the weave-gitops repo.

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**
To prevent CI from failing when running in forks.