### PR TITLE
Ensure the yarn.lock file is being used in container images

### DIFF
--- a/gitops-server.dockerfile
+++ b/gitops-server.dockerfile
@@ -5,6 +5,7 @@ RUN mkdir -p /home/app && chown -R node:node /home/app
 WORKDIR /home/app
 USER node
 COPY --chown=node:node package*.json /home/app/
+COPY --chown=node:node yarn.lock /home/app
 COPY --chown=node:node Makefile /home/app/
 COPY --chown=node:node tsconfig.json /home/app/
 COPY --chown=node:node .parcelrc /home/app/


### PR DESCRIPTION
FIxes an issues where dependencies will get upgraded unintentionally in container builds.

We originally had a `package-lock.json` that was being used to ensure consistent builds, but #3592 converted to `yarn` which has a separate `yarn.lock` file that needs to be copied.