### PR TITLE
ci: Remove Slack notification to archived channel

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -287,20 +287,3 @@ jobs:
                 "description":"release not required",
                 "context":"release"
               }'
-
-  notify-failure:
-    name: Notify Slack on Failure
-    runs-on: ubuntu-latest
-    needs:
-      - finish-ci-merge
-    if: ${{ failure() }}
-    steps:
-    - name: Send alert
-      if: github.event_name == 'push'
-      uses: actions-ecosystem/action-slack-notifier@fc778468d09c43a6f4d1b8cccaca59766656996a
-      with:
-        slack_token: ${{ secrets.SLACK_TOKEN_BLUETONIUM }}
-        message: ":sad-parrot: The <https://github.com/weaveworks/weave-gitops/commit/${{ github.sha }}|latest commit> from ${{ github.actor }} is failing on main. <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|Click here> and weep."
-        channel: team-denim
-        color: red
-        verbose: false


### PR DESCRIPTION

<!-- Describe what has changed in this PR -->
**What changed?**
Removed Slack notification job as the target Slack channel has been archived.

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**
To ensure our CI workflows are up-to-date.