### PR TITLE
fix: Skip updating release status check in forks

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -273,7 +273,7 @@ jobs:
 
   #  release step updates 'release' status check for non releases branches. See ../../doc/incidents/issues-3907 for full context.
   release:
-    if: ${{ github.event_name == 'pull_request' && !startsWith(github.event.pull_request.head.ref, 'releases/') }}
+    if: ${{ github.event_name == 'pull_request' && !startsWith(github.event.pull_request.head.ref, 'releases/') && !github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-latest
     steps:
       - name: Release


### PR DESCRIPTION
Skipping step that updates release check status on weave-gitops repo, when running in forks.