### PR TITLE
fixed format for monitoring docs

### DIFF
--- a/website/docs/operations/monitoring.mdx
+++ b/website/docs/operations/monitoring.mdx
@@ -42,11 +42,11 @@ The monitoring server holds private services, so you likely do not require to ex
 case you need, ensure that it is properly secured.
 :::
 
-### Metrics
+## Metrics
 
 It generates [Prometheus](https://prometheus.io/) metrics for monitoring both performance and business operations.
 
-#### Get Started
+### Get Started
 
 :::info
 This setup follows [Flux Monitoring](https://fluxcd.io/flux/monitoring/metrics/) approach based on [Prometheus Operator](https://prometheus-operator.dev/). Adapt it to your context as needed.
@@ -140,7 +140,7 @@ Monitor Weave Gitops GO runtime metrics like Memory Usage, Memory Heap, Goroutin
 
 Monitor Explorer golden signals. More info [here](../../explorer/operations#monitoring)
 
-### Profiling
+## Profiling
 
 Profiling can be useful during operations to help you to gain a deeper understanding, of how weave gitops runtime behaves.
 Given Weave GitOps is written in Go, profiling happens through [pprof](https://pkg.go.dev/runtime/pprof), and it is


### PR DESCRIPTION
Fixes formatting for monitoring docs. Now the table of contents look better:


<img width="334" alt="Screenshot 2023-10-19 at 15 37 16" src="https://github.com/weaveworks/weave-gitops/assets/12957664/4b69a054-ab92-4760-8f97-87e9596ebcf2">

