### PR TITLE
Fix website README

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -14,8 +14,6 @@ The website is live [here](https://docs.gitops.weave.works/).
 
 1. Install dependencies: `yarn install`.
 
-1. Set a fake Google Analytics API key to pass validation errors: `export GA_KEY=fakekey`
-
 1. Start the docs server.
 
     > If you are using newer version of Node (17+):
@@ -24,7 +22,7 @@ The website is live [here](https://docs.gitops.weave.works/).
     > ```
 
     ```bash
-    yarn start
+    GA_KEY=fake ALGOLIA_API_KEY=fake yarn start
     ```
 
     This will open a browser window. Your changes will be automatically loaded by


### PR DESCRIPTION
The new environment variable ALGOLIA_API_KEY hasn't been added to the documentation in the README so I added it and also simplified the command to run the dev server.