### PR TITLE
fix: Skip running job on forks

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -20,7 +20,7 @@ jobs:
   staging-release:
     permissions:
       statuses: write
-    if: github.event_name != 'push' && github.repository_owner == 'weaveworks'
+    if: ${{ github.event_name != 'push' && github.repository_owner == 'weaveworks' && !github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
The `staging-release` CI job builds and pushes docs to a staging environment and therefore fails when run on forks.

Example of a failure: https://github.com/weaveworks/weave-gitops/actions/runs/6546412572/job/17776816192?pr=3990