### PR TITLE
show suspended by annotations to metadata component

### DIFF
--- a/core/server/suspend.go
+++ b/core/server/suspend.go
@@ -11,6 +11,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+const SuspendedByAnnotation = "metadata.weave.works/suspended-by"
+const SuspendedCommentAnnotation = "metadata.weave.works/suspended-comment"
+
 func (cs *coreServer) ToggleSuspendResource(ctx context.Context, msg *pb.ToggleSuspendResourceRequest) (*pb.ToggleSuspendResourceResponse, error) {
 	principal := auth.Principal(ctx)
 	respErrors := multierror.Error{}
@@ -85,12 +88,14 @@ func changeSuspendAnnotations(obj fluxsync.Reconcilable, suspend bool, comment s
 		annotations = map[string]string{}
 	}
 	if suspend {
-		annotations["weave.works/suspended-by"] = principal.ID
-		annotations["weave.works/suspended-comment"] = comment
+		annotations[SuspendedByAnnotation] = principal.ID
+		if comment != "" {
+			annotations[SuspendedCommentAnnotation] = comment
+		}
 		obj.SetAnnotations(annotations)
 	} else {
-		delete(annotations, "weave.works/suspended-by")
-		delete(annotations, "weave.works/suspended-comment")
+		delete(annotations, SuspendedByAnnotation)
+		delete(annotations, SuspendedCommentAnnotation)
 		obj.SetAnnotations(annotations)
 	}
 }

--- a/core/server/suspend_test.go
+++ b/core/server/suspend_test.go
@@ -97,6 +97,7 @@ func TestSuspend_Suspend(t *testing.T) {
 			req := &api.ToggleSuspendResourceRequest{
 				Objects: []*api.ObjectRef{object},
 				Suspend: true,
+				Comment: "testing some things out",
 			}
 			principalID := "anne"
 			md := metadata.Pairs(MetadataUserKey, principalID, MetadataGroupsKey, "system:masters")
@@ -177,24 +178,24 @@ func getUnstructuredObj(t *testing.T, k client.Client, name types.NamespacedName
 func checkSuspendAnnotations(t *testing.T, principalID string, annotations map[string]string, name types.NamespacedName, suspend bool) {
 	if suspend {
 		// suspended and annotations exist check
-		if suspendedBy, ok := annotations["weave.works/suspended-by"]; ok {
+		if suspendedBy, ok := annotations["metadata.weave.works/suspended-by"]; ok {
 			// principal check if suspended and annotations exist
 			if suspendedBy != principalID {
-				t.Errorf("expected annotation weave.works/suspended-by to be set to the principal %s", principalID)
+				t.Errorf("expected annotation metadata.weave.works/suspended-by to be set to the principal %s", principalID)
 			}
 		} else {
-			t.Errorf("expected annotation weave.works/suspended-by not found for %s", name)
+			t.Errorf("expected annotation metadata.weave.works/suspended-by not found for %s", name)
 		}
-		if _, ok := annotations["weave.works/suspended-comment"]; !ok {
-			t.Errorf("expected annotation weave.works/suspended-comment not found for %s", name)
+		if _, ok := annotations["metadata.weave.works/suspended-comment"]; !ok {
+			t.Errorf("expected annotation metadata.weave.works/suspended-comment not found for %s", name)
 		}
 	} else {
 		// not suspended and annotations don't exist check
-		if _, ok := annotations["weave.works/suspended-by"]; ok {
-			t.Errorf("expected annotation weave.works/suspended-by not found for %s", name)
+		if _, ok := annotations["metadata.weave.works/suspended-by"]; ok {
+			t.Errorf("expected annotation metadata.weave.works/suspended-by not found for %s", name)
 		}
-		if _, ok := annotations["weave.works/suspended-comment"]; ok {
-			t.Errorf("expected annotation weave.works/suspended-comment not found for %s", name)
+		if _, ok := annotations["metadata.weave.works/suspended-comment"]; ok {
+			t.Errorf("expected annotation metadata.weave.works/suspended-comment not found for %s", name)
 		}
 	}
 }


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes #[3546](https://github.com/weaveworks/weave-gitops-enterprise/issues/3546)

<!-- Describe what has changed in this PR -->
**What changed?**
- Refactor suspended by annotations to have prefix "metadata".
- After adding the prefix metadata that makes the suspended to show up at the metadata component at the details page view

<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**
- Update the Tests

