### PR TITLE
Add namespaces to explorer configuration example

### DIFF
--- a/website/docs/explorer/configuration.mdx
+++ b/website/docs/explorer/configuration.mdx
@@ -149,6 +149,9 @@ rules:
   - apiGroups: [ "source.toolkit.fluxcd.io" ]
     resources: [ "buckets", "helmcharts", "gitrepositories", "helmrepositories", "ocirepositories" ]
     verbs: [ "list", "watch" ]
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["list", "watch"]
 ```
 
 </details>


### PR DESCRIPTION
Part of https://github.com/weaveworks/weave-gitops-enterprise/pull/3682

Adds namespaces to the example configuration for Explorer.