### PR TITLE
fix: remove rbac Secrets from app rules

### DIFF
--- a/core/nsaccess/nsaccess.go
+++ b/core/nsaccess/nsaccess.go
@@ -18,7 +18,7 @@ import (
 var DefautltWegoAppRules = []rbacv1.PolicyRule{
 	{
 		APIGroups: []string{""},
-		Resources: []string{"secrets", "pods", "events"},
+		Resources: []string{"pods", "events"},
 		Verbs:     []string{"get", "list"},
 	},
 	{


### PR DESCRIPTION
Be able to watch flux resources in UI without having rights to read secrets in k8s.
