### PR TITLE
UI | fix markdown editor overflow style

### DIFF
--- a/ui/components/Policies/Utils/MarkdownEditor.tsx
+++ b/ui/components/Policies/Utils/MarkdownEditor.tsx
@@ -4,7 +4,7 @@ import styled from "styled-components";
 export const MarkdownEditor = styled<any>(ReactMarkdown)`
   width: calc(100% - 24px);
   padding: ${(props) => props.theme.spacing.small};
-  overflow: scroll;
+  overflow: auto;
   background: ${(props) => props.theme.colors.neutralGray};
   max-height: 300px;
   & a {


### PR DESCRIPTION
before :
![image](https://github.com/weaveworks/weave-gitops/assets/4614360/3870a29d-5848-4cef-a8f7-fb710b64db9d)

after:
![image](https://github.com/weaveworks/weave-gitops/assets/4614360/116f7e07-f5ba-4b7c-9252-2cddf65007d6)
