### PR TITLE
Add support for V2Routes.Runtime in navigation getParentNavRouteValue

### DIFF
--- a/ui/lib/nav.ts
+++ b/ui/lib/nav.ts
@@ -82,6 +82,8 @@ export const getParentNavRouteValue = (
 
     case V2Routes.FluxRuntime:
       return V2Routes.FluxRuntime;
+    case V2Routes.Runtime:
+      return V2Routes.Runtime;
 
     case V2Routes.ImageAutomation:
     case V2Routes.ImageAutomationUpdatesDetails:


### PR DESCRIPTION
Fixes the issue of the nav item menu not being highlighted:

![Screenshot 2023-12-28 at 11 45 17](https://github.com/weaveworks/weave-gitops/assets/12957664/5f70e584-acd5-49a7-ba0d-f3cf5aa3d13e)

