### PR TITLE
add weave gitops oss release notes links for v0.37 

### DIFF
--- a/website/docs/enterprise/getting-started/releases-enterprise.mdx
+++ b/website/docs/enterprise/getting-started/releases-enterprise.mdx
@@ -41,13 +41,12 @@ RED metrics and corresponding Grafana dashboard panels have been added to the ob
 
 ### Dependency versions
 - Flux >= v2.0.0
-- weave-gitops v0.37.0
+- weave-gitops [v0.37.0](https://github.com/weaveworks/weave-gitops/releases/tag/v0.37.0)
 - cluster-controller v1.5.2
 - cluster-bootstrap-controller v0.7.1
 - (optional) pipeline-controller v0.21.0
 - (optional) policy-agent v2.5.0
 - (optional) gitopssets-controller v0.16.4
-
 
 ## v0.36.0
 2023-11-10

--- a/website/versioned_docs/version-0.37.0/enterprise/getting-started/releases-enterprise.mdx
+++ b/website/versioned_docs/version-0.37.0/enterprise/getting-started/releases-enterprise.mdx
@@ -41,7 +41,7 @@ RED metrics and corresponding Grafana dashboard panels have been added to the ob
 
 ### Dependency versions
 - Flux >= v2.0.0
-- weave-gitops v0.37.0
+- weave-gitops [v0.37.0](https://github.com/weaveworks/weave-gitops/releases/tag/v0.37.0)
 - cluster-controller v1.5.2
 - cluster-bootstrap-controller v0.7.1
 - (optional) pipeline-controller v0.21.0


### PR DESCRIPTION
to help out ee customers to have the info more easily accessible temp for this version. we should find a long-term solution to the problem. 
