### PR TITLE
Bump Flux CRDs to Flux 2.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -233,10 +233,10 @@ download-test-crds:
 	for group_resource in $$group_resources; do \
 		group="$${group_resource%/*}"; resource="$${group_resource#*/}"; \
 		echo "Downloading $${group}.$${resource}"; \
-		curl -sL "https://raw.githubusercontent.com/fluxcd/source-controller/v1.3.0/config/crd/bases/$${group}.toolkit.fluxcd.io_$${resource}.yaml" -o "tools/testcrds/$${group}.toolkit.fluxcd.io_$${resource}.yaml"; \
+		curl -sL "https://raw.githubusercontent.com/fluxcd/source-controller/v1.4.1/config/crd/bases/$${group}.toolkit.fluxcd.io_$${resource}.yaml" -o "tools/testcrds/$${group}.toolkit.fluxcd.io_$${resource}.yaml"; \
 	done
-	curl -sL "https://raw.githubusercontent.com/fluxcd/kustomize-controller/v1.3.0/config/crd/bases/kustomize.toolkit.fluxcd.io_kustomizations.yaml" -o "tools/testcrds/kustomize.toolkit.fluxcd.io_kustomizations.yaml"
-	curl -sL "https://raw.githubusercontent.com/fluxcd/helm-controller/v1.0.1/config/crd/bases/helm.toolkit.fluxcd.io_helmreleases.yaml" -o "tools/testcrds/helm.toolkit.fluxcd.io_helmreleases.yaml"
+	curl -sL "https://raw.githubusercontent.com/fluxcd/kustomize-controller/v1.4.0/config/crd/bases/kustomize.toolkit.fluxcd.io_kustomizations.yaml" -o "tools/testcrds/kustomize.toolkit.fluxcd.io_kustomizations.yaml"
+	curl -sL "https://raw.githubusercontent.com/fluxcd/helm-controller/v1.1.0/config/crd/bases/helm.toolkit.fluxcd.io_helmreleases.yaml" -o "tools/testcrds/helm.toolkit.fluxcd.io_helmreleases.yaml"
 
 .PHONY: help
 # Thanks to https://www.thapaliya.com/en/writings/well-documented-makefiles/

--- a/tools/testcrds/helm.toolkit.fluxcd.io_helmreleases.yaml
+++ b/tools/testcrds/helm.toolkit.fluxcd.io_helmreleases.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.1
   name: helmreleases.helm.toolkit.fluxcd.io
 spec:
   group: helm.toolkit.fluxcd.io
@@ -12,3739 +12,3671 @@ spec:
     listKind: HelmReleaseList
     plural: helmreleases
     shortNames:
-      - hr
+    - hr
     singular: helmrelease
   scope: Namespaced
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .metadata.creationTimestamp
-          name: Age
-          type: date
-        - jsonPath: .status.conditions[?(@.type=="Ready")].status
-          name: Ready
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].message
-          name: Status
-          type: string
-      name: v2
-      schema:
-        openAPIV3Schema:
-          description: HelmRelease is the Schema for the helmreleases API
-          properties:
-            apiVersion:
-              description: |-
-                APIVersion defines the versioned schema of this representation of an object.
-                Servers should convert recognized schemas to the latest internal value, and
-                may reject unrecognized values.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-              type: string
-            kind:
-              description: |-
-                Kind is a string value representing the REST resource this object represents.
-                Servers may infer this from the endpoint the client submits requests to.
-                Cannot be updated.
-                In CamelCase.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: HelmReleaseSpec defines the desired state of a Helm release.
-              properties:
-                chart:
-                  description: |-
-                    Chart defines the template of the v1.HelmChart that should be created
-                    for this HelmRelease.
-                  properties:
-                    metadata:
-                      description: ObjectMeta holds the template for metadata like labels
-                        and annotations.
-                      properties:
-                        annotations:
-                          additionalProperties:
-                            type: string
-                          description: |-
-                            Annotations is an unstructured key value map stored with a resource that may be
-                            set by external tools to store and retrieve arbitrary metadata. They are not
-                            queryable and should be preserved when modifying objects.
-                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
-                          type: object
-                        labels:
-                          additionalProperties:
-                            type: string
-                          description: |-
-                            Map of string keys and values that can be used to organize and categorize
-                            (scope and select) objects.
-                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
-                          type: object
-                      type: object
-                    spec:
-                      description: Spec holds the template for the v1.HelmChartSpec
-                        for this HelmRelease.
-                      properties:
-                        chart:
-                          description: The name or path the Helm chart is available
-                            at in the SourceRef.
-                          maxLength: 2048
-                          minLength: 1
-                          type: string
-                        ignoreMissingValuesFiles:
-                          description: IgnoreMissingValuesFiles controls whether to
-                            silently ignore missing values files rather than failing.
-                          type: boolean
-                        interval:
-                          description: |-
-                            Interval at which to check the v1.Source for updates. Defaults to
-                            'HelmReleaseSpec.Interval'.
-                          pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                          type: string
-                        reconcileStrategy:
-                          default: ChartVersion
-                          description: |-
-                            Determines what enables the creation of a new artifact. Valid values are
-                            ('ChartVersion', 'Revision').
-                            See the documentation of the values for an explanation on their behavior.
-                            Defaults to ChartVersion when omitted.
-                          enum:
-                            - ChartVersion
-                            - Revision
-                          type: string
-                        sourceRef:
-                          description: The name and namespace of the v1.Source the chart
-                            is available at.
-                          properties:
-                            apiVersion:
-                              description: APIVersion of the referent.
-                              type: string
-                            kind:
-                              description: Kind of the referent.
-                              enum:
-                                - HelmRepository
-                                - GitRepository
-                                - Bucket
-                              type: string
-                            name:
-                              description: Name of the referent.
-                              maxLength: 253
-                              minLength: 1
-                              type: string
-                            namespace:
-                              description: Namespace of the referent.
-                              maxLength: 63
-                              minLength: 1
-                              type: string
-                          required:
-                            - name
-                          type: object
-                        valuesFiles:
-                          description: |-
-                            Alternative list of values files to use as the chart values (values.yaml
-                            is not included by default), expected to be a relative path in the SourceRef.
-                            Values files are merged in the order of this list with the last file overriding
-                            the first. Ignored when omitted.
-                          items:
-                            type: string
-                          type: array
-                        verify:
-                          description: |-
-                            Verify contains the secret name containing the trusted public keys
-                            used to verify the signature and specifies which provider to use to check
-                            whether OCI image is authentic.
-                            This field is only supported for OCI sources.
-                            Chart dependencies, which are not bundled in the umbrella chart artifact,
-                            are not verified.
-                          properties:
-                            provider:
-                              default: cosign
-                              description: Provider specifies the technology used to
-                                sign the OCI Helm chart.
-                              enum:
-                                - cosign
-                                - notation
-                              type: string
-                            secretRef:
-                              description: |-
-                                SecretRef specifies the Kubernetes Secret containing the
-                                trusted public keys.
-                              properties:
-                                name:
-                                  description: Name of the referent.
-                                  type: string
-                              required:
-                                - name
-                              type: object
-                          required:
-                            - provider
-                          type: object
-                        version:
-                          default: '*'
-                          description: |-
-                            Version semver expression, ignored for charts from v1.GitRepository and
-                            v1beta2.Bucket sources. Defaults to latest when omitted.
-                          type: string
-                      required:
-                        - chart
-                        - sourceRef
-                      type: object
-                  required:
-                    - spec
-                  type: object
-                chartRef:
-                  description: |-
-                    ChartRef holds a reference to a source controller resource containing the
-                    Helm chart artifact.
-                  properties:
-                    apiVersion:
-                      description: APIVersion of the referent.
-                      type: string
-                    kind:
-                      description: Kind of the referent.
-                      enum:
-                        - OCIRepository
-                        - HelmChart
-                      type: string
-                    name:
-                      description: Name of the referent.
-                      maxLength: 253
-                      minLength: 1
-                      type: string
-                    namespace:
-                      description: |-
-                        Namespace of the referent, defaults to the namespace of the Kubernetes
-                        resource object that contains the reference.
-                      maxLength: 63
-                      minLength: 1
-                      type: string
-                  required:
-                    - kind
-                    - name
-                  type: object
-                dependsOn:
-                  description: |-
-                    DependsOn may contain a meta.NamespacedObjectReference slice with
-                    references to HelmRelease resources that must be ready before this HelmRelease
-                    can be reconciled.
-                  items:
-                    description: |-
-                      NamespacedObjectReference contains enough information to locate the referenced Kubernetes resource object in any
-                      namespace.
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      type: string
+    name: v2
+    schema:
+      openAPIV3Schema:
+        description: HelmRelease is the Schema for the helmreleases API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: HelmReleaseSpec defines the desired state of a Helm release.
+            properties:
+              chart:
+                description: |-
+                  Chart defines the template of the v1.HelmChart that should be created
+                  for this HelmRelease.
+                properties:
+                  metadata:
+                    description: ObjectMeta holds the template for metadata like labels
+                      and annotations.
                     properties:
-                      name:
-                        description: Name of the referent.
-                        type: string
-                      namespace:
-                        description: Namespace of the referent, when not specified it
-                          acts as LocalObjectReference.
-                        type: string
-                    required:
-                      - name
-                    type: object
-                  type: array
-                driftDetection:
-                  description: |-
-                    DriftDetection holds the configuration for detecting and handling
-                    differences between the manifest in the Helm storage and the resources
-                    currently existing in the cluster.
-                  properties:
-                    ignore:
-                      description: |-
-                        Ignore contains a list of rules for specifying which changes to ignore
-                        during diffing.
-                      items:
+                      annotations:
+                        additionalProperties:
+                          type: string
                         description: |-
-                          IgnoreRule defines a rule to selectively disregard specific changes during
-                          the drift detection process.
-                        properties:
-                          paths:
-                            description: |-
-                              Paths is a list of JSON Pointer (RFC 6901) paths to be excluded from
-                              consideration in a Kubernetes object.
-                            items:
-                              type: string
-                            type: array
-                          target:
-                            description: |-
-                              Target is a selector for specifying Kubernetes objects to which this
-                              rule applies.
-                              If Target is not set, the Paths will be ignored for all Kubernetes
-                              objects within the manifest of the Helm release.
-                            properties:
-                              annotationSelector:
-                                description: |-
-                                  AnnotationSelector is a string that follows the label selection expression
-                                  https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
-                                  It matches with the resource annotations.
-                                type: string
-                              group:
-                                description: |-
-                                  Group is the API group to select resources from.
-                                  Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources.
-                                  https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
-                                type: string
-                              kind:
-                                description: |-
-                                  Kind of the API Group to select resources from.
-                                  Together with Group and Version it is capable of unambiguously
-                                  identifying and/or selecting resources.
-                                  https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
-                                type: string
-                              labelSelector:
-                                description: |-
-                                  LabelSelector is a string that follows the label selection expression
-                                  https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
-                                  It matches with the resource labels.
-                                type: string
-                              name:
-                                description: Name to match resources with.
-                                type: string
-                              namespace:
-                                description: Namespace to select resources from.
-                                type: string
-                              version:
-                                description: |-
-                                  Version of the API Group to select resources from.
-                                  Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources.
-                                  https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
-                                type: string
-                            type: object
-                        required:
-                          - paths
+                          Annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
                         type: object
-                      type: array
-                    mode:
-                      description: |-
-                        Mode defines how differences should be handled between the Helm manifest
-                        and the manifest currently applied to the cluster.
-                        If not explicitly set, it defaults to DiffModeDisabled.
-                      enum:
-                        - enabled
-                        - warn
-                        - disabled
-                      type: string
-                  type: object
-                install:
-                  description: Install holds the configuration for Helm install actions
-                    for this HelmRelease.
-                  properties:
-                    crds:
-                      description: |-
-                        CRDs upgrade CRDs from the Helm Chart's crds directory according
-                        to the CRD upgrade policy provided here. Valid values are `Skip`,
-                        `Create` or `CreateReplace`. Default is `Create` and if omitted
-                        CRDs are installed but not updated.
-                        
-                        
-                        Skip: do neither install nor replace (update) any CRDs.
-                        
-                        
-                        Create: new CRDs are created, existing CRDs are neither updated nor deleted.
-                        
-                        
-                        CreateReplace: new CRDs are created, existing CRDs are updated (replaced)
-                        but not deleted.
-                        
-                        
-                        By default, CRDs are applied (installed) during Helm install action.
-                        With this option users can opt in to CRD replace existing CRDs on Helm
-                        install actions, which is not (yet) natively supported by Helm.
-                        https://helm.sh/docs/chart_best_practices/custom_resource_definitions.
-                      enum:
-                        - Skip
-                        - Create
-                        - CreateReplace
-                      type: string
-                    createNamespace:
-                      description: |-
-                        CreateNamespace tells the Helm install action to create the
-                        HelmReleaseSpec.TargetNamespace if it does not exist yet.
-                        On uninstall, the namespace will not be garbage collected.
-                      type: boolean
-                    disableHooks:
-                      description: DisableHooks prevents hooks from running during the
-                        Helm install action.
-                      type: boolean
-                    disableOpenAPIValidation:
-                      description: |-
-                        DisableOpenAPIValidation prevents the Helm install action from validating
-                        rendered templates against the Kubernetes OpenAPI Schema.
-                      type: boolean
-                    disableWait:
-                      description: |-
-                        DisableWait disables the waiting for resources to be ready after a Helm
-                        install has been performed.
-                      type: boolean
-                    disableWaitForJobs:
-                      description: |-
-                        DisableWaitForJobs disables waiting for jobs to complete after a Helm
-                        install has been performed.
-                      type: boolean
-                    remediation:
-                      description: |-
-                        Remediation holds the remediation configuration for when the Helm install
-                        action for the HelmRelease fails. The default is to not perform any action.
-                      properties:
-                        ignoreTestFailures:
-                          description: |-
-                            IgnoreTestFailures tells the controller to skip remediation when the Helm
-                            tests are run after an install action but fail. Defaults to
-                            'Test.IgnoreFailures'.
-                          type: boolean
-                        remediateLastFailure:
-                          description: |-
-                            RemediateLastFailure tells the controller to remediate the last failure, when
-                            no retries remain. Defaults to 'false'.
-                          type: boolean
-                        retries:
-                          description: |-
-                            Retries is the number of retries that should be attempted on failures before
-                            bailing. Remediation, using an uninstall, is performed between each attempt.
-                            Defaults to '0', a negative integer equals to unlimited retries.
-                          type: integer
-                      type: object
-                    replace:
-                      description: |-
-                        Replace tells the Helm install action to re-use the 'ReleaseName', but only
-                        if that name is a deleted release which remains in the history.
-                      type: boolean
-                    skipCRDs:
-                      description: |-
-                        SkipCRDs tells the Helm install action to not install any CRDs. By default,
-                        CRDs are installed if not already present.
-                        
-                        
-                        Deprecated use CRD policy (`crds`) attribute with value `Skip` instead.
-                      type: boolean
-                    timeout:
-                      description: |-
-                        Timeout is the time to wait for any individual Kubernetes operation (like
-                        Jobs for hooks) during the performance of a Helm install action. Defaults to
-                        'HelmReleaseSpec.Timeout'.
-                      pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                      type: string
-                  type: object
-                interval:
-                  description: Interval at which to reconcile the Helm release.
-                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                  type: string
-                kubeConfig:
-                  description: |-
-                    KubeConfig for reconciling the HelmRelease on a remote cluster.
-                    When used in combination with HelmReleaseSpec.ServiceAccountName,
-                    forces the controller to act on behalf of that Service Account at the
-                    target cluster.
-                    If the --default-service-account flag is set, its value will be used as
-                    a controller level fallback for when HelmReleaseSpec.ServiceAccountName
-                    is empty.
-                  properties:
-                    secretRef:
-                      description: |-
-                        SecretRef holds the name of a secret that contains a key with
-                        the kubeconfig file as the value. If no key is set, the key will default
-                        to 'value'.
-                        It is recommended that the kubeconfig is self-contained, and the secret
-                        is regularly updated if credentials such as a cloud-access-token expire.
-                        Cloud specific `cmd-path` auth helpers will not function without adding
-                        binaries and credentials to the Pod that is responsible for reconciling
-                        Kubernetes resources.
-                      properties:
-                        key:
-                          description: Key in the Secret, when not specified an implementation-specific
-                            default key is used.
+                      labels:
+                        additionalProperties:
                           type: string
-                        name:
-                          description: Name of the Secret.
-                          type: string
-                      required:
-                        - name
-                      type: object
-                  required:
-                    - secretRef
-                  type: object
-                maxHistory:
-                  description: |-
-                    MaxHistory is the number of revisions saved by Helm for this HelmRelease.
-                    Use '0' for an unlimited number of revisions; defaults to '5'.
-                  type: integer
-                persistentClient:
-                  description: |-
-                    PersistentClient tells the controller to use a persistent Kubernetes
-                    client for this release. When enabled, the client will be reused for the
-                    duration of the reconciliation, instead of being created and destroyed
-                    for each (step of a) Helm action.
-                    
-                    
-                    This can improve performance, but may cause issues with some Helm charts
-                    that for example do create Custom Resource Definitions during installation
-                    outside Helm's CRD lifecycle hooks, which are then not observed to be
-                    available by e.g. post-install hooks.
-                    
-                    
-                    If not set, it defaults to true.
-                  type: boolean
-                postRenderers:
-                  description: |-
-                    PostRenderers holds an array of Helm PostRenderers, which will be applied in order
-                    of their definition.
-                  items:
-                    description: PostRenderer contains a Helm PostRenderer specification.
-                    properties:
-                      kustomize:
-                        description: Kustomization to apply as PostRenderer.
-                        properties:
-                          images:
-                            description: |-
-                              Images is a list of (image name, new name, new tag or digest)
-                              for changing image names, tags or digests. This can also be achieved with a
-                              patch, but this operator is simpler to specify.
-                            items:
-                              description: Image contains an image name, a new name,
-                                a new tag or digest, which will replace the original
-                                name and tag.
-                              properties:
-                                digest:
-                                  description: |-
-                                    Digest is the value used to replace the original image tag.
-                                    If digest is present NewTag value is ignored.
-                                  type: string
-                                name:
-                                  description: Name is a tag-less image name.
-                                  type: string
-                                newName:
-                                  description: NewName is the value used to replace
-                                    the original name.
-                                  type: string
-                                newTag:
-                                  description: NewTag is the value used to replace the
-                                    original tag.
-                                  type: string
-                              required:
-                                - name
-                              type: object
-                            type: array
-                          patches:
-                            description: |-
-                              Strategic merge and JSON patches, defined as inline YAML objects,
-                              capable of targeting objects based on kind, label and annotation selectors.
-                            items:
-                              description: |-
-                                Patch contains an inline StrategicMerge or JSON6902 patch, and the target the patch should
-                                be applied to.
-                              properties:
-                                patch:
-                                  description: |-
-                                    Patch contains an inline StrategicMerge patch or an inline JSON6902 patch with
-                                    an array of operation objects.
-                                  type: string
-                                target:
-                                  description: Target points to the resources that the
-                                    patch document should be applied to.
-                                  properties:
-                                    annotationSelector:
-                                      description: |-
-                                        AnnotationSelector is a string that follows the label selection expression
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
-                                        It matches with the resource annotations.
-                                      type: string
-                                    group:
-                                      description: |-
-                                        Group is the API group to select resources from.
-                                        Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources.
-                                        https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
-                                      type: string
-                                    kind:
-                                      description: |-
-                                        Kind of the API Group to select resources from.
-                                        Together with Group and Version it is capable of unambiguously
-                                        identifying and/or selecting resources.
-                                        https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
-                                      type: string
-                                    labelSelector:
-                                      description: |-
-                                        LabelSelector is a string that follows the label selection expression
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
-                                        It matches with the resource labels.
-                                      type: string
-                                    name:
-                                      description: Name to match resources with.
-                                      type: string
-                                    namespace:
-                                      description: Namespace to select resources from.
-                                      type: string
-                                    version:
-                                      description: |-
-                                        Version of the API Group to select resources from.
-                                        Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources.
-                                        https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
-                                      type: string
-                                  type: object
-                              required:
-                                - patch
-                              type: object
-                            type: array
+                        description: |-
+                          Map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
                         type: object
                     type: object
-                  type: array
-                releaseName:
-                  description: |-
-                    ReleaseName used for the Helm release. Defaults to a composition of
-                    '[TargetNamespace-]Name'.
-                  maxLength: 53
-                  minLength: 1
-                  type: string
-                rollback:
-                  description: Rollback holds the configuration for Helm rollback actions
-                    for this HelmRelease.
-                  properties:
-                    cleanupOnFail:
-                      description: |-
-                        CleanupOnFail allows deletion of new resources created during the Helm
-                        rollback action when it fails.
-                      type: boolean
-                    disableHooks:
-                      description: DisableHooks prevents hooks from running during the
-                        Helm rollback action.
-                      type: boolean
-                    disableWait:
-                      description: |-
-                        DisableWait disables the waiting for resources to be ready after a Helm
-                        rollback has been performed.
-                      type: boolean
-                    disableWaitForJobs:
-                      description: |-
-                        DisableWaitForJobs disables waiting for jobs to complete after a Helm
-                        rollback has been performed.
-                      type: boolean
-                    force:
-                      description: Force forces resource updates through a replacement
-                        strategy.
-                      type: boolean
-                    recreate:
-                      description: Recreate performs pod restarts for the resource if
-                        applicable.
-                      type: boolean
-                    timeout:
-                      description: |-
-                        Timeout is the time to wait for any individual Kubernetes operation (like
-                        Jobs for hooks) during the performance of a Helm rollback action. Defaults to
-                        'HelmReleaseSpec.Timeout'.
-                      pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                      type: string
-                  type: object
-                serviceAccountName:
-                  description: |-
-                    The name of the Kubernetes service account to impersonate
-                    when reconciling this HelmRelease.
-                  maxLength: 253
-                  minLength: 1
-                  type: string
-                storageNamespace:
-                  description: |-
-                    StorageNamespace used for the Helm storage.
-                    Defaults to the namespace of the HelmRelease.
-                  maxLength: 63
-                  minLength: 1
-                  type: string
-                suspend:
-                  description: |-
-                    Suspend tells the controller to suspend reconciliation for this HelmRelease,
-                    it does not apply to already started reconciliations. Defaults to false.
-                  type: boolean
-                targetNamespace:
-                  description: |-
-                    TargetNamespace to target when performing operations for the HelmRelease.
-                    Defaults to the namespace of the HelmRelease.
-                  maxLength: 63
-                  minLength: 1
-                  type: string
-                test:
-                  description: Test holds the configuration for Helm test actions for
-                    this HelmRelease.
-                  properties:
-                    enable:
-                      description: |-
-                        Enable enables Helm test actions for this HelmRelease after an Helm install
-                        or upgrade action has been performed.
-                      type: boolean
-                    filters:
-                      description: Filters is a list of tests to run or exclude from
-                        running.
-                      items:
-                        description: Filter holds the configuration for individual Helm
-                          test filters.
+                  spec:
+                    description: Spec holds the template for the v1.HelmChartSpec
+                      for this HelmRelease.
+                    properties:
+                      chart:
+                        description: The name or path the Helm chart is available
+                          at in the SourceRef.
+                        maxLength: 2048
+                        minLength: 1
+                        type: string
+                      ignoreMissingValuesFiles:
+                        description: IgnoreMissingValuesFiles controls whether to
+                          silently ignore missing values files rather than failing.
+                        type: boolean
+                      interval:
+                        description: |-
+                          Interval at which to check the v1.Source for updates. Defaults to
+                          'HelmReleaseSpec.Interval'.
+                        pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                        type: string
+                      reconcileStrategy:
+                        default: ChartVersion
+                        description: |-
+                          Determines what enables the creation of a new artifact. Valid values are
+                          ('ChartVersion', 'Revision').
+                          See the documentation of the values for an explanation on their behavior.
+                          Defaults to ChartVersion when omitted.
+                        enum:
+                        - ChartVersion
+                        - Revision
+                        type: string
+                      sourceRef:
+                        description: The name and namespace of the v1.Source the chart
+                          is available at.
                         properties:
-                          exclude:
-                            description: Exclude specifies whether the named test should
-                              be excluded.
-                            type: boolean
+                          apiVersion:
+                            description: APIVersion of the referent.
+                            type: string
+                          kind:
+                            description: Kind of the referent.
+                            enum:
+                            - HelmRepository
+                            - GitRepository
+                            - Bucket
+                            type: string
                           name:
-                            description: Name is the name of the test.
+                            description: Name of the referent.
                             maxLength: 253
                             minLength: 1
                             type: string
-                        required:
-                          - name
-                        type: object
-                      type: array
-                    ignoreFailures:
-                      description: |-
-                        IgnoreFailures tells the controller to skip remediation when the Helm tests
-                        are run but fail. Can be overwritten for tests run after install or upgrade
-                        actions in 'Install.IgnoreTestFailures' and 'Upgrade.IgnoreTestFailures'.
-                      type: boolean
-                    timeout:
-                      description: |-
-                        Timeout is the time to wait for any individual Kubernetes operation during
-                        the performance of a Helm test action. Defaults to 'HelmReleaseSpec.Timeout'.
-                      pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                      type: string
-                  type: object
-                timeout:
-                  description: |-
-                    Timeout is the time to wait for any individual Kubernetes operation (like Jobs
-                    for hooks) during the performance of a Helm action. Defaults to '5m0s'.
-                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                  type: string
-                uninstall:
-                  description: Uninstall holds the configuration for Helm uninstall
-                    actions for this HelmRelease.
-                  properties:
-                    deletionPropagation:
-                      default: background
-                      description: |-
-                        DeletionPropagation specifies the deletion propagation policy when
-                        a Helm uninstall is performed.
-                      enum:
-                        - background
-                        - foreground
-                        - orphan
-                      type: string
-                    disableHooks:
-                      description: DisableHooks prevents hooks from running during the
-                        Helm rollback action.
-                      type: boolean
-                    disableWait:
-                      description: |-
-                        DisableWait disables waiting for all the resources to be deleted after
-                        a Helm uninstall is performed.
-                      type: boolean
-                    keepHistory:
-                      description: |-
-                        KeepHistory tells Helm to remove all associated resources and mark the
-                        release as deleted, but retain the release history.
-                      type: boolean
-                    timeout:
-                      description: |-
-                        Timeout is the time to wait for any individual Kubernetes operation (like
-                        Jobs for hooks) during the performance of a Helm uninstall action. Defaults
-                        to 'HelmReleaseSpec.Timeout'.
-                      pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                      type: string
-                  type: object
-                upgrade:
-                  description: Upgrade holds the configuration for Helm upgrade actions
-                    for this HelmRelease.
-                  properties:
-                    cleanupOnFail:
-                      description: |-
-                        CleanupOnFail allows deletion of new resources created during the Helm
-                        upgrade action when it fails.
-                      type: boolean
-                    crds:
-                      description: |-
-                        CRDs upgrade CRDs from the Helm Chart's crds directory according
-                        to the CRD upgrade policy provided here. Valid values are `Skip`,
-                        `Create` or `CreateReplace`. Default is `Skip` and if omitted
-                        CRDs are neither installed nor upgraded.
-                        
-                        
-                        Skip: do neither install nor replace (update) any CRDs.
-                        
-                        
-                        Create: new CRDs are created, existing CRDs are neither updated nor deleted.
-                        
-                        
-                        CreateReplace: new CRDs are created, existing CRDs are updated (replaced)
-                        but not deleted.
-                        
-                        
-                        By default, CRDs are not applied during Helm upgrade action. With this
-                        option users can opt-in to CRD upgrade, which is not (yet) natively supported by Helm.
-                        https://helm.sh/docs/chart_best_practices/custom_resource_definitions.
-                      enum:
-                        - Skip
-                        - Create
-                        - CreateReplace
-                      type: string
-                    disableHooks:
-                      description: DisableHooks prevents hooks from running during the
-                        Helm upgrade action.
-                      type: boolean
-                    disableOpenAPIValidation:
-                      description: |-
-                        DisableOpenAPIValidation prevents the Helm upgrade action from validating
-                        rendered templates against the Kubernetes OpenAPI Schema.
-                      type: boolean
-                    disableWait:
-                      description: |-
-                        DisableWait disables the waiting for resources to be ready after a Helm
-                        upgrade has been performed.
-                      type: boolean
-                    disableWaitForJobs:
-                      description: |-
-                        DisableWaitForJobs disables waiting for jobs to complete after a Helm
-                        upgrade has been performed.
-                      type: boolean
-                    force:
-                      description: Force forces resource updates through a replacement
-                        strategy.
-                      type: boolean
-                    preserveValues:
-                      description: |-
-                        PreserveValues will make Helm reuse the last release's values and merge in
-                        overrides from 'Values'. Setting this flag makes the HelmRelease
-                        non-declarative.
-                      type: boolean
-                    remediation:
-                      description: |-
-                        Remediation holds the remediation configuration for when the Helm upgrade
-                        action for the HelmRelease fails. The default is to not perform any action.
-                      properties:
-                        ignoreTestFailures:
-                          description: |-
-                            IgnoreTestFailures tells the controller to skip remediation when the Helm
-                            tests are run after an upgrade action but fail.
-                            Defaults to 'Test.IgnoreFailures'.
-                          type: boolean
-                        remediateLastFailure:
-                          description: |-
-                            RemediateLastFailure tells the controller to remediate the last failure, when
-                            no retries remain. Defaults to 'false' unless 'Retries' is greater than 0.
-                          type: boolean
-                        retries:
-                          description: |-
-                            Retries is the number of retries that should be attempted on failures before
-                            bailing. Remediation, using 'Strategy', is performed between each attempt.
-                            Defaults to '0', a negative integer equals to unlimited retries.
-                          type: integer
-                        strategy:
-                          description: Strategy to use for failure remediation. Defaults
-                            to 'rollback'.
-                          enum:
-                            - rollback
-                            - uninstall
-                          type: string
-                      type: object
-                    timeout:
-                      description: |-
-                        Timeout is the time to wait for any individual Kubernetes operation (like
-                        Jobs for hooks) during the performance of a Helm upgrade action. Defaults to
-                        'HelmReleaseSpec.Timeout'.
-                      pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                      type: string
-                  type: object
-                values:
-                  description: Values holds the values for this Helm release.
-                  x-kubernetes-preserve-unknown-fields: true
-                valuesFrom:
-                  description: |-
-                    ValuesFrom holds references to resources containing Helm values for this HelmRelease,
-                    and information about how they should be merged.
-                  items:
-                    description: |-
-                      ValuesReference contains a reference to a resource containing Helm values,
-                      and optionally the key they can be found at.
-                    properties:
-                      kind:
-                        description: Kind of the values referent, valid values are ('Secret',
-                          'ConfigMap').
-                        enum:
-                          - Secret
-                          - ConfigMap
-                        type: string
-                      name:
-                        description: |-
-                          Name of the values referent. Should reside in the same namespace as the
-                          referring resource.
-                        maxLength: 253
-                        minLength: 1
-                        type: string
-                      optional:
-                        description: |-
-                          Optional marks this ValuesReference as optional. When set, a not found error
-                          for the values reference is ignored, but any ValuesKey, TargetPath or
-                          transient error will still result in a reconciliation failure.
-                        type: boolean
-                      targetPath:
-                        description: |-
-                          TargetPath is the YAML dot notation path the value should be merged at. When
-                          set, the ValuesKey is expected to be a single flat value. Defaults to 'None',
-                          which results in the values getting merged at the root.
-                        maxLength: 250
-                        pattern: ^([a-zA-Z0-9_\-.\\\/]|\[[0-9]{1,5}\])+$
-                        type: string
-                      valuesKey:
-                        description: |-
-                          ValuesKey is the data key where the values.yaml or a specific value can be
-                          found at. Defaults to 'values.yaml'.
-                        maxLength: 253
-                        pattern: ^[\-._a-zA-Z0-9]+$
-                        type: string
-                    required:
-                      - kind
-                      - name
-                    type: object
-                  type: array
-              required:
-                - interval
-              type: object
-              x-kubernetes-validations:
-                - message: either chart or chartRef must be set
-                  rule: (has(self.chart) && !has(self.chartRef)) || (!has(self.chart)
-                    && has(self.chartRef))
-            status:
-              default:
-                observedGeneration: -1
-              description: HelmReleaseStatus defines the observed state of a HelmRelease.
-              properties:
-                conditions:
-                  description: Conditions holds the conditions for the HelmRelease.
-                  items:
-                    description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
-                    properties:
-                      lastTransitionTime:
-                        description: |-
-                          lastTransitionTime is the last time the condition transitioned from one status to another.
-                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                        format: date-time
-                        type: string
-                      message:
-                        description: |-
-                          message is a human readable message indicating details about the transition.
-                          This may be an empty string.
-                        maxLength: 32768
-                        type: string
-                      observedGeneration:
-                        description: |-
-                          observedGeneration represents the .metadata.generation that the condition was set based upon.
-                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                          with respect to the current state of the instance.
-                        format: int64
-                        minimum: 0
-                        type: integer
-                      reason:
-                        description: |-
-                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                          Producers of specific condition types may define expected values and meanings for this field,
-                          and whether the values are considered a guaranteed API.
-                          The value should be a CamelCase string.
-                          This field may not be empty.
-                        maxLength: 1024
-                        minLength: 1
-                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                        type: string
-                      status:
-                        description: status of the condition, one of True, False, Unknown.
-                        enum:
-                          - "True"
-                          - "False"
-                          - Unknown
-                        type: string
-                      type:
-                        description: |-
-                          type of condition in CamelCase or in foo.example.com/CamelCase.
-                          ---
-                          Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                          useful (see .node.status.conditions), the ability to deconflict is important.
-                          The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                        maxLength: 316
-                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                        type: string
-                    required:
-                      - lastTransitionTime
-                      - message
-                      - reason
-                      - status
-                      - type
-                    type: object
-                  type: array
-                failures:
-                  description: |-
-                    Failures is the reconciliation failure count against the latest desired
-                    state. It is reset after a successful reconciliation.
-                  format: int64
-                  type: integer
-                helmChart:
-                  description: |-
-                    HelmChart is the namespaced name of the HelmChart resource created by
-                    the controller for the HelmRelease.
-                  type: string
-                history:
-                  description: |-
-                    History holds the history of Helm releases performed for this HelmRelease
-                    up to the last successfully completed release.
-                  items:
-                    description: |-
-                      Snapshot captures a point-in-time copy of the status information for a Helm release,
-                      as managed by the controller.
-                    properties:
-                      apiVersion:
-                        description: |-
-                          APIVersion is the API version of the Snapshot.
-                          Provisional: when the calculation method of the Digest field is changed,
-                          this field will be used to distinguish between the old and new methods.
-                        type: string
-                      appVersion:
-                        description: AppVersion is the chart app version of the release
-                          object in storage.
-                        type: string
-                      chartName:
-                        description: ChartName is the chart name of the release object
-                          in storage.
-                        type: string
-                      chartVersion:
-                        description: |-
-                          ChartVersion is the chart version of the release object in
-                          storage.
-                        type: string
-                      configDigest:
-                        description: |-
-                          ConfigDigest is the checksum of the config (better known as
-                          "values") of the release object in storage.
-                          It has the format of `<algo>:<checksum>`.
-                        type: string
-                      deleted:
-                        description: Deleted is when the release was deleted.
-                        format: date-time
-                        type: string
-                      digest:
-                        description: |-
-                          Digest is the checksum of the release object in storage.
-                          It has the format of `<algo>:<checksum>`.
-                        type: string
-                      firstDeployed:
-                        description: FirstDeployed is when the release was first deployed.
-                        format: date-time
-                        type: string
-                      lastDeployed:
-                        description: LastDeployed is when the release was last deployed.
-                        format: date-time
-                        type: string
-                      name:
-                        description: Name is the name of the release.
-                        type: string
-                      namespace:
-                        description: Namespace is the namespace the release is deployed
-                          to.
-                        type: string
-                      ociDigest:
-                        description: OCIDigest is the digest of the OCI artifact associated
-                          with the release.
-                        type: string
-                      status:
-                        description: Status is the current state of the release.
-                        type: string
-                      testHooks:
-                        additionalProperties:
-                          description: |-
-                            TestHookStatus holds the status information for a test hook as observed
-                            to be run by the controller.
-                          properties:
-                            lastCompleted:
-                              description: LastCompleted is the time the test hook last
-                                completed.
-                              format: date-time
-                              type: string
-                            lastStarted:
-                              description: LastStarted is the time the test hook was
-                                last started.
-                              format: date-time
-                              type: string
-                            phase:
-                              description: Phase the test hook was observed to be in.
-                              type: string
-                          type: object
-                        description: |-
-                          TestHooks is the list of test hooks for the release as observed to be
-                          run by the controller.
-                        type: object
-                      version:
-                        description: Version is the version of the release object in
-                          storage.
-                        type: integer
-                    required:
-                      - chartName
-                      - chartVersion
-                      - configDigest
-                      - digest
-                      - firstDeployed
-                      - lastDeployed
-                      - name
-                      - namespace
-                      - status
-                      - version
-                    type: object
-                  type: array
-                installFailures:
-                  description: |-
-                    InstallFailures is the install failure count against the latest desired
-                    state. It is reset after a successful reconciliation.
-                  format: int64
-                  type: integer
-                lastAttemptedConfigDigest:
-                  description: |-
-                    LastAttemptedConfigDigest is the digest for the config (better known as
-                    "values") of the last reconciliation attempt.
-                  type: string
-                lastAttemptedGeneration:
-                  description: |-
-                    LastAttemptedGeneration is the last generation the controller attempted
-                    to reconcile.
-                  format: int64
-                  type: integer
-                lastAttemptedReleaseAction:
-                  description: |-
-                    LastAttemptedReleaseAction is the last release action performed for this
-                    HelmRelease. It is used to determine the active remediation strategy.
-                  enum:
-                    - install
-                    - upgrade
-                  type: string
-                lastAttemptedRevision:
-                  description: |-
-                    LastAttemptedRevision is the Source revision of the last reconciliation
-                    attempt. For OCIRepository  sources, the 12 first characters of the digest are
-                    appended to the chart version e.g. "1.2.3+1234567890ab".
-                  type: string
-                lastAttemptedRevisionDigest:
-                  description: |-
-                    LastAttemptedRevisionDigest is the digest of the last reconciliation attempt.
-                    This is only set for OCIRepository sources.
-                  type: string
-                lastAttemptedValuesChecksum:
-                  description: |-
-                    LastAttemptedValuesChecksum is the SHA1 checksum for the values of the last
-                    reconciliation attempt.
-                    Deprecated: Use LastAttemptedConfigDigest instead.
-                  type: string
-                lastHandledForceAt:
-                  description: |-
-                    LastHandledForceAt holds the value of the most recent force request
-                    value, so a change of the annotation value can be detected.
-                  type: string
-                lastHandledReconcileAt:
-                  description: |-
-                    LastHandledReconcileAt holds the value of the most recent
-                    reconcile request value, so a change of the annotation value
-                    can be detected.
-                  type: string
-                lastHandledResetAt:
-                  description: |-
-                    LastHandledResetAt holds the value of the most recent reset request
-                    value, so a change of the annotation value can be detected.
-                  type: string
-                lastReleaseRevision:
-                  description: |-
-                    LastReleaseRevision is the revision of the last successful Helm release.
-                    Deprecated: Use History instead.
-                  type: integer
-                observedGeneration:
-                  description: ObservedGeneration is the last observed generation.
-                  format: int64
-                  type: integer
-                observedPostRenderersDigest:
-                  description: |-
-                    ObservedPostRenderersDigest is the digest for the post-renderers of
-                    the last successful reconciliation attempt.
-                  type: string
-                storageNamespace:
-                  description: |-
-                    StorageNamespace is the namespace of the Helm release storage for the
-                    current release.
-                  maxLength: 63
-                  minLength: 1
-                  type: string
-                upgradeFailures:
-                  description: |-
-                    UpgradeFailures is the upgrade failure count against the latest desired
-                    state. It is reset after a successful reconciliation.
-                  format: int64
-                  type: integer
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
-    - additionalPrinterColumns:
-        - jsonPath: .metadata.creationTimestamp
-          name: Age
-          type: date
-        - jsonPath: .status.conditions[?(@.type=="Ready")].status
-          name: Ready
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].message
-          name: Status
-          type: string
-      deprecated: true
-      deprecationWarning: v2beta1 HelmRelease is deprecated, upgrade to v2
-      name: v2beta1
-      schema:
-        openAPIV3Schema:
-          description: HelmRelease is the Schema for the helmreleases API
-          properties:
-            apiVersion:
-              description: |-
-                APIVersion defines the versioned schema of this representation of an object.
-                Servers should convert recognized schemas to the latest internal value, and
-                may reject unrecognized values.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-              type: string
-            kind:
-              description: |-
-                Kind is a string value representing the REST resource this object represents.
-                Servers may infer this from the endpoint the client submits requests to.
-                Cannot be updated.
-                In CamelCase.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: HelmReleaseSpec defines the desired state of a Helm release.
-              properties:
-                chart:
-                  description: |-
-                    Chart defines the template of the v1beta2.HelmChart that should be created
-                    for this HelmRelease.
-                  properties:
-                    metadata:
-                      description: ObjectMeta holds the template for metadata like labels
-                        and annotations.
-                      properties:
-                        annotations:
-                          additionalProperties:
-                            type: string
-                          description: |-
-                            Annotations is an unstructured key value map stored with a resource that may be
-                            set by external tools to store and retrieve arbitrary metadata. They are not
-                            queryable and should be preserved when modifying objects.
-                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
-                          type: object
-                        labels:
-                          additionalProperties:
-                            type: string
-                          description: |-
-                            Map of string keys and values that can be used to organize and categorize
-                            (scope and select) objects.
-                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
-                          type: object
-                      type: object
-                    spec:
-                      description: Spec holds the template for the v1beta2.HelmChartSpec
-                        for this HelmRelease.
-                      properties:
-                        chart:
-                          description: The name or path the Helm chart is available
-                            at in the SourceRef.
-                          type: string
-                        interval:
-                          description: |-
-                            Interval at which to check the v1beta2.Source for updates. Defaults to
-                            'HelmReleaseSpec.Interval'.
-                          pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                          type: string
-                        reconcileStrategy:
-                          default: ChartVersion
-                          description: |-
-                            Determines what enables the creation of a new artifact. Valid values are
-                            ('ChartVersion', 'Revision').
-                            See the documentation of the values for an explanation on their behavior.
-                            Defaults to ChartVersion when omitted.
-                          enum:
-                            - ChartVersion
-                            - Revision
-                          type: string
-                        sourceRef:
-                          description: The name and namespace of the v1beta2.Source
-                            the chart is available at.
-                          properties:
-                            apiVersion:
-                              description: APIVersion of the referent.
-                              type: string
-                            kind:
-                              description: Kind of the referent.
-                              enum:
-                                - HelmRepository
-                                - GitRepository
-                                - Bucket
-                              type: string
-                            name:
-                              description: Name of the referent.
-                              maxLength: 253
-                              minLength: 1
-                              type: string
-                            namespace:
-                              description: Namespace of the referent.
-                              maxLength: 63
-                              minLength: 1
-                              type: string
-                          required:
-                            - name
-                          type: object
-                        valuesFile:
-                          description: |-
-                            Alternative values file to use as the default chart values, expected to
-                            be a relative path in the SourceRef. Deprecated in favor of ValuesFiles,
-                            for backwards compatibility the file defined here is merged before the
-                            ValuesFiles items. Ignored when omitted.
-                          type: string
-                        valuesFiles:
-                          description: |-
-                            Alternative list of values files to use as the chart values (values.yaml
-                            is not included by default), expected to be a relative path in the SourceRef.
-                            Values files are merged in the order of this list with the last file overriding
-                            the first. Ignored when omitted.
-                          items:
-                            type: string
-                          type: array
-                        verify:
-                          description: |-
-                            Verify contains the secret name containing the trusted public keys
-                            used to verify the signature and specifies which provider to use to check
-                            whether OCI image is authentic.
-                            This field is only supported for OCI sources.
-                            Chart dependencies, which are not bundled in the umbrella chart artifact, are not verified.
-                          properties:
-                            provider:
-                              default: cosign
-                              description: Provider specifies the technology used to
-                                sign the OCI Helm chart.
-                              enum:
-                                - cosign
-                              type: string
-                            secretRef:
-                              description: |-
-                                SecretRef specifies the Kubernetes Secret containing the
-                                trusted public keys.
-                              properties:
-                                name:
-                                  description: Name of the referent.
-                                  type: string
-                              required:
-                                - name
-                              type: object
-                          required:
-                            - provider
-                          type: object
-                        version:
-                          default: '*'
-                          description: |-
-                            Version semver expression, ignored for charts from v1beta2.GitRepository and
-                            v1beta2.Bucket sources. Defaults to latest when omitted.
-                          type: string
-                      required:
-                        - chart
-                        - sourceRef
-                      type: object
-                  required:
-                    - spec
-                  type: object
-                chartRef:
-                  description: |-
-                    ChartRef holds a reference to a source controller resource containing the
-                    Helm chart artifact.
-                    
-                    
-                    Note: this field is provisional to the v2 API, and not actively used
-                    by v2beta1 HelmReleases.
-                  properties:
-                    apiVersion:
-                      description: APIVersion of the referent.
-                      type: string
-                    kind:
-                      description: Kind of the referent.
-                      enum:
-                        - OCIRepository
-                        - HelmChart
-                      type: string
-                    name:
-                      description: Name of the referent.
-                      maxLength: 253
-                      minLength: 1
-                      type: string
-                    namespace:
-                      description: |-
-                        Namespace of the referent, defaults to the namespace of the Kubernetes
-                        resource object that contains the reference.
-                      maxLength: 63
-                      minLength: 1
-                      type: string
-                  required:
-                    - kind
-                    - name
-                  type: object
-                dependsOn:
-                  description: |-
-                    DependsOn may contain a meta.NamespacedObjectReference slice with
-                    references to HelmRelease resources that must be ready before this HelmRelease
-                    can be reconciled.
-                  items:
-                    description: |-
-                      NamespacedObjectReference contains enough information to locate the referenced Kubernetes resource object in any
-                      namespace.
-                    properties:
-                      name:
-                        description: Name of the referent.
-                        type: string
-                      namespace:
-                        description: Namespace of the referent, when not specified it
-                          acts as LocalObjectReference.
-                        type: string
-                    required:
-                      - name
-                    type: object
-                  type: array
-                driftDetection:
-                  description: |-
-                    DriftDetection holds the configuration for detecting and handling
-                    differences between the manifest in the Helm storage and the resources
-                    currently existing in the cluster.
-                    
-                    
-                    Note: this field is provisional to the v2beta2 API, and not actively used
-                    by v2beta1 HelmReleases.
-                  properties:
-                    ignore:
-                      description: |-
-                        Ignore contains a list of rules for specifying which changes to ignore
-                        during diffing.
-                      items:
-                        description: |-
-                          IgnoreRule defines a rule to selectively disregard specific changes during
-                          the drift detection process.
-                        properties:
-                          paths:
-                            description: |-
-                              Paths is a list of JSON Pointer (RFC 6901) paths to be excluded from
-                              consideration in a Kubernetes object.
-                            items:
-                              type: string
-                            type: array
-                          target:
-                            description: |-
-                              Target is a selector for specifying Kubernetes objects to which this
-                              rule applies.
-                              If Target is not set, the Paths will be ignored for all Kubernetes
-                              objects within the manifest of the Helm release.
-                            properties:
-                              annotationSelector:
-                                description: |-
-                                  AnnotationSelector is a string that follows the label selection expression
-                                  https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
-                                  It matches with the resource annotations.
-                                type: string
-                              group:
-                                description: |-
-                                  Group is the API group to select resources from.
-                                  Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources.
-                                  https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
-                                type: string
-                              kind:
-                                description: |-
-                                  Kind of the API Group to select resources from.
-                                  Together with Group and Version it is capable of unambiguously
-                                  identifying and/or selecting resources.
-                                  https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
-                                type: string
-                              labelSelector:
-                                description: |-
-                                  LabelSelector is a string that follows the label selection expression
-                                  https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
-                                  It matches with the resource labels.
-                                type: string
-                              name:
-                                description: Name to match resources with.
-                                type: string
-                              namespace:
-                                description: Namespace to select resources from.
-                                type: string
-                              version:
-                                description: |-
-                                  Version of the API Group to select resources from.
-                                  Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources.
-                                  https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
-                                type: string
-                            type: object
-                        required:
-                          - paths
-                        type: object
-                      type: array
-                    mode:
-                      description: |-
-                        Mode defines how differences should be handled between the Helm manifest
-                        and the manifest currently applied to the cluster.
-                        If not explicitly set, it defaults to DiffModeDisabled.
-                      enum:
-                        - enabled
-                        - warn
-                        - disabled
-                      type: string
-                  type: object
-                install:
-                  description: Install holds the configuration for Helm install actions
-                    for this HelmRelease.
-                  properties:
-                    crds:
-                      description: |-
-                        CRDs upgrade CRDs from the Helm Chart's crds directory according
-                        to the CRD upgrade policy provided here. Valid values are `Skip`,
-                        `Create` or `CreateReplace`. Default is `Create` and if omitted
-                        CRDs are installed but not updated.
-                        
-                        
-                        Skip: do neither install nor replace (update) any CRDs.
-                        
-                        
-                        Create: new CRDs are created, existing CRDs are neither updated nor deleted.
-                        
-                        
-                        CreateReplace: new CRDs are created, existing CRDs are updated (replaced)
-                        but not deleted.
-                        
-                        
-                        By default, CRDs are applied (installed) during Helm install action.
-                        With this option users can opt-in to CRD replace existing CRDs on Helm
-                        install actions, which is not (yet) natively supported by Helm.
-                        https://helm.sh/docs/chart_best_practices/custom_resource_definitions.
-                      enum:
-                        - Skip
-                        - Create
-                        - CreateReplace
-                      type: string
-                    createNamespace:
-                      description: |-
-                        CreateNamespace tells the Helm install action to create the
-                        HelmReleaseSpec.TargetNamespace if it does not exist yet.
-                        On uninstall, the namespace will not be garbage collected.
-                      type: boolean
-                    disableHooks:
-                      description: DisableHooks prevents hooks from running during the
-                        Helm install action.
-                      type: boolean
-                    disableOpenAPIValidation:
-                      description: |-
-                        DisableOpenAPIValidation prevents the Helm install action from validating
-                        rendered templates against the Kubernetes OpenAPI Schema.
-                      type: boolean
-                    disableWait:
-                      description: |-
-                        DisableWait disables the waiting for resources to be ready after a Helm
-                        install has been performed.
-                      type: boolean
-                    disableWaitForJobs:
-                      description: |-
-                        DisableWaitForJobs disables waiting for jobs to complete after a Helm
-                        install has been performed.
-                      type: boolean
-                    remediation:
-                      description: |-
-                        Remediation holds the remediation configuration for when the Helm install
-                        action for the HelmRelease fails. The default is to not perform any action.
-                      properties:
-                        ignoreTestFailures:
-                          description: |-
-                            IgnoreTestFailures tells the controller to skip remediation when the Helm
-                            tests are run after an install action but fail. Defaults to
-                            'Test.IgnoreFailures'.
-                          type: boolean
-                        remediateLastFailure:
-                          description: |-
-                            RemediateLastFailure tells the controller to remediate the last failure, when
-                            no retries remain. Defaults to 'false'.
-                          type: boolean
-                        retries:
-                          description: |-
-                            Retries is the number of retries that should be attempted on failures before
-                            bailing. Remediation, using an uninstall, is performed between each attempt.
-                            Defaults to '0', a negative integer equals to unlimited retries.
-                          type: integer
-                      type: object
-                    replace:
-                      description: |-
-                        Replace tells the Helm install action to re-use the 'ReleaseName', but only
-                        if that name is a deleted release which remains in the history.
-                      type: boolean
-                    skipCRDs:
-                      description: |-
-                        SkipCRDs tells the Helm install action to not install any CRDs. By default,
-                        CRDs are installed if not already present.
-                        
-                        
-                        Deprecated use CRD policy (`crds`) attribute with value `Skip` instead.
-                      type: boolean
-                    timeout:
-                      description: |-
-                        Timeout is the time to wait for any individual Kubernetes operation (like
-                        Jobs for hooks) during the performance of a Helm install action. Defaults to
-                        'HelmReleaseSpec.Timeout'.
-                      pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                      type: string
-                  type: object
-                interval:
-                  description: |-
-                    Interval at which to reconcile the Helm release.
-                    This interval is approximate and may be subject to jitter to ensure
-                    efficient use of resources.
-                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                  type: string
-                kubeConfig:
-                  description: |-
-                    KubeConfig for reconciling the HelmRelease on a remote cluster.
-                    When used in combination with HelmReleaseSpec.ServiceAccountName,
-                    forces the controller to act on behalf of that Service Account at the
-                    target cluster.
-                    If the --default-service-account flag is set, its value will be used as
-                    a controller level fallback for when HelmReleaseSpec.ServiceAccountName
-                    is empty.
-                  properties:
-                    secretRef:
-                      description: |-
-                        SecretRef holds the name of a secret that contains a key with
-                        the kubeconfig file as the value. If no key is set, the key will default
-                        to 'value'.
-                        It is recommended that the kubeconfig is self-contained, and the secret
-                        is regularly updated if credentials such as a cloud-access-token expire.
-                        Cloud specific `cmd-path` auth helpers will not function without adding
-                        binaries and credentials to the Pod that is responsible for reconciling
-                        Kubernetes resources.
-                      properties:
-                        key:
-                          description: Key in the Secret, when not specified an implementation-specific
-                            default key is used.
-                          type: string
-                        name:
-                          description: Name of the Secret.
-                          type: string
-                      required:
-                        - name
-                      type: object
-                  required:
-                    - secretRef
-                  type: object
-                maxHistory:
-                  description: |-
-                    MaxHistory is the number of revisions saved by Helm for this HelmRelease.
-                    Use '0' for an unlimited number of revisions; defaults to '10'.
-                  type: integer
-                persistentClient:
-                  description: |-
-                    PersistentClient tells the controller to use a persistent Kubernetes
-                    client for this release. When enabled, the client will be reused for the
-                    duration of the reconciliation, instead of being created and destroyed
-                    for each (step of a) Helm action.
-                    
-                    
-                    This can improve performance, but may cause issues with some Helm charts
-                    that for example do create Custom Resource Definitions during installation
-                    outside Helm's CRD lifecycle hooks, which are then not observed to be
-                    available by e.g. post-install hooks.
-                    
-                    
-                    If not set, it defaults to true.
-                  type: boolean
-                postRenderers:
-                  description: |-
-                    PostRenderers holds an array of Helm PostRenderers, which will be applied in order
-                    of their definition.
-                  items:
-                    description: PostRenderer contains a Helm PostRenderer specification.
-                    properties:
-                      kustomize:
-                        description: Kustomization to apply as PostRenderer.
-                        properties:
-                          images:
-                            description: |-
-                              Images is a list of (image name, new name, new tag or digest)
-                              for changing image names, tags or digests. This can also be achieved with a
-                              patch, but this operator is simpler to specify.
-                            items:
-                              description: Image contains an image name, a new name,
-                                a new tag or digest, which will replace the original
-                                name and tag.
-                              properties:
-                                digest:
-                                  description: |-
-                                    Digest is the value used to replace the original image tag.
-                                    If digest is present NewTag value is ignored.
-                                  type: string
-                                name:
-                                  description: Name is a tag-less image name.
-                                  type: string
-                                newName:
-                                  description: NewName is the value used to replace
-                                    the original name.
-                                  type: string
-                                newTag:
-                                  description: NewTag is the value used to replace the
-                                    original tag.
-                                  type: string
-                              required:
-                                - name
-                              type: object
-                            type: array
-                          patches:
-                            description: |-
-                              Strategic merge and JSON patches, defined as inline YAML objects,
-                              capable of targeting objects based on kind, label and annotation selectors.
-                            items:
-                              description: |-
-                                Patch contains an inline StrategicMerge or JSON6902 patch, and the target the patch should
-                                be applied to.
-                              properties:
-                                patch:
-                                  description: |-
-                                    Patch contains an inline StrategicMerge patch or an inline JSON6902 patch with
-                                    an array of operation objects.
-                                  type: string
-                                target:
-                                  description: Target points to the resources that the
-                                    patch document should be applied to.
-                                  properties:
-                                    annotationSelector:
-                                      description: |-
-                                        AnnotationSelector is a string that follows the label selection expression
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
-                                        It matches with the resource annotations.
-                                      type: string
-                                    group:
-                                      description: |-
-                                        Group is the API group to select resources from.
-                                        Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources.
-                                        https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
-                                      type: string
-                                    kind:
-                                      description: |-
-                                        Kind of the API Group to select resources from.
-                                        Together with Group and Version it is capable of unambiguously
-                                        identifying and/or selecting resources.
-                                        https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
-                                      type: string
-                                    labelSelector:
-                                      description: |-
-                                        LabelSelector is a string that follows the label selection expression
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
-                                        It matches with the resource labels.
-                                      type: string
-                                    name:
-                                      description: Name to match resources with.
-                                      type: string
-                                    namespace:
-                                      description: Namespace to select resources from.
-                                      type: string
-                                    version:
-                                      description: |-
-                                        Version of the API Group to select resources from.
-                                        Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources.
-                                        https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
-                                      type: string
-                                  type: object
-                              required:
-                                - patch
-                              type: object
-                            type: array
-                          patchesJson6902:
-                            description: JSON 6902 patches, defined as inline YAML objects.
-                            items:
-                              description: JSON6902Patch contains a JSON6902 patch and
-                                the target the patch should be applied to.
-                              properties:
-                                patch:
-                                  description: Patch contains the JSON6902 patch document
-                                    with an array of operation objects.
-                                  items:
-                                    description: |-
-                                      JSON6902 is a JSON6902 operation object.
-                                      https://datatracker.ietf.org/doc/html/rfc6902#section-4
-                                    properties:
-                                      from:
-                                        description: |-
-                                          From contains a JSON-pointer value that references a location within the target document where the operation is
-                                          performed. The meaning of the value depends on the value of Op, and is NOT taken into account by all operations.
-                                        type: string
-                                      op:
-                                        description: |-
-                                          Op indicates the operation to perform. Its value MUST be one of "add", "remove", "replace", "move", "copy", or
-                                          "test".
-                                          https://datatracker.ietf.org/doc/html/rfc6902#section-4
-                                        enum:
-                                          - test
-                                          - remove
-                                          - add
-                                          - replace
-                                          - move
-                                          - copy
-                                        type: string
-                                      path:
-                                        description: |-
-                                          Path contains the JSON-pointer value that references a location within the target document where the operation
-                                          is performed. The meaning of the value depends on the value of Op.
-                                        type: string
-                                      value:
-                                        description: |-
-                                          Value contains a valid JSON structure. The meaning of the value depends on the value of Op, and is NOT taken into
-                                          account by all operations.
-                                        x-kubernetes-preserve-unknown-fields: true
-                                    required:
-                                      - op
-                                      - path
-                                    type: object
-                                  type: array
-                                target:
-                                  description: Target points to the resources that the
-                                    patch document should be applied to.
-                                  properties:
-                                    annotationSelector:
-                                      description: |-
-                                        AnnotationSelector is a string that follows the label selection expression
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
-                                        It matches with the resource annotations.
-                                      type: string
-                                    group:
-                                      description: |-
-                                        Group is the API group to select resources from.
-                                        Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources.
-                                        https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
-                                      type: string
-                                    kind:
-                                      description: |-
-                                        Kind of the API Group to select resources from.
-                                        Together with Group and Version it is capable of unambiguously
-                                        identifying and/or selecting resources.
-                                        https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
-                                      type: string
-                                    labelSelector:
-                                      description: |-
-                                        LabelSelector is a string that follows the label selection expression
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
-                                        It matches with the resource labels.
-                                      type: string
-                                    name:
-                                      description: Name to match resources with.
-                                      type: string
-                                    namespace:
-                                      description: Namespace to select resources from.
-                                      type: string
-                                    version:
-                                      description: |-
-                                        Version of the API Group to select resources from.
-                                        Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources.
-                                        https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
-                                      type: string
-                                  type: object
-                              required:
-                                - patch
-                                - target
-                              type: object
-                            type: array
-                          patchesStrategicMerge:
-                            description: Strategic merge patches, defined as inline
-                              YAML objects.
-                            items:
-                              x-kubernetes-preserve-unknown-fields: true
-                            type: array
-                        type: object
-                    type: object
-                  type: array
-                releaseName:
-                  description: |-
-                    ReleaseName used for the Helm release. Defaults to a composition of
-                    '[TargetNamespace-]Name'.
-                  maxLength: 53
-                  minLength: 1
-                  type: string
-                rollback:
-                  description: Rollback holds the configuration for Helm rollback actions
-                    for this HelmRelease.
-                  properties:
-                    cleanupOnFail:
-                      description: |-
-                        CleanupOnFail allows deletion of new resources created during the Helm
-                        rollback action when it fails.
-                      type: boolean
-                    disableHooks:
-                      description: DisableHooks prevents hooks from running during the
-                        Helm rollback action.
-                      type: boolean
-                    disableWait:
-                      description: |-
-                        DisableWait disables the waiting for resources to be ready after a Helm
-                        rollback has been performed.
-                      type: boolean
-                    disableWaitForJobs:
-                      description: |-
-                        DisableWaitForJobs disables waiting for jobs to complete after a Helm
-                        rollback has been performed.
-                      type: boolean
-                    force:
-                      description: Force forces resource updates through a replacement
-                        strategy.
-                      type: boolean
-                    recreate:
-                      description: Recreate performs pod restarts for the resource if
-                        applicable.
-                      type: boolean
-                    timeout:
-                      description: |-
-                        Timeout is the time to wait for any individual Kubernetes operation (like
-                        Jobs for hooks) during the performance of a Helm rollback action. Defaults to
-                        'HelmReleaseSpec.Timeout'.
-                      pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                      type: string
-                  type: object
-                serviceAccountName:
-                  description: |-
-                    The name of the Kubernetes service account to impersonate
-                    when reconciling this HelmRelease.
-                  type: string
-                storageNamespace:
-                  description: |-
-                    StorageNamespace used for the Helm storage.
-                    Defaults to the namespace of the HelmRelease.
-                  maxLength: 63
-                  minLength: 1
-                  type: string
-                suspend:
-                  description: |-
-                    Suspend tells the controller to suspend reconciliation for this HelmRelease,
-                    it does not apply to already started reconciliations. Defaults to false.
-                  type: boolean
-                targetNamespace:
-                  description: |-
-                    TargetNamespace to target when performing operations for the HelmRelease.
-                    Defaults to the namespace of the HelmRelease.
-                  maxLength: 63
-                  minLength: 1
-                  type: string
-                test:
-                  description: Test holds the configuration for Helm test actions for
-                    this HelmRelease.
-                  properties:
-                    enable:
-                      description: |-
-                        Enable enables Helm test actions for this HelmRelease after an Helm install
-                        or upgrade action has been performed.
-                      type: boolean
-                    ignoreFailures:
-                      description: |-
-                        IgnoreFailures tells the controller to skip remediation when the Helm tests
-                        are run but fail. Can be overwritten for tests run after install or upgrade
-                        actions in 'Install.IgnoreTestFailures' and 'Upgrade.IgnoreTestFailures'.
-                      type: boolean
-                    timeout:
-                      description: |-
-                        Timeout is the time to wait for any individual Kubernetes operation during
-                        the performance of a Helm test action. Defaults to 'HelmReleaseSpec.Timeout'.
-                      pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                      type: string
-                  type: object
-                timeout:
-                  description: |-
-                    Timeout is the time to wait for any individual Kubernetes operation (like Jobs
-                    for hooks) during the performance of a Helm action. Defaults to '5m0s'.
-                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                  type: string
-                uninstall:
-                  description: Uninstall holds the configuration for Helm uninstall
-                    actions for this HelmRelease.
-                  properties:
-                    deletionPropagation:
-                      default: background
-                      description: |-
-                        DeletionPropagation specifies the deletion propagation policy when
-                        a Helm uninstall is performed.
-                      enum:
-                        - background
-                        - foreground
-                        - orphan
-                      type: string
-                    disableHooks:
-                      description: DisableHooks prevents hooks from running during the
-                        Helm rollback action.
-                      type: boolean
-                    disableWait:
-                      description: |-
-                        DisableWait disables waiting for all the resources to be deleted after
-                        a Helm uninstall is performed.
-                      type: boolean
-                    keepHistory:
-                      description: |-
-                        KeepHistory tells Helm to remove all associated resources and mark the
-                        release as deleted, but retain the release history.
-                      type: boolean
-                    timeout:
-                      description: |-
-                        Timeout is the time to wait for any individual Kubernetes operation (like
-                        Jobs for hooks) during the performance of a Helm uninstall action. Defaults
-                        to 'HelmReleaseSpec.Timeout'.
-                      pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                      type: string
-                  type: object
-                upgrade:
-                  description: Upgrade holds the configuration for Helm upgrade actions
-                    for this HelmRelease.
-                  properties:
-                    cleanupOnFail:
-                      description: |-
-                        CleanupOnFail allows deletion of new resources created during the Helm
-                        upgrade action when it fails.
-                      type: boolean
-                    crds:
-                      description: |-
-                        CRDs upgrade CRDs from the Helm Chart's crds directory according
-                        to the CRD upgrade policy provided here. Valid values are `Skip`,
-                        `Create` or `CreateReplace`. Default is `Skip` and if omitted
-                        CRDs are neither installed nor upgraded.
-                        
-                        
-                        Skip: do neither install nor replace (update) any CRDs.
-                        
-                        
-                        Create: new CRDs are created, existing CRDs are neither updated nor deleted.
-                        
-                        
-                        CreateReplace: new CRDs are created, existing CRDs are updated (replaced)
-                        but not deleted.
-                        
-                        
-                        By default, CRDs are not applied during Helm upgrade action. With this
-                        option users can opt-in to CRD upgrade, which is not (yet) natively supported by Helm.
-                        https://helm.sh/docs/chart_best_practices/custom_resource_definitions.
-                      enum:
-                        - Skip
-                        - Create
-                        - CreateReplace
-                      type: string
-                    disableHooks:
-                      description: DisableHooks prevents hooks from running during the
-                        Helm upgrade action.
-                      type: boolean
-                    disableOpenAPIValidation:
-                      description: |-
-                        DisableOpenAPIValidation prevents the Helm upgrade action from validating
-                        rendered templates against the Kubernetes OpenAPI Schema.
-                      type: boolean
-                    disableWait:
-                      description: |-
-                        DisableWait disables the waiting for resources to be ready after a Helm
-                        upgrade has been performed.
-                      type: boolean
-                    disableWaitForJobs:
-                      description: |-
-                        DisableWaitForJobs disables waiting for jobs to complete after a Helm
-                        upgrade has been performed.
-                      type: boolean
-                    force:
-                      description: Force forces resource updates through a replacement
-                        strategy.
-                      type: boolean
-                    preserveValues:
-                      description: |-
-                        PreserveValues will make Helm reuse the last release's values and merge in
-                        overrides from 'Values'. Setting this flag makes the HelmRelease
-                        non-declarative.
-                      type: boolean
-                    remediation:
-                      description: |-
-                        Remediation holds the remediation configuration for when the Helm upgrade
-                        action for the HelmRelease fails. The default is to not perform any action.
-                      properties:
-                        ignoreTestFailures:
-                          description: |-
-                            IgnoreTestFailures tells the controller to skip remediation when the Helm
-                            tests are run after an upgrade action but fail.
-                            Defaults to 'Test.IgnoreFailures'.
-                          type: boolean
-                        remediateLastFailure:
-                          description: |-
-                            RemediateLastFailure tells the controller to remediate the last failure, when
-                            no retries remain. Defaults to 'false' unless 'Retries' is greater than 0.
-                          type: boolean
-                        retries:
-                          description: |-
-                            Retries is the number of retries that should be attempted on failures before
-                            bailing. Remediation, using 'Strategy', is performed between each attempt.
-                            Defaults to '0', a negative integer equals to unlimited retries.
-                          type: integer
-                        strategy:
-                          description: Strategy to use for failure remediation. Defaults
-                            to 'rollback'.
-                          enum:
-                            - rollback
-                            - uninstall
-                          type: string
-                      type: object
-                    timeout:
-                      description: |-
-                        Timeout is the time to wait for any individual Kubernetes operation (like
-                        Jobs for hooks) during the performance of a Helm upgrade action. Defaults to
-                        'HelmReleaseSpec.Timeout'.
-                      pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                      type: string
-                  type: object
-                values:
-                  description: Values holds the values for this Helm release.
-                  x-kubernetes-preserve-unknown-fields: true
-                valuesFrom:
-                  description: |-
-                    ValuesFrom holds references to resources containing Helm values for this HelmRelease,
-                    and information about how they should be merged.
-                  items:
-                    description: |-
-                      ValuesReference contains a reference to a resource containing Helm values,
-                      and optionally the key they can be found at.
-                    properties:
-                      kind:
-                        description: Kind of the values referent, valid values are ('Secret',
-                          'ConfigMap').
-                        enum:
-                          - Secret
-                          - ConfigMap
-                        type: string
-                      name:
-                        description: |-
-                          Name of the values referent. Should reside in the same namespace as the
-                          referring resource.
-                        maxLength: 253
-                        minLength: 1
-                        type: string
-                      optional:
-                        description: |-
-                          Optional marks this ValuesReference as optional. When set, a not found error
-                          for the values reference is ignored, but any ValuesKey, TargetPath or
-                          transient error will still result in a reconciliation failure.
-                        type: boolean
-                      targetPath:
-                        description: |-
-                          TargetPath is the YAML dot notation path the value should be merged at. When
-                          set, the ValuesKey is expected to be a single flat value. Defaults to 'None',
-                          which results in the values getting merged at the root.
-                        maxLength: 250
-                        pattern: ^([a-zA-Z0-9_\-.\\\/]|\[[0-9]{1,5}\])+$
-                        type: string
-                      valuesKey:
-                        description: |-
-                          ValuesKey is the data key where the values.yaml or a specific value can be
-                          found at. Defaults to 'values.yaml'.
-                          When set, must be a valid Data Key, consisting of alphanumeric characters,
-                          '-', '_' or '.'.
-                        maxLength: 253
-                        pattern: ^[\-._a-zA-Z0-9]+$
-                        type: string
-                    required:
-                      - kind
-                      - name
-                    type: object
-                  type: array
-              required:
-                - interval
-              type: object
-            status:
-              default:
-                observedGeneration: -1
-              description: HelmReleaseStatus defines the observed state of a HelmRelease.
-              properties:
-                conditions:
-                  description: Conditions holds the conditions for the HelmRelease.
-                  items:
-                    description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
-                    properties:
-                      lastTransitionTime:
-                        description: |-
-                          lastTransitionTime is the last time the condition transitioned from one status to another.
-                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                        format: date-time
-                        type: string
-                      message:
-                        description: |-
-                          message is a human readable message indicating details about the transition.
-                          This may be an empty string.
-                        maxLength: 32768
-                        type: string
-                      observedGeneration:
-                        description: |-
-                          observedGeneration represents the .metadata.generation that the condition was set based upon.
-                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                          with respect to the current state of the instance.
-                        format: int64
-                        minimum: 0
-                        type: integer
-                      reason:
-                        description: |-
-                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                          Producers of specific condition types may define expected values and meanings for this field,
-                          and whether the values are considered a guaranteed API.
-                          The value should be a CamelCase string.
-                          This field may not be empty.
-                        maxLength: 1024
-                        minLength: 1
-                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                        type: string
-                      status:
-                        description: status of the condition, one of True, False, Unknown.
-                        enum:
-                          - "True"
-                          - "False"
-                          - Unknown
-                        type: string
-                      type:
-                        description: |-
-                          type of condition in CamelCase or in foo.example.com/CamelCase.
-                          ---
-                          Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                          useful (see .node.status.conditions), the ability to deconflict is important.
-                          The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                        maxLength: 316
-                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                        type: string
-                    required:
-                      - lastTransitionTime
-                      - message
-                      - reason
-                      - status
-                      - type
-                    type: object
-                  type: array
-                failures:
-                  description: |-
-                    Failures is the reconciliation failure count against the latest desired
-                    state. It is reset after a successful reconciliation.
-                  format: int64
-                  type: integer
-                helmChart:
-                  description: |-
-                    HelmChart is the namespaced name of the HelmChart resource created by
-                    the controller for the HelmRelease.
-                  type: string
-                history:
-                  description: |-
-                    History holds the history of Helm releases performed for this HelmRelease
-                    up to the last successfully completed release.
-                    
-                    
-                    Note: this field is provisional to the v2beta2 API, and not actively used
-                    by v2beta1 HelmReleases.
-                  items:
-                    description: |-
-                      Snapshot captures a point-in-time copy of the status information for a Helm release,
-                      as managed by the controller.
-                    properties:
-                      apiVersion:
-                        description: |-
-                          APIVersion is the API version of the Snapshot.
-                          Provisional: when the calculation method of the Digest field is changed,
-                          this field will be used to distinguish between the old and new methods.
-                        type: string
-                      appVersion:
-                        description: AppVersion is the chart app version of the release
-                          object in storage.
-                        type: string
-                      chartName:
-                        description: ChartName is the chart name of the release object
-                          in storage.
-                        type: string
-                      chartVersion:
-                        description: |-
-                          ChartVersion is the chart version of the release object in
-                          storage.
-                        type: string
-                      configDigest:
-                        description: |-
-                          ConfigDigest is the checksum of the config (better known as
-                          "values") of the release object in storage.
-                          It has the format of `<algo>:<checksum>`.
-                        type: string
-                      deleted:
-                        description: Deleted is when the release was deleted.
-                        format: date-time
-                        type: string
-                      digest:
-                        description: |-
-                          Digest is the checksum of the release object in storage.
-                          It has the format of `<algo>:<checksum>`.
-                        type: string
-                      firstDeployed:
-                        description: FirstDeployed is when the release was first deployed.
-                        format: date-time
-                        type: string
-                      lastDeployed:
-                        description: LastDeployed is when the release was last deployed.
-                        format: date-time
-                        type: string
-                      name:
-                        description: Name is the name of the release.
-                        type: string
-                      namespace:
-                        description: Namespace is the namespace the release is deployed
-                          to.
-                        type: string
-                      ociDigest:
-                        description: OCIDigest is the digest of the OCI artifact associated
-                          with the release.
-                        type: string
-                      status:
-                        description: Status is the current state of the release.
-                        type: string
-                      testHooks:
-                        additionalProperties:
-                          description: |-
-                            TestHookStatus holds the status information for a test hook as observed
-                            to be run by the controller.
-                          properties:
-                            lastCompleted:
-                              description: LastCompleted is the time the test hook last
-                                completed.
-                              format: date-time
-                              type: string
-                            lastStarted:
-                              description: LastStarted is the time the test hook was
-                                last started.
-                              format: date-time
-                              type: string
-                            phase:
-                              description: Phase the test hook was observed to be in.
-                              type: string
-                          type: object
-                        description: |-
-                          TestHooks is the list of test hooks for the release as observed to be
-                          run by the controller.
-                        type: object
-                      version:
-                        description: Version is the version of the release object in
-                          storage.
-                        type: integer
-                    required:
-                      - chartName
-                      - chartVersion
-                      - configDigest
-                      - digest
-                      - firstDeployed
-                      - lastDeployed
-                      - name
-                      - namespace
-                      - status
-                      - version
-                    type: object
-                  type: array
-                installFailures:
-                  description: |-
-                    InstallFailures is the install failure count against the latest desired
-                    state. It is reset after a successful reconciliation.
-                  format: int64
-                  type: integer
-                lastAppliedRevision:
-                  description: LastAppliedRevision is the revision of the last successfully
-                    applied source.
-                  type: string
-                lastAttemptedConfigDigest:
-                  description: |-
-                    LastAttemptedConfigDigest is the digest for the config (better known as
-                    "values") of the last reconciliation attempt.
-                    
-                    
-                    Note: this field is provisional to the v2beta2 API, and not actively used
-                    by v2beta1 HelmReleases.
-                  type: string
-                lastAttemptedGeneration:
-                  description: |-
-                    LastAttemptedGeneration is the last generation the controller attempted
-                    to reconcile.
-                    
-                    
-                    Note: this field is provisional to the v2beta2 API, and not actively used
-                    by v2beta1 HelmReleases.
-                  format: int64
-                  type: integer
-                lastAttemptedReleaseAction:
-                  description: |-
-                    LastAttemptedReleaseAction is the last release action performed for this
-                    HelmRelease. It is used to determine the active remediation strategy.
-                    
-                    
-                    Note: this field is provisional to the v2beta2 API, and not actively used
-                    by v2beta1 HelmReleases.
-                  type: string
-                lastAttemptedRevision:
-                  description: LastAttemptedRevision is the revision of the last reconciliation
-                    attempt.
-                  type: string
-                lastAttemptedValuesChecksum:
-                  description: |-
-                    LastAttemptedValuesChecksum is the SHA1 checksum of the values of the last
-                    reconciliation attempt.
-                  type: string
-                lastHandledForceAt:
-                  description: |-
-                    LastHandledForceAt holds the value of the most recent force request
-                    value, so a change of the annotation value can be detected.
-                    
-                    
-                    Note: this field is provisional to the v2beta2 API, and not actively used
-                    by v2beta1 HelmReleases.
-                  type: string
-                lastHandledReconcileAt:
-                  description: |-
-                    LastHandledReconcileAt holds the value of the most recent
-                    reconcile request value, so a change of the annotation value
-                    can be detected.
-                  type: string
-                lastHandledResetAt:
-                  description: |-
-                    LastHandledResetAt holds the value of the most recent reset request
-                    value, so a change of the annotation value can be detected.
-                    
-                    
-                    Note: this field is provisional to the v2beta2 API, and not actively used
-                    by v2beta1 HelmReleases.
-                  type: string
-                lastReleaseRevision:
-                  description: LastReleaseRevision is the revision of the last successful
-                    Helm release.
-                  type: integer
-                observedGeneration:
-                  description: ObservedGeneration is the last observed generation.
-                  format: int64
-                  type: integer
-                observedPostRenderersDigest:
-                  description: |-
-                    ObservedPostRenderersDigest is the digest for the post-renderers of
-                    the last successful reconciliation attempt.
-                  type: string
-                storageNamespace:
-                  description: |-
-                    StorageNamespace is the namespace of the Helm release storage for the
-                    current release.
-                    
-                    
-                    Note: this field is provisional to the v2beta2 API, and not actively used
-                    by v2beta1 HelmReleases.
-                  type: string
-                upgradeFailures:
-                  description: |-
-                    UpgradeFailures is the upgrade failure count against the latest desired
-                    state. It is reset after a successful reconciliation.
-                  format: int64
-                  type: integer
-              type: object
-          type: object
-      served: true
-      storage: false
-      subresources:
-        status: {}
-    - additionalPrinterColumns:
-        - jsonPath: .metadata.creationTimestamp
-          name: Age
-          type: date
-        - jsonPath: .status.conditions[?(@.type=="Ready")].status
-          name: Ready
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].message
-          name: Status
-          type: string
-      deprecated: true
-      deprecationWarning: v2beta2 HelmRelease is deprecated, upgrade to v2
-      name: v2beta2
-      schema:
-        openAPIV3Schema:
-          description: HelmRelease is the Schema for the helmreleases API
-          properties:
-            apiVersion:
-              description: |-
-                APIVersion defines the versioned schema of this representation of an object.
-                Servers should convert recognized schemas to the latest internal value, and
-                may reject unrecognized values.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-              type: string
-            kind:
-              description: |-
-                Kind is a string value representing the REST resource this object represents.
-                Servers may infer this from the endpoint the client submits requests to.
-                Cannot be updated.
-                In CamelCase.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: HelmReleaseSpec defines the desired state of a Helm release.
-              properties:
-                chart:
-                  description: |-
-                    Chart defines the template of the v1beta2.HelmChart that should be created
-                    for this HelmRelease.
-                  properties:
-                    metadata:
-                      description: ObjectMeta holds the template for metadata like labels
-                        and annotations.
-                      properties:
-                        annotations:
-                          additionalProperties:
-                            type: string
-                          description: |-
-                            Annotations is an unstructured key value map stored with a resource that may be
-                            set by external tools to store and retrieve arbitrary metadata. They are not
-                            queryable and should be preserved when modifying objects.
-                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
-                          type: object
-                        labels:
-                          additionalProperties:
-                            type: string
-                          description: |-
-                            Map of string keys and values that can be used to organize and categorize
-                            (scope and select) objects.
-                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
-                          type: object
-                      type: object
-                    spec:
-                      description: Spec holds the template for the v1beta2.HelmChartSpec
-                        for this HelmRelease.
-                      properties:
-                        chart:
-                          description: The name or path the Helm chart is available
-                            at in the SourceRef.
-                          maxLength: 2048
-                          minLength: 1
-                          type: string
-                        ignoreMissingValuesFiles:
-                          description: IgnoreMissingValuesFiles controls whether to
-                            silently ignore missing values files rather than failing.
-                          type: boolean
-                        interval:
-                          description: |-
-                            Interval at which to check the v1.Source for updates. Defaults to
-                            'HelmReleaseSpec.Interval'.
-                          pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                          type: string
-                        reconcileStrategy:
-                          default: ChartVersion
-                          description: |-
-                            Determines what enables the creation of a new artifact. Valid values are
-                            ('ChartVersion', 'Revision').
-                            See the documentation of the values for an explanation on their behavior.
-                            Defaults to ChartVersion when omitted.
-                          enum:
-                            - ChartVersion
-                            - Revision
-                          type: string
-                        sourceRef:
-                          description: The name and namespace of the v1.Source the chart
-                            is available at.
-                          properties:
-                            apiVersion:
-                              description: APIVersion of the referent.
-                              type: string
-                            kind:
-                              description: Kind of the referent.
-                              enum:
-                                - HelmRepository
-                                - GitRepository
-                                - Bucket
-                              type: string
-                            name:
-                              description: Name of the referent.
-                              maxLength: 253
-                              minLength: 1
-                              type: string
-                            namespace:
-                              description: Namespace of the referent.
-                              maxLength: 63
-                              minLength: 1
-                              type: string
-                          required:
-                            - name
-                          type: object
-                        valuesFile:
-                          description: |-
-                            Alternative values file to use as the default chart values, expected to
-                            be a relative path in the SourceRef. Deprecated in favor of ValuesFiles,
-                            for backwards compatibility the file defined here is merged before the
-                            ValuesFiles items. Ignored when omitted.
-                          type: string
-                        valuesFiles:
-                          description: |-
-                            Alternative list of values files to use as the chart values (values.yaml
-                            is not included by default), expected to be a relative path in the SourceRef.
-                            Values files are merged in the order of this list with the last file overriding
-                            the first. Ignored when omitted.
-                          items:
-                            type: string
-                          type: array
-                        verify:
-                          description: |-
-                            Verify contains the secret name containing the trusted public keys
-                            used to verify the signature and specifies which provider to use to check
-                            whether OCI image is authentic.
-                            This field is only supported for OCI sources.
-                            Chart dependencies, which are not bundled in the umbrella chart artifact,
-                            are not verified.
-                          properties:
-                            provider:
-                              default: cosign
-                              description: Provider specifies the technology used to
-                                sign the OCI Helm chart.
-                              enum:
-                                - cosign
-                                - notation
-                              type: string
-                            secretRef:
-                              description: |-
-                                SecretRef specifies the Kubernetes Secret containing the
-                                trusted public keys.
-                              properties:
-                                name:
-                                  description: Name of the referent.
-                                  type: string
-                              required:
-                                - name
-                              type: object
-                          required:
-                            - provider
-                          type: object
-                        version:
-                          default: '*'
-                          description: |-
-                            Version semver expression, ignored for charts from v1beta2.GitRepository and
-                            v1beta2.Bucket sources. Defaults to latest when omitted.
-                          type: string
-                      required:
-                        - chart
-                        - sourceRef
-                      type: object
-                  required:
-                    - spec
-                  type: object
-                chartRef:
-                  description: |-
-                    ChartRef holds a reference to a source controller resource containing the
-                    Helm chart artifact.
-                    
-                    
-                    Note: this field is provisional to the v2 API, and not actively used
-                    by v2beta2 HelmReleases.
-                  properties:
-                    apiVersion:
-                      description: APIVersion of the referent.
-                      type: string
-                    kind:
-                      description: Kind of the referent.
-                      enum:
-                        - OCIRepository
-                        - HelmChart
-                      type: string
-                    name:
-                      description: Name of the referent.
-                      maxLength: 253
-                      minLength: 1
-                      type: string
-                    namespace:
-                      description: |-
-                        Namespace of the referent, defaults to the namespace of the Kubernetes
-                        resource object that contains the reference.
-                      maxLength: 63
-                      minLength: 1
-                      type: string
-                  required:
-                    - kind
-                    - name
-                  type: object
-                dependsOn:
-                  description: |-
-                    DependsOn may contain a meta.NamespacedObjectReference slice with
-                    references to HelmRelease resources that must be ready before this HelmRelease
-                    can be reconciled.
-                  items:
-                    description: |-
-                      NamespacedObjectReference contains enough information to locate the referenced Kubernetes resource object in any
-                      namespace.
-                    properties:
-                      name:
-                        description: Name of the referent.
-                        type: string
-                      namespace:
-                        description: Namespace of the referent, when not specified it
-                          acts as LocalObjectReference.
-                        type: string
-                    required:
-                      - name
-                    type: object
-                  type: array
-                driftDetection:
-                  description: |-
-                    DriftDetection holds the configuration for detecting and handling
-                    differences between the manifest in the Helm storage and the resources
-                    currently existing in the cluster.
-                  properties:
-                    ignore:
-                      description: |-
-                        Ignore contains a list of rules for specifying which changes to ignore
-                        during diffing.
-                      items:
-                        description: |-
-                          IgnoreRule defines a rule to selectively disregard specific changes during
-                          the drift detection process.
-                        properties:
-                          paths:
-                            description: |-
-                              Paths is a list of JSON Pointer (RFC 6901) paths to be excluded from
-                              consideration in a Kubernetes object.
-                            items:
-                              type: string
-                            type: array
-                          target:
-                            description: |-
-                              Target is a selector for specifying Kubernetes objects to which this
-                              rule applies.
-                              If Target is not set, the Paths will be ignored for all Kubernetes
-                              objects within the manifest of the Helm release.
-                            properties:
-                              annotationSelector:
-                                description: |-
-                                  AnnotationSelector is a string that follows the label selection expression
-                                  https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
-                                  It matches with the resource annotations.
-                                type: string
-                              group:
-                                description: |-
-                                  Group is the API group to select resources from.
-                                  Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources.
-                                  https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
-                                type: string
-                              kind:
-                                description: |-
-                                  Kind of the API Group to select resources from.
-                                  Together with Group and Version it is capable of unambiguously
-                                  identifying and/or selecting resources.
-                                  https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
-                                type: string
-                              labelSelector:
-                                description: |-
-                                  LabelSelector is a string that follows the label selection expression
-                                  https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
-                                  It matches with the resource labels.
-                                type: string
-                              name:
-                                description: Name to match resources with.
-                                type: string
-                              namespace:
-                                description: Namespace to select resources from.
-                                type: string
-                              version:
-                                description: |-
-                                  Version of the API Group to select resources from.
-                                  Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources.
-                                  https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
-                                type: string
-                            type: object
-                        required:
-                          - paths
-                        type: object
-                      type: array
-                    mode:
-                      description: |-
-                        Mode defines how differences should be handled between the Helm manifest
-                        and the manifest currently applied to the cluster.
-                        If not explicitly set, it defaults to DiffModeDisabled.
-                      enum:
-                        - enabled
-                        - warn
-                        - disabled
-                      type: string
-                  type: object
-                install:
-                  description: Install holds the configuration for Helm install actions
-                    for this HelmRelease.
-                  properties:
-                    crds:
-                      description: |-
-                        CRDs upgrade CRDs from the Helm Chart's crds directory according
-                        to the CRD upgrade policy provided here. Valid values are `Skip`,
-                        `Create` or `CreateReplace`. Default is `Create` and if omitted
-                        CRDs are installed but not updated.
-                        
-                        
-                        Skip: do neither install nor replace (update) any CRDs.
-                        
-                        
-                        Create: new CRDs are created, existing CRDs are neither updated nor deleted.
-                        
-                        
-                        CreateReplace: new CRDs are created, existing CRDs are updated (replaced)
-                        but not deleted.
-                        
-                        
-                        By default, CRDs are applied (installed) during Helm install action.
-                        With this option users can opt in to CRD replace existing CRDs on Helm
-                        install actions, which is not (yet) natively supported by Helm.
-                        https://helm.sh/docs/chart_best_practices/custom_resource_definitions.
-                      enum:
-                        - Skip
-                        - Create
-                        - CreateReplace
-                      type: string
-                    createNamespace:
-                      description: |-
-                        CreateNamespace tells the Helm install action to create the
-                        HelmReleaseSpec.TargetNamespace if it does not exist yet.
-                        On uninstall, the namespace will not be garbage collected.
-                      type: boolean
-                    disableHooks:
-                      description: DisableHooks prevents hooks from running during the
-                        Helm install action.
-                      type: boolean
-                    disableOpenAPIValidation:
-                      description: |-
-                        DisableOpenAPIValidation prevents the Helm install action from validating
-                        rendered templates against the Kubernetes OpenAPI Schema.
-                      type: boolean
-                    disableWait:
-                      description: |-
-                        DisableWait disables the waiting for resources to be ready after a Helm
-                        install has been performed.
-                      type: boolean
-                    disableWaitForJobs:
-                      description: |-
-                        DisableWaitForJobs disables waiting for jobs to complete after a Helm
-                        install has been performed.
-                      type: boolean
-                    remediation:
-                      description: |-
-                        Remediation holds the remediation configuration for when the Helm install
-                        action for the HelmRelease fails. The default is to not perform any action.
-                      properties:
-                        ignoreTestFailures:
-                          description: |-
-                            IgnoreTestFailures tells the controller to skip remediation when the Helm
-                            tests are run after an install action but fail. Defaults to
-                            'Test.IgnoreFailures'.
-                          type: boolean
-                        remediateLastFailure:
-                          description: |-
-                            RemediateLastFailure tells the controller to remediate the last failure, when
-                            no retries remain. Defaults to 'false'.
-                          type: boolean
-                        retries:
-                          description: |-
-                            Retries is the number of retries that should be attempted on failures before
-                            bailing. Remediation, using an uninstall, is performed between each attempt.
-                            Defaults to '0', a negative integer equals to unlimited retries.
-                          type: integer
-                      type: object
-                    replace:
-                      description: |-
-                        Replace tells the Helm install action to re-use the 'ReleaseName', but only
-                        if that name is a deleted release which remains in the history.
-                      type: boolean
-                    skipCRDs:
-                      description: |-
-                        SkipCRDs tells the Helm install action to not install any CRDs. By default,
-                        CRDs are installed if not already present.
-                        
-                        
-                        Deprecated use CRD policy (`crds`) attribute with value `Skip` instead.
-                      type: boolean
-                    timeout:
-                      description: |-
-                        Timeout is the time to wait for any individual Kubernetes operation (like
-                        Jobs for hooks) during the performance of a Helm install action. Defaults to
-                        'HelmReleaseSpec.Timeout'.
-                      pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                      type: string
-                  type: object
-                interval:
-                  description: Interval at which to reconcile the Helm release.
-                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                  type: string
-                kubeConfig:
-                  description: |-
-                    KubeConfig for reconciling the HelmRelease on a remote cluster.
-                    When used in combination with HelmReleaseSpec.ServiceAccountName,
-                    forces the controller to act on behalf of that Service Account at the
-                    target cluster.
-                    If the --default-service-account flag is set, its value will be used as
-                    a controller level fallback for when HelmReleaseSpec.ServiceAccountName
-                    is empty.
-                  properties:
-                    secretRef:
-                      description: |-
-                        SecretRef holds the name of a secret that contains a key with
-                        the kubeconfig file as the value. If no key is set, the key will default
-                        to 'value'.
-                        It is recommended that the kubeconfig is self-contained, and the secret
-                        is regularly updated if credentials such as a cloud-access-token expire.
-                        Cloud specific `cmd-path` auth helpers will not function without adding
-                        binaries and credentials to the Pod that is responsible for reconciling
-                        Kubernetes resources.
-                      properties:
-                        key:
-                          description: Key in the Secret, when not specified an implementation-specific
-                            default key is used.
-                          type: string
-                        name:
-                          description: Name of the Secret.
-                          type: string
-                      required:
-                        - name
-                      type: object
-                  required:
-                    - secretRef
-                  type: object
-                maxHistory:
-                  description: |-
-                    MaxHistory is the number of revisions saved by Helm for this HelmRelease.
-                    Use '0' for an unlimited number of revisions; defaults to '5'.
-                  type: integer
-                persistentClient:
-                  description: |-
-                    PersistentClient tells the controller to use a persistent Kubernetes
-                    client for this release. When enabled, the client will be reused for the
-                    duration of the reconciliation, instead of being created and destroyed
-                    for each (step of a) Helm action.
-                    
-                    
-                    This can improve performance, but may cause issues with some Helm charts
-                    that for example do create Custom Resource Definitions during installation
-                    outside Helm's CRD lifecycle hooks, which are then not observed to be
-                    available by e.g. post-install hooks.
-                    
-                    
-                    If not set, it defaults to true.
-                  type: boolean
-                postRenderers:
-                  description: |-
-                    PostRenderers holds an array of Helm PostRenderers, which will be applied in order
-                    of their definition.
-                  items:
-                    description: PostRenderer contains a Helm PostRenderer specification.
-                    properties:
-                      kustomize:
-                        description: Kustomization to apply as PostRenderer.
-                        properties:
-                          images:
-                            description: |-
-                              Images is a list of (image name, new name, new tag or digest)
-                              for changing image names, tags or digests. This can also be achieved with a
-                              patch, but this operator is simpler to specify.
-                            items:
-                              description: Image contains an image name, a new name,
-                                a new tag or digest, which will replace the original
-                                name and tag.
-                              properties:
-                                digest:
-                                  description: |-
-                                    Digest is the value used to replace the original image tag.
-                                    If digest is present NewTag value is ignored.
-                                  type: string
-                                name:
-                                  description: Name is a tag-less image name.
-                                  type: string
-                                newName:
-                                  description: NewName is the value used to replace
-                                    the original name.
-                                  type: string
-                                newTag:
-                                  description: NewTag is the value used to replace the
-                                    original tag.
-                                  type: string
-                              required:
-                                - name
-                              type: object
-                            type: array
-                          patches:
-                            description: |-
-                              Strategic merge and JSON patches, defined as inline YAML objects,
-                              capable of targeting objects based on kind, label and annotation selectors.
-                            items:
-                              description: |-
-                                Patch contains an inline StrategicMerge or JSON6902 patch, and the target the patch should
-                                be applied to.
-                              properties:
-                                patch:
-                                  description: |-
-                                    Patch contains an inline StrategicMerge patch or an inline JSON6902 patch with
-                                    an array of operation objects.
-                                  type: string
-                                target:
-                                  description: Target points to the resources that the
-                                    patch document should be applied to.
-                                  properties:
-                                    annotationSelector:
-                                      description: |-
-                                        AnnotationSelector is a string that follows the label selection expression
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
-                                        It matches with the resource annotations.
-                                      type: string
-                                    group:
-                                      description: |-
-                                        Group is the API group to select resources from.
-                                        Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources.
-                                        https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
-                                      type: string
-                                    kind:
-                                      description: |-
-                                        Kind of the API Group to select resources from.
-                                        Together with Group and Version it is capable of unambiguously
-                                        identifying and/or selecting resources.
-                                        https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
-                                      type: string
-                                    labelSelector:
-                                      description: |-
-                                        LabelSelector is a string that follows the label selection expression
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
-                                        It matches with the resource labels.
-                                      type: string
-                                    name:
-                                      description: Name to match resources with.
-                                      type: string
-                                    namespace:
-                                      description: Namespace to select resources from.
-                                      type: string
-                                    version:
-                                      description: |-
-                                        Version of the API Group to select resources from.
-                                        Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources.
-                                        https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
-                                      type: string
-                                  type: object
-                              required:
-                                - patch
-                              type: object
-                            type: array
-                          patchesJson6902:
-                            description: |-
-                              JSON 6902 patches, defined as inline YAML objects.
-                              Deprecated: use Patches instead.
-                            items:
-                              description: JSON6902Patch contains a JSON6902 patch and
-                                the target the patch should be applied to.
-                              properties:
-                                patch:
-                                  description: Patch contains the JSON6902 patch document
-                                    with an array of operation objects.
-                                  items:
-                                    description: |-
-                                      JSON6902 is a JSON6902 operation object.
-                                      https://datatracker.ietf.org/doc/html/rfc6902#section-4
-                                    properties:
-                                      from:
-                                        description: |-
-                                          From contains a JSON-pointer value that references a location within the target document where the operation is
-                                          performed. The meaning of the value depends on the value of Op, and is NOT taken into account by all operations.
-                                        type: string
-                                      op:
-                                        description: |-
-                                          Op indicates the operation to perform. Its value MUST be one of "add", "remove", "replace", "move", "copy", or
-                                          "test".
-                                          https://datatracker.ietf.org/doc/html/rfc6902#section-4
-                                        enum:
-                                          - test
-                                          - remove
-                                          - add
-                                          - replace
-                                          - move
-                                          - copy
-                                        type: string
-                                      path:
-                                        description: |-
-                                          Path contains the JSON-pointer value that references a location within the target document where the operation
-                                          is performed. The meaning of the value depends on the value of Op.
-                                        type: string
-                                      value:
-                                        description: |-
-                                          Value contains a valid JSON structure. The meaning of the value depends on the value of Op, and is NOT taken into
-                                          account by all operations.
-                                        x-kubernetes-preserve-unknown-fields: true
-                                    required:
-                                      - op
-                                      - path
-                                    type: object
-                                  type: array
-                                target:
-                                  description: Target points to the resources that the
-                                    patch document should be applied to.
-                                  properties:
-                                    annotationSelector:
-                                      description: |-
-                                        AnnotationSelector is a string that follows the label selection expression
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
-                                        It matches with the resource annotations.
-                                      type: string
-                                    group:
-                                      description: |-
-                                        Group is the API group to select resources from.
-                                        Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources.
-                                        https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
-                                      type: string
-                                    kind:
-                                      description: |-
-                                        Kind of the API Group to select resources from.
-                                        Together with Group and Version it is capable of unambiguously
-                                        identifying and/or selecting resources.
-                                        https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
-                                      type: string
-                                    labelSelector:
-                                      description: |-
-                                        LabelSelector is a string that follows the label selection expression
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
-                                        It matches with the resource labels.
-                                      type: string
-                                    name:
-                                      description: Name to match resources with.
-                                      type: string
-                                    namespace:
-                                      description: Namespace to select resources from.
-                                      type: string
-                                    version:
-                                      description: |-
-                                        Version of the API Group to select resources from.
-                                        Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources.
-                                        https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
-                                      type: string
-                                  type: object
-                              required:
-                                - patch
-                                - target
-                              type: object
-                            type: array
-                          patchesStrategicMerge:
-                            description: |-
-                              Strategic merge patches, defined as inline YAML objects.
-                              Deprecated: use Patches instead.
-                            items:
-                              x-kubernetes-preserve-unknown-fields: true
-                            type: array
-                        type: object
-                    type: object
-                  type: array
-                releaseName:
-                  description: |-
-                    ReleaseName used for the Helm release. Defaults to a composition of
-                    '[TargetNamespace-]Name'.
-                  maxLength: 53
-                  minLength: 1
-                  type: string
-                rollback:
-                  description: Rollback holds the configuration for Helm rollback actions
-                    for this HelmRelease.
-                  properties:
-                    cleanupOnFail:
-                      description: |-
-                        CleanupOnFail allows deletion of new resources created during the Helm
-                        rollback action when it fails.
-                      type: boolean
-                    disableHooks:
-                      description: DisableHooks prevents hooks from running during the
-                        Helm rollback action.
-                      type: boolean
-                    disableWait:
-                      description: |-
-                        DisableWait disables the waiting for resources to be ready after a Helm
-                        rollback has been performed.
-                      type: boolean
-                    disableWaitForJobs:
-                      description: |-
-                        DisableWaitForJobs disables waiting for jobs to complete after a Helm
-                        rollback has been performed.
-                      type: boolean
-                    force:
-                      description: Force forces resource updates through a replacement
-                        strategy.
-                      type: boolean
-                    recreate:
-                      description: Recreate performs pod restarts for the resource if
-                        applicable.
-                      type: boolean
-                    timeout:
-                      description: |-
-                        Timeout is the time to wait for any individual Kubernetes operation (like
-                        Jobs for hooks) during the performance of a Helm rollback action. Defaults to
-                        'HelmReleaseSpec.Timeout'.
-                      pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                      type: string
-                  type: object
-                serviceAccountName:
-                  description: |-
-                    The name of the Kubernetes service account to impersonate
-                    when reconciling this HelmRelease.
-                  maxLength: 253
-                  minLength: 1
-                  type: string
-                storageNamespace:
-                  description: |-
-                    StorageNamespace used for the Helm storage.
-                    Defaults to the namespace of the HelmRelease.
-                  maxLength: 63
-                  minLength: 1
-                  type: string
-                suspend:
-                  description: |-
-                    Suspend tells the controller to suspend reconciliation for this HelmRelease,
-                    it does not apply to already started reconciliations. Defaults to false.
-                  type: boolean
-                targetNamespace:
-                  description: |-
-                    TargetNamespace to target when performing operations for the HelmRelease.
-                    Defaults to the namespace of the HelmRelease.
-                  maxLength: 63
-                  minLength: 1
-                  type: string
-                test:
-                  description: Test holds the configuration for Helm test actions for
-                    this HelmRelease.
-                  properties:
-                    enable:
-                      description: |-
-                        Enable enables Helm test actions for this HelmRelease after an Helm install
-                        or upgrade action has been performed.
-                      type: boolean
-                    filters:
-                      description: Filters is a list of tests to run or exclude from
-                        running.
-                      items:
-                        description: Filter holds the configuration for individual Helm
-                          test filters.
-                        properties:
-                          exclude:
-                            description: Exclude specifies whether the named test should
-                              be excluded.
-                            type: boolean
-                          name:
-                            description: Name is the name of the test.
-                            maxLength: 253
+                          namespace:
+                            description: Namespace of the referent.
+                            maxLength: 63
                             minLength: 1
                             type: string
                         required:
-                          - name
+                        - kind
+                        - name
                         type: object
-                      type: array
-                    ignoreFailures:
-                      description: |-
-                        IgnoreFailures tells the controller to skip remediation when the Helm tests
-                        are run but fail. Can be overwritten for tests run after install or upgrade
-                        actions in 'Install.IgnoreTestFailures' and 'Upgrade.IgnoreTestFailures'.
-                      type: boolean
-                    timeout:
-                      description: |-
-                        Timeout is the time to wait for any individual Kubernetes operation during
-                        the performance of a Helm test action. Defaults to 'HelmReleaseSpec.Timeout'.
-                      pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                      type: string
-                  type: object
-                timeout:
-                  description: |-
-                    Timeout is the time to wait for any individual Kubernetes operation (like Jobs
-                    for hooks) during the performance of a Helm action. Defaults to '5m0s'.
-                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                  type: string
-                uninstall:
-                  description: Uninstall holds the configuration for Helm uninstall
-                    actions for this HelmRelease.
-                  properties:
-                    deletionPropagation:
-                      default: background
-                      description: |-
-                        DeletionPropagation specifies the deletion propagation policy when
-                        a Helm uninstall is performed.
-                      enum:
-                        - background
-                        - foreground
-                        - orphan
-                      type: string
-                    disableHooks:
-                      description: DisableHooks prevents hooks from running during the
-                        Helm rollback action.
-                      type: boolean
-                    disableWait:
-                      description: |-
-                        DisableWait disables waiting for all the resources to be deleted after
-                        a Helm uninstall is performed.
-                      type: boolean
-                    keepHistory:
-                      description: |-
-                        KeepHistory tells Helm to remove all associated resources and mark the
-                        release as deleted, but retain the release history.
-                      type: boolean
-                    timeout:
-                      description: |-
-                        Timeout is the time to wait for any individual Kubernetes operation (like
-                        Jobs for hooks) during the performance of a Helm uninstall action. Defaults
-                        to 'HelmReleaseSpec.Timeout'.
-                      pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                      type: string
-                  type: object
-                upgrade:
-                  description: Upgrade holds the configuration for Helm upgrade actions
-                    for this HelmRelease.
-                  properties:
-                    cleanupOnFail:
-                      description: |-
-                        CleanupOnFail allows deletion of new resources created during the Helm
-                        upgrade action when it fails.
-                      type: boolean
-                    crds:
-                      description: |-
-                        CRDs upgrade CRDs from the Helm Chart's crds directory according
-                        to the CRD upgrade policy provided here. Valid values are `Skip`,
-                        `Create` or `CreateReplace`. Default is `Skip` and if omitted
-                        CRDs are neither installed nor upgraded.
-                        
-                        
-                        Skip: do neither install nor replace (update) any CRDs.
-                        
-                        
-                        Create: new CRDs are created, existing CRDs are neither updated nor deleted.
-                        
-                        
-                        CreateReplace: new CRDs are created, existing CRDs are updated (replaced)
-                        but not deleted.
-                        
-                        
-                        By default, CRDs are not applied during Helm upgrade action. With this
-                        option users can opt-in to CRD upgrade, which is not (yet) natively supported by Helm.
-                        https://helm.sh/docs/chart_best_practices/custom_resource_definitions.
-                      enum:
-                        - Skip
-                        - Create
-                        - CreateReplace
-                      type: string
-                    disableHooks:
-                      description: DisableHooks prevents hooks from running during the
-                        Helm upgrade action.
-                      type: boolean
-                    disableOpenAPIValidation:
-                      description: |-
-                        DisableOpenAPIValidation prevents the Helm upgrade action from validating
-                        rendered templates against the Kubernetes OpenAPI Schema.
-                      type: boolean
-                    disableWait:
-                      description: |-
-                        DisableWait disables the waiting for resources to be ready after a Helm
-                        upgrade has been performed.
-                      type: boolean
-                    disableWaitForJobs:
-                      description: |-
-                        DisableWaitForJobs disables waiting for jobs to complete after a Helm
-                        upgrade has been performed.
-                      type: boolean
-                    force:
-                      description: Force forces resource updates through a replacement
-                        strategy.
-                      type: boolean
-                    preserveValues:
-                      description: |-
-                        PreserveValues will make Helm reuse the last release's values and merge in
-                        overrides from 'Values'. Setting this flag makes the HelmRelease
-                        non-declarative.
-                      type: boolean
-                    remediation:
-                      description: |-
-                        Remediation holds the remediation configuration for when the Helm upgrade
-                        action for the HelmRelease fails. The default is to not perform any action.
-                      properties:
-                        ignoreTestFailures:
-                          description: |-
-                            IgnoreTestFailures tells the controller to skip remediation when the Helm
-                            tests are run after an upgrade action but fail.
-                            Defaults to 'Test.IgnoreFailures'.
-                          type: boolean
-                        remediateLastFailure:
-                          description: |-
-                            RemediateLastFailure tells the controller to remediate the last failure, when
-                            no retries remain. Defaults to 'false' unless 'Retries' is greater than 0.
-                          type: boolean
-                        retries:
-                          description: |-
-                            Retries is the number of retries that should be attempted on failures before
-                            bailing. Remediation, using 'Strategy', is performed between each attempt.
-                            Defaults to '0', a negative integer equals to unlimited retries.
-                          type: integer
-                        strategy:
-                          description: Strategy to use for failure remediation. Defaults
-                            to 'rollback'.
-                          enum:
-                            - rollback
-                            - uninstall
+                      valuesFiles:
+                        description: |-
+                          Alternative list of values files to use as the chart values (values.yaml
+                          is not included by default), expected to be a relative path in the SourceRef.
+                          Values files are merged in the order of this list with the last file overriding
+                          the first. Ignored when omitted.
+                        items:
                           type: string
-                      type: object
-                    timeout:
-                      description: |-
-                        Timeout is the time to wait for any individual Kubernetes operation (like
-                        Jobs for hooks) during the performance of a Helm upgrade action. Defaults to
-                        'HelmReleaseSpec.Timeout'.
-                      pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                      type: string
-                  type: object
-                values:
-                  description: Values holds the values for this Helm release.
-                  x-kubernetes-preserve-unknown-fields: true
-                valuesFrom:
-                  description: |-
-                    ValuesFrom holds references to resources containing Helm values for this HelmRelease,
-                    and information about how they should be merged.
-                  items:
-                    description: |-
-                      ValuesReference contains a reference to a resource containing Helm values,
-                      and optionally the key they can be found at.
-                    properties:
-                      kind:
-                        description: Kind of the values referent, valid values are ('Secret',
-                          'ConfigMap').
-                        enum:
-                          - Secret
-                          - ConfigMap
-                        type: string
-                      name:
+                        type: array
+                      verify:
                         description: |-
-                          Name of the values referent. Should reside in the same namespace as the
-                          referring resource.
-                        maxLength: 253
-                        minLength: 1
-                        type: string
-                      optional:
-                        description: |-
-                          Optional marks this ValuesReference as optional. When set, a not found error
-                          for the values reference is ignored, but any ValuesKey, TargetPath or
-                          transient error will still result in a reconciliation failure.
-                        type: boolean
-                      targetPath:
-                        description: |-
-                          TargetPath is the YAML dot notation path the value should be merged at. When
-                          set, the ValuesKey is expected to be a single flat value. Defaults to 'None',
-                          which results in the values getting merged at the root.
-                        maxLength: 250
-                        pattern: ^([a-zA-Z0-9_\-.\\\/]|\[[0-9]{1,5}\])+$
-                        type: string
-                      valuesKey:
-                        description: |-
-                          ValuesKey is the data key where the values.yaml or a specific value can be
-                          found at. Defaults to 'values.yaml'.
-                        maxLength: 253
-                        pattern: ^[\-._a-zA-Z0-9]+$
-                        type: string
-                    required:
-                      - kind
-                      - name
-                    type: object
-                  type: array
-              required:
-                - interval
-              type: object
-              x-kubernetes-validations:
-                - message: either chart or chartRef must be set
-                  rule: (has(self.chart) && !has(self.chartRef)) || (!has(self.chart)
-                    && has(self.chartRef))
-            status:
-              default:
-                observedGeneration: -1
-              description: HelmReleaseStatus defines the observed state of a HelmRelease.
-              properties:
-                conditions:
-                  description: Conditions holds the conditions for the HelmRelease.
-                  items:
-                    description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
-                    properties:
-                      lastTransitionTime:
-                        description: |-
-                          lastTransitionTime is the last time the condition transitioned from one status to another.
-                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                        format: date-time
-                        type: string
-                      message:
-                        description: |-
-                          message is a human readable message indicating details about the transition.
-                          This may be an empty string.
-                        maxLength: 32768
-                        type: string
-                      observedGeneration:
-                        description: |-
-                          observedGeneration represents the .metadata.generation that the condition was set based upon.
-                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                          with respect to the current state of the instance.
-                        format: int64
-                        minimum: 0
-                        type: integer
-                      reason:
-                        description: |-
-                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                          Producers of specific condition types may define expected values and meanings for this field,
-                          and whether the values are considered a guaranteed API.
-                          The value should be a CamelCase string.
-                          This field may not be empty.
-                        maxLength: 1024
-                        minLength: 1
-                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                        type: string
-                      status:
-                        description: status of the condition, one of True, False, Unknown.
-                        enum:
-                          - "True"
-                          - "False"
-                          - Unknown
-                        type: string
-                      type:
-                        description: |-
-                          type of condition in CamelCase or in foo.example.com/CamelCase.
-                          ---
-                          Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                          useful (see .node.status.conditions), the ability to deconflict is important.
-                          The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                        maxLength: 316
-                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                        type: string
-                    required:
-                      - lastTransitionTime
-                      - message
-                      - reason
-                      - status
-                      - type
-                    type: object
-                  type: array
-                failures:
-                  description: |-
-                    Failures is the reconciliation failure count against the latest desired
-                    state. It is reset after a successful reconciliation.
-                  format: int64
-                  type: integer
-                helmChart:
-                  description: |-
-                    HelmChart is the namespaced name of the HelmChart resource created by
-                    the controller for the HelmRelease.
-                  type: string
-                history:
-                  description: |-
-                    History holds the history of Helm releases performed for this HelmRelease
-                    up to the last successfully completed release.
-                  items:
-                    description: |-
-                      Snapshot captures a point-in-time copy of the status information for a Helm release,
-                      as managed by the controller.
-                    properties:
-                      apiVersion:
-                        description: |-
-                          APIVersion is the API version of the Snapshot.
-                          Provisional: when the calculation method of the Digest field is changed,
-                          this field will be used to distinguish between the old and new methods.
-                        type: string
-                      appVersion:
-                        description: AppVersion is the chart app version of the release
-                          object in storage.
-                        type: string
-                      chartName:
-                        description: ChartName is the chart name of the release object
-                          in storage.
-                        type: string
-                      chartVersion:
-                        description: |-
-                          ChartVersion is the chart version of the release object in
-                          storage.
-                        type: string
-                      configDigest:
-                        description: |-
-                          ConfigDigest is the checksum of the config (better known as
-                          "values") of the release object in storage.
-                          It has the format of `<algo>:<checksum>`.
-                        type: string
-                      deleted:
-                        description: Deleted is when the release was deleted.
-                        format: date-time
-                        type: string
-                      digest:
-                        description: |-
-                          Digest is the checksum of the release object in storage.
-                          It has the format of `<algo>:<checksum>`.
-                        type: string
-                      firstDeployed:
-                        description: FirstDeployed is when the release was first deployed.
-                        format: date-time
-                        type: string
-                      lastDeployed:
-                        description: LastDeployed is when the release was last deployed.
-                        format: date-time
-                        type: string
-                      name:
-                        description: Name is the name of the release.
-                        type: string
-                      namespace:
-                        description: Namespace is the namespace the release is deployed
-                          to.
-                        type: string
-                      ociDigest:
-                        description: OCIDigest is the digest of the OCI artifact associated
-                          with the release.
-                        type: string
-                      status:
-                        description: Status is the current state of the release.
-                        type: string
-                      testHooks:
-                        additionalProperties:
-                          description: |-
-                            TestHookStatus holds the status information for a test hook as observed
-                            to be run by the controller.
-                          properties:
-                            lastCompleted:
-                              description: LastCompleted is the time the test hook last
-                                completed.
-                              format: date-time
-                              type: string
-                            lastStarted:
-                              description: LastStarted is the time the test hook was
-                                last started.
-                              format: date-time
-                              type: string
-                            phase:
-                              description: Phase the test hook was observed to be in.
-                              type: string
-                          type: object
-                        description: |-
-                          TestHooks is the list of test hooks for the release as observed to be
-                          run by the controller.
+                          Verify contains the secret name containing the trusted public keys
+                          used to verify the signature and specifies which provider to use to check
+                          whether OCI image is authentic.
+                          This field is only supported for OCI sources.
+                          Chart dependencies, which are not bundled in the umbrella chart artifact,
+                          are not verified.
+                        properties:
+                          provider:
+                            default: cosign
+                            description: Provider specifies the technology used to
+                              sign the OCI Helm chart.
+                            enum:
+                            - cosign
+                            - notation
+                            type: string
+                          secretRef:
+                            description: |-
+                              SecretRef specifies the Kubernetes Secret containing the
+                              trusted public keys.
+                            properties:
+                              name:
+                                description: Name of the referent.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                        required:
+                        - provider
                         type: object
                       version:
-                        description: Version is the version of the release object in
-                          storage.
-                        type: integer
+                        default: '*'
+                        description: |-
+                          Version semver expression, ignored for charts from v1.GitRepository and
+                          v1beta2.Bucket sources. Defaults to latest when omitted.
+                        type: string
                     required:
-                      - chartName
-                      - chartVersion
-                      - configDigest
-                      - digest
-                      - firstDeployed
-                      - lastDeployed
-                      - name
-                      - namespace
-                      - status
-                      - version
+                    - chart
+                    - sourceRef
                     type: object
-                  type: array
-                installFailures:
+                required:
+                - spec
+                type: object
+              chartRef:
+                description: |-
+                  ChartRef holds a reference to a source controller resource containing the
+                  Helm chart artifact.
+                properties:
+                  apiVersion:
+                    description: APIVersion of the referent.
+                    type: string
+                  kind:
+                    description: Kind of the referent.
+                    enum:
+                    - OCIRepository
+                    - HelmChart
+                    type: string
+                  name:
+                    description: Name of the referent.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent, defaults to the namespace of the Kubernetes
+                      resource object that contains the reference.
+                    maxLength: 63
+                    minLength: 1
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              dependsOn:
+                description: |-
+                  DependsOn may contain a meta.NamespacedObjectReference slice with
+                  references to HelmRelease resources that must be ready before this HelmRelease
+                  can be reconciled.
+                items:
                   description: |-
-                    InstallFailures is the install failure count against the latest desired
-                    state. It is reset after a successful reconciliation.
-                  format: int64
-                  type: integer
-                lastAppliedRevision:
+                    NamespacedObjectReference contains enough information to locate the referenced Kubernetes resource object in any
+                    namespace.
+                  properties:
+                    name:
+                      description: Name of the referent.
+                      type: string
+                    namespace:
+                      description: Namespace of the referent, when not specified it
+                        acts as LocalObjectReference.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              driftDetection:
+                description: |-
+                  DriftDetection holds the configuration for detecting and handling
+                  differences between the manifest in the Helm storage and the resources
+                  currently existing in the cluster.
+                properties:
+                  ignore:
+                    description: |-
+                      Ignore contains a list of rules for specifying which changes to ignore
+                      during diffing.
+                    items:
+                      description: |-
+                        IgnoreRule defines a rule to selectively disregard specific changes during
+                        the drift detection process.
+                      properties:
+                        paths:
+                          description: |-
+                            Paths is a list of JSON Pointer (RFC 6901) paths to be excluded from
+                            consideration in a Kubernetes object.
+                          items:
+                            type: string
+                          type: array
+                        target:
+                          description: |-
+                            Target is a selector for specifying Kubernetes objects to which this
+                            rule applies.
+                            If Target is not set, the Paths will be ignored for all Kubernetes
+                            objects within the manifest of the Helm release.
+                          properties:
+                            annotationSelector:
+                              description: |-
+                                AnnotationSelector is a string that follows the label selection expression
+                                https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                                It matches with the resource annotations.
+                              type: string
+                            group:
+                              description: |-
+                                Group is the API group to select resources from.
+                                Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources.
+                                https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                              type: string
+                            kind:
+                              description: |-
+                                Kind of the API Group to select resources from.
+                                Together with Group and Version it is capable of unambiguously
+                                identifying and/or selecting resources.
+                                https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                              type: string
+                            labelSelector:
+                              description: |-
+                                LabelSelector is a string that follows the label selection expression
+                                https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                                It matches with the resource labels.
+                              type: string
+                            name:
+                              description: Name to match resources with.
+                              type: string
+                            namespace:
+                              description: Namespace to select resources from.
+                              type: string
+                            version:
+                              description: |-
+                                Version of the API Group to select resources from.
+                                Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources.
+                                https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                              type: string
+                          type: object
+                      required:
+                      - paths
+                      type: object
+                    type: array
+                  mode:
+                    description: |-
+                      Mode defines how differences should be handled between the Helm manifest
+                      and the manifest currently applied to the cluster.
+                      If not explicitly set, it defaults to DiffModeDisabled.
+                    enum:
+                    - enabled
+                    - warn
+                    - disabled
+                    type: string
+                type: object
+              install:
+                description: Install holds the configuration for Helm install actions
+                  for this HelmRelease.
+                properties:
+                  crds:
+                    description: |-
+                      CRDs upgrade CRDs from the Helm Chart's crds directory according
+                      to the CRD upgrade policy provided here. Valid values are `Skip`,
+                      `Create` or `CreateReplace`. Default is `Create` and if omitted
+                      CRDs are installed but not updated.
+
+                      Skip: do neither install nor replace (update) any CRDs.
+
+                      Create: new CRDs are created, existing CRDs are neither updated nor deleted.
+
+                      CreateReplace: new CRDs are created, existing CRDs are updated (replaced)
+                      but not deleted.
+
+                      By default, CRDs are applied (installed) during Helm install action.
+                      With this option users can opt in to CRD replace existing CRDs on Helm
+                      install actions, which is not (yet) natively supported by Helm.
+                      https://helm.sh/docs/chart_best_practices/custom_resource_definitions.
+                    enum:
+                    - Skip
+                    - Create
+                    - CreateReplace
+                    type: string
+                  createNamespace:
+                    description: |-
+                      CreateNamespace tells the Helm install action to create the
+                      HelmReleaseSpec.TargetNamespace if it does not exist yet.
+                      On uninstall, the namespace will not be garbage collected.
+                    type: boolean
+                  disableHooks:
+                    description: DisableHooks prevents hooks from running during the
+                      Helm install action.
+                    type: boolean
+                  disableOpenAPIValidation:
+                    description: |-
+                      DisableOpenAPIValidation prevents the Helm install action from validating
+                      rendered templates against the Kubernetes OpenAPI Schema.
+                    type: boolean
+                  disableSchemaValidation:
+                    description: |-
+                      DisableSchemaValidation prevents the Helm install action from validating
+                      the values against the JSON Schema.
+                    type: boolean
+                  disableWait:
+                    description: |-
+                      DisableWait disables the waiting for resources to be ready after a Helm
+                      install has been performed.
+                    type: boolean
+                  disableWaitForJobs:
+                    description: |-
+                      DisableWaitForJobs disables waiting for jobs to complete after a Helm
+                      install has been performed.
+                    type: boolean
+                  remediation:
+                    description: |-
+                      Remediation holds the remediation configuration for when the Helm install
+                      action for the HelmRelease fails. The default is to not perform any action.
+                    properties:
+                      ignoreTestFailures:
+                        description: |-
+                          IgnoreTestFailures tells the controller to skip remediation when the Helm
+                          tests are run after an install action but fail. Defaults to
+                          'Test.IgnoreFailures'.
+                        type: boolean
+                      remediateLastFailure:
+                        description: |-
+                          RemediateLastFailure tells the controller to remediate the last failure, when
+                          no retries remain. Defaults to 'false'.
+                        type: boolean
+                      retries:
+                        description: |-
+                          Retries is the number of retries that should be attempted on failures before
+                          bailing. Remediation, using an uninstall, is performed between each attempt.
+                          Defaults to '0', a negative integer equals to unlimited retries.
+                        type: integer
+                    type: object
+                  replace:
+                    description: |-
+                      Replace tells the Helm install action to re-use the 'ReleaseName', but only
+                      if that name is a deleted release which remains in the history.
+                    type: boolean
+                  skipCRDs:
+                    description: |-
+                      SkipCRDs tells the Helm install action to not install any CRDs. By default,
+                      CRDs are installed if not already present.
+
+                      Deprecated use CRD policy (`crds`) attribute with value `Skip` instead.
+                    type: boolean
+                  timeout:
+                    description: |-
+                      Timeout is the time to wait for any individual Kubernetes operation (like
+                      Jobs for hooks) during the performance of a Helm install action. Defaults to
+                      'HelmReleaseSpec.Timeout'.
+                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                    type: string
+                type: object
+              interval:
+                description: Interval at which to reconcile the Helm release.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                type: string
+              kubeConfig:
+                description: |-
+                  KubeConfig for reconciling the HelmRelease on a remote cluster.
+                  When used in combination with HelmReleaseSpec.ServiceAccountName,
+                  forces the controller to act on behalf of that Service Account at the
+                  target cluster.
+                  If the --default-service-account flag is set, its value will be used as
+                  a controller level fallback for when HelmReleaseSpec.ServiceAccountName
+                  is empty.
+                properties:
+                  secretRef:
+                    description: |-
+                      SecretRef holds the name of a secret that contains a key with
+                      the kubeconfig file as the value. If no key is set, the key will default
+                      to 'value'.
+                      It is recommended that the kubeconfig is self-contained, and the secret
+                      is regularly updated if credentials such as a cloud-access-token expire.
+                      Cloud specific `cmd-path` auth helpers will not function without adding
+                      binaries and credentials to the Pod that is responsible for reconciling
+                      Kubernetes resources.
+                    properties:
+                      key:
+                        description: Key in the Secret, when not specified an implementation-specific
+                          default key is used.
+                        type: string
+                      name:
+                        description: Name of the Secret.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                required:
+                - secretRef
+                type: object
+              maxHistory:
+                description: |-
+                  MaxHistory is the number of revisions saved by Helm for this HelmRelease.
+                  Use '0' for an unlimited number of revisions; defaults to '5'.
+                type: integer
+              persistentClient:
+                description: |-
+                  PersistentClient tells the controller to use a persistent Kubernetes
+                  client for this release. When enabled, the client will be reused for the
+                  duration of the reconciliation, instead of being created and destroyed
+                  for each (step of a) Helm action.
+
+                  This can improve performance, but may cause issues with some Helm charts
+                  that for example do create Custom Resource Definitions during installation
+                  outside Helm's CRD lifecycle hooks, which are then not observed to be
+                  available by e.g. post-install hooks.
+
+                  If not set, it defaults to true.
+                type: boolean
+              postRenderers:
+                description: |-
+                  PostRenderers holds an array of Helm PostRenderers, which will be applied in order
+                  of their definition.
+                items:
+                  description: PostRenderer contains a Helm PostRenderer specification.
+                  properties:
+                    kustomize:
+                      description: Kustomization to apply as PostRenderer.
+                      properties:
+                        images:
+                          description: |-
+                            Images is a list of (image name, new name, new tag or digest)
+                            for changing image names, tags or digests. This can also be achieved with a
+                            patch, but this operator is simpler to specify.
+                          items:
+                            description: Image contains an image name, a new name,
+                              a new tag or digest, which will replace the original
+                              name and tag.
+                            properties:
+                              digest:
+                                description: |-
+                                  Digest is the value used to replace the original image tag.
+                                  If digest is present NewTag value is ignored.
+                                type: string
+                              name:
+                                description: Name is a tag-less image name.
+                                type: string
+                              newName:
+                                description: NewName is the value used to replace
+                                  the original name.
+                                type: string
+                              newTag:
+                                description: NewTag is the value used to replace the
+                                  original tag.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          type: array
+                        patches:
+                          description: |-
+                            Strategic merge and JSON patches, defined as inline YAML objects,
+                            capable of targeting objects based on kind, label and annotation selectors.
+                          items:
+                            description: |-
+                              Patch contains an inline StrategicMerge or JSON6902 patch, and the target the patch should
+                              be applied to.
+                            properties:
+                              patch:
+                                description: |-
+                                  Patch contains an inline StrategicMerge patch or an inline JSON6902 patch with
+                                  an array of operation objects.
+                                type: string
+                              target:
+                                description: Target points to the resources that the
+                                  patch document should be applied to.
+                                properties:
+                                  annotationSelector:
+                                    description: |-
+                                      AnnotationSelector is a string that follows the label selection expression
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                                      It matches with the resource annotations.
+                                    type: string
+                                  group:
+                                    description: |-
+                                      Group is the API group to select resources from.
+                                      Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources.
+                                      https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                                    type: string
+                                  kind:
+                                    description: |-
+                                      Kind of the API Group to select resources from.
+                                      Together with Group and Version it is capable of unambiguously
+                                      identifying and/or selecting resources.
+                                      https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                                    type: string
+                                  labelSelector:
+                                    description: |-
+                                      LabelSelector is a string that follows the label selection expression
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                                      It matches with the resource labels.
+                                    type: string
+                                  name:
+                                    description: Name to match resources with.
+                                    type: string
+                                  namespace:
+                                    description: Namespace to select resources from.
+                                    type: string
+                                  version:
+                                    description: |-
+                                      Version of the API Group to select resources from.
+                                      Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources.
+                                      https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                                    type: string
+                                type: object
+                            required:
+                            - patch
+                            type: object
+                          type: array
+                      type: object
+                  type: object
+                type: array
+              releaseName:
+                description: |-
+                  ReleaseName used for the Helm release. Defaults to a composition of
+                  '[TargetNamespace-]Name'.
+                maxLength: 53
+                minLength: 1
+                type: string
+              rollback:
+                description: Rollback holds the configuration for Helm rollback actions
+                  for this HelmRelease.
+                properties:
+                  cleanupOnFail:
+                    description: |-
+                      CleanupOnFail allows deletion of new resources created during the Helm
+                      rollback action when it fails.
+                    type: boolean
+                  disableHooks:
+                    description: DisableHooks prevents hooks from running during the
+                      Helm rollback action.
+                    type: boolean
+                  disableWait:
+                    description: |-
+                      DisableWait disables the waiting for resources to be ready after a Helm
+                      rollback has been performed.
+                    type: boolean
+                  disableWaitForJobs:
+                    description: |-
+                      DisableWaitForJobs disables waiting for jobs to complete after a Helm
+                      rollback has been performed.
+                    type: boolean
+                  force:
+                    description: Force forces resource updates through a replacement
+                      strategy.
+                    type: boolean
+                  recreate:
+                    description: Recreate performs pod restarts for the resource if
+                      applicable.
+                    type: boolean
+                  timeout:
+                    description: |-
+                      Timeout is the time to wait for any individual Kubernetes operation (like
+                      Jobs for hooks) during the performance of a Helm rollback action. Defaults to
+                      'HelmReleaseSpec.Timeout'.
+                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                    type: string
+                type: object
+              serviceAccountName:
+                description: |-
+                  The name of the Kubernetes service account to impersonate
+                  when reconciling this HelmRelease.
+                maxLength: 253
+                minLength: 1
+                type: string
+              storageNamespace:
+                description: |-
+                  StorageNamespace used for the Helm storage.
+                  Defaults to the namespace of the HelmRelease.
+                maxLength: 63
+                minLength: 1
+                type: string
+              suspend:
+                description: |-
+                  Suspend tells the controller to suspend reconciliation for this HelmRelease,
+                  it does not apply to already started reconciliations. Defaults to false.
+                type: boolean
+              targetNamespace:
+                description: |-
+                  TargetNamespace to target when performing operations for the HelmRelease.
+                  Defaults to the namespace of the HelmRelease.
+                maxLength: 63
+                minLength: 1
+                type: string
+              test:
+                description: Test holds the configuration for Helm test actions for
+                  this HelmRelease.
+                properties:
+                  enable:
+                    description: |-
+                      Enable enables Helm test actions for this HelmRelease after an Helm install
+                      or upgrade action has been performed.
+                    type: boolean
+                  filters:
+                    description: Filters is a list of tests to run or exclude from
+                      running.
+                    items:
+                      description: Filter holds the configuration for individual Helm
+                        test filters.
+                      properties:
+                        exclude:
+                          description: Exclude specifies whether the named test should
+                            be excluded.
+                          type: boolean
+                        name:
+                          description: Name is the name of the test.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  ignoreFailures:
+                    description: |-
+                      IgnoreFailures tells the controller to skip remediation when the Helm tests
+                      are run but fail. Can be overwritten for tests run after install or upgrade
+                      actions in 'Install.IgnoreTestFailures' and 'Upgrade.IgnoreTestFailures'.
+                    type: boolean
+                  timeout:
+                    description: |-
+                      Timeout is the time to wait for any individual Kubernetes operation during
+                      the performance of a Helm test action. Defaults to 'HelmReleaseSpec.Timeout'.
+                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                    type: string
+                type: object
+              timeout:
+                description: |-
+                  Timeout is the time to wait for any individual Kubernetes operation (like Jobs
+                  for hooks) during the performance of a Helm action. Defaults to '5m0s'.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                type: string
+              uninstall:
+                description: Uninstall holds the configuration for Helm uninstall
+                  actions for this HelmRelease.
+                properties:
+                  deletionPropagation:
+                    default: background
+                    description: |-
+                      DeletionPropagation specifies the deletion propagation policy when
+                      a Helm uninstall is performed.
+                    enum:
+                    - background
+                    - foreground
+                    - orphan
+                    type: string
+                  disableHooks:
+                    description: DisableHooks prevents hooks from running during the
+                      Helm rollback action.
+                    type: boolean
+                  disableWait:
+                    description: |-
+                      DisableWait disables waiting for all the resources to be deleted after
+                      a Helm uninstall is performed.
+                    type: boolean
+                  keepHistory:
+                    description: |-
+                      KeepHistory tells Helm to remove all associated resources and mark the
+                      release as deleted, but retain the release history.
+                    type: boolean
+                  timeout:
+                    description: |-
+                      Timeout is the time to wait for any individual Kubernetes operation (like
+                      Jobs for hooks) during the performance of a Helm uninstall action. Defaults
+                      to 'HelmReleaseSpec.Timeout'.
+                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                    type: string
+                type: object
+              upgrade:
+                description: Upgrade holds the configuration for Helm upgrade actions
+                  for this HelmRelease.
+                properties:
+                  cleanupOnFail:
+                    description: |-
+                      CleanupOnFail allows deletion of new resources created during the Helm
+                      upgrade action when it fails.
+                    type: boolean
+                  crds:
+                    description: |-
+                      CRDs upgrade CRDs from the Helm Chart's crds directory according
+                      to the CRD upgrade policy provided here. Valid values are `Skip`,
+                      `Create` or `CreateReplace`. Default is `Skip` and if omitted
+                      CRDs are neither installed nor upgraded.
+
+                      Skip: do neither install nor replace (update) any CRDs.
+
+                      Create: new CRDs are created, existing CRDs are neither updated nor deleted.
+
+                      CreateReplace: new CRDs are created, existing CRDs are updated (replaced)
+                      but not deleted.
+
+                      By default, CRDs are not applied during Helm upgrade action. With this
+                      option users can opt-in to CRD upgrade, which is not (yet) natively supported by Helm.
+                      https://helm.sh/docs/chart_best_practices/custom_resource_definitions.
+                    enum:
+                    - Skip
+                    - Create
+                    - CreateReplace
+                    type: string
+                  disableHooks:
+                    description: DisableHooks prevents hooks from running during the
+                      Helm upgrade action.
+                    type: boolean
+                  disableOpenAPIValidation:
+                    description: |-
+                      DisableOpenAPIValidation prevents the Helm upgrade action from validating
+                      rendered templates against the Kubernetes OpenAPI Schema.
+                    type: boolean
+                  disableSchemaValidation:
+                    description: |-
+                      DisableSchemaValidation prevents the Helm upgrade action from validating
+                      the values against the JSON Schema.
+                    type: boolean
+                  disableWait:
+                    description: |-
+                      DisableWait disables the waiting for resources to be ready after a Helm
+                      upgrade has been performed.
+                    type: boolean
+                  disableWaitForJobs:
+                    description: |-
+                      DisableWaitForJobs disables waiting for jobs to complete after a Helm
+                      upgrade has been performed.
+                    type: boolean
+                  force:
+                    description: Force forces resource updates through a replacement
+                      strategy.
+                    type: boolean
+                  preserveValues:
+                    description: |-
+                      PreserveValues will make Helm reuse the last release's values and merge in
+                      overrides from 'Values'. Setting this flag makes the HelmRelease
+                      non-declarative.
+                    type: boolean
+                  remediation:
+                    description: |-
+                      Remediation holds the remediation configuration for when the Helm upgrade
+                      action for the HelmRelease fails. The default is to not perform any action.
+                    properties:
+                      ignoreTestFailures:
+                        description: |-
+                          IgnoreTestFailures tells the controller to skip remediation when the Helm
+                          tests are run after an upgrade action but fail.
+                          Defaults to 'Test.IgnoreFailures'.
+                        type: boolean
+                      remediateLastFailure:
+                        description: |-
+                          RemediateLastFailure tells the controller to remediate the last failure, when
+                          no retries remain. Defaults to 'false' unless 'Retries' is greater than 0.
+                        type: boolean
+                      retries:
+                        description: |-
+                          Retries is the number of retries that should be attempted on failures before
+                          bailing. Remediation, using 'Strategy', is performed between each attempt.
+                          Defaults to '0', a negative integer equals to unlimited retries.
+                        type: integer
+                      strategy:
+                        description: Strategy to use for failure remediation. Defaults
+                          to 'rollback'.
+                        enum:
+                        - rollback
+                        - uninstall
+                        type: string
+                    type: object
+                  timeout:
+                    description: |-
+                      Timeout is the time to wait for any individual Kubernetes operation (like
+                      Jobs for hooks) during the performance of a Helm upgrade action. Defaults to
+                      'HelmReleaseSpec.Timeout'.
+                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                    type: string
+                type: object
+              values:
+                description: Values holds the values for this Helm release.
+                x-kubernetes-preserve-unknown-fields: true
+              valuesFrom:
+                description: |-
+                  ValuesFrom holds references to resources containing Helm values for this HelmRelease,
+                  and information about how they should be merged.
+                items:
                   description: |-
-                    LastAppliedRevision is the revision of the last successfully applied
-                    source.
-                    Deprecated: the revision can now be found in the History.
-                  type: string
-                lastAttemptedConfigDigest:
+                    ValuesReference contains a reference to a resource containing Helm values,
+                    and optionally the key they can be found at.
+                  properties:
+                    kind:
+                      description: Kind of the values referent, valid values are ('Secret',
+                        'ConfigMap').
+                      enum:
+                      - Secret
+                      - ConfigMap
+                      type: string
+                    name:
+                      description: |-
+                        Name of the values referent. Should reside in the same namespace as the
+                        referring resource.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    optional:
+                      description: |-
+                        Optional marks this ValuesReference as optional. When set, a not found error
+                        for the values reference is ignored, but any ValuesKey, TargetPath or
+                        transient error will still result in a reconciliation failure.
+                      type: boolean
+                    targetPath:
+                      description: |-
+                        TargetPath is the YAML dot notation path the value should be merged at. When
+                        set, the ValuesKey is expected to be a single flat value. Defaults to 'None',
+                        which results in the values getting merged at the root.
+                      maxLength: 250
+                      pattern: ^([a-zA-Z0-9_\-.\\\/]|\[[0-9]{1,5}\])+$
+                      type: string
+                    valuesKey:
+                      description: |-
+                        ValuesKey is the data key where the values.yaml or a specific value can be
+                        found at. Defaults to 'values.yaml'.
+                      maxLength: 253
+                      pattern: ^[\-._a-zA-Z0-9]+$
+                      type: string
+                  required:
+                  - kind
+                  - name
+                  type: object
+                type: array
+            required:
+            - interval
+            type: object
+            x-kubernetes-validations:
+            - message: either chart or chartRef must be set
+              rule: (has(self.chart) && !has(self.chartRef)) || (!has(self.chart)
+                && has(self.chartRef))
+          status:
+            default:
+              observedGeneration: -1
+            description: HelmReleaseStatus defines the observed state of a HelmRelease.
+            properties:
+              conditions:
+                description: Conditions holds the conditions for the HelmRelease.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              failures:
+                description: |-
+                  Failures is the reconciliation failure count against the latest desired
+                  state. It is reset after a successful reconciliation.
+                format: int64
+                type: integer
+              helmChart:
+                description: |-
+                  HelmChart is the namespaced name of the HelmChart resource created by
+                  the controller for the HelmRelease.
+                type: string
+              history:
+                description: |-
+                  History holds the history of Helm releases performed for this HelmRelease
+                  up to the last successfully completed release.
+                items:
                   description: |-
-                    LastAttemptedConfigDigest is the digest for the config (better known as
-                    "values") of the last reconciliation attempt.
-                  type: string
-                lastAttemptedGeneration:
+                    Snapshot captures a point-in-time copy of the status information for a Helm release,
+                    as managed by the controller.
+                  properties:
+                    apiVersion:
+                      description: |-
+                        APIVersion is the API version of the Snapshot.
+                        Provisional: when the calculation method of the Digest field is changed,
+                        this field will be used to distinguish between the old and new methods.
+                      type: string
+                    appVersion:
+                      description: AppVersion is the chart app version of the release
+                        object in storage.
+                      type: string
+                    chartName:
+                      description: ChartName is the chart name of the release object
+                        in storage.
+                      type: string
+                    chartVersion:
+                      description: |-
+                        ChartVersion is the chart version of the release object in
+                        storage.
+                      type: string
+                    configDigest:
+                      description: |-
+                        ConfigDigest is the checksum of the config (better known as
+                        "values") of the release object in storage.
+                        It has the format of `<algo>:<checksum>`.
+                      type: string
+                    deleted:
+                      description: Deleted is when the release was deleted.
+                      format: date-time
+                      type: string
+                    digest:
+                      description: |-
+                        Digest is the checksum of the release object in storage.
+                        It has the format of `<algo>:<checksum>`.
+                      type: string
+                    firstDeployed:
+                      description: FirstDeployed is when the release was first deployed.
+                      format: date-time
+                      type: string
+                    lastDeployed:
+                      description: LastDeployed is when the release was last deployed.
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the release.
+                      type: string
+                    namespace:
+                      description: Namespace is the namespace the release is deployed
+                        to.
+                      type: string
+                    ociDigest:
+                      description: OCIDigest is the digest of the OCI artifact associated
+                        with the release.
+                      type: string
+                    status:
+                      description: Status is the current state of the release.
+                      type: string
+                    testHooks:
+                      additionalProperties:
+                        description: |-
+                          TestHookStatus holds the status information for a test hook as observed
+                          to be run by the controller.
+                        properties:
+                          lastCompleted:
+                            description: LastCompleted is the time the test hook last
+                              completed.
+                            format: date-time
+                            type: string
+                          lastStarted:
+                            description: LastStarted is the time the test hook was
+                              last started.
+                            format: date-time
+                            type: string
+                          phase:
+                            description: Phase the test hook was observed to be in.
+                            type: string
+                        type: object
+                      description: |-
+                        TestHooks is the list of test hooks for the release as observed to be
+                        run by the controller.
+                      type: object
+                    version:
+                      description: Version is the version of the release object in
+                        storage.
+                      type: integer
+                  required:
+                  - chartName
+                  - chartVersion
+                  - configDigest
+                  - digest
+                  - firstDeployed
+                  - lastDeployed
+                  - name
+                  - namespace
+                  - status
+                  - version
+                  type: object
+                type: array
+              installFailures:
+                description: |-
+                  InstallFailures is the install failure count against the latest desired
+                  state. It is reset after a successful reconciliation.
+                format: int64
+                type: integer
+              lastAttemptedConfigDigest:
+                description: |-
+                  LastAttemptedConfigDigest is the digest for the config (better known as
+                  "values") of the last reconciliation attempt.
+                type: string
+              lastAttemptedGeneration:
+                description: |-
+                  LastAttemptedGeneration is the last generation the controller attempted
+                  to reconcile.
+                format: int64
+                type: integer
+              lastAttemptedReleaseAction:
+                description: |-
+                  LastAttemptedReleaseAction is the last release action performed for this
+                  HelmRelease. It is used to determine the active remediation strategy.
+                enum:
+                - install
+                - upgrade
+                type: string
+              lastAttemptedRevision:
+                description: |-
+                  LastAttemptedRevision is the Source revision of the last reconciliation
+                  attempt. For OCIRepository  sources, the 12 first characters of the digest are
+                  appended to the chart version e.g. "1.2.3+1234567890ab".
+                type: string
+              lastAttemptedRevisionDigest:
+                description: |-
+                  LastAttemptedRevisionDigest is the digest of the last reconciliation attempt.
+                  This is only set for OCIRepository sources.
+                type: string
+              lastAttemptedValuesChecksum:
+                description: |-
+                  LastAttemptedValuesChecksum is the SHA1 checksum for the values of the last
+                  reconciliation attempt.
+                  Deprecated: Use LastAttemptedConfigDigest instead.
+                type: string
+              lastHandledForceAt:
+                description: |-
+                  LastHandledForceAt holds the value of the most recent force request
+                  value, so a change of the annotation value can be detected.
+                type: string
+              lastHandledReconcileAt:
+                description: |-
+                  LastHandledReconcileAt holds the value of the most recent
+                  reconcile request value, so a change of the annotation value
+                  can be detected.
+                type: string
+              lastHandledResetAt:
+                description: |-
+                  LastHandledResetAt holds the value of the most recent reset request
+                  value, so a change of the annotation value can be detected.
+                type: string
+              lastReleaseRevision:
+                description: |-
+                  LastReleaseRevision is the revision of the last successful Helm release.
+                  Deprecated: Use History instead.
+                type: integer
+              observedGeneration:
+                description: ObservedGeneration is the last observed generation.
+                format: int64
+                type: integer
+              observedPostRenderersDigest:
+                description: |-
+                  ObservedPostRenderersDigest is the digest for the post-renderers of
+                  the last successful reconciliation attempt.
+                type: string
+              storageNamespace:
+                description: |-
+                  StorageNamespace is the namespace of the Helm release storage for the
+                  current release.
+                maxLength: 63
+                minLength: 1
+                type: string
+              upgradeFailures:
+                description: |-
+                  UpgradeFailures is the upgrade failure count against the latest desired
+                  state. It is reset after a successful reconciliation.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      type: string
+    deprecated: true
+    deprecationWarning: v2beta1 HelmRelease is deprecated, upgrade to v2
+    name: v2beta1
+    schema:
+      openAPIV3Schema:
+        description: HelmRelease is the Schema for the helmreleases API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: HelmReleaseSpec defines the desired state of a Helm release.
+            properties:
+              chart:
+                description: |-
+                  Chart defines the template of the v1beta2.HelmChart that should be created
+                  for this HelmRelease.
+                properties:
+                  metadata:
+                    description: ObjectMeta holds the template for metadata like labels
+                      and annotations.
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+                        type: object
+                    type: object
+                  spec:
+                    description: Spec holds the template for the v1beta2.HelmChartSpec
+                      for this HelmRelease.
+                    properties:
+                      chart:
+                        description: The name or path the Helm chart is available
+                          at in the SourceRef.
+                        type: string
+                      interval:
+                        description: |-
+                          Interval at which to check the v1beta2.Source for updates. Defaults to
+                          'HelmReleaseSpec.Interval'.
+                        pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                        type: string
+                      reconcileStrategy:
+                        default: ChartVersion
+                        description: |-
+                          Determines what enables the creation of a new artifact. Valid values are
+                          ('ChartVersion', 'Revision').
+                          See the documentation of the values for an explanation on their behavior.
+                          Defaults to ChartVersion when omitted.
+                        enum:
+                        - ChartVersion
+                        - Revision
+                        type: string
+                      sourceRef:
+                        description: The name and namespace of the v1beta2.Source
+                          the chart is available at.
+                        properties:
+                          apiVersion:
+                            description: APIVersion of the referent.
+                            type: string
+                          kind:
+                            description: Kind of the referent.
+                            enum:
+                            - HelmRepository
+                            - GitRepository
+                            - Bucket
+                            type: string
+                          name:
+                            description: Name of the referent.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: Namespace of the referent.
+                            maxLength: 63
+                            minLength: 1
+                            type: string
+                        required:
+                        - kind
+                        - name
+                        type: object
+                      valuesFile:
+                        description: |-
+                          Alternative values file to use as the default chart values, expected to
+                          be a relative path in the SourceRef. Deprecated in favor of ValuesFiles,
+                          for backwards compatibility the file defined here is merged before the
+                          ValuesFiles items. Ignored when omitted.
+                        type: string
+                      valuesFiles:
+                        description: |-
+                          Alternative list of values files to use as the chart values (values.yaml
+                          is not included by default), expected to be a relative path in the SourceRef.
+                          Values files are merged in the order of this list with the last file overriding
+                          the first. Ignored when omitted.
+                        items:
+                          type: string
+                        type: array
+                      verify:
+                        description: |-
+                          Verify contains the secret name containing the trusted public keys
+                          used to verify the signature and specifies which provider to use to check
+                          whether OCI image is authentic.
+                          This field is only supported for OCI sources.
+                          Chart dependencies, which are not bundled in the umbrella chart artifact, are not verified.
+                        properties:
+                          provider:
+                            default: cosign
+                            description: Provider specifies the technology used to
+                              sign the OCI Helm chart.
+                            enum:
+                            - cosign
+                            type: string
+                          secretRef:
+                            description: |-
+                              SecretRef specifies the Kubernetes Secret containing the
+                              trusted public keys.
+                            properties:
+                              name:
+                                description: Name of the referent.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                        required:
+                        - provider
+                        type: object
+                      version:
+                        default: '*'
+                        description: |-
+                          Version semver expression, ignored for charts from v1beta2.GitRepository and
+                          v1beta2.Bucket sources. Defaults to latest when omitted.
+                        type: string
+                    required:
+                    - chart
+                    - sourceRef
+                    type: object
+                required:
+                - spec
+                type: object
+              chartRef:
+                description: |-
+                  ChartRef holds a reference to a source controller resource containing the
+                  Helm chart artifact.
+
+                  Note: this field is provisional to the v2 API, and not actively used
+                  by v2beta1 HelmReleases.
+                properties:
+                  apiVersion:
+                    description: APIVersion of the referent.
+                    type: string
+                  kind:
+                    description: Kind of the referent.
+                    enum:
+                    - OCIRepository
+                    - HelmChart
+                    type: string
+                  name:
+                    description: Name of the referent.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent, defaults to the namespace of the Kubernetes
+                      resource object that contains the reference.
+                    maxLength: 63
+                    minLength: 1
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              dependsOn:
+                description: |-
+                  DependsOn may contain a meta.NamespacedObjectReference slice with
+                  references to HelmRelease resources that must be ready before this HelmRelease
+                  can be reconciled.
+                items:
                   description: |-
-                    LastAttemptedGeneration is the last generation the controller attempted
-                    to reconcile.
-                  format: int64
-                  type: integer
-                lastAttemptedReleaseAction:
+                    NamespacedObjectReference contains enough information to locate the referenced Kubernetes resource object in any
+                    namespace.
+                  properties:
+                    name:
+                      description: Name of the referent.
+                      type: string
+                    namespace:
+                      description: Namespace of the referent, when not specified it
+                        acts as LocalObjectReference.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              driftDetection:
+                description: |-
+                  DriftDetection holds the configuration for detecting and handling
+                  differences between the manifest in the Helm storage and the resources
+                  currently existing in the cluster.
+
+                  Note: this field is provisional to the v2beta2 API, and not actively used
+                  by v2beta1 HelmReleases.
+                properties:
+                  ignore:
+                    description: |-
+                      Ignore contains a list of rules for specifying which changes to ignore
+                      during diffing.
+                    items:
+                      description: |-
+                        IgnoreRule defines a rule to selectively disregard specific changes during
+                        the drift detection process.
+                      properties:
+                        paths:
+                          description: |-
+                            Paths is a list of JSON Pointer (RFC 6901) paths to be excluded from
+                            consideration in a Kubernetes object.
+                          items:
+                            type: string
+                          type: array
+                        target:
+                          description: |-
+                            Target is a selector for specifying Kubernetes objects to which this
+                            rule applies.
+                            If Target is not set, the Paths will be ignored for all Kubernetes
+                            objects within the manifest of the Helm release.
+                          properties:
+                            annotationSelector:
+                              description: |-
+                                AnnotationSelector is a string that follows the label selection expression
+                                https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                                It matches with the resource annotations.
+                              type: string
+                            group:
+                              description: |-
+                                Group is the API group to select resources from.
+                                Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources.
+                                https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                              type: string
+                            kind:
+                              description: |-
+                                Kind of the API Group to select resources from.
+                                Together with Group and Version it is capable of unambiguously
+                                identifying and/or selecting resources.
+                                https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                              type: string
+                            labelSelector:
+                              description: |-
+                                LabelSelector is a string that follows the label selection expression
+                                https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                                It matches with the resource labels.
+                              type: string
+                            name:
+                              description: Name to match resources with.
+                              type: string
+                            namespace:
+                              description: Namespace to select resources from.
+                              type: string
+                            version:
+                              description: |-
+                                Version of the API Group to select resources from.
+                                Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources.
+                                https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                              type: string
+                          type: object
+                      required:
+                      - paths
+                      type: object
+                    type: array
+                  mode:
+                    description: |-
+                      Mode defines how differences should be handled between the Helm manifest
+                      and the manifest currently applied to the cluster.
+                      If not explicitly set, it defaults to DiffModeDisabled.
+                    enum:
+                    - enabled
+                    - warn
+                    - disabled
+                    type: string
+                type: object
+              install:
+                description: Install holds the configuration for Helm install actions
+                  for this HelmRelease.
+                properties:
+                  crds:
+                    description: |-
+                      CRDs upgrade CRDs from the Helm Chart's crds directory according
+                      to the CRD upgrade policy provided here. Valid values are `Skip`,
+                      `Create` or `CreateReplace`. Default is `Create` and if omitted
+                      CRDs are installed but not updated.
+
+                      Skip: do neither install nor replace (update) any CRDs.
+
+                      Create: new CRDs are created, existing CRDs are neither updated nor deleted.
+
+                      CreateReplace: new CRDs are created, existing CRDs are updated (replaced)
+                      but not deleted.
+
+                      By default, CRDs are applied (installed) during Helm install action.
+                      With this option users can opt-in to CRD replace existing CRDs on Helm
+                      install actions, which is not (yet) natively supported by Helm.
+                      https://helm.sh/docs/chart_best_practices/custom_resource_definitions.
+                    enum:
+                    - Skip
+                    - Create
+                    - CreateReplace
+                    type: string
+                  createNamespace:
+                    description: |-
+                      CreateNamespace tells the Helm install action to create the
+                      HelmReleaseSpec.TargetNamespace if it does not exist yet.
+                      On uninstall, the namespace will not be garbage collected.
+                    type: boolean
+                  disableHooks:
+                    description: DisableHooks prevents hooks from running during the
+                      Helm install action.
+                    type: boolean
+                  disableOpenAPIValidation:
+                    description: |-
+                      DisableOpenAPIValidation prevents the Helm install action from validating
+                      rendered templates against the Kubernetes OpenAPI Schema.
+                    type: boolean
+                  disableWait:
+                    description: |-
+                      DisableWait disables the waiting for resources to be ready after a Helm
+                      install has been performed.
+                    type: boolean
+                  disableWaitForJobs:
+                    description: |-
+                      DisableWaitForJobs disables waiting for jobs to complete after a Helm
+                      install has been performed.
+                    type: boolean
+                  remediation:
+                    description: |-
+                      Remediation holds the remediation configuration for when the Helm install
+                      action for the HelmRelease fails. The default is to not perform any action.
+                    properties:
+                      ignoreTestFailures:
+                        description: |-
+                          IgnoreTestFailures tells the controller to skip remediation when the Helm
+                          tests are run after an install action but fail. Defaults to
+                          'Test.IgnoreFailures'.
+                        type: boolean
+                      remediateLastFailure:
+                        description: |-
+                          RemediateLastFailure tells the controller to remediate the last failure, when
+                          no retries remain. Defaults to 'false'.
+                        type: boolean
+                      retries:
+                        description: |-
+                          Retries is the number of retries that should be attempted on failures before
+                          bailing. Remediation, using an uninstall, is performed between each attempt.
+                          Defaults to '0', a negative integer equals to unlimited retries.
+                        type: integer
+                    type: object
+                  replace:
+                    description: |-
+                      Replace tells the Helm install action to re-use the 'ReleaseName', but only
+                      if that name is a deleted release which remains in the history.
+                    type: boolean
+                  skipCRDs:
+                    description: |-
+                      SkipCRDs tells the Helm install action to not install any CRDs. By default,
+                      CRDs are installed if not already present.
+
+                      Deprecated use CRD policy (`crds`) attribute with value `Skip` instead.
+                    type: boolean
+                  timeout:
+                    description: |-
+                      Timeout is the time to wait for any individual Kubernetes operation (like
+                      Jobs for hooks) during the performance of a Helm install action. Defaults to
+                      'HelmReleaseSpec.Timeout'.
+                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                    type: string
+                type: object
+              interval:
+                description: |-
+                  Interval at which to reconcile the Helm release.
+                  This interval is approximate and may be subject to jitter to ensure
+                  efficient use of resources.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                type: string
+              kubeConfig:
+                description: |-
+                  KubeConfig for reconciling the HelmRelease on a remote cluster.
+                  When used in combination with HelmReleaseSpec.ServiceAccountName,
+                  forces the controller to act on behalf of that Service Account at the
+                  target cluster.
+                  If the --default-service-account flag is set, its value will be used as
+                  a controller level fallback for when HelmReleaseSpec.ServiceAccountName
+                  is empty.
+                properties:
+                  secretRef:
+                    description: |-
+                      SecretRef holds the name of a secret that contains a key with
+                      the kubeconfig file as the value. If no key is set, the key will default
+                      to 'value'.
+                      It is recommended that the kubeconfig is self-contained, and the secret
+                      is regularly updated if credentials such as a cloud-access-token expire.
+                      Cloud specific `cmd-path` auth helpers will not function without adding
+                      binaries and credentials to the Pod that is responsible for reconciling
+                      Kubernetes resources.
+                    properties:
+                      key:
+                        description: Key in the Secret, when not specified an implementation-specific
+                          default key is used.
+                        type: string
+                      name:
+                        description: Name of the Secret.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                required:
+                - secretRef
+                type: object
+              maxHistory:
+                description: |-
+                  MaxHistory is the number of revisions saved by Helm for this HelmRelease.
+                  Use '0' for an unlimited number of revisions; defaults to '10'.
+                type: integer
+              persistentClient:
+                description: |-
+                  PersistentClient tells the controller to use a persistent Kubernetes
+                  client for this release. When enabled, the client will be reused for the
+                  duration of the reconciliation, instead of being created and destroyed
+                  for each (step of a) Helm action.
+
+                  This can improve performance, but may cause issues with some Helm charts
+                  that for example do create Custom Resource Definitions during installation
+                  outside Helm's CRD lifecycle hooks, which are then not observed to be
+                  available by e.g. post-install hooks.
+
+                  If not set, it defaults to true.
+                type: boolean
+              postRenderers:
+                description: |-
+                  PostRenderers holds an array of Helm PostRenderers, which will be applied in order
+                  of their definition.
+                items:
+                  description: PostRenderer contains a Helm PostRenderer specification.
+                  properties:
+                    kustomize:
+                      description: Kustomization to apply as PostRenderer.
+                      properties:
+                        images:
+                          description: |-
+                            Images is a list of (image name, new name, new tag or digest)
+                            for changing image names, tags or digests. This can also be achieved with a
+                            patch, but this operator is simpler to specify.
+                          items:
+                            description: Image contains an image name, a new name,
+                              a new tag or digest, which will replace the original
+                              name and tag.
+                            properties:
+                              digest:
+                                description: |-
+                                  Digest is the value used to replace the original image tag.
+                                  If digest is present NewTag value is ignored.
+                                type: string
+                              name:
+                                description: Name is a tag-less image name.
+                                type: string
+                              newName:
+                                description: NewName is the value used to replace
+                                  the original name.
+                                type: string
+                              newTag:
+                                description: NewTag is the value used to replace the
+                                  original tag.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          type: array
+                        patches:
+                          description: |-
+                            Strategic merge and JSON patches, defined as inline YAML objects,
+                            capable of targeting objects based on kind, label and annotation selectors.
+                          items:
+                            description: |-
+                              Patch contains an inline StrategicMerge or JSON6902 patch, and the target the patch should
+                              be applied to.
+                            properties:
+                              patch:
+                                description: |-
+                                  Patch contains an inline StrategicMerge patch or an inline JSON6902 patch with
+                                  an array of operation objects.
+                                type: string
+                              target:
+                                description: Target points to the resources that the
+                                  patch document should be applied to.
+                                properties:
+                                  annotationSelector:
+                                    description: |-
+                                      AnnotationSelector is a string that follows the label selection expression
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                                      It matches with the resource annotations.
+                                    type: string
+                                  group:
+                                    description: |-
+                                      Group is the API group to select resources from.
+                                      Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources.
+                                      https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                                    type: string
+                                  kind:
+                                    description: |-
+                                      Kind of the API Group to select resources from.
+                                      Together with Group and Version it is capable of unambiguously
+                                      identifying and/or selecting resources.
+                                      https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                                    type: string
+                                  labelSelector:
+                                    description: |-
+                                      LabelSelector is a string that follows the label selection expression
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                                      It matches with the resource labels.
+                                    type: string
+                                  name:
+                                    description: Name to match resources with.
+                                    type: string
+                                  namespace:
+                                    description: Namespace to select resources from.
+                                    type: string
+                                  version:
+                                    description: |-
+                                      Version of the API Group to select resources from.
+                                      Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources.
+                                      https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                                    type: string
+                                type: object
+                            required:
+                            - patch
+                            type: object
+                          type: array
+                        patchesJson6902:
+                          description: JSON 6902 patches, defined as inline YAML objects.
+                          items:
+                            description: JSON6902Patch contains a JSON6902 patch and
+                              the target the patch should be applied to.
+                            properties:
+                              patch:
+                                description: Patch contains the JSON6902 patch document
+                                  with an array of operation objects.
+                                items:
+                                  description: |-
+                                    JSON6902 is a JSON6902 operation object.
+                                    https://datatracker.ietf.org/doc/html/rfc6902#section-4
+                                  properties:
+                                    from:
+                                      description: |-
+                                        From contains a JSON-pointer value that references a location within the target document where the operation is
+                                        performed. The meaning of the value depends on the value of Op, and is NOT taken into account by all operations.
+                                      type: string
+                                    op:
+                                      description: |-
+                                        Op indicates the operation to perform. Its value MUST be one of "add", "remove", "replace", "move", "copy", or
+                                        "test".
+                                        https://datatracker.ietf.org/doc/html/rfc6902#section-4
+                                      enum:
+                                      - test
+                                      - remove
+                                      - add
+                                      - replace
+                                      - move
+                                      - copy
+                                      type: string
+                                    path:
+                                      description: |-
+                                        Path contains the JSON-pointer value that references a location within the target document where the operation
+                                        is performed. The meaning of the value depends on the value of Op.
+                                      type: string
+                                    value:
+                                      description: |-
+                                        Value contains a valid JSON structure. The meaning of the value depends on the value of Op, and is NOT taken into
+                                        account by all operations.
+                                      x-kubernetes-preserve-unknown-fields: true
+                                  required:
+                                  - op
+                                  - path
+                                  type: object
+                                type: array
+                              target:
+                                description: Target points to the resources that the
+                                  patch document should be applied to.
+                                properties:
+                                  annotationSelector:
+                                    description: |-
+                                      AnnotationSelector is a string that follows the label selection expression
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                                      It matches with the resource annotations.
+                                    type: string
+                                  group:
+                                    description: |-
+                                      Group is the API group to select resources from.
+                                      Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources.
+                                      https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                                    type: string
+                                  kind:
+                                    description: |-
+                                      Kind of the API Group to select resources from.
+                                      Together with Group and Version it is capable of unambiguously
+                                      identifying and/or selecting resources.
+                                      https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                                    type: string
+                                  labelSelector:
+                                    description: |-
+                                      LabelSelector is a string that follows the label selection expression
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                                      It matches with the resource labels.
+                                    type: string
+                                  name:
+                                    description: Name to match resources with.
+                                    type: string
+                                  namespace:
+                                    description: Namespace to select resources from.
+                                    type: string
+                                  version:
+                                    description: |-
+                                      Version of the API Group to select resources from.
+                                      Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources.
+                                      https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                                    type: string
+                                type: object
+                            required:
+                            - patch
+                            - target
+                            type: object
+                          type: array
+                        patchesStrategicMerge:
+                          description: Strategic merge patches, defined as inline
+                            YAML objects.
+                          items:
+                            x-kubernetes-preserve-unknown-fields: true
+                          type: array
+                      type: object
+                  type: object
+                type: array
+              releaseName:
+                description: |-
+                  ReleaseName used for the Helm release. Defaults to a composition of
+                  '[TargetNamespace-]Name'.
+                maxLength: 53
+                minLength: 1
+                type: string
+              rollback:
+                description: Rollback holds the configuration for Helm rollback actions
+                  for this HelmRelease.
+                properties:
+                  cleanupOnFail:
+                    description: |-
+                      CleanupOnFail allows deletion of new resources created during the Helm
+                      rollback action when it fails.
+                    type: boolean
+                  disableHooks:
+                    description: DisableHooks prevents hooks from running during the
+                      Helm rollback action.
+                    type: boolean
+                  disableWait:
+                    description: |-
+                      DisableWait disables the waiting for resources to be ready after a Helm
+                      rollback has been performed.
+                    type: boolean
+                  disableWaitForJobs:
+                    description: |-
+                      DisableWaitForJobs disables waiting for jobs to complete after a Helm
+                      rollback has been performed.
+                    type: boolean
+                  force:
+                    description: Force forces resource updates through a replacement
+                      strategy.
+                    type: boolean
+                  recreate:
+                    description: Recreate performs pod restarts for the resource if
+                      applicable.
+                    type: boolean
+                  timeout:
+                    description: |-
+                      Timeout is the time to wait for any individual Kubernetes operation (like
+                      Jobs for hooks) during the performance of a Helm rollback action. Defaults to
+                      'HelmReleaseSpec.Timeout'.
+                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                    type: string
+                type: object
+              serviceAccountName:
+                description: |-
+                  The name of the Kubernetes service account to impersonate
+                  when reconciling this HelmRelease.
+                type: string
+              storageNamespace:
+                description: |-
+                  StorageNamespace used for the Helm storage.
+                  Defaults to the namespace of the HelmRelease.
+                maxLength: 63
+                minLength: 1
+                type: string
+              suspend:
+                description: |-
+                  Suspend tells the controller to suspend reconciliation for this HelmRelease,
+                  it does not apply to already started reconciliations. Defaults to false.
+                type: boolean
+              targetNamespace:
+                description: |-
+                  TargetNamespace to target when performing operations for the HelmRelease.
+                  Defaults to the namespace of the HelmRelease.
+                maxLength: 63
+                minLength: 1
+                type: string
+              test:
+                description: Test holds the configuration for Helm test actions for
+                  this HelmRelease.
+                properties:
+                  enable:
+                    description: |-
+                      Enable enables Helm test actions for this HelmRelease after an Helm install
+                      or upgrade action has been performed.
+                    type: boolean
+                  ignoreFailures:
+                    description: |-
+                      IgnoreFailures tells the controller to skip remediation when the Helm tests
+                      are run but fail. Can be overwritten for tests run after install or upgrade
+                      actions in 'Install.IgnoreTestFailures' and 'Upgrade.IgnoreTestFailures'.
+                    type: boolean
+                  timeout:
+                    description: |-
+                      Timeout is the time to wait for any individual Kubernetes operation during
+                      the performance of a Helm test action. Defaults to 'HelmReleaseSpec.Timeout'.
+                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                    type: string
+                type: object
+              timeout:
+                description: |-
+                  Timeout is the time to wait for any individual Kubernetes operation (like Jobs
+                  for hooks) during the performance of a Helm action. Defaults to '5m0s'.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                type: string
+              uninstall:
+                description: Uninstall holds the configuration for Helm uninstall
+                  actions for this HelmRelease.
+                properties:
+                  deletionPropagation:
+                    default: background
+                    description: |-
+                      DeletionPropagation specifies the deletion propagation policy when
+                      a Helm uninstall is performed.
+                    enum:
+                    - background
+                    - foreground
+                    - orphan
+                    type: string
+                  disableHooks:
+                    description: DisableHooks prevents hooks from running during the
+                      Helm rollback action.
+                    type: boolean
+                  disableWait:
+                    description: |-
+                      DisableWait disables waiting for all the resources to be deleted after
+                      a Helm uninstall is performed.
+                    type: boolean
+                  keepHistory:
+                    description: |-
+                      KeepHistory tells Helm to remove all associated resources and mark the
+                      release as deleted, but retain the release history.
+                    type: boolean
+                  timeout:
+                    description: |-
+                      Timeout is the time to wait for any individual Kubernetes operation (like
+                      Jobs for hooks) during the performance of a Helm uninstall action. Defaults
+                      to 'HelmReleaseSpec.Timeout'.
+                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                    type: string
+                type: object
+              upgrade:
+                description: Upgrade holds the configuration for Helm upgrade actions
+                  for this HelmRelease.
+                properties:
+                  cleanupOnFail:
+                    description: |-
+                      CleanupOnFail allows deletion of new resources created during the Helm
+                      upgrade action when it fails.
+                    type: boolean
+                  crds:
+                    description: |-
+                      CRDs upgrade CRDs from the Helm Chart's crds directory according
+                      to the CRD upgrade policy provided here. Valid values are `Skip`,
+                      `Create` or `CreateReplace`. Default is `Skip` and if omitted
+                      CRDs are neither installed nor upgraded.
+
+                      Skip: do neither install nor replace (update) any CRDs.
+
+                      Create: new CRDs are created, existing CRDs are neither updated nor deleted.
+
+                      CreateReplace: new CRDs are created, existing CRDs are updated (replaced)
+                      but not deleted.
+
+                      By default, CRDs are not applied during Helm upgrade action. With this
+                      option users can opt-in to CRD upgrade, which is not (yet) natively supported by Helm.
+                      https://helm.sh/docs/chart_best_practices/custom_resource_definitions.
+                    enum:
+                    - Skip
+                    - Create
+                    - CreateReplace
+                    type: string
+                  disableHooks:
+                    description: DisableHooks prevents hooks from running during the
+                      Helm upgrade action.
+                    type: boolean
+                  disableOpenAPIValidation:
+                    description: |-
+                      DisableOpenAPIValidation prevents the Helm upgrade action from validating
+                      rendered templates against the Kubernetes OpenAPI Schema.
+                    type: boolean
+                  disableWait:
+                    description: |-
+                      DisableWait disables the waiting for resources to be ready after a Helm
+                      upgrade has been performed.
+                    type: boolean
+                  disableWaitForJobs:
+                    description: |-
+                      DisableWaitForJobs disables waiting for jobs to complete after a Helm
+                      upgrade has been performed.
+                    type: boolean
+                  force:
+                    description: Force forces resource updates through a replacement
+                      strategy.
+                    type: boolean
+                  preserveValues:
+                    description: |-
+                      PreserveValues will make Helm reuse the last release's values and merge in
+                      overrides from 'Values'. Setting this flag makes the HelmRelease
+                      non-declarative.
+                    type: boolean
+                  remediation:
+                    description: |-
+                      Remediation holds the remediation configuration for when the Helm upgrade
+                      action for the HelmRelease fails. The default is to not perform any action.
+                    properties:
+                      ignoreTestFailures:
+                        description: |-
+                          IgnoreTestFailures tells the controller to skip remediation when the Helm
+                          tests are run after an upgrade action but fail.
+                          Defaults to 'Test.IgnoreFailures'.
+                        type: boolean
+                      remediateLastFailure:
+                        description: |-
+                          RemediateLastFailure tells the controller to remediate the last failure, when
+                          no retries remain. Defaults to 'false' unless 'Retries' is greater than 0.
+                        type: boolean
+                      retries:
+                        description: |-
+                          Retries is the number of retries that should be attempted on failures before
+                          bailing. Remediation, using 'Strategy', is performed between each attempt.
+                          Defaults to '0', a negative integer equals to unlimited retries.
+                        type: integer
+                      strategy:
+                        description: Strategy to use for failure remediation. Defaults
+                          to 'rollback'.
+                        enum:
+                        - rollback
+                        - uninstall
+                        type: string
+                    type: object
+                  timeout:
+                    description: |-
+                      Timeout is the time to wait for any individual Kubernetes operation (like
+                      Jobs for hooks) during the performance of a Helm upgrade action. Defaults to
+                      'HelmReleaseSpec.Timeout'.
+                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                    type: string
+                type: object
+              values:
+                description: Values holds the values for this Helm release.
+                x-kubernetes-preserve-unknown-fields: true
+              valuesFrom:
+                description: |-
+                  ValuesFrom holds references to resources containing Helm values for this HelmRelease,
+                  and information about how they should be merged.
+                items:
                   description: |-
-                    LastAttemptedReleaseAction is the last release action performed for this
-                    HelmRelease. It is used to determine the active remediation strategy.
-                  enum:
-                    - install
-                    - upgrade
-                  type: string
-                lastAttemptedRevision:
+                    ValuesReference contains a reference to a resource containing Helm values,
+                    and optionally the key they can be found at.
+                  properties:
+                    kind:
+                      description: Kind of the values referent, valid values are ('Secret',
+                        'ConfigMap').
+                      enum:
+                      - Secret
+                      - ConfigMap
+                      type: string
+                    name:
+                      description: |-
+                        Name of the values referent. Should reside in the same namespace as the
+                        referring resource.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    optional:
+                      description: |-
+                        Optional marks this ValuesReference as optional. When set, a not found error
+                        for the values reference is ignored, but any ValuesKey, TargetPath or
+                        transient error will still result in a reconciliation failure.
+                      type: boolean
+                    targetPath:
+                      description: |-
+                        TargetPath is the YAML dot notation path the value should be merged at. When
+                        set, the ValuesKey is expected to be a single flat value. Defaults to 'None',
+                        which results in the values getting merged at the root.
+                      maxLength: 250
+                      pattern: ^([a-zA-Z0-9_\-.\\\/]|\[[0-9]{1,5}\])+$
+                      type: string
+                    valuesKey:
+                      description: |-
+                        ValuesKey is the data key where the values.yaml or a specific value can be
+                        found at. Defaults to 'values.yaml'.
+                        When set, must be a valid Data Key, consisting of alphanumeric characters,
+                        '-', '_' or '.'.
+                      maxLength: 253
+                      pattern: ^[\-._a-zA-Z0-9]+$
+                      type: string
+                  required:
+                  - kind
+                  - name
+                  type: object
+                type: array
+            required:
+            - chart
+            - interval
+            type: object
+          status:
+            default:
+              observedGeneration: -1
+            description: HelmReleaseStatus defines the observed state of a HelmRelease.
+            properties:
+              conditions:
+                description: Conditions holds the conditions for the HelmRelease.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              failures:
+                description: |-
+                  Failures is the reconciliation failure count against the latest desired
+                  state. It is reset after a successful reconciliation.
+                format: int64
+                type: integer
+              helmChart:
+                description: |-
+                  HelmChart is the namespaced name of the HelmChart resource created by
+                  the controller for the HelmRelease.
+                type: string
+              history:
+                description: |-
+                  History holds the history of Helm releases performed for this HelmRelease
+                  up to the last successfully completed release.
+
+                  Note: this field is provisional to the v2beta2 API, and not actively used
+                  by v2beta1 HelmReleases.
+                items:
                   description: |-
-                    LastAttemptedRevision is the Source revision of the last reconciliation
-                    attempt. For OCIRepository  sources, the 12 first characters of the digest are
-                    appended to the chart version e.g. "1.2.3+1234567890ab".
-                  type: string
-                lastAttemptedRevisionDigest:
+                    Snapshot captures a point-in-time copy of the status information for a Helm release,
+                    as managed by the controller.
+                  properties:
+                    apiVersion:
+                      description: |-
+                        APIVersion is the API version of the Snapshot.
+                        Provisional: when the calculation method of the Digest field is changed,
+                        this field will be used to distinguish between the old and new methods.
+                      type: string
+                    appVersion:
+                      description: AppVersion is the chart app version of the release
+                        object in storage.
+                      type: string
+                    chartName:
+                      description: ChartName is the chart name of the release object
+                        in storage.
+                      type: string
+                    chartVersion:
+                      description: |-
+                        ChartVersion is the chart version of the release object in
+                        storage.
+                      type: string
+                    configDigest:
+                      description: |-
+                        ConfigDigest is the checksum of the config (better known as
+                        "values") of the release object in storage.
+                        It has the format of `<algo>:<checksum>`.
+                      type: string
+                    deleted:
+                      description: Deleted is when the release was deleted.
+                      format: date-time
+                      type: string
+                    digest:
+                      description: |-
+                        Digest is the checksum of the release object in storage.
+                        It has the format of `<algo>:<checksum>`.
+                      type: string
+                    firstDeployed:
+                      description: FirstDeployed is when the release was first deployed.
+                      format: date-time
+                      type: string
+                    lastDeployed:
+                      description: LastDeployed is when the release was last deployed.
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the release.
+                      type: string
+                    namespace:
+                      description: Namespace is the namespace the release is deployed
+                        to.
+                      type: string
+                    ociDigest:
+                      description: OCIDigest is the digest of the OCI artifact associated
+                        with the release.
+                      type: string
+                    status:
+                      description: Status is the current state of the release.
+                      type: string
+                    testHooks:
+                      additionalProperties:
+                        description: |-
+                          TestHookStatus holds the status information for a test hook as observed
+                          to be run by the controller.
+                        properties:
+                          lastCompleted:
+                            description: LastCompleted is the time the test hook last
+                              completed.
+                            format: date-time
+                            type: string
+                          lastStarted:
+                            description: LastStarted is the time the test hook was
+                              last started.
+                            format: date-time
+                            type: string
+                          phase:
+                            description: Phase the test hook was observed to be in.
+                            type: string
+                        type: object
+                      description: |-
+                        TestHooks is the list of test hooks for the release as observed to be
+                        run by the controller.
+                      type: object
+                    version:
+                      description: Version is the version of the release object in
+                        storage.
+                      type: integer
+                  required:
+                  - chartName
+                  - chartVersion
+                  - configDigest
+                  - digest
+                  - firstDeployed
+                  - lastDeployed
+                  - name
+                  - namespace
+                  - status
+                  - version
+                  type: object
+                type: array
+              installFailures:
+                description: |-
+                  InstallFailures is the install failure count against the latest desired
+                  state. It is reset after a successful reconciliation.
+                format: int64
+                type: integer
+              lastAppliedRevision:
+                description: LastAppliedRevision is the revision of the last successfully
+                  applied source.
+                type: string
+              lastAttemptedConfigDigest:
+                description: |-
+                  LastAttemptedConfigDigest is the digest for the config (better known as
+                  "values") of the last reconciliation attempt.
+
+                  Note: this field is provisional to the v2beta2 API, and not actively used
+                  by v2beta1 HelmReleases.
+                type: string
+              lastAttemptedGeneration:
+                description: |-
+                  LastAttemptedGeneration is the last generation the controller attempted
+                  to reconcile.
+
+                  Note: this field is provisional to the v2beta2 API, and not actively used
+                  by v2beta1 HelmReleases.
+                format: int64
+                type: integer
+              lastAttemptedReleaseAction:
+                description: |-
+                  LastAttemptedReleaseAction is the last release action performed for this
+                  HelmRelease. It is used to determine the active remediation strategy.
+
+                  Note: this field is provisional to the v2beta2 API, and not actively used
+                  by v2beta1 HelmReleases.
+                type: string
+              lastAttemptedRevision:
+                description: LastAttemptedRevision is the revision of the last reconciliation
+                  attempt.
+                type: string
+              lastAttemptedValuesChecksum:
+                description: |-
+                  LastAttemptedValuesChecksum is the SHA1 checksum of the values of the last
+                  reconciliation attempt.
+                type: string
+              lastHandledForceAt:
+                description: |-
+                  LastHandledForceAt holds the value of the most recent force request
+                  value, so a change of the annotation value can be detected.
+
+                  Note: this field is provisional to the v2beta2 API, and not actively used
+                  by v2beta1 HelmReleases.
+                type: string
+              lastHandledReconcileAt:
+                description: |-
+                  LastHandledReconcileAt holds the value of the most recent
+                  reconcile request value, so a change of the annotation value
+                  can be detected.
+                type: string
+              lastHandledResetAt:
+                description: |-
+                  LastHandledResetAt holds the value of the most recent reset request
+                  value, so a change of the annotation value can be detected.
+
+                  Note: this field is provisional to the v2beta2 API, and not actively used
+                  by v2beta1 HelmReleases.
+                type: string
+              lastReleaseRevision:
+                description: LastReleaseRevision is the revision of the last successful
+                  Helm release.
+                type: integer
+              observedGeneration:
+                description: ObservedGeneration is the last observed generation.
+                format: int64
+                type: integer
+              observedPostRenderersDigest:
+                description: |-
+                  ObservedPostRenderersDigest is the digest for the post-renderers of
+                  the last successful reconciliation attempt.
+                type: string
+              storageNamespace:
+                description: |-
+                  StorageNamespace is the namespace of the Helm release storage for the
+                  current release.
+
+                  Note: this field is provisional to the v2beta2 API, and not actively used
+                  by v2beta1 HelmReleases.
+                type: string
+              upgradeFailures:
+                description: |-
+                  UpgradeFailures is the upgrade failure count against the latest desired
+                  state. It is reset after a successful reconciliation.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      type: string
+    deprecated: true
+    deprecationWarning: v2beta2 HelmRelease is deprecated, upgrade to v2
+    name: v2beta2
+    schema:
+      openAPIV3Schema:
+        description: HelmRelease is the Schema for the helmreleases API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: HelmReleaseSpec defines the desired state of a Helm release.
+            properties:
+              chart:
+                description: |-
+                  Chart defines the template of the v1beta2.HelmChart that should be created
+                  for this HelmRelease.
+                properties:
+                  metadata:
+                    description: ObjectMeta holds the template for metadata like labels
+                      and annotations.
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+                        type: object
+                    type: object
+                  spec:
+                    description: Spec holds the template for the v1beta2.HelmChartSpec
+                      for this HelmRelease.
+                    properties:
+                      chart:
+                        description: The name or path the Helm chart is available
+                          at in the SourceRef.
+                        maxLength: 2048
+                        minLength: 1
+                        type: string
+                      ignoreMissingValuesFiles:
+                        description: IgnoreMissingValuesFiles controls whether to
+                          silently ignore missing values files rather than failing.
+                        type: boolean
+                      interval:
+                        description: |-
+                          Interval at which to check the v1.Source for updates. Defaults to
+                          'HelmReleaseSpec.Interval'.
+                        pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                        type: string
+                      reconcileStrategy:
+                        default: ChartVersion
+                        description: |-
+                          Determines what enables the creation of a new artifact. Valid values are
+                          ('ChartVersion', 'Revision').
+                          See the documentation of the values for an explanation on their behavior.
+                          Defaults to ChartVersion when omitted.
+                        enum:
+                        - ChartVersion
+                        - Revision
+                        type: string
+                      sourceRef:
+                        description: The name and namespace of the v1.Source the chart
+                          is available at.
+                        properties:
+                          apiVersion:
+                            description: APIVersion of the referent.
+                            type: string
+                          kind:
+                            description: Kind of the referent.
+                            enum:
+                            - HelmRepository
+                            - GitRepository
+                            - Bucket
+                            type: string
+                          name:
+                            description: Name of the referent.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: Namespace of the referent.
+                            maxLength: 63
+                            minLength: 1
+                            type: string
+                        required:
+                        - kind
+                        - name
+                        type: object
+                      valuesFile:
+                        description: |-
+                          Alternative values file to use as the default chart values, expected to
+                          be a relative path in the SourceRef. Deprecated in favor of ValuesFiles,
+                          for backwards compatibility the file defined here is merged before the
+                          ValuesFiles items. Ignored when omitted.
+                        type: string
+                      valuesFiles:
+                        description: |-
+                          Alternative list of values files to use as the chart values (values.yaml
+                          is not included by default), expected to be a relative path in the SourceRef.
+                          Values files are merged in the order of this list with the last file overriding
+                          the first. Ignored when omitted.
+                        items:
+                          type: string
+                        type: array
+                      verify:
+                        description: |-
+                          Verify contains the secret name containing the trusted public keys
+                          used to verify the signature and specifies which provider to use to check
+                          whether OCI image is authentic.
+                          This field is only supported for OCI sources.
+                          Chart dependencies, which are not bundled in the umbrella chart artifact,
+                          are not verified.
+                        properties:
+                          provider:
+                            default: cosign
+                            description: Provider specifies the technology used to
+                              sign the OCI Helm chart.
+                            enum:
+                            - cosign
+                            - notation
+                            type: string
+                          secretRef:
+                            description: |-
+                              SecretRef specifies the Kubernetes Secret containing the
+                              trusted public keys.
+                            properties:
+                              name:
+                                description: Name of the referent.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                        required:
+                        - provider
+                        type: object
+                      version:
+                        default: '*'
+                        description: |-
+                          Version semver expression, ignored for charts from v1beta2.GitRepository and
+                          v1beta2.Bucket sources. Defaults to latest when omitted.
+                        type: string
+                    required:
+                    - chart
+                    - sourceRef
+                    type: object
+                required:
+                - spec
+                type: object
+              chartRef:
+                description: |-
+                  ChartRef holds a reference to a source controller resource containing the
+                  Helm chart artifact.
+
+                  Note: this field is provisional to the v2 API, and not actively used
+                  by v2beta2 HelmReleases.
+                properties:
+                  apiVersion:
+                    description: APIVersion of the referent.
+                    type: string
+                  kind:
+                    description: Kind of the referent.
+                    enum:
+                    - OCIRepository
+                    - HelmChart
+                    type: string
+                  name:
+                    description: Name of the referent.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent, defaults to the namespace of the Kubernetes
+                      resource object that contains the reference.
+                    maxLength: 63
+                    minLength: 1
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              dependsOn:
+                description: |-
+                  DependsOn may contain a meta.NamespacedObjectReference slice with
+                  references to HelmRelease resources that must be ready before this HelmRelease
+                  can be reconciled.
+                items:
                   description: |-
-                    LastAttemptedRevisionDigest is the digest of the last reconciliation attempt.
-                    This is only set for OCIRepository sources.
-                  type: string
-                lastAttemptedValuesChecksum:
+                    NamespacedObjectReference contains enough information to locate the referenced Kubernetes resource object in any
+                    namespace.
+                  properties:
+                    name:
+                      description: Name of the referent.
+                      type: string
+                    namespace:
+                      description: Namespace of the referent, when not specified it
+                        acts as LocalObjectReference.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              driftDetection:
+                description: |-
+                  DriftDetection holds the configuration for detecting and handling
+                  differences between the manifest in the Helm storage and the resources
+                  currently existing in the cluster.
+                properties:
+                  ignore:
+                    description: |-
+                      Ignore contains a list of rules for specifying which changes to ignore
+                      during diffing.
+                    items:
+                      description: |-
+                        IgnoreRule defines a rule to selectively disregard specific changes during
+                        the drift detection process.
+                      properties:
+                        paths:
+                          description: |-
+                            Paths is a list of JSON Pointer (RFC 6901) paths to be excluded from
+                            consideration in a Kubernetes object.
+                          items:
+                            type: string
+                          type: array
+                        target:
+                          description: |-
+                            Target is a selector for specifying Kubernetes objects to which this
+                            rule applies.
+                            If Target is not set, the Paths will be ignored for all Kubernetes
+                            objects within the manifest of the Helm release.
+                          properties:
+                            annotationSelector:
+                              description: |-
+                                AnnotationSelector is a string that follows the label selection expression
+                                https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                                It matches with the resource annotations.
+                              type: string
+                            group:
+                              description: |-
+                                Group is the API group to select resources from.
+                                Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources.
+                                https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                              type: string
+                            kind:
+                              description: |-
+                                Kind of the API Group to select resources from.
+                                Together with Group and Version it is capable of unambiguously
+                                identifying and/or selecting resources.
+                                https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                              type: string
+                            labelSelector:
+                              description: |-
+                                LabelSelector is a string that follows the label selection expression
+                                https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                                It matches with the resource labels.
+                              type: string
+                            name:
+                              description: Name to match resources with.
+                              type: string
+                            namespace:
+                              description: Namespace to select resources from.
+                              type: string
+                            version:
+                              description: |-
+                                Version of the API Group to select resources from.
+                                Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources.
+                                https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                              type: string
+                          type: object
+                      required:
+                      - paths
+                      type: object
+                    type: array
+                  mode:
+                    description: |-
+                      Mode defines how differences should be handled between the Helm manifest
+                      and the manifest currently applied to the cluster.
+                      If not explicitly set, it defaults to DiffModeDisabled.
+                    enum:
+                    - enabled
+                    - warn
+                    - disabled
+                    type: string
+                type: object
+              install:
+                description: Install holds the configuration for Helm install actions
+                  for this HelmRelease.
+                properties:
+                  crds:
+                    description: |-
+                      CRDs upgrade CRDs from the Helm Chart's crds directory according
+                      to the CRD upgrade policy provided here. Valid values are `Skip`,
+                      `Create` or `CreateReplace`. Default is `Create` and if omitted
+                      CRDs are installed but not updated.
+
+                      Skip: do neither install nor replace (update) any CRDs.
+
+                      Create: new CRDs are created, existing CRDs are neither updated nor deleted.
+
+                      CreateReplace: new CRDs are created, existing CRDs are updated (replaced)
+                      but not deleted.
+
+                      By default, CRDs are applied (installed) during Helm install action.
+                      With this option users can opt in to CRD replace existing CRDs on Helm
+                      install actions, which is not (yet) natively supported by Helm.
+                      https://helm.sh/docs/chart_best_practices/custom_resource_definitions.
+                    enum:
+                    - Skip
+                    - Create
+                    - CreateReplace
+                    type: string
+                  createNamespace:
+                    description: |-
+                      CreateNamespace tells the Helm install action to create the
+                      HelmReleaseSpec.TargetNamespace if it does not exist yet.
+                      On uninstall, the namespace will not be garbage collected.
+                    type: boolean
+                  disableHooks:
+                    description: DisableHooks prevents hooks from running during the
+                      Helm install action.
+                    type: boolean
+                  disableOpenAPIValidation:
+                    description: |-
+                      DisableOpenAPIValidation prevents the Helm install action from validating
+                      rendered templates against the Kubernetes OpenAPI Schema.
+                    type: boolean
+                  disableWait:
+                    description: |-
+                      DisableWait disables the waiting for resources to be ready after a Helm
+                      install has been performed.
+                    type: boolean
+                  disableWaitForJobs:
+                    description: |-
+                      DisableWaitForJobs disables waiting for jobs to complete after a Helm
+                      install has been performed.
+                    type: boolean
+                  remediation:
+                    description: |-
+                      Remediation holds the remediation configuration for when the Helm install
+                      action for the HelmRelease fails. The default is to not perform any action.
+                    properties:
+                      ignoreTestFailures:
+                        description: |-
+                          IgnoreTestFailures tells the controller to skip remediation when the Helm
+                          tests are run after an install action but fail. Defaults to
+                          'Test.IgnoreFailures'.
+                        type: boolean
+                      remediateLastFailure:
+                        description: |-
+                          RemediateLastFailure tells the controller to remediate the last failure, when
+                          no retries remain. Defaults to 'false'.
+                        type: boolean
+                      retries:
+                        description: |-
+                          Retries is the number of retries that should be attempted on failures before
+                          bailing. Remediation, using an uninstall, is performed between each attempt.
+                          Defaults to '0', a negative integer equals to unlimited retries.
+                        type: integer
+                    type: object
+                  replace:
+                    description: |-
+                      Replace tells the Helm install action to re-use the 'ReleaseName', but only
+                      if that name is a deleted release which remains in the history.
+                    type: boolean
+                  skipCRDs:
+                    description: |-
+                      SkipCRDs tells the Helm install action to not install any CRDs. By default,
+                      CRDs are installed if not already present.
+
+                      Deprecated use CRD policy (`crds`) attribute with value `Skip` instead.
+                    type: boolean
+                  timeout:
+                    description: |-
+                      Timeout is the time to wait for any individual Kubernetes operation (like
+                      Jobs for hooks) during the performance of a Helm install action. Defaults to
+                      'HelmReleaseSpec.Timeout'.
+                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                    type: string
+                type: object
+              interval:
+                description: Interval at which to reconcile the Helm release.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                type: string
+              kubeConfig:
+                description: |-
+                  KubeConfig for reconciling the HelmRelease on a remote cluster.
+                  When used in combination with HelmReleaseSpec.ServiceAccountName,
+                  forces the controller to act on behalf of that Service Account at the
+                  target cluster.
+                  If the --default-service-account flag is set, its value will be used as
+                  a controller level fallback for when HelmReleaseSpec.ServiceAccountName
+                  is empty.
+                properties:
+                  secretRef:
+                    description: |-
+                      SecretRef holds the name of a secret that contains a key with
+                      the kubeconfig file as the value. If no key is set, the key will default
+                      to 'value'.
+                      It is recommended that the kubeconfig is self-contained, and the secret
+                      is regularly updated if credentials such as a cloud-access-token expire.
+                      Cloud specific `cmd-path` auth helpers will not function without adding
+                      binaries and credentials to the Pod that is responsible for reconciling
+                      Kubernetes resources.
+                    properties:
+                      key:
+                        description: Key in the Secret, when not specified an implementation-specific
+                          default key is used.
+                        type: string
+                      name:
+                        description: Name of the Secret.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                required:
+                - secretRef
+                type: object
+              maxHistory:
+                description: |-
+                  MaxHistory is the number of revisions saved by Helm for this HelmRelease.
+                  Use '0' for an unlimited number of revisions; defaults to '5'.
+                type: integer
+              persistentClient:
+                description: |-
+                  PersistentClient tells the controller to use a persistent Kubernetes
+                  client for this release. When enabled, the client will be reused for the
+                  duration of the reconciliation, instead of being created and destroyed
+                  for each (step of a) Helm action.
+
+                  This can improve performance, but may cause issues with some Helm charts
+                  that for example do create Custom Resource Definitions during installation
+                  outside Helm's CRD lifecycle hooks, which are then not observed to be
+                  available by e.g. post-install hooks.
+
+                  If not set, it defaults to true.
+                type: boolean
+              postRenderers:
+                description: |-
+                  PostRenderers holds an array of Helm PostRenderers, which will be applied in order
+                  of their definition.
+                items:
+                  description: PostRenderer contains a Helm PostRenderer specification.
+                  properties:
+                    kustomize:
+                      description: Kustomization to apply as PostRenderer.
+                      properties:
+                        images:
+                          description: |-
+                            Images is a list of (image name, new name, new tag or digest)
+                            for changing image names, tags or digests. This can also be achieved with a
+                            patch, but this operator is simpler to specify.
+                          items:
+                            description: Image contains an image name, a new name,
+                              a new tag or digest, which will replace the original
+                              name and tag.
+                            properties:
+                              digest:
+                                description: |-
+                                  Digest is the value used to replace the original image tag.
+                                  If digest is present NewTag value is ignored.
+                                type: string
+                              name:
+                                description: Name is a tag-less image name.
+                                type: string
+                              newName:
+                                description: NewName is the value used to replace
+                                  the original name.
+                                type: string
+                              newTag:
+                                description: NewTag is the value used to replace the
+                                  original tag.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          type: array
+                        patches:
+                          description: |-
+                            Strategic merge and JSON patches, defined as inline YAML objects,
+                            capable of targeting objects based on kind, label and annotation selectors.
+                          items:
+                            description: |-
+                              Patch contains an inline StrategicMerge or JSON6902 patch, and the target the patch should
+                              be applied to.
+                            properties:
+                              patch:
+                                description: |-
+                                  Patch contains an inline StrategicMerge patch or an inline JSON6902 patch with
+                                  an array of operation objects.
+                                type: string
+                              target:
+                                description: Target points to the resources that the
+                                  patch document should be applied to.
+                                properties:
+                                  annotationSelector:
+                                    description: |-
+                                      AnnotationSelector is a string that follows the label selection expression
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                                      It matches with the resource annotations.
+                                    type: string
+                                  group:
+                                    description: |-
+                                      Group is the API group to select resources from.
+                                      Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources.
+                                      https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                                    type: string
+                                  kind:
+                                    description: |-
+                                      Kind of the API Group to select resources from.
+                                      Together with Group and Version it is capable of unambiguously
+                                      identifying and/or selecting resources.
+                                      https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                                    type: string
+                                  labelSelector:
+                                    description: |-
+                                      LabelSelector is a string that follows the label selection expression
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                                      It matches with the resource labels.
+                                    type: string
+                                  name:
+                                    description: Name to match resources with.
+                                    type: string
+                                  namespace:
+                                    description: Namespace to select resources from.
+                                    type: string
+                                  version:
+                                    description: |-
+                                      Version of the API Group to select resources from.
+                                      Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources.
+                                      https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                                    type: string
+                                type: object
+                            required:
+                            - patch
+                            type: object
+                          type: array
+                        patchesJson6902:
+                          description: |-
+                            JSON 6902 patches, defined as inline YAML objects.
+                            Deprecated: use Patches instead.
+                          items:
+                            description: JSON6902Patch contains a JSON6902 patch and
+                              the target the patch should be applied to.
+                            properties:
+                              patch:
+                                description: Patch contains the JSON6902 patch document
+                                  with an array of operation objects.
+                                items:
+                                  description: |-
+                                    JSON6902 is a JSON6902 operation object.
+                                    https://datatracker.ietf.org/doc/html/rfc6902#section-4
+                                  properties:
+                                    from:
+                                      description: |-
+                                        From contains a JSON-pointer value that references a location within the target document where the operation is
+                                        performed. The meaning of the value depends on the value of Op, and is NOT taken into account by all operations.
+                                      type: string
+                                    op:
+                                      description: |-
+                                        Op indicates the operation to perform. Its value MUST be one of "add", "remove", "replace", "move", "copy", or
+                                        "test".
+                                        https://datatracker.ietf.org/doc/html/rfc6902#section-4
+                                      enum:
+                                      - test
+                                      - remove
+                                      - add
+                                      - replace
+                                      - move
+                                      - copy
+                                      type: string
+                                    path:
+                                      description: |-
+                                        Path contains the JSON-pointer value that references a location within the target document where the operation
+                                        is performed. The meaning of the value depends on the value of Op.
+                                      type: string
+                                    value:
+                                      description: |-
+                                        Value contains a valid JSON structure. The meaning of the value depends on the value of Op, and is NOT taken into
+                                        account by all operations.
+                                      x-kubernetes-preserve-unknown-fields: true
+                                  required:
+                                  - op
+                                  - path
+                                  type: object
+                                type: array
+                              target:
+                                description: Target points to the resources that the
+                                  patch document should be applied to.
+                                properties:
+                                  annotationSelector:
+                                    description: |-
+                                      AnnotationSelector is a string that follows the label selection expression
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                                      It matches with the resource annotations.
+                                    type: string
+                                  group:
+                                    description: |-
+                                      Group is the API group to select resources from.
+                                      Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources.
+                                      https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                                    type: string
+                                  kind:
+                                    description: |-
+                                      Kind of the API Group to select resources from.
+                                      Together with Group and Version it is capable of unambiguously
+                                      identifying and/or selecting resources.
+                                      https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                                    type: string
+                                  labelSelector:
+                                    description: |-
+                                      LabelSelector is a string that follows the label selection expression
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                                      It matches with the resource labels.
+                                    type: string
+                                  name:
+                                    description: Name to match resources with.
+                                    type: string
+                                  namespace:
+                                    description: Namespace to select resources from.
+                                    type: string
+                                  version:
+                                    description: |-
+                                      Version of the API Group to select resources from.
+                                      Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources.
+                                      https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                                    type: string
+                                type: object
+                            required:
+                            - patch
+                            - target
+                            type: object
+                          type: array
+                        patchesStrategicMerge:
+                          description: |-
+                            Strategic merge patches, defined as inline YAML objects.
+                            Deprecated: use Patches instead.
+                          items:
+                            x-kubernetes-preserve-unknown-fields: true
+                          type: array
+                      type: object
+                  type: object
+                type: array
+              releaseName:
+                description: |-
+                  ReleaseName used for the Helm release. Defaults to a composition of
+                  '[TargetNamespace-]Name'.
+                maxLength: 53
+                minLength: 1
+                type: string
+              rollback:
+                description: Rollback holds the configuration for Helm rollback actions
+                  for this HelmRelease.
+                properties:
+                  cleanupOnFail:
+                    description: |-
+                      CleanupOnFail allows deletion of new resources created during the Helm
+                      rollback action when it fails.
+                    type: boolean
+                  disableHooks:
+                    description: DisableHooks prevents hooks from running during the
+                      Helm rollback action.
+                    type: boolean
+                  disableWait:
+                    description: |-
+                      DisableWait disables the waiting for resources to be ready after a Helm
+                      rollback has been performed.
+                    type: boolean
+                  disableWaitForJobs:
+                    description: |-
+                      DisableWaitForJobs disables waiting for jobs to complete after a Helm
+                      rollback has been performed.
+                    type: boolean
+                  force:
+                    description: Force forces resource updates through a replacement
+                      strategy.
+                    type: boolean
+                  recreate:
+                    description: Recreate performs pod restarts for the resource if
+                      applicable.
+                    type: boolean
+                  timeout:
+                    description: |-
+                      Timeout is the time to wait for any individual Kubernetes operation (like
+                      Jobs for hooks) during the performance of a Helm rollback action. Defaults to
+                      'HelmReleaseSpec.Timeout'.
+                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                    type: string
+                type: object
+              serviceAccountName:
+                description: |-
+                  The name of the Kubernetes service account to impersonate
+                  when reconciling this HelmRelease.
+                maxLength: 253
+                minLength: 1
+                type: string
+              storageNamespace:
+                description: |-
+                  StorageNamespace used for the Helm storage.
+                  Defaults to the namespace of the HelmRelease.
+                maxLength: 63
+                minLength: 1
+                type: string
+              suspend:
+                description: |-
+                  Suspend tells the controller to suspend reconciliation for this HelmRelease,
+                  it does not apply to already started reconciliations. Defaults to false.
+                type: boolean
+              targetNamespace:
+                description: |-
+                  TargetNamespace to target when performing operations for the HelmRelease.
+                  Defaults to the namespace of the HelmRelease.
+                maxLength: 63
+                minLength: 1
+                type: string
+              test:
+                description: Test holds the configuration for Helm test actions for
+                  this HelmRelease.
+                properties:
+                  enable:
+                    description: |-
+                      Enable enables Helm test actions for this HelmRelease after an Helm install
+                      or upgrade action has been performed.
+                    type: boolean
+                  filters:
+                    description: Filters is a list of tests to run or exclude from
+                      running.
+                    items:
+                      description: Filter holds the configuration for individual Helm
+                        test filters.
+                      properties:
+                        exclude:
+                          description: Exclude specifies whether the named test should
+                            be excluded.
+                          type: boolean
+                        name:
+                          description: Name is the name of the test.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  ignoreFailures:
+                    description: |-
+                      IgnoreFailures tells the controller to skip remediation when the Helm tests
+                      are run but fail. Can be overwritten for tests run after install or upgrade
+                      actions in 'Install.IgnoreTestFailures' and 'Upgrade.IgnoreTestFailures'.
+                    type: boolean
+                  timeout:
+                    description: |-
+                      Timeout is the time to wait for any individual Kubernetes operation during
+                      the performance of a Helm test action. Defaults to 'HelmReleaseSpec.Timeout'.
+                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                    type: string
+                type: object
+              timeout:
+                description: |-
+                  Timeout is the time to wait for any individual Kubernetes operation (like Jobs
+                  for hooks) during the performance of a Helm action. Defaults to '5m0s'.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                type: string
+              uninstall:
+                description: Uninstall holds the configuration for Helm uninstall
+                  actions for this HelmRelease.
+                properties:
+                  deletionPropagation:
+                    default: background
+                    description: |-
+                      DeletionPropagation specifies the deletion propagation policy when
+                      a Helm uninstall is performed.
+                    enum:
+                    - background
+                    - foreground
+                    - orphan
+                    type: string
+                  disableHooks:
+                    description: DisableHooks prevents hooks from running during the
+                      Helm rollback action.
+                    type: boolean
+                  disableWait:
+                    description: |-
+                      DisableWait disables waiting for all the resources to be deleted after
+                      a Helm uninstall is performed.
+                    type: boolean
+                  keepHistory:
+                    description: |-
+                      KeepHistory tells Helm to remove all associated resources and mark the
+                      release as deleted, but retain the release history.
+                    type: boolean
+                  timeout:
+                    description: |-
+                      Timeout is the time to wait for any individual Kubernetes operation (like
+                      Jobs for hooks) during the performance of a Helm uninstall action. Defaults
+                      to 'HelmReleaseSpec.Timeout'.
+                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                    type: string
+                type: object
+              upgrade:
+                description: Upgrade holds the configuration for Helm upgrade actions
+                  for this HelmRelease.
+                properties:
+                  cleanupOnFail:
+                    description: |-
+                      CleanupOnFail allows deletion of new resources created during the Helm
+                      upgrade action when it fails.
+                    type: boolean
+                  crds:
+                    description: |-
+                      CRDs upgrade CRDs from the Helm Chart's crds directory according
+                      to the CRD upgrade policy provided here. Valid values are `Skip`,
+                      `Create` or `CreateReplace`. Default is `Skip` and if omitted
+                      CRDs are neither installed nor upgraded.
+
+                      Skip: do neither install nor replace (update) any CRDs.
+
+                      Create: new CRDs are created, existing CRDs are neither updated nor deleted.
+
+                      CreateReplace: new CRDs are created, existing CRDs are updated (replaced)
+                      but not deleted.
+
+                      By default, CRDs are not applied during Helm upgrade action. With this
+                      option users can opt-in to CRD upgrade, which is not (yet) natively supported by Helm.
+                      https://helm.sh/docs/chart_best_practices/custom_resource_definitions.
+                    enum:
+                    - Skip
+                    - Create
+                    - CreateReplace
+                    type: string
+                  disableHooks:
+                    description: DisableHooks prevents hooks from running during the
+                      Helm upgrade action.
+                    type: boolean
+                  disableOpenAPIValidation:
+                    description: |-
+                      DisableOpenAPIValidation prevents the Helm upgrade action from validating
+                      rendered templates against the Kubernetes OpenAPI Schema.
+                    type: boolean
+                  disableWait:
+                    description: |-
+                      DisableWait disables the waiting for resources to be ready after a Helm
+                      upgrade has been performed.
+                    type: boolean
+                  disableWaitForJobs:
+                    description: |-
+                      DisableWaitForJobs disables waiting for jobs to complete after a Helm
+                      upgrade has been performed.
+                    type: boolean
+                  force:
+                    description: Force forces resource updates through a replacement
+                      strategy.
+                    type: boolean
+                  preserveValues:
+                    description: |-
+                      PreserveValues will make Helm reuse the last release's values and merge in
+                      overrides from 'Values'. Setting this flag makes the HelmRelease
+                      non-declarative.
+                    type: boolean
+                  remediation:
+                    description: |-
+                      Remediation holds the remediation configuration for when the Helm upgrade
+                      action for the HelmRelease fails. The default is to not perform any action.
+                    properties:
+                      ignoreTestFailures:
+                        description: |-
+                          IgnoreTestFailures tells the controller to skip remediation when the Helm
+                          tests are run after an upgrade action but fail.
+                          Defaults to 'Test.IgnoreFailures'.
+                        type: boolean
+                      remediateLastFailure:
+                        description: |-
+                          RemediateLastFailure tells the controller to remediate the last failure, when
+                          no retries remain. Defaults to 'false' unless 'Retries' is greater than 0.
+                        type: boolean
+                      retries:
+                        description: |-
+                          Retries is the number of retries that should be attempted on failures before
+                          bailing. Remediation, using 'Strategy', is performed between each attempt.
+                          Defaults to '0', a negative integer equals to unlimited retries.
+                        type: integer
+                      strategy:
+                        description: Strategy to use for failure remediation. Defaults
+                          to 'rollback'.
+                        enum:
+                        - rollback
+                        - uninstall
+                        type: string
+                    type: object
+                  timeout:
+                    description: |-
+                      Timeout is the time to wait for any individual Kubernetes operation (like
+                      Jobs for hooks) during the performance of a Helm upgrade action. Defaults to
+                      'HelmReleaseSpec.Timeout'.
+                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                    type: string
+                type: object
+              values:
+                description: Values holds the values for this Helm release.
+                x-kubernetes-preserve-unknown-fields: true
+              valuesFrom:
+                description: |-
+                  ValuesFrom holds references to resources containing Helm values for this HelmRelease,
+                  and information about how they should be merged.
+                items:
                   description: |-
-                    LastAttemptedValuesChecksum is the SHA1 checksum for the values of the last
-                    reconciliation attempt.
-                    Deprecated: Use LastAttemptedConfigDigest instead.
-                  type: string
-                lastHandledForceAt:
+                    ValuesReference contains a reference to a resource containing Helm values,
+                    and optionally the key they can be found at.
+                  properties:
+                    kind:
+                      description: Kind of the values referent, valid values are ('Secret',
+                        'ConfigMap').
+                      enum:
+                      - Secret
+                      - ConfigMap
+                      type: string
+                    name:
+                      description: |-
+                        Name of the values referent. Should reside in the same namespace as the
+                        referring resource.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    optional:
+                      description: |-
+                        Optional marks this ValuesReference as optional. When set, a not found error
+                        for the values reference is ignored, but any ValuesKey, TargetPath or
+                        transient error will still result in a reconciliation failure.
+                      type: boolean
+                    targetPath:
+                      description: |-
+                        TargetPath is the YAML dot notation path the value should be merged at. When
+                        set, the ValuesKey is expected to be a single flat value. Defaults to 'None',
+                        which results in the values getting merged at the root.
+                      maxLength: 250
+                      pattern: ^([a-zA-Z0-9_\-.\\\/]|\[[0-9]{1,5}\])+$
+                      type: string
+                    valuesKey:
+                      description: |-
+                        ValuesKey is the data key where the values.yaml or a specific value can be
+                        found at. Defaults to 'values.yaml'.
+                      maxLength: 253
+                      pattern: ^[\-._a-zA-Z0-9]+$
+                      type: string
+                  required:
+                  - kind
+                  - name
+                  type: object
+                type: array
+            required:
+            - interval
+            type: object
+            x-kubernetes-validations:
+            - message: either chart or chartRef must be set
+              rule: (has(self.chart) && !has(self.chartRef)) || (!has(self.chart)
+                && has(self.chartRef))
+          status:
+            default:
+              observedGeneration: -1
+            description: HelmReleaseStatus defines the observed state of a HelmRelease.
+            properties:
+              conditions:
+                description: Conditions holds the conditions for the HelmRelease.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              failures:
+                description: |-
+                  Failures is the reconciliation failure count against the latest desired
+                  state. It is reset after a successful reconciliation.
+                format: int64
+                type: integer
+              helmChart:
+                description: |-
+                  HelmChart is the namespaced name of the HelmChart resource created by
+                  the controller for the HelmRelease.
+                type: string
+              history:
+                description: |-
+                  History holds the history of Helm releases performed for this HelmRelease
+                  up to the last successfully completed release.
+                items:
                   description: |-
-                    LastHandledForceAt holds the value of the most recent force request
-                    value, so a change of the annotation value can be detected.
-                  type: string
-                lastHandledReconcileAt:
-                  description: |-
-                    LastHandledReconcileAt holds the value of the most recent
-                    reconcile request value, so a change of the annotation value
-                    can be detected.
-                  type: string
-                lastHandledResetAt:
-                  description: |-
-                    LastHandledResetAt holds the value of the most recent reset request
-                    value, so a change of the annotation value can be detected.
-                  type: string
-                lastReleaseRevision:
-                  description: |-
-                    LastReleaseRevision is the revision of the last successful Helm release.
-                    Deprecated: Use History instead.
-                  type: integer
-                observedGeneration:
-                  description: ObservedGeneration is the last observed generation.
-                  format: int64
-                  type: integer
-                observedPostRenderersDigest:
-                  description: |-
-                    ObservedPostRenderersDigest is the digest for the post-renderers of
-                    the last successful reconciliation attempt.
-                  type: string
-                storageNamespace:
-                  description: |-
-                    StorageNamespace is the namespace of the Helm release storage for the
-                    current release.
-                  maxLength: 63
-                  minLength: 1
-                  type: string
-                upgradeFailures:
-                  description: |-
-                    UpgradeFailures is the upgrade failure count against the latest desired
-                    state. It is reset after a successful reconciliation.
-                  format: int64
-                  type: integer
-              type: object
-          type: object
-      served: true
-      storage: false
-      subresources:
-        status: {}
+                    Snapshot captures a point-in-time copy of the status information for a Helm release,
+                    as managed by the controller.
+                  properties:
+                    apiVersion:
+                      description: |-
+                        APIVersion is the API version of the Snapshot.
+                        Provisional: when the calculation method of the Digest field is changed,
+                        this field will be used to distinguish between the old and new methods.
+                      type: string
+                    appVersion:
+                      description: AppVersion is the chart app version of the release
+                        object in storage.
+                      type: string
+                    chartName:
+                      description: ChartName is the chart name of the release object
+                        in storage.
+                      type: string
+                    chartVersion:
+                      description: |-
+                        ChartVersion is the chart version of the release object in
+                        storage.
+                      type: string
+                    configDigest:
+                      description: |-
+                        ConfigDigest is the checksum of the config (better known as
+                        "values") of the release object in storage.
+                        It has the format of `<algo>:<checksum>`.
+                      type: string
+                    deleted:
+                      description: Deleted is when the release was deleted.
+                      format: date-time
+                      type: string
+                    digest:
+                      description: |-
+                        Digest is the checksum of the release object in storage.
+                        It has the format of `<algo>:<checksum>`.
+                      type: string
+                    firstDeployed:
+                      description: FirstDeployed is when the release was first deployed.
+                      format: date-time
+                      type: string
+                    lastDeployed:
+                      description: LastDeployed is when the release was last deployed.
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the release.
+                      type: string
+                    namespace:
+                      description: Namespace is the namespace the release is deployed
+                        to.
+                      type: string
+                    ociDigest:
+                      description: OCIDigest is the digest of the OCI artifact associated
+                        with the release.
+                      type: string
+                    status:
+                      description: Status is the current state of the release.
+                      type: string
+                    testHooks:
+                      additionalProperties:
+                        description: |-
+                          TestHookStatus holds the status information for a test hook as observed
+                          to be run by the controller.
+                        properties:
+                          lastCompleted:
+                            description: LastCompleted is the time the test hook last
+                              completed.
+                            format: date-time
+                            type: string
+                          lastStarted:
+                            description: LastStarted is the time the test hook was
+                              last started.
+                            format: date-time
+                            type: string
+                          phase:
+                            description: Phase the test hook was observed to be in.
+                            type: string
+                        type: object
+                      description: |-
+                        TestHooks is the list of test hooks for the release as observed to be
+                        run by the controller.
+                      type: object
+                    version:
+                      description: Version is the version of the release object in
+                        storage.
+                      type: integer
+                  required:
+                  - chartName
+                  - chartVersion
+                  - configDigest
+                  - digest
+                  - firstDeployed
+                  - lastDeployed
+                  - name
+                  - namespace
+                  - status
+                  - version
+                  type: object
+                type: array
+              installFailures:
+                description: |-
+                  InstallFailures is the install failure count against the latest desired
+                  state. It is reset after a successful reconciliation.
+                format: int64
+                type: integer
+              lastAppliedRevision:
+                description: |-
+                  LastAppliedRevision is the revision of the last successfully applied
+                  source.
+                  Deprecated: the revision can now be found in the History.
+                type: string
+              lastAttemptedConfigDigest:
+                description: |-
+                  LastAttemptedConfigDigest is the digest for the config (better known as
+                  "values") of the last reconciliation attempt.
+                type: string
+              lastAttemptedGeneration:
+                description: |-
+                  LastAttemptedGeneration is the last generation the controller attempted
+                  to reconcile.
+                format: int64
+                type: integer
+              lastAttemptedReleaseAction:
+                description: |-
+                  LastAttemptedReleaseAction is the last release action performed for this
+                  HelmRelease. It is used to determine the active remediation strategy.
+                enum:
+                - install
+                - upgrade
+                type: string
+              lastAttemptedRevision:
+                description: |-
+                  LastAttemptedRevision is the Source revision of the last reconciliation
+                  attempt. For OCIRepository  sources, the 12 first characters of the digest are
+                  appended to the chart version e.g. "1.2.3+1234567890ab".
+                type: string
+              lastAttemptedRevisionDigest:
+                description: |-
+                  LastAttemptedRevisionDigest is the digest of the last reconciliation attempt.
+                  This is only set for OCIRepository sources.
+                type: string
+              lastAttemptedValuesChecksum:
+                description: |-
+                  LastAttemptedValuesChecksum is the SHA1 checksum for the values of the last
+                  reconciliation attempt.
+                  Deprecated: Use LastAttemptedConfigDigest instead.
+                type: string
+              lastHandledForceAt:
+                description: |-
+                  LastHandledForceAt holds the value of the most recent force request
+                  value, so a change of the annotation value can be detected.
+                type: string
+              lastHandledReconcileAt:
+                description: |-
+                  LastHandledReconcileAt holds the value of the most recent
+                  reconcile request value, so a change of the annotation value
+                  can be detected.
+                type: string
+              lastHandledResetAt:
+                description: |-
+                  LastHandledResetAt holds the value of the most recent reset request
+                  value, so a change of the annotation value can be detected.
+                type: string
+              lastReleaseRevision:
+                description: |-
+                  LastReleaseRevision is the revision of the last successful Helm release.
+                  Deprecated: Use History instead.
+                type: integer
+              observedGeneration:
+                description: ObservedGeneration is the last observed generation.
+                format: int64
+                type: integer
+              observedPostRenderersDigest:
+                description: |-
+                  ObservedPostRenderersDigest is the digest for the post-renderers of
+                  the last successful reconciliation attempt.
+                type: string
+              storageNamespace:
+                description: |-
+                  StorageNamespace is the namespace of the Helm release storage for the
+                  current release.
+                maxLength: 63
+                minLength: 1
+                type: string
+              upgradeFailures:
+                description: |-
+                  UpgradeFailures is the upgrade failure count against the latest desired
+                  state. It is reset after a successful reconciliation.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}

--- a/tools/testcrds/kustomize.toolkit.fluxcd.io_kustomizations.yaml
+++ b/tools/testcrds/kustomize.toolkit.fluxcd.io_kustomizations.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.1
   name: kustomizations.kustomize.toolkit.fluxcd.io
 spec:
   group: kustomize.toolkit.fluxcd.io
@@ -12,1743 +12,1706 @@ spec:
     listKind: KustomizationList
     plural: kustomizations
     shortNames:
-      - ks
+    - ks
     singular: kustomization
   scope: Namespaced
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .metadata.creationTimestamp
-          name: Age
-          type: date
-        - jsonPath: .status.conditions[?(@.type=="Ready")].status
-          name: Ready
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].message
-          name: Status
-          type: string
-      name: v1
-      schema:
-        openAPIV3Schema:
-          description: Kustomization is the Schema for the kustomizations API.
-          properties:
-            apiVersion:
-              description: |-
-                APIVersion defines the versioned schema of this representation of an object.
-                Servers should convert recognized schemas to the latest internal value, and
-                may reject unrecognized values.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-              type: string
-            kind:
-              description: |-
-                Kind is a string value representing the REST resource this object represents.
-                Servers may infer this from the endpoint the client submits requests to.
-                Cannot be updated.
-                In CamelCase.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: |-
-                KustomizationSpec defines the configuration to calculate the desired state
-                from a Source using Kustomize.
-              properties:
-                commonMetadata:
-                  description: |-
-                    CommonMetadata specifies the common labels and annotations that are
-                    applied to all resources. Any existing label or annotation will be
-                    overridden if its key matches a common one.
-                  properties:
-                    annotations:
-                      additionalProperties:
-                        type: string
-                      description: Annotations to be added to the object's metadata.
-                      type: object
-                    labels:
-                      additionalProperties:
-                        type: string
-                      description: Labels to be added to the object's metadata.
-                      type: object
-                  type: object
-                components:
-                  description: Components specifies relative paths to specifications
-                    of other Components.
-                  items:
-                    type: string
-                  type: array
-                decryption:
-                  description: Decrypt Kubernetes secrets before applying them on the
-                    cluster.
-                  properties:
-                    provider:
-                      description: Provider is the name of the decryption engine.
-                      enum:
-                        - sops
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: Kustomization is the Schema for the kustomizations API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              KustomizationSpec defines the configuration to calculate the desired state
+              from a Source using Kustomize.
+            properties:
+              commonMetadata:
+                description: |-
+                  CommonMetadata specifies the common labels and annotations that are
+                  applied to all resources. Any existing label or annotation will be
+                  overridden if its key matches a common one.
+                properties:
+                  annotations:
+                    additionalProperties:
                       type: string
-                    secretRef:
-                      description: The secret name containing the private OpenPGP keys
-                        used for decryption.
-                      properties:
-                        name:
-                          description: Name of the referent.
-                          type: string
-                      required:
-                        - name
-                      type: object
-                  required:
-                    - provider
-                  type: object
-                dependsOn:
-                  description: |-
-                    DependsOn may contain a meta.NamespacedObjectReference slice
-                    with references to Kustomization resources that must be ready before this
-                    Kustomization can be reconciled.
-                  items:
-                    description: |-
-                      NamespacedObjectReference contains enough information to locate the referenced Kubernetes resource object in any
-                      namespace.
+                    description: Annotations to be added to the object's metadata.
+                    type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Labels to be added to the object's metadata.
+                    type: object
+                type: object
+              components:
+                description: Components specifies relative paths to specifications
+                  of other Components.
+                items:
+                  type: string
+                type: array
+              decryption:
+                description: Decrypt Kubernetes secrets before applying them on the
+                  cluster.
+                properties:
+                  provider:
+                    description: Provider is the name of the decryption engine.
+                    enum:
+                    - sops
+                    type: string
+                  secretRef:
+                    description: The secret name containing the private OpenPGP keys
+                      used for decryption.
                     properties:
                       name:
                         description: Name of the referent.
                         type: string
-                      namespace:
-                        description: Namespace of the referent, when not specified it
-                          acts as LocalObjectReference.
-                        type: string
                     required:
-                      - name
+                    - name
                     type: object
-                  type: array
-                force:
-                  default: false
+                required:
+                - provider
+                type: object
+              dependsOn:
+                description: |-
+                  DependsOn may contain a meta.NamespacedObjectReference slice
+                  with references to Kustomization resources that must be ready before this
+                  Kustomization can be reconciled.
+                items:
                   description: |-
-                    Force instructs the controller to recreate resources
-                    when patching fails due to an immutable field change.
-                  type: boolean
-                healthChecks:
-                  description: A list of resources to be included in the health assessment.
-                  items:
-                    description: |-
-                      NamespacedObjectKindReference contains enough information to locate the typed referenced Kubernetes resource object
-                      in any namespace.
-                    properties:
-                      apiVersion:
-                        description: API version of the referent, if not specified the
-                          Kubernetes preferred version will be used.
-                        type: string
-                      kind:
-                        description: Kind of the referent.
-                        type: string
-                      name:
-                        description: Name of the referent.
-                        type: string
-                      namespace:
-                        description: Namespace of the referent, when not specified it
-                          acts as LocalObjectReference.
-                        type: string
-                    required:
-                      - kind
-                      - name
-                    type: object
-                  type: array
-                images:
-                  description: |-
-                    Images is a list of (image name, new name, new tag or digest)
-                    for changing image names, tags or digests. This can also be achieved with a
-                    patch, but this operator is simpler to specify.
-                  items:
-                    description: Image contains an image name, a new name, a new tag
-                      or digest, which will replace the original name and tag.
-                    properties:
-                      digest:
-                        description: |-
-                          Digest is the value used to replace the original image tag.
-                          If digest is present NewTag value is ignored.
-                        type: string
-                      name:
-                        description: Name is a tag-less image name.
-                        type: string
-                      newName:
-                        description: NewName is the value used to replace the original
-                          name.
-                        type: string
-                      newTag:
-                        description: NewTag is the value used to replace the original
-                          tag.
-                        type: string
-                    required:
-                      - name
-                    type: object
-                  type: array
-                interval:
-                  description: |-
-                    The interval at which to reconcile the Kustomization.
-                    This interval is approximate and may be subject to jitter to ensure
-                    efficient use of resources.
-                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                  type: string
-                kubeConfig:
-                  description: |-
-                    The KubeConfig for reconciling the Kustomization on a remote cluster.
-                    When used in combination with KustomizationSpec.ServiceAccountName,
-                    forces the controller to act on behalf of that Service Account at the
-                    target cluster.
-                    If the --default-service-account flag is set, its value will be used as
-                    a controller level fallback for when KustomizationSpec.ServiceAccountName
-                    is empty.
+                    NamespacedObjectReference contains enough information to locate the referenced Kubernetes resource object in any
+                    namespace.
                   properties:
-                    secretRef:
-                      description: |-
-                        SecretRef holds the name of a secret that contains a key with
-                        the kubeconfig file as the value. If no key is set, the key will default
-                        to 'value'.
-                        It is recommended that the kubeconfig is self-contained, and the secret
-                        is regularly updated if credentials such as a cloud-access-token expire.
-                        Cloud specific `cmd-path` auth helpers will not function without adding
-                        binaries and credentials to the Pod that is responsible for reconciling
-                        Kubernetes resources.
-                      properties:
-                        key:
-                          description: Key in the Secret, when not specified an implementation-specific
-                            default key is used.
-                          type: string
-                        name:
-                          description: Name of the Secret.
-                          type: string
-                      required:
-                        - name
-                      type: object
+                    name:
+                      description: Name of the referent.
+                      type: string
+                    namespace:
+                      description: Namespace of the referent, when not specified it
+                        acts as LocalObjectReference.
+                      type: string
                   required:
-                    - secretRef
+                  - name
                   type: object
-                namePrefix:
-                  description: NamePrefix will prefix the names of all managed resources.
-                  maxLength: 200
-                  minLength: 1
-                  type: string
-                nameSuffix:
-                  description: NameSuffix will suffix the names of all managed resources.
-                  maxLength: 200
-                  minLength: 1
-                  type: string
-                patches:
+                type: array
+              force:
+                default: false
+                description: |-
+                  Force instructs the controller to recreate resources
+                  when patching fails due to an immutable field change.
+                type: boolean
+              healthChecks:
+                description: A list of resources to be included in the health assessment.
+                items:
                   description: |-
-                    Strategic merge and JSON patches, defined as inline YAML objects,
-                    capable of targeting objects based on kind, label and annotation selectors.
-                  items:
-                    description: |-
-                      Patch contains an inline StrategicMerge or JSON6902 patch, and the target the patch should
-                      be applied to.
-                    properties:
-                      patch:
-                        description: |-
-                          Patch contains an inline StrategicMerge patch or an inline JSON6902 patch with
-                          an array of operation objects.
-                        type: string
-                      target:
-                        description: Target points to the resources that the patch document
-                          should be applied to.
-                        properties:
-                          annotationSelector:
-                            description: |-
-                              AnnotationSelector is a string that follows the label selection expression
-                              https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
-                              It matches with the resource annotations.
-                            type: string
-                          group:
-                            description: |-
-                              Group is the API group to select resources from.
-                              Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources.
-                              https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
-                            type: string
-                          kind:
-                            description: |-
-                              Kind of the API Group to select resources from.
-                              Together with Group and Version it is capable of unambiguously
-                              identifying and/or selecting resources.
-                              https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
-                            type: string
-                          labelSelector:
-                            description: |-
-                              LabelSelector is a string that follows the label selection expression
-                              https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
-                              It matches with the resource labels.
-                            type: string
-                          name:
-                            description: Name to match resources with.
-                            type: string
-                          namespace:
-                            description: Namespace to select resources from.
-                            type: string
-                          version:
-                            description: |-
-                              Version of the API Group to select resources from.
-                              Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources.
-                              https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
-                            type: string
-                        type: object
-                    required:
-                      - patch
-                    type: object
-                  type: array
-                path:
-                  description: |-
-                    Path to the directory containing the kustomization.yaml file, or the
-                    set of plain YAMLs a kustomization.yaml should be generated for.
-                    Defaults to 'None', which translates to the root path of the SourceRef.
-                  type: string
-                postBuild:
-                  description: |-
-                    PostBuild describes which actions to perform on the YAML manifest
-                    generated by building the kustomize overlay.
-                  properties:
-                    substitute:
-                      additionalProperties:
-                        type: string
-                      description: |-
-                        Substitute holds a map of key/value pairs.
-                        The variables defined in your YAML manifests that match any of the keys
-                        defined in the map will be substituted with the set value.
-                        Includes support for bash string replacement functions
-                        e.g. ${var:=default}, ${var:position} and ${var/substring/replacement}.
-                      type: object
-                    substituteFrom:
-                      description: |-
-                        SubstituteFrom holds references to ConfigMaps and Secrets containing
-                        the variables and their values to be substituted in the YAML manifests.
-                        The ConfigMap and the Secret data keys represent the var names, and they
-                        must match the vars declared in the manifests for the substitution to
-                        happen.
-                      items:
-                        description: |-
-                          SubstituteReference contains a reference to a resource containing
-                          the variables name and value.
-                        properties:
-                          kind:
-                            description: Kind of the values referent, valid values are
-                              ('Secret', 'ConfigMap').
-                            enum:
-                              - Secret
-                              - ConfigMap
-                            type: string
-                          name:
-                            description: |-
-                              Name of the values referent. Should reside in the same namespace as the
-                              referring resource.
-                            maxLength: 253
-                            minLength: 1
-                            type: string
-                          optional:
-                            default: false
-                            description: |-
-                              Optional indicates whether the referenced resource must exist, or whether to
-                              tolerate its absence. If true and the referenced resource is absent, proceed
-                              as if the resource was present but empty, without any variables defined.
-                            type: boolean
-                        required:
-                          - kind
-                          - name
-                        type: object
-                      type: array
-                  type: object
-                prune:
-                  description: Prune enables garbage collection.
-                  type: boolean
-                retryInterval:
-                  description: |-
-                    The interval at which to retry a previously failed reconciliation.
-                    When not specified, the controller uses the KustomizationSpec.Interval
-                    value to retry failures.
-                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                  type: string
-                serviceAccountName:
-                  description: |-
-                    The name of the Kubernetes service account to impersonate
-                    when reconciling this Kustomization.
-                  type: string
-                sourceRef:
-                  description: Reference of the source where the kustomization file
-                    is.
+                    NamespacedObjectKindReference contains enough information to locate the typed referenced Kubernetes resource object
+                    in any namespace.
                   properties:
                     apiVersion:
-                      description: API version of the referent.
+                      description: API version of the referent, if not specified the
+                        Kubernetes preferred version will be used.
                       type: string
                     kind:
                       description: Kind of the referent.
-                      enum:
-                        - OCIRepository
-                        - GitRepository
-                        - Bucket
                       type: string
                     name:
                       description: Name of the referent.
                       type: string
                     namespace:
-                      description: |-
-                        Namespace of the referent, defaults to the namespace of the Kubernetes
-                        resource object that contains the reference.
+                      description: Namespace of the referent, when not specified it
+                        acts as LocalObjectReference.
                       type: string
                   required:
-                    - kind
-                    - name
+                  - kind
+                  - name
                   type: object
-                suspend:
-                  description: |-
-                    This flag tells the controller to suspend subsequent kustomize executions,
-                    it does not apply to already started executions. Defaults to false.
-                  type: boolean
-                targetNamespace:
-                  description: |-
-                    TargetNamespace sets or overrides the namespace in the
-                    kustomization.yaml file.
-                  maxLength: 63
-                  minLength: 1
-                  type: string
-                timeout:
-                  description: |-
-                    Timeout for validation, apply and health checking operations.
-                    Defaults to 'Interval' duration.
-                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                  type: string
-                wait:
-                  description: |-
-                    Wait instructs the controller to check the health of all the reconciled
-                    resources. When enabled, the HealthChecks are ignored. Defaults to false.
-                  type: boolean
-              required:
-                - interval
-                - prune
-                - sourceRef
-              type: object
-            status:
-              default:
-                observedGeneration: -1
-              description: KustomizationStatus defines the observed state of a kustomization.
-              properties:
-                conditions:
-                  items:
-                    description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
-                    properties:
-                      lastTransitionTime:
-                        description: |-
-                          lastTransitionTime is the last time the condition transitioned from one status to another.
-                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                        format: date-time
-                        type: string
-                      message:
-                        description: |-
-                          message is a human readable message indicating details about the transition.
-                          This may be an empty string.
-                        maxLength: 32768
-                        type: string
-                      observedGeneration:
-                        description: |-
-                          observedGeneration represents the .metadata.generation that the condition was set based upon.
-                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                          with respect to the current state of the instance.
-                        format: int64
-                        minimum: 0
-                        type: integer
-                      reason:
-                        description: |-
-                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                          Producers of specific condition types may define expected values and meanings for this field,
-                          and whether the values are considered a guaranteed API.
-                          The value should be a CamelCase string.
-                          This field may not be empty.
-                        maxLength: 1024
-                        minLength: 1
-                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                        type: string
-                      status:
-                        description: status of the condition, one of True, False, Unknown.
-                        enum:
-                          - "True"
-                          - "False"
-                          - Unknown
-                        type: string
-                      type:
-                        description: |-
-                          type of condition in CamelCase or in foo.example.com/CamelCase.
-                          ---
-                          Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                          useful (see .node.status.conditions), the ability to deconflict is important.
-                          The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                        maxLength: 316
-                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                        type: string
-                    required:
-                      - lastTransitionTime
-                      - message
-                      - reason
-                      - status
-                      - type
-                    type: object
-                  type: array
-                inventory:
-                  description: |-
-                    Inventory contains the list of Kubernetes resource object references that
-                    have been successfully applied.
+                type: array
+              images:
+                description: |-
+                  Images is a list of (image name, new name, new tag or digest)
+                  for changing image names, tags or digests. This can also be achieved with a
+                  patch, but this operator is simpler to specify.
+                items:
+                  description: Image contains an image name, a new name, a new tag
+                    or digest, which will replace the original name and tag.
                   properties:
-                    entries:
-                      description: Entries of Kubernetes resource object references.
-                      items:
-                        description: ResourceRef contains the information necessary
-                          to locate a resource within a cluster.
-                        properties:
-                          id:
-                            description: |-
-                              ID is the string representation of the Kubernetes resource object's metadata,
-                              in the format '<namespace>_<name>_<group>_<kind>'.
-                            type: string
-                          v:
-                            description: Version is the API version of the Kubernetes
-                              resource object's kind.
-                            type: string
-                        required:
-                          - id
-                          - v
-                        type: object
-                      type: array
-                  required:
-                    - entries
-                  type: object
-                lastAppliedRevision:
-                  description: |-
-                    The last successfully applied revision.
-                    Equals the Revision of the applied Artifact from the referenced Source.
-                  type: string
-                lastAttemptedRevision:
-                  description: LastAttemptedRevision is the revision of the last reconciliation
-                    attempt.
-                  type: string
-                lastHandledReconcileAt:
-                  description: |-
-                    LastHandledReconcileAt holds the value of the most recent
-                    reconcile request value, so a change of the annotation value
-                    can be detected.
-                  type: string
-                observedGeneration:
-                  description: ObservedGeneration is the last reconciled generation.
-                  format: int64
-                  type: integer
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
-    - additionalPrinterColumns:
-        - jsonPath: .status.conditions[?(@.type=="Ready")].status
-          name: Ready
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].message
-          name: Status
-          type: string
-        - jsonPath: .metadata.creationTimestamp
-          name: Age
-          type: date
-      deprecated: true
-      deprecationWarning: v1beta1 Kustomization is deprecated, upgrade to v1
-      name: v1beta1
-      schema:
-        openAPIV3Schema:
-          description: Kustomization is the Schema for the kustomizations API.
-          properties:
-            apiVersion:
-              description: |-
-                APIVersion defines the versioned schema of this representation of an object.
-                Servers should convert recognized schemas to the latest internal value, and
-                may reject unrecognized values.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-              type: string
-            kind:
-              description: |-
-                Kind is a string value representing the REST resource this object represents.
-                Servers may infer this from the endpoint the client submits requests to.
-                Cannot be updated.
-                In CamelCase.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: KustomizationSpec defines the desired state of a kustomization.
-              properties:
-                decryption:
-                  description: Decrypt Kubernetes secrets before applying them on the
-                    cluster.
-                  properties:
-                    provider:
-                      description: Provider is the name of the decryption engine.
-                      enum:
-                        - sops
-                      type: string
-                    secretRef:
-                      description: The secret name containing the private OpenPGP keys
-                        used for decryption.
-                      properties:
-                        name:
-                          description: Name of the referent.
-                          type: string
-                      required:
-                        - name
-                      type: object
-                  required:
-                    - provider
-                  type: object
-                dependsOn:
-                  description: |-
-                    DependsOn may contain a meta.NamespacedObjectReference slice
-                    with references to Kustomization resources that must be ready before this
-                    Kustomization can be reconciled.
-                  items:
-                    description: |-
-                      NamespacedObjectReference contains enough information to locate the referenced Kubernetes resource object in any
-                      namespace.
-                    properties:
-                      name:
-                        description: Name of the referent.
-                        type: string
-                      namespace:
-                        description: Namespace of the referent, when not specified it
-                          acts as LocalObjectReference.
-                        type: string
-                    required:
-                      - name
-                    type: object
-                  type: array
-                force:
-                  default: false
-                  description: |-
-                    Force instructs the controller to recreate resources
-                    when patching fails due to an immutable field change.
-                  type: boolean
-                healthChecks:
-                  description: A list of resources to be included in the health assessment.
-                  items:
-                    description: |-
-                      NamespacedObjectKindReference contains enough information to locate the typed referenced Kubernetes resource object
-                      in any namespace.
-                    properties:
-                      apiVersion:
-                        description: API version of the referent, if not specified the
-                          Kubernetes preferred version will be used.
-                        type: string
-                      kind:
-                        description: Kind of the referent.
-                        type: string
-                      name:
-                        description: Name of the referent.
-                        type: string
-                      namespace:
-                        description: Namespace of the referent, when not specified it
-                          acts as LocalObjectReference.
-                        type: string
-                    required:
-                      - kind
-                      - name
-                    type: object
-                  type: array
-                images:
-                  description: |-
-                    Images is a list of (image name, new name, new tag or digest)
-                    for changing image names, tags or digests. This can also be achieved with a
-                    patch, but this operator is simpler to specify.
-                  items:
-                    description: Image contains an image name, a new name, a new tag
-                      or digest, which will replace the original name and tag.
-                    properties:
-                      digest:
-                        description: |-
-                          Digest is the value used to replace the original image tag.
-                          If digest is present NewTag value is ignored.
-                        type: string
-                      name:
-                        description: Name is a tag-less image name.
-                        type: string
-                      newName:
-                        description: NewName is the value used to replace the original
-                          name.
-                        type: string
-                      newTag:
-                        description: NewTag is the value used to replace the original
-                          tag.
-                        type: string
-                    required:
-                      - name
-                    type: object
-                  type: array
-                interval:
-                  description: The interval at which to reconcile the Kustomization.
-                  type: string
-                kubeConfig:
-                  description: |-
-                    The KubeConfig for reconciling the Kustomization on a remote cluster.
-                    When specified, KubeConfig takes precedence over ServiceAccountName.
-                  properties:
-                    secretRef:
+                    digest:
                       description: |-
-                        SecretRef holds the name to a secret that contains a 'value' key with
-                        the kubeconfig file as the value. It must be in the same namespace as
-                        the Kustomization.
-                        It is recommended that the kubeconfig is self-contained, and the secret
-                        is regularly updated if credentials such as a cloud-access-token expire.
-                        Cloud specific `cmd-path` auth helpers will not function without adding
-                        binaries and credentials to the Pod that is responsible for reconciling
-                        the Kustomization.
-                      properties:
-                        name:
-                          description: Name of the referent.
-                          type: string
-                      required:
-                        - name
-                      type: object
-                  type: object
-                patches:
-                  description: |-
-                    Strategic merge and JSON patches, defined as inline YAML objects,
-                    capable of targeting objects based on kind, label and annotation selectors.
-                  items:
-                    description: |-
-                      Patch contains an inline StrategicMerge or JSON6902 patch, and the target the patch should
-                      be applied to.
-                    properties:
-                      patch:
-                        description: |-
-                          Patch contains an inline StrategicMerge patch or an inline JSON6902 patch with
-                          an array of operation objects.
-                        type: string
-                      target:
-                        description: Target points to the resources that the patch document
-                          should be applied to.
-                        properties:
-                          annotationSelector:
-                            description: |-
-                              AnnotationSelector is a string that follows the label selection expression
-                              https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
-                              It matches with the resource annotations.
-                            type: string
-                          group:
-                            description: |-
-                              Group is the API group to select resources from.
-                              Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources.
-                              https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
-                            type: string
-                          kind:
-                            description: |-
-                              Kind of the API Group to select resources from.
-                              Together with Group and Version it is capable of unambiguously
-                              identifying and/or selecting resources.
-                              https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
-                            type: string
-                          labelSelector:
-                            description: |-
-                              LabelSelector is a string that follows the label selection expression
-                              https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
-                              It matches with the resource labels.
-                            type: string
-                          name:
-                            description: Name to match resources with.
-                            type: string
-                          namespace:
-                            description: Namespace to select resources from.
-                            type: string
-                          version:
-                            description: |-
-                              Version of the API Group to select resources from.
-                              Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources.
-                              https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
-                            type: string
-                        type: object
-                    required:
-                      - patch
-                    type: object
-                  type: array
-                patchesJson6902:
-                  description: JSON 6902 patches, defined as inline YAML objects.
-                  items:
-                    description: JSON6902Patch contains a JSON6902 patch and the target
-                      the patch should be applied to.
-                    properties:
-                      patch:
-                        description: Patch contains the JSON6902 patch document with
-                          an array of operation objects.
-                        items:
-                          description: |-
-                            JSON6902 is a JSON6902 operation object.
-                            https://datatracker.ietf.org/doc/html/rfc6902#section-4
-                          properties:
-                            from:
-                              description: |-
-                                From contains a JSON-pointer value that references a location within the target document where the operation is
-                                performed. The meaning of the value depends on the value of Op, and is NOT taken into account by all operations.
-                              type: string
-                            op:
-                              description: |-
-                                Op indicates the operation to perform. Its value MUST be one of "add", "remove", "replace", "move", "copy", or
-                                "test".
-                                https://datatracker.ietf.org/doc/html/rfc6902#section-4
-                              enum:
-                                - test
-                                - remove
-                                - add
-                                - replace
-                                - move
-                                - copy
-                              type: string
-                            path:
-                              description: |-
-                                Path contains the JSON-pointer value that references a location within the target document where the operation
-                                is performed. The meaning of the value depends on the value of Op.
-                              type: string
-                            value:
-                              description: |-
-                                Value contains a valid JSON structure. The meaning of the value depends on the value of Op, and is NOT taken into
-                                account by all operations.
-                              x-kubernetes-preserve-unknown-fields: true
-                          required:
-                            - op
-                            - path
-                          type: object
-                        type: array
-                      target:
-                        description: Target points to the resources that the patch document
-                          should be applied to.
-                        properties:
-                          annotationSelector:
-                            description: |-
-                              AnnotationSelector is a string that follows the label selection expression
-                              https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
-                              It matches with the resource annotations.
-                            type: string
-                          group:
-                            description: |-
-                              Group is the API group to select resources from.
-                              Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources.
-                              https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
-                            type: string
-                          kind:
-                            description: |-
-                              Kind of the API Group to select resources from.
-                              Together with Group and Version it is capable of unambiguously
-                              identifying and/or selecting resources.
-                              https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
-                            type: string
-                          labelSelector:
-                            description: |-
-                              LabelSelector is a string that follows the label selection expression
-                              https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
-                              It matches with the resource labels.
-                            type: string
-                          name:
-                            description: Name to match resources with.
-                            type: string
-                          namespace:
-                            description: Namespace to select resources from.
-                            type: string
-                          version:
-                            description: |-
-                              Version of the API Group to select resources from.
-                              Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources.
-                              https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
-                            type: string
-                        type: object
-                    required:
-                      - patch
-                      - target
-                    type: object
-                  type: array
-                patchesStrategicMerge:
-                  description: Strategic merge patches, defined as inline YAML objects.
-                  items:
-                    x-kubernetes-preserve-unknown-fields: true
-                  type: array
-                path:
-                  description: |-
-                    Path to the directory containing the kustomization.yaml file, or the
-                    set of plain YAMLs a kustomization.yaml should be generated for.
-                    Defaults to 'None', which translates to the root path of the SourceRef.
-                  type: string
-                postBuild:
-                  description: |-
-                    PostBuild describes which actions to perform on the YAML manifest
-                    generated by building the kustomize overlay.
-                  properties:
-                    substitute:
-                      additionalProperties:
-                        type: string
-                      description: |-
-                        Substitute holds a map of key/value pairs.
-                        The variables defined in your YAML manifests
-                        that match any of the keys defined in the map
-                        will be substituted with the set value.
-                        Includes support for bash string replacement functions
-                        e.g. ${var:=default}, ${var:position} and ${var/substring/replacement}.
-                      type: object
-                    substituteFrom:
-                      description: |-
-                        SubstituteFrom holds references to ConfigMaps and Secrets containing
-                        the variables and their values to be substituted in the YAML manifests.
-                        The ConfigMap and the Secret data keys represent the var names and they
-                        must match the vars declared in the manifests for the substitution to happen.
-                      items:
-                        description: |-
-                          SubstituteReference contains a reference to a resource containing
-                          the variables name and value.
-                        properties:
-                          kind:
-                            description: Kind of the values referent, valid values are
-                              ('Secret', 'ConfigMap').
-                            enum:
-                              - Secret
-                              - ConfigMap
-                            type: string
-                          name:
-                            description: |-
-                              Name of the values referent. Should reside in the same namespace as the
-                              referring resource.
-                            maxLength: 253
-                            minLength: 1
-                            type: string
-                        required:
-                          - kind
-                          - name
-                        type: object
-                      type: array
-                  type: object
-                prune:
-                  description: Prune enables garbage collection.
-                  type: boolean
-                retryInterval:
-                  description: |-
-                    The interval at which to retry a previously failed reconciliation.
-                    When not specified, the controller uses the KustomizationSpec.Interval
-                    value to retry failures.
-                  type: string
-                serviceAccountName:
-                  description: |-
-                    The name of the Kubernetes service account to impersonate
-                    when reconciling this Kustomization.
-                  type: string
-                sourceRef:
-                  description: Reference of the source where the kustomization file
-                    is.
-                  properties:
-                    apiVersion:
-                      description: API version of the referent
-                      type: string
-                    kind:
-                      description: Kind of the referent
-                      enum:
-                        - GitRepository
-                        - Bucket
+                        Digest is the value used to replace the original image tag.
+                        If digest is present NewTag value is ignored.
                       type: string
                     name:
-                      description: Name of the referent
+                      description: Name is a tag-less image name.
                       type: string
-                    namespace:
-                      description: Namespace of the referent, defaults to the Kustomization
-                        namespace
+                    newName:
+                      description: NewName is the value used to replace the original
+                        name.
+                      type: string
+                    newTag:
+                      description: NewTag is the value used to replace the original
+                        tag.
                       type: string
                   required:
-                    - kind
+                  - name
+                  type: object
+                type: array
+              interval:
+                description: |-
+                  The interval at which to reconcile the Kustomization.
+                  This interval is approximate and may be subject to jitter to ensure
+                  efficient use of resources.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                type: string
+              kubeConfig:
+                description: |-
+                  The KubeConfig for reconciling the Kustomization on a remote cluster.
+                  When used in combination with KustomizationSpec.ServiceAccountName,
+                  forces the controller to act on behalf of that Service Account at the
+                  target cluster.
+                  If the --default-service-account flag is set, its value will be used as
+                  a controller level fallback for when KustomizationSpec.ServiceAccountName
+                  is empty.
+                properties:
+                  secretRef:
+                    description: |-
+                      SecretRef holds the name of a secret that contains a key with
+                      the kubeconfig file as the value. If no key is set, the key will default
+                      to 'value'.
+                      It is recommended that the kubeconfig is self-contained, and the secret
+                      is regularly updated if credentials such as a cloud-access-token expire.
+                      Cloud specific `cmd-path` auth helpers will not function without adding
+                      binaries and credentials to the Pod that is responsible for reconciling
+                      Kubernetes resources.
+                    properties:
+                      key:
+                        description: Key in the Secret, when not specified an implementation-specific
+                          default key is used.
+                        type: string
+                      name:
+                        description: Name of the Secret.
+                        type: string
+                    required:
                     - name
-                  type: object
-                suspend:
-                  description: |-
-                    This flag tells the controller to suspend subsequent kustomize executions,
-                    it does not apply to already started executions. Defaults to false.
-                  type: boolean
-                targetNamespace:
-                  description: |-
-                    TargetNamespace sets or overrides the namespace in the
-                    kustomization.yaml file.
-                  maxLength: 63
-                  minLength: 1
-                  type: string
-                timeout:
-                  description: |-
-                    Timeout for validation, apply and health checking operations.
-                    Defaults to 'Interval' duration.
-                  type: string
-                validation:
-                  description: |-
-                    Validate the Kubernetes objects before applying them on the cluster.
-                    The validation strategy can be 'client' (local dry-run), 'server'
-                    (APIServer dry-run) or 'none'.
-                    When 'Force' is 'true', validation will fallback to 'client' if set to
-                    'server' because server-side validation is not supported in this scenario.
-                  enum:
-                    - none
-                    - client
-                    - server
-                  type: string
-              required:
-                - interval
-                - prune
-                - sourceRef
-              type: object
-            status:
-              default:
-                observedGeneration: -1
-              description: KustomizationStatus defines the observed state of a kustomization.
-              properties:
-                conditions:
-                  items:
-                    description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
-                    properties:
-                      lastTransitionTime:
-                        description: |-
-                          lastTransitionTime is the last time the condition transitioned from one status to another.
-                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                        format: date-time
-                        type: string
-                      message:
-                        description: |-
-                          message is a human readable message indicating details about the transition.
-                          This may be an empty string.
-                        maxLength: 32768
-                        type: string
-                      observedGeneration:
-                        description: |-
-                          observedGeneration represents the .metadata.generation that the condition was set based upon.
-                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                          with respect to the current state of the instance.
-                        format: int64
-                        minimum: 0
-                        type: integer
-                      reason:
-                        description: |-
-                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                          Producers of specific condition types may define expected values and meanings for this field,
-                          and whether the values are considered a guaranteed API.
-                          The value should be a CamelCase string.
-                          This field may not be empty.
-                        maxLength: 1024
-                        minLength: 1
-                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                        type: string
-                      status:
-                        description: status of the condition, one of True, False, Unknown.
-                        enum:
-                          - "True"
-                          - "False"
-                          - Unknown
-                        type: string
-                      type:
-                        description: |-
-                          type of condition in CamelCase or in foo.example.com/CamelCase.
-                          ---
-                          Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                          useful (see .node.status.conditions), the ability to deconflict is important.
-                          The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                        maxLength: 316
-                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                        type: string
-                    required:
-                      - lastTransitionTime
-                      - message
-                      - reason
-                      - status
-                      - type
                     type: object
-                  type: array
-                lastAppliedRevision:
+                required:
+                - secretRef
+                type: object
+              namePrefix:
+                description: NamePrefix will prefix the names of all managed resources.
+                maxLength: 200
+                minLength: 1
+                type: string
+              nameSuffix:
+                description: NameSuffix will suffix the names of all managed resources.
+                maxLength: 200
+                minLength: 1
+                type: string
+              patches:
+                description: |-
+                  Strategic merge and JSON patches, defined as inline YAML objects,
+                  capable of targeting objects based on kind, label and annotation selectors.
+                items:
                   description: |-
-                    The last successfully applied revision.
-                    The revision format for Git sources is <branch|tag>/<commit-sha>.
-                  type: string
-                lastAttemptedRevision:
-                  description: LastAttemptedRevision is the revision of the last reconciliation
-                    attempt.
-                  type: string
-                lastHandledReconcileAt:
-                  description: |-
-                    LastHandledReconcileAt holds the value of the most recent
-                    reconcile request value, so a change of the annotation value
-                    can be detected.
-                  type: string
-                observedGeneration:
-                  description: ObservedGeneration is the last reconciled generation.
-                  format: int64
-                  type: integer
-                snapshot:
-                  description: The last successfully applied revision metadata.
+                    Patch contains an inline StrategicMerge or JSON6902 patch, and the target the patch should
+                    be applied to.
                   properties:
-                    checksum:
-                      description: The manifests sha1 checksum.
+                    patch:
+                      description: |-
+                        Patch contains an inline StrategicMerge patch or an inline JSON6902 patch with
+                        an array of operation objects.
                       type: string
-                    entries:
-                      description: A list of Kubernetes kinds grouped by namespace.
-                      items:
-                        description: |-
-                          Snapshot holds the metadata of namespaced
-                          Kubernetes objects
-                        properties:
-                          kinds:
-                            additionalProperties:
-                              type: string
-                            description: The list of Kubernetes kinds.
-                            type: object
-                          namespace:
-                            description: The namespace of this entry.
-                            type: string
-                        required:
-                          - kinds
-                        type: object
-                      type: array
-                  required:
-                    - checksum
-                    - entries
-                  type: object
-              type: object
-          type: object
-      served: true
-      storage: false
-      subresources:
-        status: {}
-    - additionalPrinterColumns:
-        - jsonPath: .metadata.creationTimestamp
-          name: Age
-          type: date
-        - jsonPath: .status.conditions[?(@.type=="Ready")].status
-          name: Ready
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].message
-          name: Status
-          type: string
-      deprecated: true
-      deprecationWarning: v1beta2 Kustomization is deprecated, upgrade to v1
-      name: v1beta2
-      schema:
-        openAPIV3Schema:
-          description: Kustomization is the Schema for the kustomizations API.
-          properties:
-            apiVersion:
-              description: |-
-                APIVersion defines the versioned schema of this representation of an object.
-                Servers should convert recognized schemas to the latest internal value, and
-                may reject unrecognized values.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-              type: string
-            kind:
-              description: |-
-                Kind is a string value representing the REST resource this object represents.
-                Servers may infer this from the endpoint the client submits requests to.
-                Cannot be updated.
-                In CamelCase.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: KustomizationSpec defines the configuration to calculate
-                the desired state from a Source using Kustomize.
-              properties:
-                commonMetadata:
-                  description: |-
-                    CommonMetadata specifies the common labels and annotations that are applied to all resources.
-                    Any existing label or annotation will be overridden if its key matches a common one.
-                  properties:
-                    annotations:
-                      additionalProperties:
-                        type: string
-                      description: Annotations to be added to the object's metadata.
-                      type: object
-                    labels:
-                      additionalProperties:
-                        type: string
-                      description: Labels to be added to the object's metadata.
-                      type: object
-                  type: object
-                components:
-                  description: Components specifies relative paths to specifications
-                    of other Components.
-                  items:
-                    type: string
-                  type: array
-                decryption:
-                  description: Decrypt Kubernetes secrets before applying them on the
-                    cluster.
-                  properties:
-                    provider:
-                      description: Provider is the name of the decryption engine.
-                      enum:
-                        - sops
-                      type: string
-                    secretRef:
-                      description: The secret name containing the private OpenPGP keys
-                        used for decryption.
+                    target:
+                      description: Target points to the resources that the patch document
+                        should be applied to.
                       properties:
-                        name:
-                          description: Name of the referent.
+                        annotationSelector:
+                          description: |-
+                            AnnotationSelector is a string that follows the label selection expression
+                            https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                            It matches with the resource annotations.
                           type: string
-                      required:
-                        - name
+                        group:
+                          description: |-
+                            Group is the API group to select resources from.
+                            Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources.
+                            https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                          type: string
+                        kind:
+                          description: |-
+                            Kind of the API Group to select resources from.
+                            Together with Group and Version it is capable of unambiguously
+                            identifying and/or selecting resources.
+                            https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                          type: string
+                        labelSelector:
+                          description: |-
+                            LabelSelector is a string that follows the label selection expression
+                            https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                            It matches with the resource labels.
+                          type: string
+                        name:
+                          description: Name to match resources with.
+                          type: string
+                        namespace:
+                          description: Namespace to select resources from.
+                          type: string
+                        version:
+                          description: |-
+                            Version of the API Group to select resources from.
+                            Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources.
+                            https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                          type: string
                       type: object
                   required:
-                    - provider
+                  - patch
                   type: object
-                dependsOn:
-                  description: |-
-                    DependsOn may contain a meta.NamespacedObjectReference slice
-                    with references to Kustomization resources that must be ready before this
-                    Kustomization can be reconciled.
-                  items:
+                type: array
+              path:
+                description: |-
+                  Path to the directory containing the kustomization.yaml file, or the
+                  set of plain YAMLs a kustomization.yaml should be generated for.
+                  Defaults to 'None', which translates to the root path of the SourceRef.
+                type: string
+              postBuild:
+                description: |-
+                  PostBuild describes which actions to perform on the YAML manifest
+                  generated by building the kustomize overlay.
+                properties:
+                  substitute:
+                    additionalProperties:
+                      type: string
                     description: |-
-                      NamespacedObjectReference contains enough information to locate the referenced Kubernetes resource object in any
-                      namespace.
-                    properties:
-                      name:
-                        description: Name of the referent.
-                        type: string
-                      namespace:
-                        description: Namespace of the referent, when not specified it
-                          acts as LocalObjectReference.
-                        type: string
-                    required:
-                      - name
+                      Substitute holds a map of key/value pairs.
+                      The variables defined in your YAML manifests that match any of the keys
+                      defined in the map will be substituted with the set value.
+                      Includes support for bash string replacement functions
+                      e.g. ${var:=default}, ${var:position} and ${var/substring/replacement}.
                     type: object
-                  type: array
-                force:
-                  default: false
-                  description: |-
-                    Force instructs the controller to recreate resources
-                    when patching fails due to an immutable field change.
-                  type: boolean
-                healthChecks:
-                  description: A list of resources to be included in the health assessment.
-                  items:
+                  substituteFrom:
                     description: |-
-                      NamespacedObjectKindReference contains enough information to locate the typed referenced Kubernetes resource object
-                      in any namespace.
-                    properties:
-                      apiVersion:
-                        description: API version of the referent, if not specified the
-                          Kubernetes preferred version will be used.
-                        type: string
-                      kind:
-                        description: Kind of the referent.
-                        type: string
-                      name:
-                        description: Name of the referent.
-                        type: string
-                      namespace:
-                        description: Namespace of the referent, when not specified it
-                          acts as LocalObjectReference.
-                        type: string
-                    required:
+                      SubstituteFrom holds references to ConfigMaps and Secrets containing
+                      the variables and their values to be substituted in the YAML manifests.
+                      The ConfigMap and the Secret data keys represent the var names, and they
+                      must match the vars declared in the manifests for the substitution to
+                      happen.
+                    items:
+                      description: |-
+                        SubstituteReference contains a reference to a resource containing
+                        the variables name and value.
+                      properties:
+                        kind:
+                          description: Kind of the values referent, valid values are
+                            ('Secret', 'ConfigMap').
+                          enum:
+                          - Secret
+                          - ConfigMap
+                          type: string
+                        name:
+                          description: |-
+                            Name of the values referent. Should reside in the same namespace as the
+                            referring resource.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        optional:
+                          default: false
+                          description: |-
+                            Optional indicates whether the referenced resource must exist, or whether to
+                            tolerate its absence. If true and the referenced resource is absent, proceed
+                            as if the resource was present but empty, without any variables defined.
+                          type: boolean
+                      required:
                       - kind
                       - name
-                    type: object
-                  type: array
-                images:
-                  description: |-
-                    Images is a list of (image name, new name, new tag or digest)
-                    for changing image names, tags or digests. This can also be achieved with a
-                    patch, but this operator is simpler to specify.
-                  items:
-                    description: Image contains an image name, a new name, a new tag
-                      or digest, which will replace the original name and tag.
-                    properties:
-                      digest:
-                        description: |-
-                          Digest is the value used to replace the original image tag.
-                          If digest is present NewTag value is ignored.
-                        type: string
-                      name:
-                        description: Name is a tag-less image name.
-                        type: string
-                      newName:
-                        description: NewName is the value used to replace the original
-                          name.
-                        type: string
-                      newTag:
-                        description: NewTag is the value used to replace the original
-                          tag.
-                        type: string
-                    required:
-                      - name
-                    type: object
-                  type: array
-                interval:
-                  description: The interval at which to reconcile the Kustomization.
-                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                  type: string
-                kubeConfig:
-                  description: |-
-                    The KubeConfig for reconciling the Kustomization on a remote cluster.
-                    When used in combination with KustomizationSpec.ServiceAccountName,
-                    forces the controller to act on behalf of that Service Account at the
-                    target cluster.
-                    If the --default-service-account flag is set, its value will be used as
-                    a controller level fallback for when KustomizationSpec.ServiceAccountName
-                    is empty.
+                      type: object
+                    type: array
+                type: object
+              prune:
+                description: Prune enables garbage collection.
+                type: boolean
+              retryInterval:
+                description: |-
+                  The interval at which to retry a previously failed reconciliation.
+                  When not specified, the controller uses the KustomizationSpec.Interval
+                  value to retry failures.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                type: string
+              serviceAccountName:
+                description: |-
+                  The name of the Kubernetes service account to impersonate
+                  when reconciling this Kustomization.
+                type: string
+              sourceRef:
+                description: Reference of the source where the kustomization file
+                  is.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  kind:
+                    description: Kind of the referent.
+                    enum:
+                    - OCIRepository
+                    - GitRepository
+                    - Bucket
+                    type: string
+                  name:
+                    description: Name of the referent.
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent, defaults to the namespace of the Kubernetes
+                      resource object that contains the reference.
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              suspend:
+                description: |-
+                  This flag tells the controller to suspend subsequent kustomize executions,
+                  it does not apply to already started executions. Defaults to false.
+                type: boolean
+              targetNamespace:
+                description: |-
+                  TargetNamespace sets or overrides the namespace in the
+                  kustomization.yaml file.
+                maxLength: 63
+                minLength: 1
+                type: string
+              timeout:
+                description: |-
+                  Timeout for validation, apply and health checking operations.
+                  Defaults to 'Interval' duration.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                type: string
+              wait:
+                description: |-
+                  Wait instructs the controller to check the health of all the reconciled
+                  resources. When enabled, the HealthChecks are ignored. Defaults to false.
+                type: boolean
+            required:
+            - interval
+            - prune
+            - sourceRef
+            type: object
+          status:
+            default:
+              observedGeneration: -1
+            description: KustomizationStatus defines the observed state of a kustomization.
+            properties:
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
-                    secretRef:
+                    lastTransitionTime:
                       description: |-
-                        SecretRef holds the name of a secret that contains a key with
-                        the kubeconfig file as the value. If no key is set, the key will default
-                        to 'value'.
-                        It is recommended that the kubeconfig is self-contained, and the secret
-                        is regularly updated if credentials such as a cloud-access-token expire.
-                        Cloud specific `cmd-path` auth helpers will not function without adding
-                        binaries and credentials to the Pod that is responsible for reconciling
-                        Kubernetes resources.
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              inventory:
+                description: |-
+                  Inventory contains the list of Kubernetes resource object references that
+                  have been successfully applied.
+                properties:
+                  entries:
+                    description: Entries of Kubernetes resource object references.
+                    items:
+                      description: ResourceRef contains the information necessary
+                        to locate a resource within a cluster.
                       properties:
-                        key:
-                          description: Key in the Secret, when not specified an implementation-specific
-                            default key is used.
+                        id:
+                          description: |-
+                            ID is the string representation of the Kubernetes resource object's metadata,
+                            in the format '<namespace>_<name>_<group>_<kind>'.
                           type: string
-                        name:
-                          description: Name of the Secret.
+                        v:
+                          description: Version is the API version of the Kubernetes
+                            resource object's kind.
                           type: string
                       required:
-                        - name
+                      - id
+                      - v
                       type: object
-                  required:
-                    - secretRef
-                  type: object
-                patches:
-                  description: |-
-                    Strategic merge and JSON patches, defined as inline YAML objects,
-                    capable of targeting objects based on kind, label and annotation selectors.
-                  items:
-                    description: |-
-                      Patch contains an inline StrategicMerge or JSON6902 patch, and the target the patch should
-                      be applied to.
+                    type: array
+                required:
+                - entries
+                type: object
+              lastAppliedRevision:
+                description: |-
+                  The last successfully applied revision.
+                  Equals the Revision of the applied Artifact from the referenced Source.
+                type: string
+              lastAttemptedRevision:
+                description: LastAttemptedRevision is the revision of the last reconciliation
+                  attempt.
+                type: string
+              lastHandledReconcileAt:
+                description: |-
+                  LastHandledReconcileAt holds the value of the most recent
+                  reconcile request value, so a change of the annotation value
+                  can be detected.
+                type: string
+              observedGeneration:
+                description: ObservedGeneration is the last reconciled generation.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    deprecated: true
+    deprecationWarning: v1beta1 Kustomization is deprecated, upgrade to v1
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Kustomization is the Schema for the kustomizations API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KustomizationSpec defines the desired state of a kustomization.
+            properties:
+              decryption:
+                description: Decrypt Kubernetes secrets before applying them on the
+                  cluster.
+                properties:
+                  provider:
+                    description: Provider is the name of the decryption engine.
+                    enum:
+                    - sops
+                    type: string
+                  secretRef:
+                    description: The secret name containing the private OpenPGP keys
+                      used for decryption.
                     properties:
-                      patch:
-                        description: |-
-                          Patch contains an inline StrategicMerge patch or an inline JSON6902 patch with
-                          an array of operation objects.
+                      name:
+                        description: Name of the referent.
                         type: string
-                      target:
-                        description: Target points to the resources that the patch document
-                          should be applied to.
-                        properties:
-                          annotationSelector:
-                            description: |-
-                              AnnotationSelector is a string that follows the label selection expression
-                              https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
-                              It matches with the resource annotations.
-                            type: string
-                          group:
-                            description: |-
-                              Group is the API group to select resources from.
-                              Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources.
-                              https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
-                            type: string
-                          kind:
-                            description: |-
-                              Kind of the API Group to select resources from.
-                              Together with Group and Version it is capable of unambiguously
-                              identifying and/or selecting resources.
-                              https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
-                            type: string
-                          labelSelector:
-                            description: |-
-                              LabelSelector is a string that follows the label selection expression
-                              https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
-                              It matches with the resource labels.
-                            type: string
-                          name:
-                            description: Name to match resources with.
-                            type: string
-                          namespace:
-                            description: Namespace to select resources from.
-                            type: string
-                          version:
-                            description: |-
-                              Version of the API Group to select resources from.
-                              Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources.
-                              https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
-                            type: string
-                        type: object
                     required:
-                      - patch
+                    - name
                     type: object
-                  type: array
-                patchesJson6902:
+                required:
+                - provider
+                type: object
+              dependsOn:
+                description: |-
+                  DependsOn may contain a meta.NamespacedObjectReference slice
+                  with references to Kustomization resources that must be ready before this
+                  Kustomization can be reconciled.
+                items:
                   description: |-
-                    JSON 6902 patches, defined as inline YAML objects.
-                    Deprecated: Use Patches instead.
-                  items:
-                    description: JSON6902Patch contains a JSON6902 patch and the target
-                      the patch should be applied to.
-                    properties:
-                      patch:
-                        description: Patch contains the JSON6902 patch document with
-                          an array of operation objects.
-                        items:
-                          description: |-
-                            JSON6902 is a JSON6902 operation object.
-                            https://datatracker.ietf.org/doc/html/rfc6902#section-4
-                          properties:
-                            from:
-                              description: |-
-                                From contains a JSON-pointer value that references a location within the target document where the operation is
-                                performed. The meaning of the value depends on the value of Op, and is NOT taken into account by all operations.
-                              type: string
-                            op:
-                              description: |-
-                                Op indicates the operation to perform. Its value MUST be one of "add", "remove", "replace", "move", "copy", or
-                                "test".
-                                https://datatracker.ietf.org/doc/html/rfc6902#section-4
-                              enum:
-                                - test
-                                - remove
-                                - add
-                                - replace
-                                - move
-                                - copy
-                              type: string
-                            path:
-                              description: |-
-                                Path contains the JSON-pointer value that references a location within the target document where the operation
-                                is performed. The meaning of the value depends on the value of Op.
-                              type: string
-                            value:
-                              description: |-
-                                Value contains a valid JSON structure. The meaning of the value depends on the value of Op, and is NOT taken into
-                                account by all operations.
-                              x-kubernetes-preserve-unknown-fields: true
-                          required:
-                            - op
-                            - path
-                          type: object
-                        type: array
-                      target:
-                        description: Target points to the resources that the patch document
-                          should be applied to.
-                        properties:
-                          annotationSelector:
-                            description: |-
-                              AnnotationSelector is a string that follows the label selection expression
-                              https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
-                              It matches with the resource annotations.
-                            type: string
-                          group:
-                            description: |-
-                              Group is the API group to select resources from.
-                              Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources.
-                              https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
-                            type: string
-                          kind:
-                            description: |-
-                              Kind of the API Group to select resources from.
-                              Together with Group and Version it is capable of unambiguously
-                              identifying and/or selecting resources.
-                              https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
-                            type: string
-                          labelSelector:
-                            description: |-
-                              LabelSelector is a string that follows the label selection expression
-                              https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
-                              It matches with the resource labels.
-                            type: string
-                          name:
-                            description: Name to match resources with.
-                            type: string
-                          namespace:
-                            description: Namespace to select resources from.
-                            type: string
-                          version:
-                            description: |-
-                              Version of the API Group to select resources from.
-                              Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources.
-                              https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
-                            type: string
-                        type: object
-                    required:
-                      - patch
-                      - target
-                    type: object
-                  type: array
-                patchesStrategicMerge:
-                  description: |-
-                    Strategic merge patches, defined as inline YAML objects.
-                    Deprecated: Use Patches instead.
-                  items:
-                    x-kubernetes-preserve-unknown-fields: true
-                  type: array
-                path:
-                  description: |-
-                    Path to the directory containing the kustomization.yaml file, or the
-                    set of plain YAMLs a kustomization.yaml should be generated for.
-                    Defaults to 'None', which translates to the root path of the SourceRef.
-                  type: string
-                postBuild:
-                  description: |-
-                    PostBuild describes which actions to perform on the YAML manifest
-                    generated by building the kustomize overlay.
+                    NamespacedObjectReference contains enough information to locate the referenced Kubernetes resource object in any
+                    namespace.
                   properties:
-                    substitute:
-                      additionalProperties:
-                        type: string
-                      description: |-
-                        Substitute holds a map of key/value pairs.
-                        The variables defined in your YAML manifests
-                        that match any of the keys defined in the map
-                        will be substituted with the set value.
-                        Includes support for bash string replacement functions
-                        e.g. ${var:=default}, ${var:position} and ${var/substring/replacement}.
-                      type: object
-                    substituteFrom:
-                      description: |-
-                        SubstituteFrom holds references to ConfigMaps and Secrets containing
-                        the variables and their values to be substituted in the YAML manifests.
-                        The ConfigMap and the Secret data keys represent the var names and they
-                        must match the vars declared in the manifests for the substitution to happen.
-                      items:
-                        description: |-
-                          SubstituteReference contains a reference to a resource containing
-                          the variables name and value.
-                        properties:
-                          kind:
-                            description: Kind of the values referent, valid values are
-                              ('Secret', 'ConfigMap').
-                            enum:
-                              - Secret
-                              - ConfigMap
-                            type: string
-                          name:
-                            description: |-
-                              Name of the values referent. Should reside in the same namespace as the
-                              referring resource.
-                            maxLength: 253
-                            minLength: 1
-                            type: string
-                          optional:
-                            default: false
-                            description: |-
-                              Optional indicates whether the referenced resource must exist, or whether to
-                              tolerate its absence. If true and the referenced resource is absent, proceed
-                              as if the resource was present but empty, without any variables defined.
-                            type: boolean
-                        required:
-                          - kind
-                          - name
-                        type: object
-                      type: array
+                    name:
+                      description: Name of the referent.
+                      type: string
+                    namespace:
+                      description: Namespace of the referent, when not specified it
+                        acts as LocalObjectReference.
+                      type: string
+                  required:
+                  - name
                   type: object
-                prune:
-                  description: Prune enables garbage collection.
-                  type: boolean
-                retryInterval:
+                type: array
+              force:
+                default: false
+                description: |-
+                  Force instructs the controller to recreate resources
+                  when patching fails due to an immutable field change.
+                type: boolean
+              healthChecks:
+                description: A list of resources to be included in the health assessment.
+                items:
                   description: |-
-                    The interval at which to retry a previously failed reconciliation.
-                    When not specified, the controller uses the KustomizationSpec.Interval
-                    value to retry failures.
-                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                  type: string
-                serviceAccountName:
-                  description: |-
-                    The name of the Kubernetes service account to impersonate
-                    when reconciling this Kustomization.
-                  type: string
-                sourceRef:
-                  description: Reference of the source where the kustomization file
-                    is.
+                    NamespacedObjectKindReference contains enough information to locate the typed referenced Kubernetes resource object
+                    in any namespace.
                   properties:
                     apiVersion:
-                      description: API version of the referent.
+                      description: API version of the referent, if not specified the
+                        Kubernetes preferred version will be used.
                       type: string
                     kind:
                       description: Kind of the referent.
-                      enum:
-                        - OCIRepository
-                        - GitRepository
-                        - Bucket
                       type: string
                     name:
                       description: Name of the referent.
                       type: string
                     namespace:
-                      description: Namespace of the referent, defaults to the namespace
-                        of the Kubernetes resource object that contains the reference.
+                      description: Namespace of the referent, when not specified it
+                        acts as LocalObjectReference.
                       type: string
                   required:
-                    - kind
-                    - name
+                  - kind
+                  - name
                   type: object
-                suspend:
-                  description: |-
-                    This flag tells the controller to suspend subsequent kustomize executions,
-                    it does not apply to already started executions. Defaults to false.
-                  type: boolean
-                targetNamespace:
-                  description: |-
-                    TargetNamespace sets or overrides the namespace in the
-                    kustomization.yaml file.
-                  maxLength: 63
-                  minLength: 1
-                  type: string
-                timeout:
-                  description: |-
-                    Timeout for validation, apply and health checking operations.
-                    Defaults to 'Interval' duration.
-                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                  type: string
-                validation:
-                  description: 'Deprecated: Not used in v1beta2.'
-                  enum:
-                    - none
-                    - client
-                    - server
-                  type: string
-                wait:
-                  description: |-
-                    Wait instructs the controller to check the health of all the reconciled resources.
-                    When enabled, the HealthChecks are ignored. Defaults to false.
-                  type: boolean
-              required:
-                - interval
-                - prune
-                - sourceRef
-              type: object
-            status:
-              default:
-                observedGeneration: -1
-              description: KustomizationStatus defines the observed state of a kustomization.
-              properties:
-                conditions:
-                  items:
-                    description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                type: array
+              images:
+                description: |-
+                  Images is a list of (image name, new name, new tag or digest)
+                  for changing image names, tags or digests. This can also be achieved with a
+                  patch, but this operator is simpler to specify.
+                items:
+                  description: Image contains an image name, a new name, a new tag
+                    or digest, which will replace the original name and tag.
+                  properties:
+                    digest:
+                      description: |-
+                        Digest is the value used to replace the original image tag.
+                        If digest is present NewTag value is ignored.
+                      type: string
+                    name:
+                      description: Name is a tag-less image name.
+                      type: string
+                    newName:
+                      description: NewName is the value used to replace the original
+                        name.
+                      type: string
+                    newTag:
+                      description: NewTag is the value used to replace the original
+                        tag.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              interval:
+                description: The interval at which to reconcile the Kustomization.
+                type: string
+              kubeConfig:
+                description: |-
+                  The KubeConfig for reconciling the Kustomization on a remote cluster.
+                  When specified, KubeConfig takes precedence over ServiceAccountName.
+                properties:
+                  secretRef:
+                    description: |-
+                      SecretRef holds the name to a secret that contains a 'value' key with
+                      the kubeconfig file as the value. It must be in the same namespace as
+                      the Kustomization.
+                      It is recommended that the kubeconfig is self-contained, and the secret
+                      is regularly updated if credentials such as a cloud-access-token expire.
+                      Cloud specific `cmd-path` auth helpers will not function without adding
+                      binaries and credentials to the Pod that is responsible for reconciling
+                      the Kustomization.
                     properties:
-                      lastTransitionTime:
-                        description: |-
-                          lastTransitionTime is the last time the condition transitioned from one status to another.
-                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                        format: date-time
-                        type: string
-                      message:
-                        description: |-
-                          message is a human readable message indicating details about the transition.
-                          This may be an empty string.
-                        maxLength: 32768
-                        type: string
-                      observedGeneration:
-                        description: |-
-                          observedGeneration represents the .metadata.generation that the condition was set based upon.
-                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                          with respect to the current state of the instance.
-                        format: int64
-                        minimum: 0
-                        type: integer
-                      reason:
-                        description: |-
-                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                          Producers of specific condition types may define expected values and meanings for this field,
-                          and whether the values are considered a guaranteed API.
-                          The value should be a CamelCase string.
-                          This field may not be empty.
-                        maxLength: 1024
-                        minLength: 1
-                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                        type: string
-                      status:
-                        description: status of the condition, one of True, False, Unknown.
-                        enum:
-                          - "True"
-                          - "False"
-                          - Unknown
-                        type: string
-                      type:
-                        description: |-
-                          type of condition in CamelCase or in foo.example.com/CamelCase.
-                          ---
-                          Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                          useful (see .node.status.conditions), the ability to deconflict is important.
-                          The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                        maxLength: 316
-                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      name:
+                        description: Name of the referent.
                         type: string
                     required:
-                      - lastTransitionTime
-                      - message
-                      - reason
-                      - status
-                      - type
+                    - name
                     type: object
-                  type: array
-                inventory:
-                  description: Inventory contains the list of Kubernetes resource object
-                    references that have been successfully applied.
+                required:
+                - secretRef
+                type: object
+              patches:
+                description: |-
+                  Strategic merge and JSON patches, defined as inline YAML objects,
+                  capable of targeting objects based on kind, label and annotation selectors.
+                items:
+                  description: |-
+                    Patch contains an inline StrategicMerge or JSON6902 patch, and the target the patch should
+                    be applied to.
                   properties:
-                    entries:
-                      description: Entries of Kubernetes resource object references.
+                    patch:
+                      description: |-
+                        Patch contains an inline StrategicMerge patch or an inline JSON6902 patch with
+                        an array of operation objects.
+                      type: string
+                    target:
+                      description: Target points to the resources that the patch document
+                        should be applied to.
+                      properties:
+                        annotationSelector:
+                          description: |-
+                            AnnotationSelector is a string that follows the label selection expression
+                            https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                            It matches with the resource annotations.
+                          type: string
+                        group:
+                          description: |-
+                            Group is the API group to select resources from.
+                            Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources.
+                            https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                          type: string
+                        kind:
+                          description: |-
+                            Kind of the API Group to select resources from.
+                            Together with Group and Version it is capable of unambiguously
+                            identifying and/or selecting resources.
+                            https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                          type: string
+                        labelSelector:
+                          description: |-
+                            LabelSelector is a string that follows the label selection expression
+                            https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                            It matches with the resource labels.
+                          type: string
+                        name:
+                          description: Name to match resources with.
+                          type: string
+                        namespace:
+                          description: Namespace to select resources from.
+                          type: string
+                        version:
+                          description: |-
+                            Version of the API Group to select resources from.
+                            Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources.
+                            https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                          type: string
+                      type: object
+                  required:
+                  - patch
+                  type: object
+                type: array
+              patchesJson6902:
+                description: JSON 6902 patches, defined as inline YAML objects.
+                items:
+                  description: JSON6902Patch contains a JSON6902 patch and the target
+                    the patch should be applied to.
+                  properties:
+                    patch:
+                      description: Patch contains the JSON6902 patch document with
+                        an array of operation objects.
                       items:
-                        description: ResourceRef contains the information necessary
-                          to locate a resource within a cluster.
+                        description: |-
+                          JSON6902 is a JSON6902 operation object.
+                          https://datatracker.ietf.org/doc/html/rfc6902#section-4
                         properties:
-                          id:
+                          from:
                             description: |-
-                              ID is the string representation of the Kubernetes resource object's metadata,
-                              in the format '<namespace>_<name>_<group>_<kind>'.
+                              From contains a JSON-pointer value that references a location within the target document where the operation is
+                              performed. The meaning of the value depends on the value of Op, and is NOT taken into account by all operations.
                             type: string
-                          v:
-                            description: Version is the API version of the Kubernetes
-                              resource object's kind.
+                          op:
+                            description: |-
+                              Op indicates the operation to perform. Its value MUST be one of "add", "remove", "replace", "move", "copy", or
+                              "test".
+                              https://datatracker.ietf.org/doc/html/rfc6902#section-4
+                            enum:
+                            - test
+                            - remove
+                            - add
+                            - replace
+                            - move
+                            - copy
                             type: string
+                          path:
+                            description: |-
+                              Path contains the JSON-pointer value that references a location within the target document where the operation
+                              is performed. The meaning of the value depends on the value of Op.
+                            type: string
+                          value:
+                            description: |-
+                              Value contains a valid JSON structure. The meaning of the value depends on the value of Op, and is NOT taken into
+                              account by all operations.
+                            x-kubernetes-preserve-unknown-fields: true
                         required:
-                          - id
-                          - v
+                        - op
+                        - path
                         type: object
                       type: array
+                    target:
+                      description: Target points to the resources that the patch document
+                        should be applied to.
+                      properties:
+                        annotationSelector:
+                          description: |-
+                            AnnotationSelector is a string that follows the label selection expression
+                            https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                            It matches with the resource annotations.
+                          type: string
+                        group:
+                          description: |-
+                            Group is the API group to select resources from.
+                            Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources.
+                            https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                          type: string
+                        kind:
+                          description: |-
+                            Kind of the API Group to select resources from.
+                            Together with Group and Version it is capable of unambiguously
+                            identifying and/or selecting resources.
+                            https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                          type: string
+                        labelSelector:
+                          description: |-
+                            LabelSelector is a string that follows the label selection expression
+                            https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                            It matches with the resource labels.
+                          type: string
+                        name:
+                          description: Name to match resources with.
+                          type: string
+                        namespace:
+                          description: Namespace to select resources from.
+                          type: string
+                        version:
+                          description: |-
+                            Version of the API Group to select resources from.
+                            Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources.
+                            https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                          type: string
+                      type: object
                   required:
-                    - entries
+                  - patch
+                  - target
                   type: object
-                lastAppliedRevision:
+                type: array
+              patchesStrategicMerge:
+                description: Strategic merge patches, defined as inline YAML objects.
+                items:
+                  x-kubernetes-preserve-unknown-fields: true
+                type: array
+              path:
+                description: |-
+                  Path to the directory containing the kustomization.yaml file, or the
+                  set of plain YAMLs a kustomization.yaml should be generated for.
+                  Defaults to 'None', which translates to the root path of the SourceRef.
+                type: string
+              postBuild:
+                description: |-
+                  PostBuild describes which actions to perform on the YAML manifest
+                  generated by building the kustomize overlay.
+                properties:
+                  substitute:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Substitute holds a map of key/value pairs.
+                      The variables defined in your YAML manifests
+                      that match any of the keys defined in the map
+                      will be substituted with the set value.
+                      Includes support for bash string replacement functions
+                      e.g. ${var:=default}, ${var:position} and ${var/substring/replacement}.
+                    type: object
+                  substituteFrom:
+                    description: |-
+                      SubstituteFrom holds references to ConfigMaps and Secrets containing
+                      the variables and their values to be substituted in the YAML manifests.
+                      The ConfigMap and the Secret data keys represent the var names and they
+                      must match the vars declared in the manifests for the substitution to happen.
+                    items:
+                      description: |-
+                        SubstituteReference contains a reference to a resource containing
+                        the variables name and value.
+                      properties:
+                        kind:
+                          description: Kind of the values referent, valid values are
+                            ('Secret', 'ConfigMap').
+                          enum:
+                          - Secret
+                          - ConfigMap
+                          type: string
+                        name:
+                          description: |-
+                            Name of the values referent. Should reside in the same namespace as the
+                            referring resource.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                      required:
+                      - kind
+                      - name
+                      type: object
+                    type: array
+                type: object
+              prune:
+                description: Prune enables garbage collection.
+                type: boolean
+              retryInterval:
+                description: |-
+                  The interval at which to retry a previously failed reconciliation.
+                  When not specified, the controller uses the KustomizationSpec.Interval
+                  value to retry failures.
+                type: string
+              serviceAccountName:
+                description: |-
+                  The name of the Kubernetes service account to impersonate
+                  when reconciling this Kustomization.
+                type: string
+              sourceRef:
+                description: Reference of the source where the kustomization file
+                  is.
+                properties:
+                  apiVersion:
+                    description: API version of the referent
+                    type: string
+                  kind:
+                    description: Kind of the referent
+                    enum:
+                    - GitRepository
+                    - Bucket
+                    type: string
+                  name:
+                    description: Name of the referent
+                    type: string
+                  namespace:
+                    description: Namespace of the referent, defaults to the Kustomization
+                      namespace
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              suspend:
+                description: |-
+                  This flag tells the controller to suspend subsequent kustomize executions,
+                  it does not apply to already started executions. Defaults to false.
+                type: boolean
+              targetNamespace:
+                description: |-
+                  TargetNamespace sets or overrides the namespace in the
+                  kustomization.yaml file.
+                maxLength: 63
+                minLength: 1
+                type: string
+              timeout:
+                description: |-
+                  Timeout for validation, apply and health checking operations.
+                  Defaults to 'Interval' duration.
+                type: string
+              validation:
+                description: |-
+                  Validate the Kubernetes objects before applying them on the cluster.
+                  The validation strategy can be 'client' (local dry-run), 'server'
+                  (APIServer dry-run) or 'none'.
+                  When 'Force' is 'true', validation will fallback to 'client' if set to
+                  'server' because server-side validation is not supported in this scenario.
+                enum:
+                - none
+                - client
+                - server
+                type: string
+            required:
+            - interval
+            - prune
+            - sourceRef
+            type: object
+          status:
+            default:
+              observedGeneration: -1
+            description: KustomizationStatus defines the observed state of a kustomization.
+            properties:
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              lastAppliedRevision:
+                description: |-
+                  The last successfully applied revision.
+                  The revision format for Git sources is <branch|tag>/<commit-sha>.
+                type: string
+              lastAttemptedRevision:
+                description: LastAttemptedRevision is the revision of the last reconciliation
+                  attempt.
+                type: string
+              lastHandledReconcileAt:
+                description: |-
+                  LastHandledReconcileAt holds the value of the most recent
+                  reconcile request value, so a change of the annotation value
+                  can be detected.
+                type: string
+              observedGeneration:
+                description: ObservedGeneration is the last reconciled generation.
+                format: int64
+                type: integer
+              snapshot:
+                description: The last successfully applied revision metadata.
+                properties:
+                  checksum:
+                    description: The manifests sha1 checksum.
+                    type: string
+                  entries:
+                    description: A list of Kubernetes kinds grouped by namespace.
+                    items:
+                      description: |-
+                        Snapshot holds the metadata of namespaced
+                        Kubernetes objects
+                      properties:
+                        kinds:
+                          additionalProperties:
+                            type: string
+                          description: The list of Kubernetes kinds.
+                          type: object
+                        namespace:
+                          description: The namespace of this entry.
+                          type: string
+                      required:
+                      - kinds
+                      type: object
+                    type: array
+                required:
+                - checksum
+                - entries
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      type: string
+    deprecated: true
+    deprecationWarning: v1beta2 Kustomization is deprecated, upgrade to v1
+    name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: Kustomization is the Schema for the kustomizations API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KustomizationSpec defines the configuration to calculate
+              the desired state from a Source using Kustomize.
+            properties:
+              commonMetadata:
+                description: |-
+                  CommonMetadata specifies the common labels and annotations that are applied to all resources.
+                  Any existing label or annotation will be overridden if its key matches a common one.
+                properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: Annotations to be added to the object's metadata.
+                    type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Labels to be added to the object's metadata.
+                    type: object
+                type: object
+              components:
+                description: Components specifies relative paths to specifications
+                  of other Components.
+                items:
+                  type: string
+                type: array
+              decryption:
+                description: Decrypt Kubernetes secrets before applying them on the
+                  cluster.
+                properties:
+                  provider:
+                    description: Provider is the name of the decryption engine.
+                    enum:
+                    - sops
+                    type: string
+                  secretRef:
+                    description: The secret name containing the private OpenPGP keys
+                      used for decryption.
+                    properties:
+                      name:
+                        description: Name of the referent.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                required:
+                - provider
+                type: object
+              dependsOn:
+                description: |-
+                  DependsOn may contain a meta.NamespacedObjectReference slice
+                  with references to Kustomization resources that must be ready before this
+                  Kustomization can be reconciled.
+                items:
                   description: |-
-                    The last successfully applied revision.
-                    Equals the Revision of the applied Artifact from the referenced Source.
-                  type: string
-                lastAttemptedRevision:
-                  description: LastAttemptedRevision is the revision of the last reconciliation
-                    attempt.
-                  type: string
-                lastHandledReconcileAt:
+                    NamespacedObjectReference contains enough information to locate the referenced Kubernetes resource object in any
+                    namespace.
+                  properties:
+                    name:
+                      description: Name of the referent.
+                      type: string
+                    namespace:
+                      description: Namespace of the referent, when not specified it
+                        acts as LocalObjectReference.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              force:
+                default: false
+                description: |-
+                  Force instructs the controller to recreate resources
+                  when patching fails due to an immutable field change.
+                type: boolean
+              healthChecks:
+                description: A list of resources to be included in the health assessment.
+                items:
                   description: |-
-                    LastHandledReconcileAt holds the value of the most recent
-                    reconcile request value, so a change of the annotation value
-                    can be detected.
-                  type: string
-                observedGeneration:
-                  description: ObservedGeneration is the last reconciled generation.
-                  format: int64
-                  type: integer
-              type: object
-          type: object
-      served: true
-      storage: false
-      subresources:
-        status: {}
+                    NamespacedObjectKindReference contains enough information to locate the typed referenced Kubernetes resource object
+                    in any namespace.
+                  properties:
+                    apiVersion:
+                      description: API version of the referent, if not specified the
+                        Kubernetes preferred version will be used.
+                      type: string
+                    kind:
+                      description: Kind of the referent.
+                      type: string
+                    name:
+                      description: Name of the referent.
+                      type: string
+                    namespace:
+                      description: Namespace of the referent, when not specified it
+                        acts as LocalObjectReference.
+                      type: string
+                  required:
+                  - kind
+                  - name
+                  type: object
+                type: array
+              images:
+                description: |-
+                  Images is a list of (image name, new name, new tag or digest)
+                  for changing image names, tags or digests. This can also be achieved with a
+                  patch, but this operator is simpler to specify.
+                items:
+                  description: Image contains an image name, a new name, a new tag
+                    or digest, which will replace the original name and tag.
+                  properties:
+                    digest:
+                      description: |-
+                        Digest is the value used to replace the original image tag.
+                        If digest is present NewTag value is ignored.
+                      type: string
+                    name:
+                      description: Name is a tag-less image name.
+                      type: string
+                    newName:
+                      description: NewName is the value used to replace the original
+                        name.
+                      type: string
+                    newTag:
+                      description: NewTag is the value used to replace the original
+                        tag.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              interval:
+                description: The interval at which to reconcile the Kustomization.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                type: string
+              kubeConfig:
+                description: |-
+                  The KubeConfig for reconciling the Kustomization on a remote cluster.
+                  When used in combination with KustomizationSpec.ServiceAccountName,
+                  forces the controller to act on behalf of that Service Account at the
+                  target cluster.
+                  If the --default-service-account flag is set, its value will be used as
+                  a controller level fallback for when KustomizationSpec.ServiceAccountName
+                  is empty.
+                properties:
+                  secretRef:
+                    description: |-
+                      SecretRef holds the name of a secret that contains a key with
+                      the kubeconfig file as the value. If no key is set, the key will default
+                      to 'value'.
+                      It is recommended that the kubeconfig is self-contained, and the secret
+                      is regularly updated if credentials such as a cloud-access-token expire.
+                      Cloud specific `cmd-path` auth helpers will not function without adding
+                      binaries and credentials to the Pod that is responsible for reconciling
+                      Kubernetes resources.
+                    properties:
+                      key:
+                        description: Key in the Secret, when not specified an implementation-specific
+                          default key is used.
+                        type: string
+                      name:
+                        description: Name of the Secret.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                required:
+                - secretRef
+                type: object
+              patches:
+                description: |-
+                  Strategic merge and JSON patches, defined as inline YAML objects,
+                  capable of targeting objects based on kind, label and annotation selectors.
+                items:
+                  description: |-
+                    Patch contains an inline StrategicMerge or JSON6902 patch, and the target the patch should
+                    be applied to.
+                  properties:
+                    patch:
+                      description: |-
+                        Patch contains an inline StrategicMerge patch or an inline JSON6902 patch with
+                        an array of operation objects.
+                      type: string
+                    target:
+                      description: Target points to the resources that the patch document
+                        should be applied to.
+                      properties:
+                        annotationSelector:
+                          description: |-
+                            AnnotationSelector is a string that follows the label selection expression
+                            https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                            It matches with the resource annotations.
+                          type: string
+                        group:
+                          description: |-
+                            Group is the API group to select resources from.
+                            Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources.
+                            https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                          type: string
+                        kind:
+                          description: |-
+                            Kind of the API Group to select resources from.
+                            Together with Group and Version it is capable of unambiguously
+                            identifying and/or selecting resources.
+                            https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                          type: string
+                        labelSelector:
+                          description: |-
+                            LabelSelector is a string that follows the label selection expression
+                            https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                            It matches with the resource labels.
+                          type: string
+                        name:
+                          description: Name to match resources with.
+                          type: string
+                        namespace:
+                          description: Namespace to select resources from.
+                          type: string
+                        version:
+                          description: |-
+                            Version of the API Group to select resources from.
+                            Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources.
+                            https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                          type: string
+                      type: object
+                  required:
+                  - patch
+                  type: object
+                type: array
+              patchesJson6902:
+                description: |-
+                  JSON 6902 patches, defined as inline YAML objects.
+                  Deprecated: Use Patches instead.
+                items:
+                  description: JSON6902Patch contains a JSON6902 patch and the target
+                    the patch should be applied to.
+                  properties:
+                    patch:
+                      description: Patch contains the JSON6902 patch document with
+                        an array of operation objects.
+                      items:
+                        description: |-
+                          JSON6902 is a JSON6902 operation object.
+                          https://datatracker.ietf.org/doc/html/rfc6902#section-4
+                        properties:
+                          from:
+                            description: |-
+                              From contains a JSON-pointer value that references a location within the target document where the operation is
+                              performed. The meaning of the value depends on the value of Op, and is NOT taken into account by all operations.
+                            type: string
+                          op:
+                            description: |-
+                              Op indicates the operation to perform. Its value MUST be one of "add", "remove", "replace", "move", "copy", or
+                              "test".
+                              https://datatracker.ietf.org/doc/html/rfc6902#section-4
+                            enum:
+                            - test
+                            - remove
+                            - add
+                            - replace
+                            - move
+                            - copy
+                            type: string
+                          path:
+                            description: |-
+                              Path contains the JSON-pointer value that references a location within the target document where the operation
+                              is performed. The meaning of the value depends on the value of Op.
+                            type: string
+                          value:
+                            description: |-
+                              Value contains a valid JSON structure. The meaning of the value depends on the value of Op, and is NOT taken into
+                              account by all operations.
+                            x-kubernetes-preserve-unknown-fields: true
+                        required:
+                        - op
+                        - path
+                        type: object
+                      type: array
+                    target:
+                      description: Target points to the resources that the patch document
+                        should be applied to.
+                      properties:
+                        annotationSelector:
+                          description: |-
+                            AnnotationSelector is a string that follows the label selection expression
+                            https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                            It matches with the resource annotations.
+                          type: string
+                        group:
+                          description: |-
+                            Group is the API group to select resources from.
+                            Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources.
+                            https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                          type: string
+                        kind:
+                          description: |-
+                            Kind of the API Group to select resources from.
+                            Together with Group and Version it is capable of unambiguously
+                            identifying and/or selecting resources.
+                            https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                          type: string
+                        labelSelector:
+                          description: |-
+                            LabelSelector is a string that follows the label selection expression
+                            https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                            It matches with the resource labels.
+                          type: string
+                        name:
+                          description: Name to match resources with.
+                          type: string
+                        namespace:
+                          description: Namespace to select resources from.
+                          type: string
+                        version:
+                          description: |-
+                            Version of the API Group to select resources from.
+                            Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources.
+                            https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                          type: string
+                      type: object
+                  required:
+                  - patch
+                  - target
+                  type: object
+                type: array
+              patchesStrategicMerge:
+                description: |-
+                  Strategic merge patches, defined as inline YAML objects.
+                  Deprecated: Use Patches instead.
+                items:
+                  x-kubernetes-preserve-unknown-fields: true
+                type: array
+              path:
+                description: |-
+                  Path to the directory containing the kustomization.yaml file, or the
+                  set of plain YAMLs a kustomization.yaml should be generated for.
+                  Defaults to 'None', which translates to the root path of the SourceRef.
+                type: string
+              postBuild:
+                description: |-
+                  PostBuild describes which actions to perform on the YAML manifest
+                  generated by building the kustomize overlay.
+                properties:
+                  substitute:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Substitute holds a map of key/value pairs.
+                      The variables defined in your YAML manifests
+                      that match any of the keys defined in the map
+                      will be substituted with the set value.
+                      Includes support for bash string replacement functions
+                      e.g. ${var:=default}, ${var:position} and ${var/substring/replacement}.
+                    type: object
+                  substituteFrom:
+                    description: |-
+                      SubstituteFrom holds references to ConfigMaps and Secrets containing
+                      the variables and their values to be substituted in the YAML manifests.
+                      The ConfigMap and the Secret data keys represent the var names and they
+                      must match the vars declared in the manifests for the substitution to happen.
+                    items:
+                      description: |-
+                        SubstituteReference contains a reference to a resource containing
+                        the variables name and value.
+                      properties:
+                        kind:
+                          description: Kind of the values referent, valid values are
+                            ('Secret', 'ConfigMap').
+                          enum:
+                          - Secret
+                          - ConfigMap
+                          type: string
+                        name:
+                          description: |-
+                            Name of the values referent. Should reside in the same namespace as the
+                            referring resource.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        optional:
+                          default: false
+                          description: |-
+                            Optional indicates whether the referenced resource must exist, or whether to
+                            tolerate its absence. If true and the referenced resource is absent, proceed
+                            as if the resource was present but empty, without any variables defined.
+                          type: boolean
+                      required:
+                      - kind
+                      - name
+                      type: object
+                    type: array
+                type: object
+              prune:
+                description: Prune enables garbage collection.
+                type: boolean
+              retryInterval:
+                description: |-
+                  The interval at which to retry a previously failed reconciliation.
+                  When not specified, the controller uses the KustomizationSpec.Interval
+                  value to retry failures.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                type: string
+              serviceAccountName:
+                description: |-
+                  The name of the Kubernetes service account to impersonate
+                  when reconciling this Kustomization.
+                type: string
+              sourceRef:
+                description: Reference of the source where the kustomization file
+                  is.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  kind:
+                    description: Kind of the referent.
+                    enum:
+                    - OCIRepository
+                    - GitRepository
+                    - Bucket
+                    type: string
+                  name:
+                    description: Name of the referent.
+                    type: string
+                  namespace:
+                    description: Namespace of the referent, defaults to the namespace
+                      of the Kubernetes resource object that contains the reference.
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              suspend:
+                description: |-
+                  This flag tells the controller to suspend subsequent kustomize executions,
+                  it does not apply to already started executions. Defaults to false.
+                type: boolean
+              targetNamespace:
+                description: |-
+                  TargetNamespace sets or overrides the namespace in the
+                  kustomization.yaml file.
+                maxLength: 63
+                minLength: 1
+                type: string
+              timeout:
+                description: |-
+                  Timeout for validation, apply and health checking operations.
+                  Defaults to 'Interval' duration.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                type: string
+              validation:
+                description: 'Deprecated: Not used in v1beta2.'
+                enum:
+                - none
+                - client
+                - server
+                type: string
+              wait:
+                description: |-
+                  Wait instructs the controller to check the health of all the reconciled resources.
+                  When enabled, the HealthChecks are ignored. Defaults to false.
+                type: boolean
+            required:
+            - interval
+            - prune
+            - sourceRef
+            type: object
+          status:
+            default:
+              observedGeneration: -1
+            description: KustomizationStatus defines the observed state of a kustomization.
+            properties:
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              inventory:
+                description: Inventory contains the list of Kubernetes resource object
+                  references that have been successfully applied.
+                properties:
+                  entries:
+                    description: Entries of Kubernetes resource object references.
+                    items:
+                      description: ResourceRef contains the information necessary
+                        to locate a resource within a cluster.
+                      properties:
+                        id:
+                          description: |-
+                            ID is the string representation of the Kubernetes resource object's metadata,
+                            in the format '<namespace>_<name>_<group>_<kind>'.
+                          type: string
+                        v:
+                          description: Version is the API version of the Kubernetes
+                            resource object's kind.
+                          type: string
+                      required:
+                      - id
+                      - v
+                      type: object
+                    type: array
+                required:
+                - entries
+                type: object
+              lastAppliedRevision:
+                description: |-
+                  The last successfully applied revision.
+                  Equals the Revision of the applied Artifact from the referenced Source.
+                type: string
+              lastAttemptedRevision:
+                description: LastAttemptedRevision is the revision of the last reconciliation
+                  attempt.
+                type: string
+              lastHandledReconcileAt:
+                description: |-
+                  LastHandledReconcileAt holds the value of the most recent
+                  reconcile request value, so a change of the annotation value
+                  can be detected.
+                type: string
+              observedGeneration:
+                description: ObservedGeneration is the last reconciled generation.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}

--- a/tools/testcrds/source.toolkit.fluxcd.io_buckets.yaml
+++ b/tools/testcrds/source.toolkit.fluxcd.io_buckets.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.1
   name: buckets.source.toolkit.fluxcd.io
 spec:
   group: source.toolkit.fluxcd.io
@@ -14,532 +14,971 @@ spec:
     singular: bucket
   scope: Namespaced
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .spec.endpoint
-          name: Endpoint
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].status
-          name: Ready
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].message
-          name: Status
-          type: string
-        - jsonPath: .metadata.creationTimestamp
-          name: Age
-          type: date
-      deprecated: true
-      deprecationWarning: v1beta1 Bucket is deprecated, upgrade to v1beta2
-      name: v1beta1
-      schema:
-        openAPIV3Schema:
-          description: Bucket is the Schema for the buckets API
-          properties:
-            apiVersion:
-              description: |-
-                APIVersion defines the versioned schema of this representation of an object.
-                Servers should convert recognized schemas to the latest internal value, and
-                may reject unrecognized values.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-              type: string
-            kind:
-              description: |-
-                Kind is a string value representing the REST resource this object represents.
-                Servers may infer this from the endpoint the client submits requests to.
-                Cannot be updated.
-                In CamelCase.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: BucketSpec defines the desired state of an S3 compatible
-                bucket
-              properties:
-                accessFrom:
-                  description: AccessFrom defines an Access Control List for allowing
-                    cross-namespace references to this object.
-                  properties:
-                    namespaceSelectors:
-                      description: |-
-                        NamespaceSelectors is the list of namespace selectors to which this ACL applies.
-                        Items in this list are evaluated using a logical OR operation.
-                      items:
-                        description: |-
-                          NamespaceSelector selects the namespaces to which this ACL applies.
-                          An empty map of MatchLabels matches all namespaces in a cluster.
-                        properties:
-                          matchLabels:
-                            additionalProperties:
-                              type: string
-                            description: |-
-                              MatchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                              map is equivalent to an element of matchExpressions, whose key field is "key", the
-                              operator is "In", and the values array contains only "value". The requirements are ANDed.
-                            type: object
-                        type: object
-                      type: array
-                  required:
-                    - namespaceSelectors
-                  type: object
-                bucketName:
-                  description: The bucket name.
-                  type: string
-                endpoint:
-                  description: The bucket endpoint address.
-                  type: string
-                ignore:
-                  description: |-
-                    Ignore overrides the set of excluded patterns in the .sourceignore format
-                    (which is the same as .gitignore). If not provided, a default will be used,
-                    consult the documentation for your version to find out what those are.
-                  type: string
-                insecure:
-                  description: Insecure allows connecting to a non-TLS S3 HTTP endpoint.
-                  type: boolean
-                interval:
-                  description: The interval at which to check for bucket updates.
-                  type: string
-                provider:
-                  default: generic
-                  description: The S3 compatible storage provider name, default ('generic').
-                  enum:
-                    - generic
-                    - aws
-                    - gcp
-                  type: string
-                region:
-                  description: The bucket region.
-                  type: string
-                secretRef:
-                  description: |-
-                    The name of the secret containing authentication credentials
-                    for the Bucket.
-                  properties:
-                    name:
-                      description: Name of the referent.
-                      type: string
-                  required:
-                    - name
-                  type: object
-                suspend:
-                  description: This flag tells the controller to suspend the reconciliation
-                    of this source.
-                  type: boolean
-                timeout:
-                  default: 60s
-                  description: The timeout for download operations, defaults to 60s.
-                  type: string
-              required:
-                - bucketName
-                - endpoint
-                - interval
-              type: object
-            status:
-              default:
-                observedGeneration: -1
-              description: BucketStatus defines the observed state of a bucket
-              properties:
-                artifact:
-                  description: Artifact represents the output of the last successful
-                    Bucket sync.
-                  properties:
-                    checksum:
-                      description: Checksum is the SHA256 checksum of the artifact.
-                      type: string
-                    lastUpdateTime:
-                      description: |-
-                        LastUpdateTime is the timestamp corresponding to the last update of this
-                        artifact.
-                      format: date-time
-                      type: string
-                    path:
-                      description: Path is the relative file path of this artifact.
-                      type: string
-                    revision:
-                      description: |-
-                        Revision is a human readable identifier traceable in the origin source
-                        system. It can be a Git commit SHA, Git tag, a Helm index timestamp, a Helm
-                        chart version, etc.
-                      type: string
-                    url:
-                      description: URL is the HTTP address of this artifact.
-                      type: string
-                  required:
-                    - path
-                    - url
-                  type: object
-                conditions:
-                  description: Conditions holds the conditions for the Bucket.
-                  items:
-                    description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+  - additionalPrinterColumns:
+    - jsonPath: .spec.endpoint
+      name: Endpoint
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: Bucket is the Schema for the buckets API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              BucketSpec specifies the required configuration to produce an Artifact for
+              an object storage bucket.
+            properties:
+              bucketName:
+                description: BucketName is the name of the object storage bucket.
+                type: string
+              certSecretRef:
+                description: |-
+                  CertSecretRef can be given the name of a Secret containing
+                  either or both of
+
+                  - a PEM-encoded client certificate (`tls.crt`) and private
+                  key (`tls.key`);
+                  - a PEM-encoded CA certificate (`ca.crt`)
+
+                  and whichever are supplied, will be used for connecting to the
+                  bucket. The client cert and key are useful if you are
+                  authenticating with a certificate; the CA cert is useful if
+                  you are using a self-signed server certificate. The Secret must
+                  be of type `Opaque` or `kubernetes.io/tls`.
+
+                  This field is only supported for the `generic` provider.
+                properties:
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - name
+                type: object
+              endpoint:
+                description: Endpoint is the object storage address the BucketName
+                  is located at.
+                type: string
+              ignore:
+                description: |-
+                  Ignore overrides the set of excluded patterns in the .sourceignore format
+                  (which is the same as .gitignore). If not provided, a default will be used,
+                  consult the documentation for your version to find out what those are.
+                type: string
+              insecure:
+                description: Insecure allows connecting to a non-TLS HTTP Endpoint.
+                type: boolean
+              interval:
+                description: |-
+                  Interval at which the Bucket Endpoint is checked for updates.
+                  This interval is approximate and may be subject to jitter to ensure
+                  efficient use of resources.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                type: string
+              prefix:
+                description: Prefix to use for server-side filtering of files in the
+                  Bucket.
+                type: string
+              provider:
+                default: generic
+                description: |-
+                  Provider of the object storage bucket.
+                  Defaults to 'generic', which expects an S3 (API) compatible object
+                  storage.
+                enum:
+                - generic
+                - aws
+                - gcp
+                - azure
+                type: string
+              proxySecretRef:
+                description: |-
+                  ProxySecretRef specifies the Secret containing the proxy configuration
+                  to use while communicating with the Bucket server.
+                properties:
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - name
+                type: object
+              region:
+                description: Region of the Endpoint where the BucketName is located
+                  in.
+                type: string
+              secretRef:
+                description: |-
+                  SecretRef specifies the Secret containing authentication credentials
+                  for the Bucket.
+                properties:
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - name
+                type: object
+              sts:
+                description: |-
+                  STS specifies the required configuration to use a Security Token
+                  Service for fetching temporary credentials to authenticate in a
+                  Bucket provider.
+
+                  This field is only supported for the `aws` and `generic` providers.
+                properties:
+                  certSecretRef:
+                    description: |-
+                      CertSecretRef can be given the name of a Secret containing
+                      either or both of
+
+                      - a PEM-encoded client certificate (`tls.crt`) and private
+                      key (`tls.key`);
+                      - a PEM-encoded CA certificate (`ca.crt`)
+
+                      and whichever are supplied, will be used for connecting to the
+                      STS endpoint. The client cert and key are useful if you are
+                      authenticating with a certificate; the CA cert is useful if
+                      you are using a self-signed server certificate. The Secret must
+                      be of type `Opaque` or `kubernetes.io/tls`.
+
+                      This field is only supported for the `ldap` provider.
                     properties:
-                      lastTransitionTime:
-                        description: |-
-                          lastTransitionTime is the last time the condition transitioned from one status to another.
-                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                        format: date-time
-                        type: string
-                      message:
-                        description: |-
-                          message is a human readable message indicating details about the transition.
-                          This may be an empty string.
-                        maxLength: 32768
-                        type: string
-                      observedGeneration:
-                        description: |-
-                          observedGeneration represents the .metadata.generation that the condition was set based upon.
-                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                          with respect to the current state of the instance.
-                        format: int64
-                        minimum: 0
-                        type: integer
-                      reason:
-                        description: |-
-                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                          Producers of specific condition types may define expected values and meanings for this field,
-                          and whether the values are considered a guaranteed API.
-                          The value should be a CamelCase string.
-                          This field may not be empty.
-                        maxLength: 1024
-                        minLength: 1
-                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                        type: string
-                      status:
-                        description: status of the condition, one of True, False, Unknown.
-                        enum:
-                          - "True"
-                          - "False"
-                          - Unknown
-                        type: string
-                      type:
-                        description: |-
-                          type of condition in CamelCase or in foo.example.com/CamelCase.
-                          ---
-                          Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                          useful (see .node.status.conditions), the ability to deconflict is important.
-                          The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                        maxLength: 316
-                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      name:
+                        description: Name of the referent.
                         type: string
                     required:
-                      - lastTransitionTime
-                      - message
-                      - reason
-                      - status
-                      - type
-                    type: object
-                  type: array
-                lastHandledReconcileAt:
-                  description: |-
-                    LastHandledReconcileAt holds the value of the most recent
-                    reconcile request value, so a change of the annotation value
-                    can be detected.
-                  type: string
-                observedGeneration:
-                  description: ObservedGeneration is the last observed generation.
-                  format: int64
-                  type: integer
-                url:
-                  description: URL is the download link for the artifact output of the
-                    last Bucket sync.
-                  type: string
-              type: object
-          type: object
-      served: true
-      storage: false
-      subresources:
-        status: {}
-    - additionalPrinterColumns:
-        - jsonPath: .spec.endpoint
-          name: Endpoint
-          type: string
-        - jsonPath: .metadata.creationTimestamp
-          name: Age
-          type: date
-        - jsonPath: .status.conditions[?(@.type=="Ready")].status
-          name: Ready
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].message
-          name: Status
-          type: string
-      name: v1beta2
-      schema:
-        openAPIV3Schema:
-          description: Bucket is the Schema for the buckets API.
-          properties:
-            apiVersion:
-              description: |-
-                APIVersion defines the versioned schema of this representation of an object.
-                Servers should convert recognized schemas to the latest internal value, and
-                may reject unrecognized values.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-              type: string
-            kind:
-              description: |-
-                Kind is a string value representing the REST resource this object represents.
-                Servers may infer this from the endpoint the client submits requests to.
-                Cannot be updated.
-                In CamelCase.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: |-
-                BucketSpec specifies the required configuration to produce an Artifact for
-                an object storage bucket.
-              properties:
-                accessFrom:
-                  description: |-
-                    AccessFrom specifies an Access Control List for allowing cross-namespace
-                    references to this object.
-                    NOTE: Not implemented, provisional as of https://github.com/fluxcd/flux2/pull/2092
-                  properties:
-                    namespaceSelectors:
-                      description: |-
-                        NamespaceSelectors is the list of namespace selectors to which this ACL applies.
-                        Items in this list are evaluated using a logical OR operation.
-                      items:
-                        description: |-
-                          NamespaceSelector selects the namespaces to which this ACL applies.
-                          An empty map of MatchLabels matches all namespaces in a cluster.
-                        properties:
-                          matchLabels:
-                            additionalProperties:
-                              type: string
-                            description: |-
-                              MatchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                              map is equivalent to an element of matchExpressions, whose key field is "key", the
-                              operator is "In", and the values array contains only "value". The requirements are ANDed.
-                            type: object
-                        type: object
-                      type: array
-                  required:
-                    - namespaceSelectors
-                  type: object
-                bucketName:
-                  description: BucketName is the name of the object storage bucket.
-                  type: string
-                endpoint:
-                  description: Endpoint is the object storage address the BucketName
-                    is located at.
-                  type: string
-                ignore:
-                  description: |-
-                    Ignore overrides the set of excluded patterns in the .sourceignore format
-                    (which is the same as .gitignore). If not provided, a default will be used,
-                    consult the documentation for your version to find out what those are.
-                  type: string
-                insecure:
-                  description: Insecure allows connecting to a non-TLS HTTP Endpoint.
-                  type: boolean
-                interval:
-                  description: |-
-                    Interval at which the Bucket Endpoint is checked for updates.
-                    This interval is approximate and may be subject to jitter to ensure
-                    efficient use of resources.
-                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                  type: string
-                prefix:
-                  description: Prefix to use for server-side filtering of files in the
-                    Bucket.
-                  type: string
-                provider:
-                  default: generic
-                  description: |-
-                    Provider of the object storage bucket.
-                    Defaults to 'generic', which expects an S3 (API) compatible object
-                    storage.
-                  enum:
-                    - generic
-                    - aws
-                    - gcp
-                    - azure
-                  type: string
-                region:
-                  description: Region of the Endpoint where the BucketName is located
-                    in.
-                  type: string
-                secretRef:
-                  description: |-
-                    SecretRef specifies the Secret containing authentication credentials
-                    for the Bucket.
-                  properties:
-                    name:
-                      description: Name of the referent.
-                      type: string
-                  required:
                     - name
-                  type: object
-                suspend:
-                  description: |-
-                    Suspend tells the controller to suspend the reconciliation of this
-                    Bucket.
-                  type: boolean
-                timeout:
-                  default: 60s
-                  description: Timeout for fetch operations, defaults to 60s.
-                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
-                  type: string
-              required:
-                - bucketName
+                    type: object
+                  endpoint:
+                    description: |-
+                      Endpoint is the HTTP/S endpoint of the Security Token Service from
+                      where temporary credentials will be fetched.
+                    pattern: ^(http|https)://.*$
+                    type: string
+                  provider:
+                    description: Provider of the Security Token Service.
+                    enum:
+                    - aws
+                    - ldap
+                    type: string
+                  secretRef:
+                    description: |-
+                      SecretRef specifies the Secret containing authentication credentials
+                      for the STS endpoint. This Secret must contain the fields `username`
+                      and `password` and is supported only for the `ldap` provider.
+                    properties:
+                      name:
+                        description: Name of the referent.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                required:
                 - endpoint
-                - interval
-              type: object
-            status:
-              default:
-                observedGeneration: -1
-              description: BucketStatus records the observed state of a Bucket.
-              properties:
-                artifact:
-                  description: Artifact represents the last successful Bucket reconciliation.
-                  properties:
-                    digest:
-                      description: Digest is the digest of the file in the form of '<algorithm>:<checksum>'.
-                      pattern: ^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$
+                - provider
+                type: object
+              suspend:
+                description: |-
+                  Suspend tells the controller to suspend the reconciliation of this
+                  Bucket.
+                type: boolean
+              timeout:
+                default: 60s
+                description: Timeout for fetch operations, defaults to 60s.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
+                type: string
+            required:
+            - bucketName
+            - endpoint
+            - interval
+            type: object
+            x-kubernetes-validations:
+            - message: STS configuration is only supported for the 'aws' and 'generic'
+                Bucket providers
+              rule: self.provider == 'aws' || self.provider == 'generic' || !has(self.sts)
+            - message: '''aws'' is the only supported STS provider for the ''aws''
+                Bucket provider'
+              rule: self.provider != 'aws' || !has(self.sts) || self.sts.provider
+                == 'aws'
+            - message: '''ldap'' is the only supported STS provider for the ''generic''
+                Bucket provider'
+              rule: self.provider != 'generic' || !has(self.sts) || self.sts.provider
+                == 'ldap'
+            - message: spec.sts.secretRef is not required for the 'aws' STS provider
+              rule: '!has(self.sts) || self.sts.provider != ''aws'' || !has(self.sts.secretRef)'
+            - message: spec.sts.certSecretRef is not required for the 'aws' STS provider
+              rule: '!has(self.sts) || self.sts.provider != ''aws'' || !has(self.sts.certSecretRef)'
+          status:
+            default:
+              observedGeneration: -1
+            description: BucketStatus records the observed state of a Bucket.
+            properties:
+              artifact:
+                description: Artifact represents the last successful Bucket reconciliation.
+                properties:
+                  digest:
+                    description: Digest is the digest of the file in the form of '<algorithm>:<checksum>'.
+                    pattern: ^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$
+                    type: string
+                  lastUpdateTime:
+                    description: |-
+                      LastUpdateTime is the timestamp corresponding to the last update of the
+                      Artifact.
+                    format: date-time
+                    type: string
+                  metadata:
+                    additionalProperties:
                       type: string
-                    lastUpdateTime:
+                    description: Metadata holds upstream information such as OCI annotations.
+                    type: object
+                  path:
+                    description: |-
+                      Path is the relative file path of the Artifact. It can be used to locate
+                      the file in the root of the Artifact storage on the local file system of
+                      the controller managing the Source.
+                    type: string
+                  revision:
+                    description: |-
+                      Revision is a human-readable identifier traceable in the origin source
+                      system. It can be a Git commit SHA, Git tag, a Helm chart version, etc.
+                    type: string
+                  size:
+                    description: Size is the number of bytes in the file.
+                    format: int64
+                    type: integer
+                  url:
+                    description: |-
+                      URL is the HTTP address of the Artifact as exposed by the controller
+                      managing the Source. It can be used to retrieve the Artifact for
+                      consumption, e.g. by another controller applying the Artifact contents.
+                    type: string
+                required:
+                - lastUpdateTime
+                - path
+                - revision
+                - url
+                type: object
+              conditions:
+                description: Conditions holds the conditions for the Bucket.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
                       description: |-
-                        LastUpdateTime is the timestamp corresponding to the last update of the
-                        Artifact.
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
-                    metadata:
-                      additionalProperties:
-                        type: string
-                      description: Metadata holds upstream information such as OCI annotations.
-                      type: object
-                    path:
+                    message:
                       description: |-
-                        Path is the relative file path of the Artifact. It can be used to locate
-                        the file in the root of the Artifact storage on the local file system of
-                        the controller managing the Source.
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
                       type: string
-                    revision:
+                    observedGeneration:
                       description: |-
-                        Revision is a human-readable identifier traceable in the origin source
-                        system. It can be a Git commit SHA, Git tag, a Helm chart version, etc.
-                      type: string
-                    size:
-                      description: Size is the number of bytes in the file.
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
                       format: int64
+                      minimum: 0
                       type: integer
-                    url:
+                    reason:
                       description: |-
-                        URL is the HTTP address of the Artifact as exposed by the controller
-                        managing the Source. It can be used to retrieve the Artifact for
-                        consumption, e.g. by another controller applying the Artifact contents.
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
                   required:
-                    - lastUpdateTime
-                    - path
-                    - revision
-                    - url
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
                   type: object
-                conditions:
-                  description: Conditions holds the conditions for the Bucket.
-                  items:
-                    description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                type: array
+              lastHandledReconcileAt:
+                description: |-
+                  LastHandledReconcileAt holds the value of the most recent
+                  reconcile request value, so a change of the annotation value
+                  can be detected.
+                type: string
+              observedGeneration:
+                description: ObservedGeneration is the last observed generation of
+                  the Bucket object.
+                format: int64
+                type: integer
+              observedIgnore:
+                description: |-
+                  ObservedIgnore is the observed exclusion patterns used for constructing
+                  the source artifact.
+                type: string
+              url:
+                description: |-
+                  URL is the dynamic fetch link for the latest Artifact.
+                  It is provided on a "best effort" basis, and using the precise
+                  BucketStatus.Artifact data is recommended.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.endpoint
+      name: Endpoint
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    deprecated: true
+    deprecationWarning: v1beta1 Bucket is deprecated, upgrade to v1
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Bucket is the Schema for the buckets API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BucketSpec defines the desired state of an S3 compatible
+              bucket
+            properties:
+              accessFrom:
+                description: AccessFrom defines an Access Control List for allowing
+                  cross-namespace references to this object.
+                properties:
+                  namespaceSelectors:
+                    description: |-
+                      NamespaceSelectors is the list of namespace selectors to which this ACL applies.
+                      Items in this list are evaluated using a logical OR operation.
+                    items:
+                      description: |-
+                        NamespaceSelector selects the namespaces to which this ACL applies.
+                        An empty map of MatchLabels matches all namespaces in a cluster.
+                      properties:
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            MatchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                    type: array
+                required:
+                - namespaceSelectors
+                type: object
+              bucketName:
+                description: The bucket name.
+                type: string
+              endpoint:
+                description: The bucket endpoint address.
+                type: string
+              ignore:
+                description: |-
+                  Ignore overrides the set of excluded patterns in the .sourceignore format
+                  (which is the same as .gitignore). If not provided, a default will be used,
+                  consult the documentation for your version to find out what those are.
+                type: string
+              insecure:
+                description: Insecure allows connecting to a non-TLS S3 HTTP endpoint.
+                type: boolean
+              interval:
+                description: The interval at which to check for bucket updates.
+                type: string
+              provider:
+                default: generic
+                description: The S3 compatible storage provider name, default ('generic').
+                enum:
+                - generic
+                - aws
+                - gcp
+                type: string
+              region:
+                description: The bucket region.
+                type: string
+              secretRef:
+                description: |-
+                  The name of the secret containing authentication credentials
+                  for the Bucket.
+                properties:
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - name
+                type: object
+              suspend:
+                description: This flag tells the controller to suspend the reconciliation
+                  of this source.
+                type: boolean
+              timeout:
+                default: 60s
+                description: The timeout for download operations, defaults to 60s.
+                type: string
+            required:
+            - bucketName
+            - endpoint
+            - interval
+            type: object
+          status:
+            default:
+              observedGeneration: -1
+            description: BucketStatus defines the observed state of a bucket
+            properties:
+              artifact:
+                description: Artifact represents the output of the last successful
+                  Bucket sync.
+                properties:
+                  checksum:
+                    description: Checksum is the SHA256 checksum of the artifact.
+                    type: string
+                  lastUpdateTime:
+                    description: |-
+                      LastUpdateTime is the timestamp corresponding to the last update of this
+                      artifact.
+                    format: date-time
+                    type: string
+                  path:
+                    description: Path is the relative file path of this artifact.
+                    type: string
+                  revision:
+                    description: |-
+                      Revision is a human readable identifier traceable in the origin source
+                      system. It can be a Git commit SHA, Git tag, a Helm index timestamp, a Helm
+                      chart version, etc.
+                    type: string
+                  url:
+                    description: URL is the HTTP address of this artifact.
+                    type: string
+                required:
+                - lastUpdateTime
+                - path
+                - url
+                type: object
+              conditions:
+                description: Conditions holds the conditions for the Bucket.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              lastHandledReconcileAt:
+                description: |-
+                  LastHandledReconcileAt holds the value of the most recent
+                  reconcile request value, so a change of the annotation value
+                  can be detected.
+                type: string
+              observedGeneration:
+                description: ObservedGeneration is the last observed generation.
+                format: int64
+                type: integer
+              url:
+                description: URL is the download link for the artifact output of the
+                  last Bucket sync.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.endpoint
+      name: Endpoint
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      type: string
+    deprecated: true
+    deprecationWarning: v1beta2 Bucket is deprecated, upgrade to v1
+    name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: Bucket is the Schema for the buckets API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              BucketSpec specifies the required configuration to produce an Artifact for
+              an object storage bucket.
+            properties:
+              accessFrom:
+                description: |-
+                  AccessFrom specifies an Access Control List for allowing cross-namespace
+                  references to this object.
+                  NOTE: Not implemented, provisional as of https://github.com/fluxcd/flux2/pull/2092
+                properties:
+                  namespaceSelectors:
+                    description: |-
+                      NamespaceSelectors is the list of namespace selectors to which this ACL applies.
+                      Items in this list are evaluated using a logical OR operation.
+                    items:
+                      description: |-
+                        NamespaceSelector selects the namespaces to which this ACL applies.
+                        An empty map of MatchLabels matches all namespaces in a cluster.
+                      properties:
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            MatchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                    type: array
+                required:
+                - namespaceSelectors
+                type: object
+              bucketName:
+                description: BucketName is the name of the object storage bucket.
+                type: string
+              certSecretRef:
+                description: |-
+                  CertSecretRef can be given the name of a Secret containing
+                  either or both of
+
+                  - a PEM-encoded client certificate (`tls.crt`) and private
+                  key (`tls.key`);
+                  - a PEM-encoded CA certificate (`ca.crt`)
+
+                  and whichever are supplied, will be used for connecting to the
+                  bucket. The client cert and key are useful if you are
+                  authenticating with a certificate; the CA cert is useful if
+                  you are using a self-signed server certificate. The Secret must
+                  be of type `Opaque` or `kubernetes.io/tls`.
+
+                  This field is only supported for the `generic` provider.
+                properties:
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - name
+                type: object
+              endpoint:
+                description: Endpoint is the object storage address the BucketName
+                  is located at.
+                type: string
+              ignore:
+                description: |-
+                  Ignore overrides the set of excluded patterns in the .sourceignore format
+                  (which is the same as .gitignore). If not provided, a default will be used,
+                  consult the documentation for your version to find out what those are.
+                type: string
+              insecure:
+                description: Insecure allows connecting to a non-TLS HTTP Endpoint.
+                type: boolean
+              interval:
+                description: |-
+                  Interval at which the Bucket Endpoint is checked for updates.
+                  This interval is approximate and may be subject to jitter to ensure
+                  efficient use of resources.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                type: string
+              prefix:
+                description: Prefix to use for server-side filtering of files in the
+                  Bucket.
+                type: string
+              provider:
+                default: generic
+                description: |-
+                  Provider of the object storage bucket.
+                  Defaults to 'generic', which expects an S3 (API) compatible object
+                  storage.
+                enum:
+                - generic
+                - aws
+                - gcp
+                - azure
+                type: string
+              proxySecretRef:
+                description: |-
+                  ProxySecretRef specifies the Secret containing the proxy configuration
+                  to use while communicating with the Bucket server.
+                properties:
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - name
+                type: object
+              region:
+                description: Region of the Endpoint where the BucketName is located
+                  in.
+                type: string
+              secretRef:
+                description: |-
+                  SecretRef specifies the Secret containing authentication credentials
+                  for the Bucket.
+                properties:
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - name
+                type: object
+              sts:
+                description: |-
+                  STS specifies the required configuration to use a Security Token
+                  Service for fetching temporary credentials to authenticate in a
+                  Bucket provider.
+
+                  This field is only supported for the `aws` and `generic` providers.
+                properties:
+                  certSecretRef:
+                    description: |-
+                      CertSecretRef can be given the name of a Secret containing
+                      either or both of
+
+                      - a PEM-encoded client certificate (`tls.crt`) and private
+                      key (`tls.key`);
+                      - a PEM-encoded CA certificate (`ca.crt`)
+
+                      and whichever are supplied, will be used for connecting to the
+                      STS endpoint. The client cert and key are useful if you are
+                      authenticating with a certificate; the CA cert is useful if
+                      you are using a self-signed server certificate. The Secret must
+                      be of type `Opaque` or `kubernetes.io/tls`.
+
+                      This field is only supported for the `ldap` provider.
                     properties:
-                      lastTransitionTime:
-                        description: |-
-                          lastTransitionTime is the last time the condition transitioned from one status to another.
-                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                        format: date-time
-                        type: string
-                      message:
-                        description: |-
-                          message is a human readable message indicating details about the transition.
-                          This may be an empty string.
-                        maxLength: 32768
-                        type: string
-                      observedGeneration:
-                        description: |-
-                          observedGeneration represents the .metadata.generation that the condition was set based upon.
-                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                          with respect to the current state of the instance.
-                        format: int64
-                        minimum: 0
-                        type: integer
-                      reason:
-                        description: |-
-                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                          Producers of specific condition types may define expected values and meanings for this field,
-                          and whether the values are considered a guaranteed API.
-                          The value should be a CamelCase string.
-                          This field may not be empty.
-                        maxLength: 1024
-                        minLength: 1
-                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                        type: string
-                      status:
-                        description: status of the condition, one of True, False, Unknown.
-                        enum:
-                          - "True"
-                          - "False"
-                          - Unknown
-                        type: string
-                      type:
-                        description: |-
-                          type of condition in CamelCase or in foo.example.com/CamelCase.
-                          ---
-                          Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                          useful (see .node.status.conditions), the ability to deconflict is important.
-                          The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                        maxLength: 316
-                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      name:
+                        description: Name of the referent.
                         type: string
                     required:
-                      - lastTransitionTime
-                      - message
-                      - reason
-                      - status
-                      - type
+                    - name
                     type: object
-                  type: array
-                lastHandledReconcileAt:
-                  description: |-
-                    LastHandledReconcileAt holds the value of the most recent
-                    reconcile request value, so a change of the annotation value
-                    can be detected.
-                  type: string
-                observedGeneration:
-                  description: ObservedGeneration is the last observed generation of
-                    the Bucket object.
-                  format: int64
-                  type: integer
-                observedIgnore:
-                  description: |-
-                    ObservedIgnore is the observed exclusion patterns used for constructing
-                    the source artifact.
-                  type: string
-                url:
-                  description: |-
-                    URL is the dynamic fetch link for the latest Artifact.
-                    It is provided on a "best effort" basis, and using the precise
-                    BucketStatus.Artifact data is recommended.
-                  type: string
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                  endpoint:
+                    description: |-
+                      Endpoint is the HTTP/S endpoint of the Security Token Service from
+                      where temporary credentials will be fetched.
+                    pattern: ^(http|https)://.*$
+                    type: string
+                  provider:
+                    description: Provider of the Security Token Service.
+                    enum:
+                    - aws
+                    - ldap
+                    type: string
+                  secretRef:
+                    description: |-
+                      SecretRef specifies the Secret containing authentication credentials
+                      for the STS endpoint. This Secret must contain the fields `username`
+                      and `password` and is supported only for the `ldap` provider.
+                    properties:
+                      name:
+                        description: Name of the referent.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                required:
+                - endpoint
+                - provider
+                type: object
+              suspend:
+                description: |-
+                  Suspend tells the controller to suspend the reconciliation of this
+                  Bucket.
+                type: boolean
+              timeout:
+                default: 60s
+                description: Timeout for fetch operations, defaults to 60s.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
+                type: string
+            required:
+            - bucketName
+            - endpoint
+            - interval
+            type: object
+            x-kubernetes-validations:
+            - message: STS configuration is only supported for the 'aws' and 'generic'
+                Bucket providers
+              rule: self.provider == 'aws' || self.provider == 'generic' || !has(self.sts)
+            - message: '''aws'' is the only supported STS provider for the ''aws''
+                Bucket provider'
+              rule: self.provider != 'aws' || !has(self.sts) || self.sts.provider
+                == 'aws'
+            - message: '''ldap'' is the only supported STS provider for the ''generic''
+                Bucket provider'
+              rule: self.provider != 'generic' || !has(self.sts) || self.sts.provider
+                == 'ldap'
+            - message: spec.sts.secretRef is not required for the 'aws' STS provider
+              rule: '!has(self.sts) || self.sts.provider != ''aws'' || !has(self.sts.secretRef)'
+            - message: spec.sts.certSecretRef is not required for the 'aws' STS provider
+              rule: '!has(self.sts) || self.sts.provider != ''aws'' || !has(self.sts.certSecretRef)'
+          status:
+            default:
+              observedGeneration: -1
+            description: BucketStatus records the observed state of a Bucket.
+            properties:
+              artifact:
+                description: Artifact represents the last successful Bucket reconciliation.
+                properties:
+                  digest:
+                    description: Digest is the digest of the file in the form of '<algorithm>:<checksum>'.
+                    pattern: ^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$
+                    type: string
+                  lastUpdateTime:
+                    description: |-
+                      LastUpdateTime is the timestamp corresponding to the last update of the
+                      Artifact.
+                    format: date-time
+                    type: string
+                  metadata:
+                    additionalProperties:
+                      type: string
+                    description: Metadata holds upstream information such as OCI annotations.
+                    type: object
+                  path:
+                    description: |-
+                      Path is the relative file path of the Artifact. It can be used to locate
+                      the file in the root of the Artifact storage on the local file system of
+                      the controller managing the Source.
+                    type: string
+                  revision:
+                    description: |-
+                      Revision is a human-readable identifier traceable in the origin source
+                      system. It can be a Git commit SHA, Git tag, a Helm chart version, etc.
+                    type: string
+                  size:
+                    description: Size is the number of bytes in the file.
+                    format: int64
+                    type: integer
+                  url:
+                    description: |-
+                      URL is the HTTP address of the Artifact as exposed by the controller
+                      managing the Source. It can be used to retrieve the Artifact for
+                      consumption, e.g. by another controller applying the Artifact contents.
+                    type: string
+                required:
+                - lastUpdateTime
+                - path
+                - revision
+                - url
+                type: object
+              conditions:
+                description: Conditions holds the conditions for the Bucket.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              lastHandledReconcileAt:
+                description: |-
+                  LastHandledReconcileAt holds the value of the most recent
+                  reconcile request value, so a change of the annotation value
+                  can be detected.
+                type: string
+              observedGeneration:
+                description: ObservedGeneration is the last observed generation of
+                  the Bucket object.
+                format: int64
+                type: integer
+              observedIgnore:
+                description: |-
+                  ObservedIgnore is the observed exclusion patterns used for constructing
+                  the source artifact.
+                type: string
+              url:
+                description: |-
+                  URL is the dynamic fetch link for the latest Artifact.
+                  It is provided on a "best effort" basis, and using the precise
+                  BucketStatus.Artifact data is recommended.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}

--- a/tools/testcrds/source.toolkit.fluxcd.io_gitrepositories.yaml
+++ b/tools/testcrds/source.toolkit.fluxcd.io_gitrepositories.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.1
   name: gitrepositories.source.toolkit.fluxcd.io
 spec:
   group: source.toolkit.fluxcd.io
@@ -12,226 +12,338 @@ spec:
     listKind: GitRepositoryList
     plural: gitrepositories
     shortNames:
-      - gitrepo
+    - gitrepo
     singular: gitrepository
   scope: Namespaced
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .spec.url
-          name: URL
-          type: string
-        - jsonPath: .metadata.creationTimestamp
-          name: Age
-          type: date
-        - jsonPath: .status.conditions[?(@.type=="Ready")].status
-          name: Ready
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].message
-          name: Status
-          type: string
-      name: v1
-      schema:
-        openAPIV3Schema:
-          description: GitRepository is the Schema for the gitrepositories API.
-          properties:
-            apiVersion:
-              description: |-
-                APIVersion defines the versioned schema of this representation of an object.
-                Servers should convert recognized schemas to the latest internal value, and
-                may reject unrecognized values.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-              type: string
-            kind:
-              description: |-
-                Kind is a string value representing the REST resource this object represents.
-                Servers may infer this from the endpoint the client submits requests to.
-                Cannot be updated.
-                In CamelCase.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: |-
-                GitRepositorySpec specifies the required configuration to produce an
-                Artifact for a Git repository.
-              properties:
-                ignore:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.url
+      name: URL
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: GitRepository is the Schema for the gitrepositories API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              GitRepositorySpec specifies the required configuration to produce an
+              Artifact for a Git repository.
+            properties:
+              ignore:
+                description: |-
+                  Ignore overrides the set of excluded patterns in the .sourceignore format
+                  (which is the same as .gitignore). If not provided, a default will be used,
+                  consult the documentation for your version to find out what those are.
+                type: string
+              include:
+                description: |-
+                  Include specifies a list of GitRepository resources which Artifacts
+                  should be included in the Artifact produced for this GitRepository.
+                items:
                   description: |-
-                    Ignore overrides the set of excluded patterns in the .sourceignore format
-                    (which is the same as .gitignore). If not provided, a default will be used,
-                    consult the documentation for your version to find out what those are.
-                  type: string
-                include:
-                  description: |-
-                    Include specifies a list of GitRepository resources which Artifacts
-                    should be included in the Artifact produced for this GitRepository.
-                  items:
-                    description: |-
-                      GitRepositoryInclude specifies a local reference to a GitRepository which
-                      Artifact (sub-)contents must be included, and where they should be placed.
-                    properties:
-                      fromPath:
-                        description: |-
-                          FromPath specifies the path to copy contents from, defaults to the root
-                          of the Artifact.
-                        type: string
-                      repository:
-                        description: |-
-                          GitRepositoryRef specifies the GitRepository which Artifact contents
-                          must be included.
-                        properties:
-                          name:
-                            description: Name of the referent.
-                            type: string
-                        required:
-                          - name
-                        type: object
-                      toPath:
-                        description: |-
-                          ToPath specifies the path to copy contents to, defaults to the name of
-                          the GitRepositoryRef.
-                        type: string
-                    required:
-                      - repository
-                    type: object
-                  type: array
-                interval:
-                  description: |-
-                    Interval at which the GitRepository URL is checked for updates.
-                    This interval is approximate and may be subject to jitter to ensure
-                    efficient use of resources.
-                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                  type: string
-                proxySecretRef:
-                  description: |-
-                    ProxySecretRef specifies the Secret containing the proxy configuration
-                    to use while communicating with the Git server.
+                    GitRepositoryInclude specifies a local reference to a GitRepository which
+                    Artifact (sub-)contents must be included, and where they should be placed.
                   properties:
-                    name:
-                      description: Name of the referent.
-                      type: string
-                  required:
-                    - name
-                  type: object
-                recurseSubmodules:
-                  description: |-
-                    RecurseSubmodules enables the initialization of all submodules within
-                    the GitRepository as cloned from the URL, using their default settings.
-                  type: boolean
-                ref:
-                  description: |-
-                    Reference specifies the Git reference to resolve and monitor for
-                    changes, defaults to the 'master' branch.
-                  properties:
-                    branch:
-                      description: Branch to check out, defaults to 'master' if no other
-                        field is defined.
-                      type: string
-                    commit:
+                    fromPath:
                       description: |-
-                        Commit SHA to check out, takes precedence over all reference fields.
-                        
-                        
-                        This can be combined with Branch to shallow clone the branch, in which
-                        the commit is expected to exist.
+                        FromPath specifies the path to copy contents from, defaults to the root
+                        of the Artifact.
                       type: string
-                    name:
+                    repository:
                       description: |-
-                        Name of the reference to check out; takes precedence over Branch, Tag and SemVer.
-                        
-                        
-                        It must be a valid Git reference: https://git-scm.com/docs/git-check-ref-format#_description
-                        Examples: "refs/heads/main", "refs/tags/v0.1.0", "refs/pull/420/head", "refs/merge-requests/1/head"
-                      type: string
-                    semver:
-                      description: SemVer tag expression to check out, takes precedence
-                        over Tag.
-                      type: string
-                    tag:
-                      description: Tag to check out, takes precedence over Branch.
-                      type: string
-                  type: object
-                secretRef:
-                  description: |-
-                    SecretRef specifies the Secret containing authentication credentials for
-                    the GitRepository.
-                    For HTTPS repositories the Secret must contain 'username' and 'password'
-                    fields for basic auth or 'bearerToken' field for token auth.
-                    For SSH repositories the Secret must contain 'identity'
-                    and 'known_hosts' fields.
-                  properties:
-                    name:
-                      description: Name of the referent.
-                      type: string
-                  required:
-                    - name
-                  type: object
-                suspend:
-                  description: |-
-                    Suspend tells the controller to suspend the reconciliation of this
-                    GitRepository.
-                  type: boolean
-                timeout:
-                  default: 60s
-                  description: Timeout for Git operations like cloning, defaults to
-                    60s.
-                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
-                  type: string
-                url:
-                  description: URL specifies the Git repository URL, it can be an HTTP/S
-                    or SSH address.
-                  pattern: ^(http|https|ssh)://.*$
-                  type: string
-                verify:
-                  description: |-
-                    Verification specifies the configuration to verify the Git commit
-                    signature(s).
-                  properties:
-                    mode:
-                      default: HEAD
-                      description: |-
-                        Mode specifies which Git object(s) should be verified.
-                        
-                        
-                        The variants "head" and "HEAD" both imply the same thing, i.e. verify
-                        the commit that the HEAD of the Git repository points to. The variant
-                        "head" solely exists to ensure backwards compatibility.
-                      enum:
-                        - head
-                        - HEAD
-                        - Tag
-                        - TagAndHEAD
-                      type: string
-                    secretRef:
-                      description: |-
-                        SecretRef specifies the Secret containing the public keys of trusted Git
-                        authors.
+                        GitRepositoryRef specifies the GitRepository which Artifact contents
+                        must be included.
                       properties:
                         name:
                           description: Name of the referent.
                           type: string
                       required:
-                        - name
+                      - name
                       type: object
+                    toPath:
+                      description: |-
+                        ToPath specifies the path to copy contents to, defaults to the name of
+                        the GitRepositoryRef.
+                      type: string
                   required:
-                    - secretRef
+                  - repository
                   type: object
-              required:
-                - interval
+                type: array
+              interval:
+                description: |-
+                  Interval at which the GitRepository URL is checked for updates.
+                  This interval is approximate and may be subject to jitter to ensure
+                  efficient use of resources.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                type: string
+              provider:
+                description: |-
+                  Provider used for authentication, can be 'azure', 'generic'.
+                  When not specified, defaults to 'generic'.
+                enum:
+                - generic
+                - azure
+                type: string
+              proxySecretRef:
+                description: |-
+                  ProxySecretRef specifies the Secret containing the proxy configuration
+                  to use while communicating with the Git server.
+                properties:
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - name
+                type: object
+              recurseSubmodules:
+                description: |-
+                  RecurseSubmodules enables the initialization of all submodules within
+                  the GitRepository as cloned from the URL, using their default settings.
+                type: boolean
+              ref:
+                description: |-
+                  Reference specifies the Git reference to resolve and monitor for
+                  changes, defaults to the 'master' branch.
+                properties:
+                  branch:
+                    description: Branch to check out, defaults to 'master' if no other
+                      field is defined.
+                    type: string
+                  commit:
+                    description: |-
+                      Commit SHA to check out, takes precedence over all reference fields.
+
+                      This can be combined with Branch to shallow clone the branch, in which
+                      the commit is expected to exist.
+                    type: string
+                  name:
+                    description: |-
+                      Name of the reference to check out; takes precedence over Branch, Tag and SemVer.
+
+                      It must be a valid Git reference: https://git-scm.com/docs/git-check-ref-format#_description
+                      Examples: "refs/heads/main", "refs/tags/v0.1.0", "refs/pull/420/head", "refs/merge-requests/1/head"
+                    type: string
+                  semver:
+                    description: SemVer tag expression to check out, takes precedence
+                      over Tag.
+                    type: string
+                  tag:
+                    description: Tag to check out, takes precedence over Branch.
+                    type: string
+                type: object
+              secretRef:
+                description: |-
+                  SecretRef specifies the Secret containing authentication credentials for
+                  the GitRepository.
+                  For HTTPS repositories the Secret must contain 'username' and 'password'
+                  fields for basic auth or 'bearerToken' field for token auth.
+                  For SSH repositories the Secret must contain 'identity'
+                  and 'known_hosts' fields.
+                properties:
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - name
+                type: object
+              suspend:
+                description: |-
+                  Suspend tells the controller to suspend the reconciliation of this
+                  GitRepository.
+                type: boolean
+              timeout:
+                default: 60s
+                description: Timeout for Git operations like cloning, defaults to
+                  60s.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
+                type: string
+              url:
+                description: URL specifies the Git repository URL, it can be an HTTP/S
+                  or SSH address.
+                pattern: ^(http|https|ssh)://.*$
+                type: string
+              verify:
+                description: |-
+                  Verification specifies the configuration to verify the Git commit
+                  signature(s).
+                properties:
+                  mode:
+                    default: HEAD
+                    description: |-
+                      Mode specifies which Git object(s) should be verified.
+
+                      The variants "head" and "HEAD" both imply the same thing, i.e. verify
+                      the commit that the HEAD of the Git repository points to. The variant
+                      "head" solely exists to ensure backwards compatibility.
+                    enum:
+                    - head
+                    - HEAD
+                    - Tag
+                    - TagAndHEAD
+                    type: string
+                  secretRef:
+                    description: |-
+                      SecretRef specifies the Secret containing the public keys of trusted Git
+                      authors.
+                    properties:
+                      name:
+                        description: Name of the referent.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                required:
+                - secretRef
+                type: object
+            required:
+            - interval
+            - url
+            type: object
+          status:
+            default:
+              observedGeneration: -1
+            description: GitRepositoryStatus records the observed state of a Git repository.
+            properties:
+              artifact:
+                description: Artifact represents the last successful GitRepository
+                  reconciliation.
+                properties:
+                  digest:
+                    description: Digest is the digest of the file in the form of '<algorithm>:<checksum>'.
+                    pattern: ^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$
+                    type: string
+                  lastUpdateTime:
+                    description: |-
+                      LastUpdateTime is the timestamp corresponding to the last update of the
+                      Artifact.
+                    format: date-time
+                    type: string
+                  metadata:
+                    additionalProperties:
+                      type: string
+                    description: Metadata holds upstream information such as OCI annotations.
+                    type: object
+                  path:
+                    description: |-
+                      Path is the relative file path of the Artifact. It can be used to locate
+                      the file in the root of the Artifact storage on the local file system of
+                      the controller managing the Source.
+                    type: string
+                  revision:
+                    description: |-
+                      Revision is a human-readable identifier traceable in the origin source
+                      system. It can be a Git commit SHA, Git tag, a Helm chart version, etc.
+                    type: string
+                  size:
+                    description: Size is the number of bytes in the file.
+                    format: int64
+                    type: integer
+                  url:
+                    description: |-
+                      URL is the HTTP address of the Artifact as exposed by the controller
+                      managing the Source. It can be used to retrieve the Artifact for
+                      consumption, e.g. by another controller applying the Artifact contents.
+                    type: string
+                required:
+                - lastUpdateTime
+                - path
+                - revision
                 - url
-              type: object
-            status:
-              default:
-                observedGeneration: -1
-              description: GitRepositoryStatus records the observed state of a Git repository.
-              properties:
-                artifact:
-                  description: Artifact represents the last successful GitRepository
-                    reconciliation.
+                type: object
+              conditions:
+                description: Conditions holds the conditions for the GitRepository.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              includedArtifacts:
+                description: |-
+                  IncludedArtifacts contains a list of the last successfully included
+                  Artifacts as instructed by GitRepositorySpec.Include.
+                items:
+                  description: Artifact represents the output of a Source reconciliation.
                   properties:
                     digest:
-                      description: Digest is the digest of the file in the form of '<algorithm>:<checksum>'.
+                      description: Digest is the digest of the file in the form of
+                        '<algorithm>:<checksum>'.
                       pattern: ^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$
                       type: string
                     lastUpdateTime:
@@ -243,7 +355,8 @@ spec:
                     metadata:
                       additionalProperties:
                         type: string
-                      description: Metadata holds upstream information such as OCI annotations.
+                      description: Metadata holds upstream information such as OCI
+                        annotations.
                       type: object
                     path:
                       description: |-
@@ -267,399 +380,367 @@ spec:
                         consumption, e.g. by another controller applying the Artifact contents.
                       type: string
                   required:
-                    - lastUpdateTime
-                    - path
-                    - revision
-                    - url
+                  - lastUpdateTime
+                  - path
+                  - revision
+                  - url
                   type: object
-                conditions:
-                  description: Conditions holds the conditions for the GitRepository.
-                  items:
-                    description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
-                    properties:
-                      lastTransitionTime:
-                        description: |-
-                          lastTransitionTime is the last time the condition transitioned from one status to another.
-                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                        format: date-time
-                        type: string
-                      message:
-                        description: |-
-                          message is a human readable message indicating details about the transition.
-                          This may be an empty string.
-                        maxLength: 32768
-                        type: string
-                      observedGeneration:
-                        description: |-
-                          observedGeneration represents the .metadata.generation that the condition was set based upon.
-                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                          with respect to the current state of the instance.
-                        format: int64
-                        minimum: 0
-                        type: integer
-                      reason:
-                        description: |-
-                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                          Producers of specific condition types may define expected values and meanings for this field,
-                          and whether the values are considered a guaranteed API.
-                          The value should be a CamelCase string.
-                          This field may not be empty.
-                        maxLength: 1024
-                        minLength: 1
-                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                        type: string
-                      status:
-                        description: status of the condition, one of True, False, Unknown.
-                        enum:
-                          - "True"
-                          - "False"
-                          - Unknown
-                        type: string
-                      type:
-                        description: |-
-                          type of condition in CamelCase or in foo.example.com/CamelCase.
-                          ---
-                          Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                          useful (see .node.status.conditions), the ability to deconflict is important.
-                          The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                        maxLength: 316
-                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                        type: string
-                    required:
-                      - lastTransitionTime
-                      - message
-                      - reason
-                      - status
-                      - type
-                    type: object
-                  type: array
-                includedArtifacts:
+                type: array
+              lastHandledReconcileAt:
+                description: |-
+                  LastHandledReconcileAt holds the value of the most recent
+                  reconcile request value, so a change of the annotation value
+                  can be detected.
+                type: string
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the last observed generation of the GitRepository
+                  object.
+                format: int64
+                type: integer
+              observedIgnore:
+                description: |-
+                  ObservedIgnore is the observed exclusion patterns used for constructing
+                  the source artifact.
+                type: string
+              observedInclude:
+                description: |-
+                  ObservedInclude is the observed list of GitRepository resources used to
+                  produce the current Artifact.
+                items:
                   description: |-
-                    IncludedArtifacts contains a list of the last successfully included
-                    Artifacts as instructed by GitRepositorySpec.Include.
-                  items:
-                    description: Artifact represents the output of a Source reconciliation.
-                    properties:
-                      digest:
-                        description: Digest is the digest of the file in the form of
-                          '<algorithm>:<checksum>'.
-                        pattern: ^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$
-                        type: string
-                      lastUpdateTime:
-                        description: |-
-                          LastUpdateTime is the timestamp corresponding to the last update of the
-                          Artifact.
-                        format: date-time
-                        type: string
-                      metadata:
-                        additionalProperties:
-                          type: string
-                        description: Metadata holds upstream information such as OCI
-                          annotations.
-                        type: object
-                      path:
-                        description: |-
-                          Path is the relative file path of the Artifact. It can be used to locate
-                          the file in the root of the Artifact storage on the local file system of
-                          the controller managing the Source.
-                        type: string
-                      revision:
-                        description: |-
-                          Revision is a human-readable identifier traceable in the origin source
-                          system. It can be a Git commit SHA, Git tag, a Helm chart version, etc.
-                        type: string
-                      size:
-                        description: Size is the number of bytes in the file.
-                        format: int64
-                        type: integer
-                      url:
-                        description: |-
-                          URL is the HTTP address of the Artifact as exposed by the controller
-                          managing the Source. It can be used to retrieve the Artifact for
-                          consumption, e.g. by another controller applying the Artifact contents.
-                        type: string
-                    required:
-                      - lastUpdateTime
-                      - path
-                      - revision
-                      - url
-                    type: object
-                  type: array
-                lastHandledReconcileAt:
-                  description: |-
-                    LastHandledReconcileAt holds the value of the most recent
-                    reconcile request value, so a change of the annotation value
-                    can be detected.
-                  type: string
-                observedGeneration:
-                  description: |-
-                    ObservedGeneration is the last observed generation of the GitRepository
-                    object.
-                  format: int64
-                  type: integer
-                observedIgnore:
-                  description: |-
-                    ObservedIgnore is the observed exclusion patterns used for constructing
-                    the source artifact.
-                  type: string
-                observedInclude:
-                  description: |-
-                    ObservedInclude is the observed list of GitRepository resources used to
-                    produce the current Artifact.
-                  items:
-                    description: |-
-                      GitRepositoryInclude specifies a local reference to a GitRepository which
-                      Artifact (sub-)contents must be included, and where they should be placed.
-                    properties:
-                      fromPath:
-                        description: |-
-                          FromPath specifies the path to copy contents from, defaults to the root
-                          of the Artifact.
-                        type: string
-                      repository:
-                        description: |-
-                          GitRepositoryRef specifies the GitRepository which Artifact contents
-                          must be included.
-                        properties:
-                          name:
-                            description: Name of the referent.
-                            type: string
-                        required:
-                          - name
-                        type: object
-                      toPath:
-                        description: |-
-                          ToPath specifies the path to copy contents to, defaults to the name of
-                          the GitRepositoryRef.
-                        type: string
-                    required:
-                      - repository
-                    type: object
-                  type: array
-                observedRecurseSubmodules:
-                  description: |-
-                    ObservedRecurseSubmodules is the observed resource submodules
-                    configuration used to produce the current Artifact.
-                  type: boolean
-                sourceVerificationMode:
-                  description: |-
-                    SourceVerificationMode is the last used verification mode indicating
-                    which Git object(s) have been verified.
-                  type: string
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
-    - additionalPrinterColumns:
-        - jsonPath: .spec.url
-          name: URL
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].status
-          name: Ready
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].message
-          name: Status
-          type: string
-        - jsonPath: .metadata.creationTimestamp
-          name: Age
-          type: date
-      deprecated: true
-      deprecationWarning: v1beta1 GitRepository is deprecated, upgrade to v1
-      name: v1beta1
-      schema:
-        openAPIV3Schema:
-          description: GitRepository is the Schema for the gitrepositories API
-          properties:
-            apiVersion:
-              description: |-
-                APIVersion defines the versioned schema of this representation of an object.
-                Servers should convert recognized schemas to the latest internal value, and
-                may reject unrecognized values.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-              type: string
-            kind:
-              description: |-
-                Kind is a string value representing the REST resource this object represents.
-                Servers may infer this from the endpoint the client submits requests to.
-                Cannot be updated.
-                In CamelCase.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: GitRepositorySpec defines the desired state of a Git repository.
-              properties:
-                accessFrom:
-                  description: AccessFrom defines an Access Control List for allowing
-                    cross-namespace references to this object.
+                    GitRepositoryInclude specifies a local reference to a GitRepository which
+                    Artifact (sub-)contents must be included, and where they should be placed.
                   properties:
-                    namespaceSelectors:
+                    fromPath:
                       description: |-
-                        NamespaceSelectors is the list of namespace selectors to which this ACL applies.
-                        Items in this list are evaluated using a logical OR operation.
-                      items:
-                        description: |-
-                          NamespaceSelector selects the namespaces to which this ACL applies.
-                          An empty map of MatchLabels matches all namespaces in a cluster.
-                        properties:
-                          matchLabels:
-                            additionalProperties:
-                              type: string
-                            description: |-
-                              MatchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                              map is equivalent to an element of matchExpressions, whose key field is "key", the
-                              operator is "In", and the values array contains only "value". The requirements are ANDed.
-                            type: object
-                        type: object
-                      type: array
-                  required:
-                    - namespaceSelectors
-                  type: object
-                gitImplementation:
-                  default: go-git
-                  description: |-
-                    Determines which git client library to use.
-                    Defaults to go-git, valid values are ('go-git', 'libgit2').
-                  enum:
-                    - go-git
-                    - libgit2
-                  type: string
-                ignore:
-                  description: |-
-                    Ignore overrides the set of excluded patterns in the .sourceignore format
-                    (which is the same as .gitignore). If not provided, a default will be used,
-                    consult the documentation for your version to find out what those are.
-                  type: string
-                include:
-                  description: Extra git repositories to map into the repository
-                  items:
-                    description: GitRepositoryInclude defines a source with a from and
-                      to path.
-                    properties:
-                      fromPath:
-                        description: The path to copy contents from, defaults to the
-                          root directory.
-                        type: string
-                      repository:
-                        description: Reference to a GitRepository to include.
-                        properties:
-                          name:
-                            description: Name of the referent.
-                            type: string
-                        required:
-                          - name
-                        type: object
-                      toPath:
-                        description: The path to copy contents to, defaults to the name
-                          of the source ref.
-                        type: string
-                    required:
-                      - repository
-                    type: object
-                  type: array
-                interval:
-                  description: The interval at which to check for repository updates.
-                  type: string
-                recurseSubmodules:
-                  description: |-
-                    When enabled, after the clone is created, initializes all submodules within,
-                    using their default settings.
-                    This option is available only when using the 'go-git' GitImplementation.
-                  type: boolean
-                ref:
-                  description: |-
-                    The Git reference to checkout and monitor for changes, defaults to
-                    master branch.
-                  properties:
-                    branch:
-                      description: The Git branch to checkout, defaults to master.
+                        FromPath specifies the path to copy contents from, defaults to the root
+                        of the Artifact.
                       type: string
-                    commit:
-                      description: The Git commit SHA to checkout, if specified Tag
-                        filters will be ignored.
-                      type: string
-                    semver:
-                      description: The Git tag semver expression, takes precedence over
-                        Tag.
-                      type: string
-                    tag:
-                      description: The Git tag to checkout, takes precedence over Branch.
-                      type: string
-                  type: object
-                secretRef:
-                  description: |-
-                    The secret name containing the Git credentials.
-                    For HTTPS repositories the secret must contain username and password
-                    fields.
-                    For SSH repositories the secret must contain identity and known_hosts
-                    fields.
-                  properties:
-                    name:
-                      description: Name of the referent.
-                      type: string
-                  required:
-                    - name
-                  type: object
-                suspend:
-                  description: This flag tells the controller to suspend the reconciliation
-                    of this source.
-                  type: boolean
-                timeout:
-                  default: 60s
-                  description: The timeout for remote Git operations like cloning, defaults
-                    to 60s.
-                  type: string
-                url:
-                  description: The repository URL, can be a HTTP/S or SSH address.
-                  pattern: ^(http|https|ssh)://.*$
-                  type: string
-                verify:
-                  description: Verify OpenPGP signature for the Git commit HEAD points
-                    to.
-                  properties:
-                    mode:
-                      description: Mode describes what git object should be verified,
-                        currently ('head').
-                      enum:
-                        - head
-                      type: string
-                    secretRef:
-                      description: The secret name containing the public keys of all
-                        trusted Git authors.
+                    repository:
+                      description: |-
+                        GitRepositoryRef specifies the GitRepository which Artifact contents
+                        must be included.
                       properties:
                         name:
                           description: Name of the referent.
                           type: string
                       required:
-                        - name
+                      - name
                       type: object
+                    toPath:
+                      description: |-
+                        ToPath specifies the path to copy contents to, defaults to the name of
+                        the GitRepositoryRef.
+                      type: string
                   required:
-                    - mode
+                  - repository
                   type: object
-              required:
-                - interval
+                type: array
+              observedRecurseSubmodules:
+                description: |-
+                  ObservedRecurseSubmodules is the observed resource submodules
+                  configuration used to produce the current Artifact.
+                type: boolean
+              sourceVerificationMode:
+                description: |-
+                  SourceVerificationMode is the last used verification mode indicating
+                  which Git object(s) have been verified.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.url
+      name: URL
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    deprecated: true
+    deprecationWarning: v1beta1 GitRepository is deprecated, upgrade to v1
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: GitRepository is the Schema for the gitrepositories API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: GitRepositorySpec defines the desired state of a Git repository.
+            properties:
+              accessFrom:
+                description: AccessFrom defines an Access Control List for allowing
+                  cross-namespace references to this object.
+                properties:
+                  namespaceSelectors:
+                    description: |-
+                      NamespaceSelectors is the list of namespace selectors to which this ACL applies.
+                      Items in this list are evaluated using a logical OR operation.
+                    items:
+                      description: |-
+                        NamespaceSelector selects the namespaces to which this ACL applies.
+                        An empty map of MatchLabels matches all namespaces in a cluster.
+                      properties:
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            MatchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                    type: array
+                required:
+                - namespaceSelectors
+                type: object
+              gitImplementation:
+                default: go-git
+                description: |-
+                  Determines which git client library to use.
+                  Defaults to go-git, valid values are ('go-git', 'libgit2').
+                enum:
+                - go-git
+                - libgit2
+                type: string
+              ignore:
+                description: |-
+                  Ignore overrides the set of excluded patterns in the .sourceignore format
+                  (which is the same as .gitignore). If not provided, a default will be used,
+                  consult the documentation for your version to find out what those are.
+                type: string
+              include:
+                description: Extra git repositories to map into the repository
+                items:
+                  description: GitRepositoryInclude defines a source with a from and
+                    to path.
+                  properties:
+                    fromPath:
+                      description: The path to copy contents from, defaults to the
+                        root directory.
+                      type: string
+                    repository:
+                      description: Reference to a GitRepository to include.
+                      properties:
+                        name:
+                          description: Name of the referent.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    toPath:
+                      description: The path to copy contents to, defaults to the name
+                        of the source ref.
+                      type: string
+                  required:
+                  - repository
+                  type: object
+                type: array
+              interval:
+                description: The interval at which to check for repository updates.
+                type: string
+              recurseSubmodules:
+                description: |-
+                  When enabled, after the clone is created, initializes all submodules within,
+                  using their default settings.
+                  This option is available only when using the 'go-git' GitImplementation.
+                type: boolean
+              ref:
+                description: |-
+                  The Git reference to checkout and monitor for changes, defaults to
+                  master branch.
+                properties:
+                  branch:
+                    description: The Git branch to checkout, defaults to master.
+                    type: string
+                  commit:
+                    description: The Git commit SHA to checkout, if specified Tag
+                      filters will be ignored.
+                    type: string
+                  semver:
+                    description: The Git tag semver expression, takes precedence over
+                      Tag.
+                    type: string
+                  tag:
+                    description: The Git tag to checkout, takes precedence over Branch.
+                    type: string
+                type: object
+              secretRef:
+                description: |-
+                  The secret name containing the Git credentials.
+                  For HTTPS repositories the secret must contain username and password
+                  fields.
+                  For SSH repositories the secret must contain identity and known_hosts
+                  fields.
+                properties:
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - name
+                type: object
+              suspend:
+                description: This flag tells the controller to suspend the reconciliation
+                  of this source.
+                type: boolean
+              timeout:
+                default: 60s
+                description: The timeout for remote Git operations like cloning, defaults
+                  to 60s.
+                type: string
+              url:
+                description: The repository URL, can be a HTTP/S or SSH address.
+                pattern: ^(http|https|ssh)://.*$
+                type: string
+              verify:
+                description: Verify OpenPGP signature for the Git commit HEAD points
+                  to.
+                properties:
+                  mode:
+                    description: Mode describes what git object should be verified,
+                      currently ('head').
+                    enum:
+                    - head
+                    type: string
+                  secretRef:
+                    description: The secret name containing the public keys of all
+                      trusted Git authors.
+                    properties:
+                      name:
+                        description: Name of the referent.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                required:
+                - mode
+                type: object
+            required:
+            - interval
+            - url
+            type: object
+          status:
+            default:
+              observedGeneration: -1
+            description: GitRepositoryStatus defines the observed state of a Git repository.
+            properties:
+              artifact:
+                description: Artifact represents the output of the last successful
+                  repository sync.
+                properties:
+                  checksum:
+                    description: Checksum is the SHA256 checksum of the artifact.
+                    type: string
+                  lastUpdateTime:
+                    description: |-
+                      LastUpdateTime is the timestamp corresponding to the last update of this
+                      artifact.
+                    format: date-time
+                    type: string
+                  path:
+                    description: Path is the relative file path of this artifact.
+                    type: string
+                  revision:
+                    description: |-
+                      Revision is a human readable identifier traceable in the origin source
+                      system. It can be a Git commit SHA, Git tag, a Helm index timestamp, a Helm
+                      chart version, etc.
+                    type: string
+                  url:
+                    description: URL is the HTTP address of this artifact.
+                    type: string
+                required:
+                - lastUpdateTime
+                - path
                 - url
-              type: object
-            status:
-              default:
-                observedGeneration: -1
-              description: GitRepositoryStatus defines the observed state of a Git repository.
-              properties:
-                artifact:
-                  description: Artifact represents the output of the last successful
-                    repository sync.
+                type: object
+              conditions:
+                description: Conditions holds the conditions for the GitRepository.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              includedArtifacts:
+                description: IncludedArtifacts represents the included artifacts from
+                  the last successful repository sync.
+                items:
+                  description: Artifact represents the output of a source synchronisation.
                   properties:
                     checksum:
                       description: Checksum is the SHA256 checksum of the artifact.
@@ -683,367 +764,387 @@ spec:
                       description: URL is the HTTP address of this artifact.
                       type: string
                   required:
-                    - path
-                    - url
+                  - lastUpdateTime
+                  - path
+                  - url
                   type: object
-                conditions:
-                  description: Conditions holds the conditions for the GitRepository.
-                  items:
-                    description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
-                    properties:
-                      lastTransitionTime:
-                        description: |-
-                          lastTransitionTime is the last time the condition transitioned from one status to another.
-                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                        format: date-time
-                        type: string
-                      message:
-                        description: |-
-                          message is a human readable message indicating details about the transition.
-                          This may be an empty string.
-                        maxLength: 32768
-                        type: string
-                      observedGeneration:
-                        description: |-
-                          observedGeneration represents the .metadata.generation that the condition was set based upon.
-                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                          with respect to the current state of the instance.
-                        format: int64
-                        minimum: 0
-                        type: integer
-                      reason:
-                        description: |-
-                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                          Producers of specific condition types may define expected values and meanings for this field,
-                          and whether the values are considered a guaranteed API.
-                          The value should be a CamelCase string.
-                          This field may not be empty.
-                        maxLength: 1024
-                        minLength: 1
-                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                        type: string
-                      status:
-                        description: status of the condition, one of True, False, Unknown.
-                        enum:
-                          - "True"
-                          - "False"
-                          - Unknown
-                        type: string
-                      type:
-                        description: |-
-                          type of condition in CamelCase or in foo.example.com/CamelCase.
-                          ---
-                          Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                          useful (see .node.status.conditions), the ability to deconflict is important.
-                          The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                        maxLength: 316
-                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                        type: string
-                    required:
-                      - lastTransitionTime
-                      - message
-                      - reason
-                      - status
-                      - type
-                    type: object
-                  type: array
-                includedArtifacts:
-                  description: IncludedArtifacts represents the included artifacts from
-                    the last successful repository sync.
-                  items:
-                    description: Artifact represents the output of a source synchronisation.
-                    properties:
-                      checksum:
-                        description: Checksum is the SHA256 checksum of the artifact.
-                        type: string
-                      lastUpdateTime:
-                        description: |-
-                          LastUpdateTime is the timestamp corresponding to the last update of this
-                          artifact.
-                        format: date-time
-                        type: string
-                      path:
-                        description: Path is the relative file path of this artifact.
-                        type: string
-                      revision:
-                        description: |-
-                          Revision is a human readable identifier traceable in the origin source
-                          system. It can be a Git commit SHA, Git tag, a Helm index timestamp, a Helm
-                          chart version, etc.
-                        type: string
-                      url:
-                        description: URL is the HTTP address of this artifact.
-                        type: string
-                    required:
-                      - path
-                      - url
-                    type: object
-                  type: array
-                lastHandledReconcileAt:
-                  description: |-
-                    LastHandledReconcileAt holds the value of the most recent
-                    reconcile request value, so a change of the annotation value
-                    can be detected.
-                  type: string
-                observedGeneration:
-                  description: ObservedGeneration is the last observed generation.
-                  format: int64
-                  type: integer
-                url:
-                  description: |-
-                    URL is the download link for the artifact output of the last repository
-                    sync.
-                  type: string
-              type: object
-          type: object
-      served: true
-      storage: false
-      subresources:
-        status: {}
-    - additionalPrinterColumns:
-        - jsonPath: .spec.url
-          name: URL
-          type: string
-        - jsonPath: .metadata.creationTimestamp
-          name: Age
-          type: date
-        - jsonPath: .status.conditions[?(@.type=="Ready")].status
-          name: Ready
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].message
-          name: Status
-          type: string
-      deprecated: true
-      deprecationWarning: v1beta2 GitRepository is deprecated, upgrade to v1
-      name: v1beta2
-      schema:
-        openAPIV3Schema:
-          description: GitRepository is the Schema for the gitrepositories API.
-          properties:
-            apiVersion:
-              description: |-
-                APIVersion defines the versioned schema of this representation of an object.
-                Servers should convert recognized schemas to the latest internal value, and
-                may reject unrecognized values.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-              type: string
-            kind:
-              description: |-
-                Kind is a string value representing the REST resource this object represents.
-                Servers may infer this from the endpoint the client submits requests to.
-                Cannot be updated.
-                In CamelCase.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: |-
-                GitRepositorySpec specifies the required configuration to produce an
-                Artifact for a Git repository.
-              properties:
-                accessFrom:
-                  description: |-
-                    AccessFrom specifies an Access Control List for allowing cross-namespace
-                    references to this object.
-                    NOTE: Not implemented, provisional as of https://github.com/fluxcd/flux2/pull/2092
-                  properties:
-                    namespaceSelectors:
-                      description: |-
-                        NamespaceSelectors is the list of namespace selectors to which this ACL applies.
-                        Items in this list are evaluated using a logical OR operation.
-                      items:
-                        description: |-
-                          NamespaceSelector selects the namespaces to which this ACL applies.
-                          An empty map of MatchLabels matches all namespaces in a cluster.
-                        properties:
-                          matchLabels:
-                            additionalProperties:
-                              type: string
-                            description: |-
-                              MatchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                              map is equivalent to an element of matchExpressions, whose key field is "key", the
-                              operator is "In", and the values array contains only "value". The requirements are ANDed.
-                            type: object
-                        type: object
-                      type: array
-                  required:
-                    - namespaceSelectors
-                  type: object
-                gitImplementation:
-                  default: go-git
-                  description: |-
-                    GitImplementation specifies which Git client library implementation to
-                    use. Defaults to 'go-git', valid values are ('go-git', 'libgit2').
-                    Deprecated: gitImplementation is deprecated now that 'go-git' is the
-                    only supported implementation.
-                  enum:
-                    - go-git
-                    - libgit2
-                  type: string
-                ignore:
-                  description: |-
-                    Ignore overrides the set of excluded patterns in the .sourceignore format
-                    (which is the same as .gitignore). If not provided, a default will be used,
-                    consult the documentation for your version to find out what those are.
-                  type: string
-                include:
-                  description: |-
-                    Include specifies a list of GitRepository resources which Artifacts
-                    should be included in the Artifact produced for this GitRepository.
-                  items:
+                type: array
+              lastHandledReconcileAt:
+                description: |-
+                  LastHandledReconcileAt holds the value of the most recent
+                  reconcile request value, so a change of the annotation value
+                  can be detected.
+                type: string
+              observedGeneration:
+                description: ObservedGeneration is the last observed generation.
+                format: int64
+                type: integer
+              url:
+                description: |-
+                  URL is the download link for the artifact output of the last repository
+                  sync.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.url
+      name: URL
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      type: string
+    deprecated: true
+    deprecationWarning: v1beta2 GitRepository is deprecated, upgrade to v1
+    name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: GitRepository is the Schema for the gitrepositories API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              GitRepositorySpec specifies the required configuration to produce an
+              Artifact for a Git repository.
+            properties:
+              accessFrom:
+                description: |-
+                  AccessFrom specifies an Access Control List for allowing cross-namespace
+                  references to this object.
+                  NOTE: Not implemented, provisional as of https://github.com/fluxcd/flux2/pull/2092
+                properties:
+                  namespaceSelectors:
                     description: |-
-                      GitRepositoryInclude specifies a local reference to a GitRepository which
-                      Artifact (sub-)contents must be included, and where they should be placed.
-                    properties:
-                      fromPath:
-                        description: |-
-                          FromPath specifies the path to copy contents from, defaults to the root
-                          of the Artifact.
-                        type: string
-                      repository:
-                        description: |-
-                          GitRepositoryRef specifies the GitRepository which Artifact contents
-                          must be included.
-                        properties:
-                          name:
-                            description: Name of the referent.
+                      NamespaceSelectors is the list of namespace selectors to which this ACL applies.
+                      Items in this list are evaluated using a logical OR operation.
+                    items:
+                      description: |-
+                        NamespaceSelector selects the namespaces to which this ACL applies.
+                        An empty map of MatchLabels matches all namespaces in a cluster.
+                      properties:
+                        matchLabels:
+                          additionalProperties:
                             type: string
-                        required:
-                          - name
-                        type: object
-                      toPath:
-                        description: |-
-                          ToPath specifies the path to copy contents to, defaults to the name of
-                          the GitRepositoryRef.
-                        type: string
-                    required:
-                      - repository
-                    type: object
-                  type: array
-                interval:
-                  description: Interval at which to check the GitRepository for updates.
-                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                  type: string
-                recurseSubmodules:
+                          description: |-
+                            MatchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                    type: array
+                required:
+                - namespaceSelectors
+                type: object
+              gitImplementation:
+                default: go-git
+                description: |-
+                  GitImplementation specifies which Git client library implementation to
+                  use. Defaults to 'go-git', valid values are ('go-git', 'libgit2').
+                  Deprecated: gitImplementation is deprecated now that 'go-git' is the
+                  only supported implementation.
+                enum:
+                - go-git
+                - libgit2
+                type: string
+              ignore:
+                description: |-
+                  Ignore overrides the set of excluded patterns in the .sourceignore format
+                  (which is the same as .gitignore). If not provided, a default will be used,
+                  consult the documentation for your version to find out what those are.
+                type: string
+              include:
+                description: |-
+                  Include specifies a list of GitRepository resources which Artifacts
+                  should be included in the Artifact produced for this GitRepository.
+                items:
                   description: |-
-                    RecurseSubmodules enables the initialization of all submodules within
-                    the GitRepository as cloned from the URL, using their default settings.
-                  type: boolean
-                ref:
-                  description: |-
-                    Reference specifies the Git reference to resolve and monitor for
-                    changes, defaults to the 'master' branch.
+                    GitRepositoryInclude specifies a local reference to a GitRepository which
+                    Artifact (sub-)contents must be included, and where they should be placed.
                   properties:
-                    branch:
-                      description: Branch to check out, defaults to 'master' if no other
-                        field is defined.
-                      type: string
-                    commit:
+                    fromPath:
                       description: |-
-                        Commit SHA to check out, takes precedence over all reference fields.
-                        
-                        
-                        This can be combined with Branch to shallow clone the branch, in which
-                        the commit is expected to exist.
+                        FromPath specifies the path to copy contents from, defaults to the root
+                        of the Artifact.
                       type: string
-                    name:
+                    repository:
                       description: |-
-                        Name of the reference to check out; takes precedence over Branch, Tag and SemVer.
-                        
-                        
-                        It must be a valid Git reference: https://git-scm.com/docs/git-check-ref-format#_description
-                        Examples: "refs/heads/main", "refs/tags/v0.1.0", "refs/pull/420/head", "refs/merge-requests/1/head"
-                      type: string
-                    semver:
-                      description: SemVer tag expression to check out, takes precedence
-                        over Tag.
-                      type: string
-                    tag:
-                      description: Tag to check out, takes precedence over Branch.
-                      type: string
-                  type: object
-                secretRef:
-                  description: |-
-                    SecretRef specifies the Secret containing authentication credentials for
-                    the GitRepository.
-                    For HTTPS repositories the Secret must contain 'username' and 'password'
-                    fields for basic auth or 'bearerToken' field for token auth.
-                    For SSH repositories the Secret must contain 'identity'
-                    and 'known_hosts' fields.
-                  properties:
-                    name:
-                      description: Name of the referent.
-                      type: string
-                  required:
-                    - name
-                  type: object
-                suspend:
-                  description: |-
-                    Suspend tells the controller to suspend the reconciliation of this
-                    GitRepository.
-                  type: boolean
-                timeout:
-                  default: 60s
-                  description: Timeout for Git operations like cloning, defaults to
-                    60s.
-                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
-                  type: string
-                url:
-                  description: URL specifies the Git repository URL, it can be an HTTP/S
-                    or SSH address.
-                  pattern: ^(http|https|ssh)://.*$
-                  type: string
-                verify:
-                  description: |-
-                    Verification specifies the configuration to verify the Git commit
-                    signature(s).
-                  properties:
-                    mode:
-                      description: Mode specifies what Git object should be verified,
-                        currently ('head').
-                      enum:
-                        - head
-                      type: string
-                    secretRef:
-                      description: |-
-                        SecretRef specifies the Secret containing the public keys of trusted Git
-                        authors.
+                        GitRepositoryRef specifies the GitRepository which Artifact contents
+                        must be included.
                       properties:
                         name:
                           description: Name of the referent.
                           type: string
                       required:
-                        - name
+                      - name
                       type: object
+                    toPath:
+                      description: |-
+                        ToPath specifies the path to copy contents to, defaults to the name of
+                        the GitRepositoryRef.
+                      type: string
                   required:
-                    - mode
-                    - secretRef
+                  - repository
                   type: object
-              required:
-                - interval
+                type: array
+              interval:
+                description: Interval at which to check the GitRepository for updates.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                type: string
+              recurseSubmodules:
+                description: |-
+                  RecurseSubmodules enables the initialization of all submodules within
+                  the GitRepository as cloned from the URL, using their default settings.
+                type: boolean
+              ref:
+                description: |-
+                  Reference specifies the Git reference to resolve and monitor for
+                  changes, defaults to the 'master' branch.
+                properties:
+                  branch:
+                    description: Branch to check out, defaults to 'master' if no other
+                      field is defined.
+                    type: string
+                  commit:
+                    description: |-
+                      Commit SHA to check out, takes precedence over all reference fields.
+
+                      This can be combined with Branch to shallow clone the branch, in which
+                      the commit is expected to exist.
+                    type: string
+                  name:
+                    description: |-
+                      Name of the reference to check out; takes precedence over Branch, Tag and SemVer.
+
+                      It must be a valid Git reference: https://git-scm.com/docs/git-check-ref-format#_description
+                      Examples: "refs/heads/main", "refs/tags/v0.1.0", "refs/pull/420/head", "refs/merge-requests/1/head"
+                    type: string
+                  semver:
+                    description: SemVer tag expression to check out, takes precedence
+                      over Tag.
+                    type: string
+                  tag:
+                    description: Tag to check out, takes precedence over Branch.
+                    type: string
+                type: object
+              secretRef:
+                description: |-
+                  SecretRef specifies the Secret containing authentication credentials for
+                  the GitRepository.
+                  For HTTPS repositories the Secret must contain 'username' and 'password'
+                  fields for basic auth or 'bearerToken' field for token auth.
+                  For SSH repositories the Secret must contain 'identity'
+                  and 'known_hosts' fields.
+                properties:
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - name
+                type: object
+              suspend:
+                description: |-
+                  Suspend tells the controller to suspend the reconciliation of this
+                  GitRepository.
+                type: boolean
+              timeout:
+                default: 60s
+                description: Timeout for Git operations like cloning, defaults to
+                  60s.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
+                type: string
+              url:
+                description: URL specifies the Git repository URL, it can be an HTTP/S
+                  or SSH address.
+                pattern: ^(http|https|ssh)://.*$
+                type: string
+              verify:
+                description: |-
+                  Verification specifies the configuration to verify the Git commit
+                  signature(s).
+                properties:
+                  mode:
+                    description: Mode specifies what Git object should be verified,
+                      currently ('head').
+                    enum:
+                    - head
+                    type: string
+                  secretRef:
+                    description: |-
+                      SecretRef specifies the Secret containing the public keys of trusted Git
+                      authors.
+                    properties:
+                      name:
+                        description: Name of the referent.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                required:
+                - mode
+                - secretRef
+                type: object
+            required:
+            - interval
+            - url
+            type: object
+          status:
+            default:
+              observedGeneration: -1
+            description: GitRepositoryStatus records the observed state of a Git repository.
+            properties:
+              artifact:
+                description: Artifact represents the last successful GitRepository
+                  reconciliation.
+                properties:
+                  digest:
+                    description: Digest is the digest of the file in the form of '<algorithm>:<checksum>'.
+                    pattern: ^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$
+                    type: string
+                  lastUpdateTime:
+                    description: |-
+                      LastUpdateTime is the timestamp corresponding to the last update of the
+                      Artifact.
+                    format: date-time
+                    type: string
+                  metadata:
+                    additionalProperties:
+                      type: string
+                    description: Metadata holds upstream information such as OCI annotations.
+                    type: object
+                  path:
+                    description: |-
+                      Path is the relative file path of the Artifact. It can be used to locate
+                      the file in the root of the Artifact storage on the local file system of
+                      the controller managing the Source.
+                    type: string
+                  revision:
+                    description: |-
+                      Revision is a human-readable identifier traceable in the origin source
+                      system. It can be a Git commit SHA, Git tag, a Helm chart version, etc.
+                    type: string
+                  size:
+                    description: Size is the number of bytes in the file.
+                    format: int64
+                    type: integer
+                  url:
+                    description: |-
+                      URL is the HTTP address of the Artifact as exposed by the controller
+                      managing the Source. It can be used to retrieve the Artifact for
+                      consumption, e.g. by another controller applying the Artifact contents.
+                    type: string
+                required:
+                - lastUpdateTime
+                - path
+                - revision
                 - url
-              type: object
-            status:
-              default:
-                observedGeneration: -1
-              description: GitRepositoryStatus records the observed state of a Git repository.
-              properties:
-                artifact:
-                  description: Artifact represents the last successful GitRepository
-                    reconciliation.
+                type: object
+              conditions:
+                description: Conditions holds the conditions for the GitRepository.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              contentConfigChecksum:
+                description: |-
+                  ContentConfigChecksum is a checksum of all the configurations related to
+                  the content of the source artifact:
+                   - .spec.ignore
+                   - .spec.recurseSubmodules
+                   - .spec.included and the checksum of the included artifacts
+                  observed in .status.observedGeneration version of the object. This can
+                  be used to determine if the content of the included repository has
+                  changed.
+                  It has the format of `<algo>:<checksum>`, for example: `sha256:<checksum>`.
+
+                  Deprecated: Replaced with explicit fields for observed artifact content
+                  config in the status.
+                type: string
+              includedArtifacts:
+                description: |-
+                  IncludedArtifacts contains a list of the last successfully included
+                  Artifacts as instructed by GitRepositorySpec.Include.
+                items:
+                  description: Artifact represents the output of a Source reconciliation.
                   properties:
                     digest:
-                      description: Digest is the digest of the file in the form of '<algorithm>:<checksum>'.
+                      description: Digest is the digest of the file in the form of
+                        '<algorithm>:<checksum>'.
                       pattern: ^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$
                       type: string
                     lastUpdateTime:
@@ -1055,7 +1156,8 @@ spec:
                     metadata:
                       additionalProperties:
                         type: string
-                      description: Metadata holds upstream information such as OCI annotations.
+                      description: Metadata holds upstream information such as OCI
+                        annotations.
                       type: object
                     path:
                       description: |-
@@ -1079,214 +1181,77 @@ spec:
                         consumption, e.g. by another controller applying the Artifact contents.
                       type: string
                   required:
-                    - lastUpdateTime
-                    - path
-                    - revision
-                    - url
+                  - lastUpdateTime
+                  - path
+                  - revision
+                  - url
                   type: object
-                conditions:
-                  description: Conditions holds the conditions for the GitRepository.
-                  items:
-                    description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
-                    properties:
-                      lastTransitionTime:
-                        description: |-
-                          lastTransitionTime is the last time the condition transitioned from one status to another.
-                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                        format: date-time
-                        type: string
-                      message:
-                        description: |-
-                          message is a human readable message indicating details about the transition.
-                          This may be an empty string.
-                        maxLength: 32768
-                        type: string
-                      observedGeneration:
-                        description: |-
-                          observedGeneration represents the .metadata.generation that the condition was set based upon.
-                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                          with respect to the current state of the instance.
-                        format: int64
-                        minimum: 0
-                        type: integer
-                      reason:
-                        description: |-
-                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                          Producers of specific condition types may define expected values and meanings for this field,
-                          and whether the values are considered a guaranteed API.
-                          The value should be a CamelCase string.
-                          This field may not be empty.
-                        maxLength: 1024
-                        minLength: 1
-                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                        type: string
-                      status:
-                        description: status of the condition, one of True, False, Unknown.
-                        enum:
-                          - "True"
-                          - "False"
-                          - Unknown
-                        type: string
-                      type:
-                        description: |-
-                          type of condition in CamelCase or in foo.example.com/CamelCase.
-                          ---
-                          Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                          useful (see .node.status.conditions), the ability to deconflict is important.
-                          The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                        maxLength: 316
-                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                        type: string
-                    required:
-                      - lastTransitionTime
-                      - message
-                      - reason
-                      - status
-                      - type
-                    type: object
-                  type: array
-                contentConfigChecksum:
+                type: array
+              lastHandledReconcileAt:
+                description: |-
+                  LastHandledReconcileAt holds the value of the most recent
+                  reconcile request value, so a change of the annotation value
+                  can be detected.
+                type: string
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the last observed generation of the GitRepository
+                  object.
+                format: int64
+                type: integer
+              observedIgnore:
+                description: |-
+                  ObservedIgnore is the observed exclusion patterns used for constructing
+                  the source artifact.
+                type: string
+              observedInclude:
+                description: |-
+                  ObservedInclude is the observed list of GitRepository resources used to
+                  to produce the current Artifact.
+                items:
                   description: |-
-                    ContentConfigChecksum is a checksum of all the configurations related to
-                    the content of the source artifact:
-                     - .spec.ignore
-                     - .spec.recurseSubmodules
-                     - .spec.included and the checksum of the included artifacts
-                    observed in .status.observedGeneration version of the object. This can
-                    be used to determine if the content of the included repository has
-                    changed.
-                    It has the format of `<algo>:<checksum>`, for example: `sha256:<checksum>`.
-                    
-                    
-                    Deprecated: Replaced with explicit fields for observed artifact content
-                    config in the status.
-                  type: string
-                includedArtifacts:
-                  description: |-
-                    IncludedArtifacts contains a list of the last successfully included
-                    Artifacts as instructed by GitRepositorySpec.Include.
-                  items:
-                    description: Artifact represents the output of a Source reconciliation.
-                    properties:
-                      digest:
-                        description: Digest is the digest of the file in the form of
-                          '<algorithm>:<checksum>'.
-                        pattern: ^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$
-                        type: string
-                      lastUpdateTime:
-                        description: |-
-                          LastUpdateTime is the timestamp corresponding to the last update of the
-                          Artifact.
-                        format: date-time
-                        type: string
-                      metadata:
-                        additionalProperties:
+                    GitRepositoryInclude specifies a local reference to a GitRepository which
+                    Artifact (sub-)contents must be included, and where they should be placed.
+                  properties:
+                    fromPath:
+                      description: |-
+                        FromPath specifies the path to copy contents from, defaults to the root
+                        of the Artifact.
+                      type: string
+                    repository:
+                      description: |-
+                        GitRepositoryRef specifies the GitRepository which Artifact contents
+                        must be included.
+                      properties:
+                        name:
+                          description: Name of the referent.
                           type: string
-                        description: Metadata holds upstream information such as OCI
-                          annotations.
-                        type: object
-                      path:
-                        description: |-
-                          Path is the relative file path of the Artifact. It can be used to locate
-                          the file in the root of the Artifact storage on the local file system of
-                          the controller managing the Source.
-                        type: string
-                      revision:
-                        description: |-
-                          Revision is a human-readable identifier traceable in the origin source
-                          system. It can be a Git commit SHA, Git tag, a Helm chart version, etc.
-                        type: string
-                      size:
-                        description: Size is the number of bytes in the file.
-                        format: int64
-                        type: integer
-                      url:
-                        description: |-
-                          URL is the HTTP address of the Artifact as exposed by the controller
-                          managing the Source. It can be used to retrieve the Artifact for
-                          consumption, e.g. by another controller applying the Artifact contents.
-                        type: string
-                    required:
-                      - lastUpdateTime
-                      - path
-                      - revision
-                      - url
-                    type: object
-                  type: array
-                lastHandledReconcileAt:
-                  description: |-
-                    LastHandledReconcileAt holds the value of the most recent
-                    reconcile request value, so a change of the annotation value
-                    can be detected.
-                  type: string
-                observedGeneration:
-                  description: |-
-                    ObservedGeneration is the last observed generation of the GitRepository
-                    object.
-                  format: int64
-                  type: integer
-                observedIgnore:
-                  description: |-
-                    ObservedIgnore is the observed exclusion patterns used for constructing
-                    the source artifact.
-                  type: string
-                observedInclude:
-                  description: |-
-                    ObservedInclude is the observed list of GitRepository resources used to
-                    to produce the current Artifact.
-                  items:
-                    description: |-
-                      GitRepositoryInclude specifies a local reference to a GitRepository which
-                      Artifact (sub-)contents must be included, and where they should be placed.
-                    properties:
-                      fromPath:
-                        description: |-
-                          FromPath specifies the path to copy contents from, defaults to the root
-                          of the Artifact.
-                        type: string
-                      repository:
-                        description: |-
-                          GitRepositoryRef specifies the GitRepository which Artifact contents
-                          must be included.
-                        properties:
-                          name:
-                            description: Name of the referent.
-                            type: string
-                        required:
-                          - name
-                        type: object
-                      toPath:
-                        description: |-
-                          ToPath specifies the path to copy contents to, defaults to the name of
-                          the GitRepositoryRef.
-                        type: string
-                    required:
-                      - repository
-                    type: object
-                  type: array
-                observedRecurseSubmodules:
-                  description: |-
-                    ObservedRecurseSubmodules is the observed resource submodules
-                    configuration used to produce the current Artifact.
-                  type: boolean
-                url:
-                  description: |-
-                    URL is the dynamic fetch link for the latest Artifact.
-                    It is provided on a "best effort" basis, and using the precise
-                    GitRepositoryStatus.Artifact data is recommended.
-                  type: string
-              type: object
-          type: object
-      served: true
-      storage: false
-      subresources:
-        status: {}
+                      required:
+                      - name
+                      type: object
+                    toPath:
+                      description: |-
+                        ToPath specifies the path to copy contents to, defaults to the name of
+                        the GitRepositoryRef.
+                      type: string
+                  required:
+                  - repository
+                  type: object
+                type: array
+              observedRecurseSubmodules:
+                description: |-
+                  ObservedRecurseSubmodules is the observed resource submodules
+                  configuration used to produce the current Artifact.
+                type: boolean
+              url:
+                description: |-
+                  URL is the dynamic fetch link for the latest Artifact.
+                  It is provided on a "best effort" basis, and using the precise
+                  GitRepositoryStatus.Artifact data is recommended.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}

--- a/tools/testcrds/source.toolkit.fluxcd.io_helmcharts.yaml
+++ b/tools/testcrds/source.toolkit.fluxcd.io_helmcharts.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.1
   name: helmcharts.source.toolkit.fluxcd.io
 spec:
   group: source.toolkit.fluxcd.io
@@ -12,1003 +12,965 @@ spec:
     listKind: HelmChartList
     plural: helmcharts
     shortNames:
-      - hc
+    - hc
     singular: helmchart
   scope: Namespaced
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .spec.chart
-          name: Chart
-          type: string
-        - jsonPath: .spec.version
-          name: Version
-          type: string
-        - jsonPath: .spec.sourceRef.kind
-          name: Source Kind
-          type: string
-        - jsonPath: .spec.sourceRef.name
-          name: Source Name
-          type: string
-        - jsonPath: .metadata.creationTimestamp
-          name: Age
-          type: date
-        - jsonPath: .status.conditions[?(@.type=="Ready")].status
-          name: Ready
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].message
-          name: Status
-          type: string
-      name: v1
-      schema:
-        openAPIV3Schema:
-          description: HelmChart is the Schema for the helmcharts API.
-          properties:
-            apiVersion:
-              description: |-
-                APIVersion defines the versioned schema of this representation of an object.
-                Servers should convert recognized schemas to the latest internal value, and
-                may reject unrecognized values.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-              type: string
-            kind:
-              description: |-
-                Kind is a string value representing the REST resource this object represents.
-                Servers may infer this from the endpoint the client submits requests to.
-                Cannot be updated.
-                In CamelCase.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: HelmChartSpec specifies the desired state of a Helm chart.
-              properties:
-                chart:
-                  description: |-
-                    Chart is the name or path the Helm chart is available at in the
-                    SourceRef.
-                  type: string
-                ignoreMissingValuesFiles:
-                  description: |-
-                    IgnoreMissingValuesFiles controls whether to silently ignore missing values
-                    files rather than failing.
-                  type: boolean
-                interval:
-                  description: |-
-                    Interval at which the HelmChart SourceRef is checked for updates.
-                    This interval is approximate and may be subject to jitter to ensure
-                    efficient use of resources.
-                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                  type: string
-                reconcileStrategy:
-                  default: ChartVersion
-                  description: |-
-                    ReconcileStrategy determines what enables the creation of a new artifact.
-                    Valid values are ('ChartVersion', 'Revision').
-                    See the documentation of the values for an explanation on their behavior.
-                    Defaults to ChartVersion when omitted.
-                  enum:
-                    - ChartVersion
-                    - Revision
-                  type: string
-                sourceRef:
-                  description: SourceRef is the reference to the Source the chart is
-                    available at.
-                  properties:
-                    apiVersion:
-                      description: APIVersion of the referent.
-                      type: string
-                    kind:
-                      description: |-
-                        Kind of the referent, valid values are ('HelmRepository', 'GitRepository',
-                        'Bucket').
-                      enum:
-                        - HelmRepository
-                        - GitRepository
-                        - Bucket
-                      type: string
-                    name:
-                      description: Name of the referent.
-                      type: string
-                  required:
-                    - kind
-                    - name
-                  type: object
-                suspend:
-                  description: |-
-                    Suspend tells the controller to suspend the reconciliation of this
-                    source.
-                  type: boolean
-                valuesFiles:
-                  description: |-
-                    ValuesFiles is an alternative list of values files to use as the chart
-                    values (values.yaml is not included by default), expected to be a
-                    relative path in the SourceRef.
-                    Values files are merged in the order of this list with the last file
-                    overriding the first. Ignored when omitted.
-                  items:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.chart
+      name: Chart
+      type: string
+    - jsonPath: .spec.version
+      name: Version
+      type: string
+    - jsonPath: .spec.sourceRef.kind
+      name: Source Kind
+      type: string
+    - jsonPath: .spec.sourceRef.name
+      name: Source Name
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: HelmChart is the Schema for the helmcharts API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: HelmChartSpec specifies the desired state of a Helm chart.
+            properties:
+              chart:
+                description: |-
+                  Chart is the name or path the Helm chart is available at in the
+                  SourceRef.
+                type: string
+              ignoreMissingValuesFiles:
+                description: |-
+                  IgnoreMissingValuesFiles controls whether to silently ignore missing values
+                  files rather than failing.
+                type: boolean
+              interval:
+                description: |-
+                  Interval at which the HelmChart SourceRef is checked for updates.
+                  This interval is approximate and may be subject to jitter to ensure
+                  efficient use of resources.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                type: string
+              reconcileStrategy:
+                default: ChartVersion
+                description: |-
+                  ReconcileStrategy determines what enables the creation of a new artifact.
+                  Valid values are ('ChartVersion', 'Revision').
+                  See the documentation of the values for an explanation on their behavior.
+                  Defaults to ChartVersion when omitted.
+                enum:
+                - ChartVersion
+                - Revision
+                type: string
+              sourceRef:
+                description: SourceRef is the reference to the Source the chart is
+                  available at.
+                properties:
+                  apiVersion:
+                    description: APIVersion of the referent.
                     type: string
-                  type: array
-                verify:
-                  description: |-
-                    Verify contains the secret name containing the trusted public keys
-                    used to verify the signature and specifies which provider to use to check
-                    whether OCI image is authentic.
-                    This field is only supported when using HelmRepository source with spec.type 'oci'.
-                    Chart dependencies, which are not bundled in the umbrella chart artifact, are not verified.
-                  properties:
-                    matchOIDCIdentity:
+                  kind:
+                    description: |-
+                      Kind of the referent, valid values are ('HelmRepository', 'GitRepository',
+                      'Bucket').
+                    enum:
+                    - HelmRepository
+                    - GitRepository
+                    - Bucket
+                    type: string
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              suspend:
+                description: |-
+                  Suspend tells the controller to suspend the reconciliation of this
+                  source.
+                type: boolean
+              valuesFiles:
+                description: |-
+                  ValuesFiles is an alternative list of values files to use as the chart
+                  values (values.yaml is not included by default), expected to be a
+                  relative path in the SourceRef.
+                  Values files are merged in the order of this list with the last file
+                  overriding the first. Ignored when omitted.
+                items:
+                  type: string
+                type: array
+              verify:
+                description: |-
+                  Verify contains the secret name containing the trusted public keys
+                  used to verify the signature and specifies which provider to use to check
+                  whether OCI image is authentic.
+                  This field is only supported when using HelmRepository source with spec.type 'oci'.
+                  Chart dependencies, which are not bundled in the umbrella chart artifact, are not verified.
+                properties:
+                  matchOIDCIdentity:
+                    description: |-
+                      MatchOIDCIdentity specifies the identity matching criteria to use
+                      while verifying an OCI artifact which was signed using Cosign keyless
+                      signing. The artifact's identity is deemed to be verified if any of the
+                      specified matchers match against the identity.
+                    items:
                       description: |-
-                        MatchOIDCIdentity specifies the identity matching criteria to use
-                        while verifying an OCI artifact which was signed using Cosign keyless
-                        signing. The artifact's identity is deemed to be verified if any of the
-                        specified matchers match against the identity.
-                      items:
-                        description: |-
-                          OIDCIdentityMatch specifies options for verifying the certificate identity,
-                          i.e. the issuer and the subject of the certificate.
-                        properties:
-                          issuer:
-                            description: |-
-                              Issuer specifies the regex pattern to match against to verify
-                              the OIDC issuer in the Fulcio certificate. The pattern must be a
-                              valid Go regular expression.
-                            type: string
-                          subject:
-                            description: |-
-                              Subject specifies the regex pattern to match against to verify
-                              the identity subject in the Fulcio certificate. The pattern must
-                              be a valid Go regular expression.
-                            type: string
-                        required:
-                          - issuer
-                          - subject
-                        type: object
-                      type: array
-                    provider:
-                      default: cosign
-                      description: Provider specifies the technology used to sign the
-                        OCI Artifact.
-                      enum:
-                        - cosign
-                        - notation
-                      type: string
-                    secretRef:
-                      description: |-
-                        SecretRef specifies the Kubernetes Secret containing the
-                        trusted public keys.
+                        OIDCIdentityMatch specifies options for verifying the certificate identity,
+                        i.e. the issuer and the subject of the certificate.
                       properties:
-                        name:
-                          description: Name of the referent.
+                        issuer:
+                          description: |-
+                            Issuer specifies the regex pattern to match against to verify
+                            the OIDC issuer in the Fulcio certificate. The pattern must be a
+                            valid Go regular expression.
+                          type: string
+                        subject:
+                          description: |-
+                            Subject specifies the regex pattern to match against to verify
+                            the identity subject in the Fulcio certificate. The pattern must
+                            be a valid Go regular expression.
                           type: string
                       required:
-                        - name
+                      - issuer
+                      - subject
                       type: object
-                  required:
-                    - provider
-                  type: object
-                version:
-                  default: '*'
-                  description: |-
-                    Version is the chart version semver expression, ignored for charts from
-                    GitRepository and Bucket sources. Defaults to latest when omitted.
-                  type: string
-              required:
-                - chart
-                - interval
-                - sourceRef
-              type: object
-            status:
-              default:
-                observedGeneration: -1
-              description: HelmChartStatus records the observed state of the HelmChart.
-              properties:
-                artifact:
-                  description: Artifact represents the output of the last successful
-                    reconciliation.
-                  properties:
-                    digest:
-                      description: Digest is the digest of the file in the form of '<algorithm>:<checksum>'.
-                      pattern: ^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$
+                    type: array
+                  provider:
+                    default: cosign
+                    description: Provider specifies the technology used to sign the
+                      OCI Artifact.
+                    enum:
+                    - cosign
+                    - notation
+                    type: string
+                  secretRef:
+                    description: |-
+                      SecretRef specifies the Kubernetes Secret containing the
+                      trusted public keys.
+                    properties:
+                      name:
+                        description: Name of the referent.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                required:
+                - provider
+                type: object
+              version:
+                default: '*'
+                description: |-
+                  Version is the chart version semver expression, ignored for charts from
+                  GitRepository and Bucket sources. Defaults to latest when omitted.
+                type: string
+            required:
+            - chart
+            - interval
+            - sourceRef
+            type: object
+          status:
+            default:
+              observedGeneration: -1
+            description: HelmChartStatus records the observed state of the HelmChart.
+            properties:
+              artifact:
+                description: Artifact represents the output of the last successful
+                  reconciliation.
+                properties:
+                  digest:
+                    description: Digest is the digest of the file in the form of '<algorithm>:<checksum>'.
+                    pattern: ^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$
+                    type: string
+                  lastUpdateTime:
+                    description: |-
+                      LastUpdateTime is the timestamp corresponding to the last update of the
+                      Artifact.
+                    format: date-time
+                    type: string
+                  metadata:
+                    additionalProperties:
                       type: string
-                    lastUpdateTime:
+                    description: Metadata holds upstream information such as OCI annotations.
+                    type: object
+                  path:
+                    description: |-
+                      Path is the relative file path of the Artifact. It can be used to locate
+                      the file in the root of the Artifact storage on the local file system of
+                      the controller managing the Source.
+                    type: string
+                  revision:
+                    description: |-
+                      Revision is a human-readable identifier traceable in the origin source
+                      system. It can be a Git commit SHA, Git tag, a Helm chart version, etc.
+                    type: string
+                  size:
+                    description: Size is the number of bytes in the file.
+                    format: int64
+                    type: integer
+                  url:
+                    description: |-
+                      URL is the HTTP address of the Artifact as exposed by the controller
+                      managing the Source. It can be used to retrieve the Artifact for
+                      consumption, e.g. by another controller applying the Artifact contents.
+                    type: string
+                required:
+                - lastUpdateTime
+                - path
+                - revision
+                - url
+                type: object
+              conditions:
+                description: Conditions holds the conditions for the HelmChart.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
                       description: |-
-                        LastUpdateTime is the timestamp corresponding to the last update of the
-                        Artifact.
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
-                    metadata:
-                      additionalProperties:
-                        type: string
-                      description: Metadata holds upstream information such as OCI annotations.
-                      type: object
-                    path:
+                    message:
                       description: |-
-                        Path is the relative file path of the Artifact. It can be used to locate
-                        the file in the root of the Artifact storage on the local file system of
-                        the controller managing the Source.
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
                       type: string
-                    revision:
+                    observedGeneration:
                       description: |-
-                        Revision is a human-readable identifier traceable in the origin source
-                        system. It can be a Git commit SHA, Git tag, a Helm chart version, etc.
-                      type: string
-                    size:
-                      description: Size is the number of bytes in the file.
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
                       format: int64
+                      minimum: 0
                       type: integer
-                    url:
+                    reason:
                       description: |-
-                        URL is the HTTP address of the Artifact as exposed by the controller
-                        managing the Source. It can be used to retrieve the Artifact for
-                        consumption, e.g. by another controller applying the Artifact contents.
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
                       type: string
-                  required:
-                    - lastUpdateTime
-                    - path
-                    - revision
-                    - url
-                  type: object
-                conditions:
-                  description: Conditions holds the conditions for the HelmChart.
-                  items:
-                    description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
-                    properties:
-                      lastTransitionTime:
-                        description: |-
-                          lastTransitionTime is the last time the condition transitioned from one status to another.
-                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                        format: date-time
-                        type: string
-                      message:
-                        description: |-
-                          message is a human readable message indicating details about the transition.
-                          This may be an empty string.
-                        maxLength: 32768
-                        type: string
-                      observedGeneration:
-                        description: |-
-                          observedGeneration represents the .metadata.generation that the condition was set based upon.
-                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                          with respect to the current state of the instance.
-                        format: int64
-                        minimum: 0
-                        type: integer
-                      reason:
-                        description: |-
-                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                          Producers of specific condition types may define expected values and meanings for this field,
-                          and whether the values are considered a guaranteed API.
-                          The value should be a CamelCase string.
-                          This field may not be empty.
-                        maxLength: 1024
-                        minLength: 1
-                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                        type: string
-                      status:
-                        description: status of the condition, one of True, False, Unknown.
-                        enum:
-                          - "True"
-                          - "False"
-                          - Unknown
-                        type: string
-                      type:
-                        description: |-
-                          type of condition in CamelCase or in foo.example.com/CamelCase.
-                          ---
-                          Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                          useful (see .node.status.conditions), the ability to deconflict is important.
-                          The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                        maxLength: 316
-                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                        type: string
-                    required:
-                      - lastTransitionTime
-                      - message
-                      - reason
-                      - status
-                      - type
-                    type: object
-                  type: array
-                lastHandledReconcileAt:
-                  description: |-
-                    LastHandledReconcileAt holds the value of the most recent
-                    reconcile request value, so a change of the annotation value
-                    can be detected.
-                  type: string
-                observedChartName:
-                  description: |-
-                    ObservedChartName is the last observed chart name as specified by the
-                    resolved chart reference.
-                  type: string
-                observedGeneration:
-                  description: |-
-                    ObservedGeneration is the last observed generation of the HelmChart
-                    object.
-                  format: int64
-                  type: integer
-                observedSourceArtifactRevision:
-                  description: |-
-                    ObservedSourceArtifactRevision is the last observed Artifact.Revision
-                    of the HelmChartSpec.SourceRef.
-                  type: string
-                observedValuesFiles:
-                  description: |-
-                    ObservedValuesFiles are the observed value files of the last successful
-                    reconciliation.
-                    It matches the chart in the last successfully reconciled artifact.
-                  items:
-                    type: string
-                  type: array
-                url:
-                  description: |-
-                    URL is the dynamic fetch link for the latest Artifact.
-                    It is provided on a "best effort" basis, and using the precise
-                    BucketStatus.Artifact data is recommended.
-                  type: string
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
-    - additionalPrinterColumns:
-        - jsonPath: .spec.chart
-          name: Chart
-          type: string
-        - jsonPath: .spec.version
-          name: Version
-          type: string
-        - jsonPath: .spec.sourceRef.kind
-          name: Source Kind
-          type: string
-        - jsonPath: .spec.sourceRef.name
-          name: Source Name
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].status
-          name: Ready
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].message
-          name: Status
-          type: string
-        - jsonPath: .metadata.creationTimestamp
-          name: Age
-          type: date
-      deprecated: true
-      deprecationWarning: v1beta1 HelmChart is deprecated, upgrade to v1
-      name: v1beta1
-      schema:
-        openAPIV3Schema:
-          description: HelmChart is the Schema for the helmcharts API
-          properties:
-            apiVersion:
-              description: |-
-                APIVersion defines the versioned schema of this representation of an object.
-                Servers should convert recognized schemas to the latest internal value, and
-                may reject unrecognized values.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-              type: string
-            kind:
-              description: |-
-                Kind is a string value representing the REST resource this object represents.
-                Servers may infer this from the endpoint the client submits requests to.
-                Cannot be updated.
-                In CamelCase.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: HelmChartSpec defines the desired state of a Helm chart.
-              properties:
-                accessFrom:
-                  description: AccessFrom defines an Access Control List for allowing
-                    cross-namespace references to this object.
-                  properties:
-                    namespaceSelectors:
-                      description: |-
-                        NamespaceSelectors is the list of namespace selectors to which this ACL applies.
-                        Items in this list are evaluated using a logical OR operation.
-                      items:
-                        description: |-
-                          NamespaceSelector selects the namespaces to which this ACL applies.
-                          An empty map of MatchLabels matches all namespaces in a cluster.
-                        properties:
-                          matchLabels:
-                            additionalProperties:
-                              type: string
-                            description: |-
-                              MatchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                              map is equivalent to an element of matchExpressions, whose key field is "key", the
-                              operator is "In", and the values array contains only "value". The requirements are ANDed.
-                            type: object
-                        type: object
-                      type: array
-                  required:
-                    - namespaceSelectors
-                  type: object
-                chart:
-                  description: The name or path the Helm chart is available at in the
-                    SourceRef.
-                  type: string
-                interval:
-                  description: The interval at which to check the Source for updates.
-                  type: string
-                reconcileStrategy:
-                  default: ChartVersion
-                  description: |-
-                    Determines what enables the creation of a new artifact. Valid values are
-                    ('ChartVersion', 'Revision').
-                    See the documentation of the values for an explanation on their behavior.
-                    Defaults to ChartVersion when omitted.
-                  enum:
-                    - ChartVersion
-                    - Revision
-                  type: string
-                sourceRef:
-                  description: The reference to the Source the chart is available at.
-                  properties:
-                    apiVersion:
-                      description: APIVersion of the referent.
-                      type: string
-                    kind:
-                      description: |-
-                        Kind of the referent, valid values are ('HelmRepository', 'GitRepository',
-                        'Bucket').
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
                       enum:
-                        - HelmRepository
-                        - GitRepository
-                        - Bucket
+                      - "True"
+                      - "False"
+                      - Unknown
                       type: string
-                    name:
-                      description: Name of the referent.
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
                   required:
-                    - kind
-                    - name
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
                   type: object
-                suspend:
-                  description: This flag tells the controller to suspend the reconciliation
-                    of this source.
-                  type: boolean
-                valuesFile:
-                  description: |-
-                    Alternative values file to use as the default chart values, expected to
-                    be a relative path in the SourceRef. Deprecated in favor of ValuesFiles,
-                    for backwards compatibility the file defined here is merged before the
-                    ValuesFiles items. Ignored when omitted.
+                type: array
+              lastHandledReconcileAt:
+                description: |-
+                  LastHandledReconcileAt holds the value of the most recent
+                  reconcile request value, so a change of the annotation value
+                  can be detected.
+                type: string
+              observedChartName:
+                description: |-
+                  ObservedChartName is the last observed chart name as specified by the
+                  resolved chart reference.
+                type: string
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the last observed generation of the HelmChart
+                  object.
+                format: int64
+                type: integer
+              observedSourceArtifactRevision:
+                description: |-
+                  ObservedSourceArtifactRevision is the last observed Artifact.Revision
+                  of the HelmChartSpec.SourceRef.
+                type: string
+              observedValuesFiles:
+                description: |-
+                  ObservedValuesFiles are the observed value files of the last successful
+                  reconciliation.
+                  It matches the chart in the last successfully reconciled artifact.
+                items:
                   type: string
-                valuesFiles:
-                  description: |-
-                    Alternative list of values files to use as the chart values (values.yaml
-                    is not included by default), expected to be a relative path in the SourceRef.
-                    Values files are merged in the order of this list with the last file overriding
-                    the first. Ignored when omitted.
-                  items:
-                    type: string
-                  type: array
-                version:
-                  default: '*'
-                  description: |-
-                    The chart version semver expression, ignored for charts from GitRepository
-                    and Bucket sources. Defaults to latest when omitted.
-                  type: string
-              required:
-                - chart
-                - interval
-                - sourceRef
-              type: object
-            status:
-              default:
-                observedGeneration: -1
-              description: HelmChartStatus defines the observed state of the HelmChart.
-              properties:
-                artifact:
-                  description: Artifact represents the output of the last successful
-                    chart sync.
-                  properties:
-                    checksum:
-                      description: Checksum is the SHA256 checksum of the artifact.
-                      type: string
-                    lastUpdateTime:
+                type: array
+              url:
+                description: |-
+                  URL is the dynamic fetch link for the latest Artifact.
+                  It is provided on a "best effort" basis, and using the precise
+                  BucketStatus.Artifact data is recommended.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.chart
+      name: Chart
+      type: string
+    - jsonPath: .spec.version
+      name: Version
+      type: string
+    - jsonPath: .spec.sourceRef.kind
+      name: Source Kind
+      type: string
+    - jsonPath: .spec.sourceRef.name
+      name: Source Name
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    deprecated: true
+    deprecationWarning: v1beta1 HelmChart is deprecated, upgrade to v1
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: HelmChart is the Schema for the helmcharts API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: HelmChartSpec defines the desired state of a Helm chart.
+            properties:
+              accessFrom:
+                description: AccessFrom defines an Access Control List for allowing
+                  cross-namespace references to this object.
+                properties:
+                  namespaceSelectors:
+                    description: |-
+                      NamespaceSelectors is the list of namespace selectors to which this ACL applies.
+                      Items in this list are evaluated using a logical OR operation.
+                    items:
                       description: |-
-                        LastUpdateTime is the timestamp corresponding to the last update of this
-                        artifact.
+                        NamespaceSelector selects the namespaces to which this ACL applies.
+                        An empty map of MatchLabels matches all namespaces in a cluster.
+                      properties:
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            MatchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                    type: array
+                required:
+                - namespaceSelectors
+                type: object
+              chart:
+                description: The name or path the Helm chart is available at in the
+                  SourceRef.
+                type: string
+              interval:
+                description: The interval at which to check the Source for updates.
+                type: string
+              reconcileStrategy:
+                default: ChartVersion
+                description: |-
+                  Determines what enables the creation of a new artifact. Valid values are
+                  ('ChartVersion', 'Revision').
+                  See the documentation of the values for an explanation on their behavior.
+                  Defaults to ChartVersion when omitted.
+                enum:
+                - ChartVersion
+                - Revision
+                type: string
+              sourceRef:
+                description: The reference to the Source the chart is available at.
+                properties:
+                  apiVersion:
+                    description: APIVersion of the referent.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent, valid values are ('HelmRepository', 'GitRepository',
+                      'Bucket').
+                    enum:
+                    - HelmRepository
+                    - GitRepository
+                    - Bucket
+                    type: string
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              suspend:
+                description: This flag tells the controller to suspend the reconciliation
+                  of this source.
+                type: boolean
+              valuesFile:
+                description: |-
+                  Alternative values file to use as the default chart values, expected to
+                  be a relative path in the SourceRef. Deprecated in favor of ValuesFiles,
+                  for backwards compatibility the file defined here is merged before the
+                  ValuesFiles items. Ignored when omitted.
+                type: string
+              valuesFiles:
+                description: |-
+                  Alternative list of values files to use as the chart values (values.yaml
+                  is not included by default), expected to be a relative path in the SourceRef.
+                  Values files are merged in the order of this list with the last file overriding
+                  the first. Ignored when omitted.
+                items:
+                  type: string
+                type: array
+              version:
+                default: '*'
+                description: |-
+                  The chart version semver expression, ignored for charts from GitRepository
+                  and Bucket sources. Defaults to latest when omitted.
+                type: string
+            required:
+            - chart
+            - interval
+            - sourceRef
+            type: object
+          status:
+            default:
+              observedGeneration: -1
+            description: HelmChartStatus defines the observed state of the HelmChart.
+            properties:
+              artifact:
+                description: Artifact represents the output of the last successful
+                  chart sync.
+                properties:
+                  checksum:
+                    description: Checksum is the SHA256 checksum of the artifact.
+                    type: string
+                  lastUpdateTime:
+                    description: |-
+                      LastUpdateTime is the timestamp corresponding to the last update of this
+                      artifact.
+                    format: date-time
+                    type: string
+                  path:
+                    description: Path is the relative file path of this artifact.
+                    type: string
+                  revision:
+                    description: |-
+                      Revision is a human readable identifier traceable in the origin source
+                      system. It can be a Git commit SHA, Git tag, a Helm index timestamp, a Helm
+                      chart version, etc.
+                    type: string
+                  url:
+                    description: URL is the HTTP address of this artifact.
+                    type: string
+                required:
+                - lastUpdateTime
+                - path
+                - url
+                type: object
+              conditions:
+                description: Conditions holds the conditions for the HelmChart.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
-                    path:
-                      description: Path is the relative file path of this artifact.
-                      type: string
-                    revision:
+                    message:
                       description: |-
-                        Revision is a human readable identifier traceable in the origin source
-                        system. It can be a Git commit SHA, Git tag, a Helm index timestamp, a Helm
-                        chart version, etc.
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
                       type: string
-                    url:
-                      description: URL is the HTTP address of this artifact.
-                      type: string
-                  required:
-                    - path
-                    - url
-                  type: object
-                conditions:
-                  description: Conditions holds the conditions for the HelmChart.
-                  items:
-                    description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
-                    properties:
-                      lastTransitionTime:
-                        description: |-
-                          lastTransitionTime is the last time the condition transitioned from one status to another.
-                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                        format: date-time
-                        type: string
-                      message:
-                        description: |-
-                          message is a human readable message indicating details about the transition.
-                          This may be an empty string.
-                        maxLength: 32768
-                        type: string
-                      observedGeneration:
-                        description: |-
-                          observedGeneration represents the .metadata.generation that the condition was set based upon.
-                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                          with respect to the current state of the instance.
-                        format: int64
-                        minimum: 0
-                        type: integer
-                      reason:
-                        description: |-
-                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                          Producers of specific condition types may define expected values and meanings for this field,
-                          and whether the values are considered a guaranteed API.
-                          The value should be a CamelCase string.
-                          This field may not be empty.
-                        maxLength: 1024
-                        minLength: 1
-                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                        type: string
-                      status:
-                        description: status of the condition, one of True, False, Unknown.
-                        enum:
-                          - "True"
-                          - "False"
-                          - Unknown
-                        type: string
-                      type:
-                        description: |-
-                          type of condition in CamelCase or in foo.example.com/CamelCase.
-                          ---
-                          Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                          useful (see .node.status.conditions), the ability to deconflict is important.
-                          The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                        maxLength: 316
-                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                        type: string
-                    required:
-                      - lastTransitionTime
-                      - message
-                      - reason
-                      - status
-                      - type
-                    type: object
-                  type: array
-                lastHandledReconcileAt:
-                  description: |-
-                    LastHandledReconcileAt holds the value of the most recent
-                    reconcile request value, so a change of the annotation value
-                    can be detected.
-                  type: string
-                observedGeneration:
-                  description: ObservedGeneration is the last observed generation.
-                  format: int64
-                  type: integer
-                url:
-                  description: URL is the download link for the last chart pulled.
-                  type: string
-              type: object
-          type: object
-      served: true
-      storage: false
-      subresources:
-        status: {}
-    - additionalPrinterColumns:
-        - jsonPath: .spec.chart
-          name: Chart
-          type: string
-        - jsonPath: .spec.version
-          name: Version
-          type: string
-        - jsonPath: .spec.sourceRef.kind
-          name: Source Kind
-          type: string
-        - jsonPath: .spec.sourceRef.name
-          name: Source Name
-          type: string
-        - jsonPath: .metadata.creationTimestamp
-          name: Age
-          type: date
-        - jsonPath: .status.conditions[?(@.type=="Ready")].status
-          name: Ready
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].message
-          name: Status
-          type: string
-      deprecated: true
-      deprecationWarning: v1beta2 HelmChart is deprecated, upgrade to v1
-      name: v1beta2
-      schema:
-        openAPIV3Schema:
-          description: HelmChart is the Schema for the helmcharts API.
-          properties:
-            apiVersion:
-              description: |-
-                APIVersion defines the versioned schema of this representation of an object.
-                Servers should convert recognized schemas to the latest internal value, and
-                may reject unrecognized values.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-              type: string
-            kind:
-              description: |-
-                Kind is a string value representing the REST resource this object represents.
-                Servers may infer this from the endpoint the client submits requests to.
-                Cannot be updated.
-                In CamelCase.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: HelmChartSpec specifies the desired state of a Helm chart.
-              properties:
-                accessFrom:
-                  description: |-
-                    AccessFrom specifies an Access Control List for allowing cross-namespace
-                    references to this object.
-                    NOTE: Not implemented, provisional as of https://github.com/fluxcd/flux2/pull/2092
-                  properties:
-                    namespaceSelectors:
+                    observedGeneration:
                       description: |-
-                        NamespaceSelectors is the list of namespace selectors to which this ACL applies.
-                        Items in this list are evaluated using a logical OR operation.
-                      items:
-                        description: |-
-                          NamespaceSelector selects the namespaces to which this ACL applies.
-                          An empty map of MatchLabels matches all namespaces in a cluster.
-                        properties:
-                          matchLabels:
-                            additionalProperties:
-                              type: string
-                            description: |-
-                              MatchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                              map is equivalent to an element of matchExpressions, whose key field is "key", the
-                              operator is "In", and the values array contains only "value". The requirements are ANDed.
-                            type: object
-                        type: object
-                      type: array
-                  required:
-                    - namespaceSelectors
-                  type: object
-                chart:
-                  description: |-
-                    Chart is the name or path the Helm chart is available at in the
-                    SourceRef.
-                  type: string
-                ignoreMissingValuesFiles:
-                  description: |-
-                    IgnoreMissingValuesFiles controls whether to silently ignore missing values
-                    files rather than failing.
-                  type: boolean
-                interval:
-                  description: |-
-                    Interval at which the HelmChart SourceRef is checked for updates.
-                    This interval is approximate and may be subject to jitter to ensure
-                    efficient use of resources.
-                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                  type: string
-                reconcileStrategy:
-                  default: ChartVersion
-                  description: |-
-                    ReconcileStrategy determines what enables the creation of a new artifact.
-                    Valid values are ('ChartVersion', 'Revision').
-                    See the documentation of the values for an explanation on their behavior.
-                    Defaults to ChartVersion when omitted.
-                  enum:
-                    - ChartVersion
-                    - Revision
-                  type: string
-                sourceRef:
-                  description: SourceRef is the reference to the Source the chart is
-                    available at.
-                  properties:
-                    apiVersion:
-                      description: APIVersion of the referent.
-                      type: string
-                    kind:
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
                       description: |-
-                        Kind of the referent, valid values are ('HelmRepository', 'GitRepository',
-                        'Bucket').
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
                       enum:
-                        - HelmRepository
-                        - GitRepository
-                        - Bucket
+                      - "True"
+                      - "False"
+                      - Unknown
                       type: string
-                    name:
-                      description: Name of the referent.
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
                   required:
-                    - kind
-                    - name
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
                   type: object
-                suspend:
-                  description: |-
-                    Suspend tells the controller to suspend the reconciliation of this
-                    source.
-                  type: boolean
-                valuesFile:
-                  description: |-
-                    ValuesFile is an alternative values file to use as the default chart
-                    values, expected to be a relative path in the SourceRef. Deprecated in
-                    favor of ValuesFiles, for backwards compatibility the file specified here
-                    is merged before the ValuesFiles items. Ignored when omitted.
-                  type: string
-                valuesFiles:
-                  description: |-
-                    ValuesFiles is an alternative list of values files to use as the chart
-                    values (values.yaml is not included by default), expected to be a
-                    relative path in the SourceRef.
-                    Values files are merged in the order of this list with the last file
-                    overriding the first. Ignored when omitted.
-                  items:
-                    type: string
-                  type: array
-                verify:
-                  description: |-
-                    Verify contains the secret name containing the trusted public keys
-                    used to verify the signature and specifies which provider to use to check
-                    whether OCI image is authentic.
-                    This field is only supported when using HelmRepository source with spec.type 'oci'.
-                    Chart dependencies, which are not bundled in the umbrella chart artifact, are not verified.
-                  properties:
-                    matchOIDCIdentity:
+                type: array
+              lastHandledReconcileAt:
+                description: |-
+                  LastHandledReconcileAt holds the value of the most recent
+                  reconcile request value, so a change of the annotation value
+                  can be detected.
+                type: string
+              observedGeneration:
+                description: ObservedGeneration is the last observed generation.
+                format: int64
+                type: integer
+              url:
+                description: URL is the download link for the last chart pulled.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.chart
+      name: Chart
+      type: string
+    - jsonPath: .spec.version
+      name: Version
+      type: string
+    - jsonPath: .spec.sourceRef.kind
+      name: Source Kind
+      type: string
+    - jsonPath: .spec.sourceRef.name
+      name: Source Name
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      type: string
+    deprecated: true
+    deprecationWarning: v1beta2 HelmChart is deprecated, upgrade to v1
+    name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: HelmChart is the Schema for the helmcharts API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: HelmChartSpec specifies the desired state of a Helm chart.
+            properties:
+              accessFrom:
+                description: |-
+                  AccessFrom specifies an Access Control List for allowing cross-namespace
+                  references to this object.
+                  NOTE: Not implemented, provisional as of https://github.com/fluxcd/flux2/pull/2092
+                properties:
+                  namespaceSelectors:
+                    description: |-
+                      NamespaceSelectors is the list of namespace selectors to which this ACL applies.
+                      Items in this list are evaluated using a logical OR operation.
+                    items:
                       description: |-
-                        MatchOIDCIdentity specifies the identity matching criteria to use
-                        while verifying an OCI artifact which was signed using Cosign keyless
-                        signing. The artifact's identity is deemed to be verified if any of the
-                        specified matchers match against the identity.
-                      items:
-                        description: |-
-                          OIDCIdentityMatch specifies options for verifying the certificate identity,
-                          i.e. the issuer and the subject of the certificate.
-                        properties:
-                          issuer:
-                            description: |-
-                              Issuer specifies the regex pattern to match against to verify
-                              the OIDC issuer in the Fulcio certificate. The pattern must be a
-                              valid Go regular expression.
-                            type: string
-                          subject:
-                            description: |-
-                              Subject specifies the regex pattern to match against to verify
-                              the identity subject in the Fulcio certificate. The pattern must
-                              be a valid Go regular expression.
-                            type: string
-                        required:
-                          - issuer
-                          - subject
-                        type: object
-                      type: array
-                    provider:
-                      default: cosign
-                      description: Provider specifies the technology used to sign the
-                        OCI Artifact.
-                      enum:
-                        - cosign
-                        - notation
-                      type: string
-                    secretRef:
-                      description: |-
-                        SecretRef specifies the Kubernetes Secret containing the
-                        trusted public keys.
+                        NamespaceSelector selects the namespaces to which this ACL applies.
+                        An empty map of MatchLabels matches all namespaces in a cluster.
                       properties:
-                        name:
-                          description: Name of the referent.
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            MatchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                    type: array
+                required:
+                - namespaceSelectors
+                type: object
+              chart:
+                description: |-
+                  Chart is the name or path the Helm chart is available at in the
+                  SourceRef.
+                type: string
+              ignoreMissingValuesFiles:
+                description: |-
+                  IgnoreMissingValuesFiles controls whether to silently ignore missing values
+                  files rather than failing.
+                type: boolean
+              interval:
+                description: |-
+                  Interval at which the HelmChart SourceRef is checked for updates.
+                  This interval is approximate and may be subject to jitter to ensure
+                  efficient use of resources.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                type: string
+              reconcileStrategy:
+                default: ChartVersion
+                description: |-
+                  ReconcileStrategy determines what enables the creation of a new artifact.
+                  Valid values are ('ChartVersion', 'Revision').
+                  See the documentation of the values for an explanation on their behavior.
+                  Defaults to ChartVersion when omitted.
+                enum:
+                - ChartVersion
+                - Revision
+                type: string
+              sourceRef:
+                description: SourceRef is the reference to the Source the chart is
+                  available at.
+                properties:
+                  apiVersion:
+                    description: APIVersion of the referent.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent, valid values are ('HelmRepository', 'GitRepository',
+                      'Bucket').
+                    enum:
+                    - HelmRepository
+                    - GitRepository
+                    - Bucket
+                    type: string
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              suspend:
+                description: |-
+                  Suspend tells the controller to suspend the reconciliation of this
+                  source.
+                type: boolean
+              valuesFile:
+                description: |-
+                  ValuesFile is an alternative values file to use as the default chart
+                  values, expected to be a relative path in the SourceRef. Deprecated in
+                  favor of ValuesFiles, for backwards compatibility the file specified here
+                  is merged before the ValuesFiles items. Ignored when omitted.
+                type: string
+              valuesFiles:
+                description: |-
+                  ValuesFiles is an alternative list of values files to use as the chart
+                  values (values.yaml is not included by default), expected to be a
+                  relative path in the SourceRef.
+                  Values files are merged in the order of this list with the last file
+                  overriding the first. Ignored when omitted.
+                items:
+                  type: string
+                type: array
+              verify:
+                description: |-
+                  Verify contains the secret name containing the trusted public keys
+                  used to verify the signature and specifies which provider to use to check
+                  whether OCI image is authentic.
+                  This field is only supported when using HelmRepository source with spec.type 'oci'.
+                  Chart dependencies, which are not bundled in the umbrella chart artifact, are not verified.
+                properties:
+                  matchOIDCIdentity:
+                    description: |-
+                      MatchOIDCIdentity specifies the identity matching criteria to use
+                      while verifying an OCI artifact which was signed using Cosign keyless
+                      signing. The artifact's identity is deemed to be verified if any of the
+                      specified matchers match against the identity.
+                    items:
+                      description: |-
+                        OIDCIdentityMatch specifies options for verifying the certificate identity,
+                        i.e. the issuer and the subject of the certificate.
+                      properties:
+                        issuer:
+                          description: |-
+                            Issuer specifies the regex pattern to match against to verify
+                            the OIDC issuer in the Fulcio certificate. The pattern must be a
+                            valid Go regular expression.
+                          type: string
+                        subject:
+                          description: |-
+                            Subject specifies the regex pattern to match against to verify
+                            the identity subject in the Fulcio certificate. The pattern must
+                            be a valid Go regular expression.
                           type: string
                       required:
-                        - name
+                      - issuer
+                      - subject
                       type: object
-                  required:
-                    - provider
-                  type: object
-                version:
-                  default: '*'
-                  description: |-
-                    Version is the chart version semver expression, ignored for charts from
-                    GitRepository and Bucket sources. Defaults to latest when omitted.
-                  type: string
-              required:
-                - chart
-                - interval
-                - sourceRef
-              type: object
-            status:
-              default:
-                observedGeneration: -1
-              description: HelmChartStatus records the observed state of the HelmChart.
-              properties:
-                artifact:
-                  description: Artifact represents the output of the last successful
-                    reconciliation.
-                  properties:
-                    digest:
-                      description: Digest is the digest of the file in the form of '<algorithm>:<checksum>'.
-                      pattern: ^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$
-                      type: string
-                    lastUpdateTime:
-                      description: |-
-                        LastUpdateTime is the timestamp corresponding to the last update of the
-                        Artifact.
-                      format: date-time
-                      type: string
-                    metadata:
-                      additionalProperties:
-                        type: string
-                      description: Metadata holds upstream information such as OCI annotations.
-                      type: object
-                    path:
-                      description: |-
-                        Path is the relative file path of the Artifact. It can be used to locate
-                        the file in the root of the Artifact storage on the local file system of
-                        the controller managing the Source.
-                      type: string
-                    revision:
-                      description: |-
-                        Revision is a human-readable identifier traceable in the origin source
-                        system. It can be a Git commit SHA, Git tag, a Helm chart version, etc.
-                      type: string
-                    size:
-                      description: Size is the number of bytes in the file.
-                      format: int64
-                      type: integer
-                    url:
-                      description: |-
-                        URL is the HTTP address of the Artifact as exposed by the controller
-                        managing the Source. It can be used to retrieve the Artifact for
-                        consumption, e.g. by another controller applying the Artifact contents.
-                      type: string
-                  required:
-                    - lastUpdateTime
-                    - path
-                    - revision
-                    - url
-                  type: object
-                conditions:
-                  description: Conditions holds the conditions for the HelmChart.
-                  items:
-                    description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                    type: array
+                  provider:
+                    default: cosign
+                    description: Provider specifies the technology used to sign the
+                      OCI Artifact.
+                    enum:
+                    - cosign
+                    - notation
+                    type: string
+                  secretRef:
+                    description: |-
+                      SecretRef specifies the Kubernetes Secret containing the
+                      trusted public keys.
                     properties:
-                      lastTransitionTime:
-                        description: |-
-                          lastTransitionTime is the last time the condition transitioned from one status to another.
-                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                        format: date-time
-                        type: string
-                      message:
-                        description: |-
-                          message is a human readable message indicating details about the transition.
-                          This may be an empty string.
-                        maxLength: 32768
-                        type: string
-                      observedGeneration:
-                        description: |-
-                          observedGeneration represents the .metadata.generation that the condition was set based upon.
-                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                          with respect to the current state of the instance.
-                        format: int64
-                        minimum: 0
-                        type: integer
-                      reason:
-                        description: |-
-                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                          Producers of specific condition types may define expected values and meanings for this field,
-                          and whether the values are considered a guaranteed API.
-                          The value should be a CamelCase string.
-                          This field may not be empty.
-                        maxLength: 1024
-                        minLength: 1
-                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                        type: string
-                      status:
-                        description: status of the condition, one of True, False, Unknown.
-                        enum:
-                          - "True"
-                          - "False"
-                          - Unknown
-                        type: string
-                      type:
-                        description: |-
-                          type of condition in CamelCase or in foo.example.com/CamelCase.
-                          ---
-                          Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                          useful (see .node.status.conditions), the ability to deconflict is important.
-                          The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                        maxLength: 316
-                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      name:
+                        description: Name of the referent.
                         type: string
                     required:
-                      - lastTransitionTime
-                      - message
-                      - reason
-                      - status
-                      - type
+                    - name
                     type: object
-                  type: array
-                lastHandledReconcileAt:
-                  description: |-
-                    LastHandledReconcileAt holds the value of the most recent
-                    reconcile request value, so a change of the annotation value
-                    can be detected.
-                  type: string
-                observedChartName:
-                  description: |-
-                    ObservedChartName is the last observed chart name as specified by the
-                    resolved chart reference.
-                  type: string
-                observedGeneration:
-                  description: |-
-                    ObservedGeneration is the last observed generation of the HelmChart
-                    object.
-                  format: int64
-                  type: integer
-                observedSourceArtifactRevision:
-                  description: |-
-                    ObservedSourceArtifactRevision is the last observed Artifact.Revision
-                    of the HelmChartSpec.SourceRef.
-                  type: string
-                observedValuesFiles:
-                  description: |-
-                    ObservedValuesFiles are the observed value files of the last successful
-                    reconciliation.
-                    It matches the chart in the last successfully reconciled artifact.
-                  items:
+                required:
+                - provider
+                type: object
+              version:
+                default: '*'
+                description: |-
+                  Version is the chart version semver expression, ignored for charts from
+                  GitRepository and Bucket sources. Defaults to latest when omitted.
+                type: string
+            required:
+            - chart
+            - interval
+            - sourceRef
+            type: object
+          status:
+            default:
+              observedGeneration: -1
+            description: HelmChartStatus records the observed state of the HelmChart.
+            properties:
+              artifact:
+                description: Artifact represents the output of the last successful
+                  reconciliation.
+                properties:
+                  digest:
+                    description: Digest is the digest of the file in the form of '<algorithm>:<checksum>'.
+                    pattern: ^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$
                     type: string
-                  type: array
-                url:
-                  description: |-
-                    URL is the dynamic fetch link for the latest Artifact.
-                    It is provided on a "best effort" basis, and using the precise
-                    BucketStatus.Artifact data is recommended.
+                  lastUpdateTime:
+                    description: |-
+                      LastUpdateTime is the timestamp corresponding to the last update of the
+                      Artifact.
+                    format: date-time
+                    type: string
+                  metadata:
+                    additionalProperties:
+                      type: string
+                    description: Metadata holds upstream information such as OCI annotations.
+                    type: object
+                  path:
+                    description: |-
+                      Path is the relative file path of the Artifact. It can be used to locate
+                      the file in the root of the Artifact storage on the local file system of
+                      the controller managing the Source.
+                    type: string
+                  revision:
+                    description: |-
+                      Revision is a human-readable identifier traceable in the origin source
+                      system. It can be a Git commit SHA, Git tag, a Helm chart version, etc.
+                    type: string
+                  size:
+                    description: Size is the number of bytes in the file.
+                    format: int64
+                    type: integer
+                  url:
+                    description: |-
+                      URL is the HTTP address of the Artifact as exposed by the controller
+                      managing the Source. It can be used to retrieve the Artifact for
+                      consumption, e.g. by another controller applying the Artifact contents.
+                    type: string
+                required:
+                - lastUpdateTime
+                - path
+                - revision
+                - url
+                type: object
+              conditions:
+                description: Conditions holds the conditions for the HelmChart.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              lastHandledReconcileAt:
+                description: |-
+                  LastHandledReconcileAt holds the value of the most recent
+                  reconcile request value, so a change of the annotation value
+                  can be detected.
+                type: string
+              observedChartName:
+                description: |-
+                  ObservedChartName is the last observed chart name as specified by the
+                  resolved chart reference.
+                type: string
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the last observed generation of the HelmChart
+                  object.
+                format: int64
+                type: integer
+              observedSourceArtifactRevision:
+                description: |-
+                  ObservedSourceArtifactRevision is the last observed Artifact.Revision
+                  of the HelmChartSpec.SourceRef.
+                type: string
+              observedValuesFiles:
+                description: |-
+                  ObservedValuesFiles are the observed value files of the last successful
+                  reconciliation.
+                  It matches the chart in the last successfully reconciled artifact.
+                items:
                   type: string
-              type: object
-          type: object
-      served: true
-      storage: false
-      subresources:
-        status: {}
+                type: array
+              url:
+                description: |-
+                  URL is the dynamic fetch link for the latest Artifact.
+                  It is provided on a "best effort" basis, and using the precise
+                  BucketStatus.Artifact data is recommended.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}

--- a/tools/testcrds/source.toolkit.fluxcd.io_helmrepositories.yaml
+++ b/tools/testcrds/source.toolkit.fluxcd.io_helmrepositories.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.1
   name: helmrepositories.source.toolkit.fluxcd.io
 spec:
   group: source.toolkit.fluxcd.io
@@ -12,877 +12,833 @@ spec:
     listKind: HelmRepositoryList
     plural: helmrepositories
     shortNames:
-      - helmrepo
+    - helmrepo
     singular: helmrepository
   scope: Namespaced
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .spec.url
-          name: URL
-          type: string
-        - jsonPath: .metadata.creationTimestamp
-          name: Age
-          type: date
-        - jsonPath: .status.conditions[?(@.type=="Ready")].status
-          name: Ready
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].message
-          name: Status
-          type: string
-      name: v1
-      schema:
-        openAPIV3Schema:
-          description: HelmRepository is the Schema for the helmrepositories API.
-          properties:
-            apiVersion:
-              description: |-
-                APIVersion defines the versioned schema of this representation of an object.
-                Servers should convert recognized schemas to the latest internal value, and
-                may reject unrecognized values.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-              type: string
-            kind:
-              description: |-
-                Kind is a string value representing the REST resource this object represents.
-                Servers may infer this from the endpoint the client submits requests to.
-                Cannot be updated.
-                In CamelCase.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: |-
-                HelmRepositorySpec specifies the required configuration to produce an
-                Artifact for a Helm repository index YAML.
-              properties:
-                accessFrom:
-                  description: |-
-                    AccessFrom specifies an Access Control List for allowing cross-namespace
-                    references to this object.
-                    NOTE: Not implemented, provisional as of https://github.com/fluxcd/flux2/pull/2092
-                  properties:
-                    namespaceSelectors:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.url
+      name: URL
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: HelmRepository is the Schema for the helmrepositories API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              HelmRepositorySpec specifies the required configuration to produce an
+              Artifact for a Helm repository index YAML.
+            properties:
+              accessFrom:
+                description: |-
+                  AccessFrom specifies an Access Control List for allowing cross-namespace
+                  references to this object.
+                  NOTE: Not implemented, provisional as of https://github.com/fluxcd/flux2/pull/2092
+                properties:
+                  namespaceSelectors:
+                    description: |-
+                      NamespaceSelectors is the list of namespace selectors to which this ACL applies.
+                      Items in this list are evaluated using a logical OR operation.
+                    items:
                       description: |-
-                        NamespaceSelectors is the list of namespace selectors to which this ACL applies.
-                        Items in this list are evaluated using a logical OR operation.
-                      items:
-                        description: |-
-                          NamespaceSelector selects the namespaces to which this ACL applies.
-                          An empty map of MatchLabels matches all namespaces in a cluster.
-                        properties:
-                          matchLabels:
-                            additionalProperties:
-                              type: string
-                            description: |-
-                              MatchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                              map is equivalent to an element of matchExpressions, whose key field is "key", the
-                              operator is "In", and the values array contains only "value". The requirements are ANDed.
-                            type: object
-                        type: object
-                      type: array
-                  required:
-                    - namespaceSelectors
-                  type: object
-                certSecretRef:
-                  description: |-
-                    CertSecretRef can be given the name of a Secret containing
-                    either or both of
-                    
-                    
-                    - a PEM-encoded client certificate (`tls.crt`) and private
-                    key (`tls.key`);
-                    - a PEM-encoded CA certificate (`ca.crt`)
-                    
-                    
-                    and whichever are supplied, will be used for connecting to the
-                    registry. The client cert and key are useful if you are
-                    authenticating with a certificate; the CA cert is useful if
-                    you are using a self-signed server certificate. The Secret must
-                    be of type `Opaque` or `kubernetes.io/tls`.
-                    
-                    
-                    It takes precedence over the values specified in the Secret referred
-                    to by `.spec.secretRef`.
-                  properties:
-                    name:
-                      description: Name of the referent.
-                      type: string
-                  required:
-                    - name
-                  type: object
-                insecure:
-                  description: |-
-                    Insecure allows connecting to a non-TLS HTTP container registry.
-                    This field is only taken into account if the .spec.type field is set to 'oci'.
-                  type: boolean
-                interval:
-                  description: |-
-                    Interval at which the HelmRepository URL is checked for updates.
-                    This interval is approximate and may be subject to jitter to ensure
-                    efficient use of resources.
-                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                  type: string
-                passCredentials:
-                  description: |-
-                    PassCredentials allows the credentials from the SecretRef to be passed
-                    on to a host that does not match the host as defined in URL.
-                    This may be required if the host of the advertised chart URLs in the
-                    index differ from the defined URL.
-                    Enabling this should be done with caution, as it can potentially result
-                    in credentials getting stolen in a MITM-attack.
-                  type: boolean
-                provider:
-                  default: generic
-                  description: |-
-                    Provider used for authentication, can be 'aws', 'azure', 'gcp' or 'generic'.
-                    This field is optional, and only taken into account if the .spec.type field is set to 'oci'.
-                    When not specified, defaults to 'generic'.
-                  enum:
-                    - generic
-                    - aws
-                    - azure
-                    - gcp
-                  type: string
-                secretRef:
-                  description: |-
-                    SecretRef specifies the Secret containing authentication credentials
-                    for the HelmRepository.
-                    For HTTP/S basic auth the secret must contain 'username' and 'password'
-                    fields.
-                    Support for TLS auth using the 'certFile' and 'keyFile', and/or 'caFile'
-                    keys is deprecated. Please use `.spec.certSecretRef` instead.
-                  properties:
-                    name:
-                      description: Name of the referent.
-                      type: string
-                  required:
-                    - name
-                  type: object
-                suspend:
-                  description: |-
-                    Suspend tells the controller to suspend the reconciliation of this
-                    HelmRepository.
-                  type: boolean
-                timeout:
-                  description: |-
-                    Timeout is used for the index fetch operation for an HTTPS helm repository,
-                    and for remote OCI Repository operations like pulling for an OCI helm
-                    chart by the associated HelmChart.
-                    Its default value is 60s.
-                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
-                  type: string
-                type:
-                  description: |-
-                    Type of the HelmRepository.
-                    When this field is set to  "oci", the URL field value must be prefixed with "oci://".
-                  enum:
-                    - default
-                    - oci
-                  type: string
-                url:
-                  description: |-
-                    URL of the Helm repository, a valid URL contains at least a protocol and
-                    host.
-                  pattern: ^(http|https|oci)://.*$
-                  type: string
-              required:
-                - url
-              type: object
-            status:
-              default:
-                observedGeneration: -1
-              description: HelmRepositoryStatus records the observed state of the HelmRepository.
-              properties:
-                artifact:
-                  description: Artifact represents the last successful HelmRepository
-                    reconciliation.
-                  properties:
-                    digest:
-                      description: Digest is the digest of the file in the form of '<algorithm>:<checksum>'.
-                      pattern: ^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$
-                      type: string
-                    lastUpdateTime:
-                      description: |-
-                        LastUpdateTime is the timestamp corresponding to the last update of the
-                        Artifact.
-                      format: date-time
-                      type: string
-                    metadata:
-                      additionalProperties:
-                        type: string
-                      description: Metadata holds upstream information such as OCI annotations.
+                        NamespaceSelector selects the namespaces to which this ACL applies.
+                        An empty map of MatchLabels matches all namespaces in a cluster.
+                      properties:
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            MatchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
                       type: object
-                    path:
-                      description: |-
-                        Path is the relative file path of the Artifact. It can be used to locate
-                        the file in the root of the Artifact storage on the local file system of
-                        the controller managing the Source.
+                    type: array
+                required:
+                - namespaceSelectors
+                type: object
+              certSecretRef:
+                description: |-
+                  CertSecretRef can be given the name of a Secret containing
+                  either or both of
+
+                  - a PEM-encoded client certificate (`tls.crt`) and private
+                  key (`tls.key`);
+                  - a PEM-encoded CA certificate (`ca.crt`)
+
+                  and whichever are supplied, will be used for connecting to the
+                  registry. The client cert and key are useful if you are
+                  authenticating with a certificate; the CA cert is useful if
+                  you are using a self-signed server certificate. The Secret must
+                  be of type `Opaque` or `kubernetes.io/tls`.
+
+                  It takes precedence over the values specified in the Secret referred
+                  to by `.spec.secretRef`.
+                properties:
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - name
+                type: object
+              insecure:
+                description: |-
+                  Insecure allows connecting to a non-TLS HTTP container registry.
+                  This field is only taken into account if the .spec.type field is set to 'oci'.
+                type: boolean
+              interval:
+                description: |-
+                  Interval at which the HelmRepository URL is checked for updates.
+                  This interval is approximate and may be subject to jitter to ensure
+                  efficient use of resources.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                type: string
+              passCredentials:
+                description: |-
+                  PassCredentials allows the credentials from the SecretRef to be passed
+                  on to a host that does not match the host as defined in URL.
+                  This may be required if the host of the advertised chart URLs in the
+                  index differ from the defined URL.
+                  Enabling this should be done with caution, as it can potentially result
+                  in credentials getting stolen in a MITM-attack.
+                type: boolean
+              provider:
+                default: generic
+                description: |-
+                  Provider used for authentication, can be 'aws', 'azure', 'gcp' or 'generic'.
+                  This field is optional, and only taken into account if the .spec.type field is set to 'oci'.
+                  When not specified, defaults to 'generic'.
+                enum:
+                - generic
+                - aws
+                - azure
+                - gcp
+                type: string
+              secretRef:
+                description: |-
+                  SecretRef specifies the Secret containing authentication credentials
+                  for the HelmRepository.
+                  For HTTP/S basic auth the secret must contain 'username' and 'password'
+                  fields.
+                  Support for TLS auth using the 'certFile' and 'keyFile', and/or 'caFile'
+                  keys is deprecated. Please use `.spec.certSecretRef` instead.
+                properties:
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - name
+                type: object
+              suspend:
+                description: |-
+                  Suspend tells the controller to suspend the reconciliation of this
+                  HelmRepository.
+                type: boolean
+              timeout:
+                description: |-
+                  Timeout is used for the index fetch operation for an HTTPS helm repository,
+                  and for remote OCI Repository operations like pulling for an OCI helm
+                  chart by the associated HelmChart.
+                  Its default value is 60s.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
+                type: string
+              type:
+                description: |-
+                  Type of the HelmRepository.
+                  When this field is set to  "oci", the URL field value must be prefixed with "oci://".
+                enum:
+                - default
+                - oci
+                type: string
+              url:
+                description: |-
+                  URL of the Helm repository, a valid URL contains at least a protocol and
+                  host.
+                pattern: ^(http|https|oci)://.*$
+                type: string
+            required:
+            - url
+            type: object
+          status:
+            default:
+              observedGeneration: -1
+            description: HelmRepositoryStatus records the observed state of the HelmRepository.
+            properties:
+              artifact:
+                description: Artifact represents the last successful HelmRepository
+                  reconciliation.
+                properties:
+                  digest:
+                    description: Digest is the digest of the file in the form of '<algorithm>:<checksum>'.
+                    pattern: ^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$
+                    type: string
+                  lastUpdateTime:
+                    description: |-
+                      LastUpdateTime is the timestamp corresponding to the last update of the
+                      Artifact.
+                    format: date-time
+                    type: string
+                  metadata:
+                    additionalProperties:
                       type: string
-                    revision:
+                    description: Metadata holds upstream information such as OCI annotations.
+                    type: object
+                  path:
+                    description: |-
+                      Path is the relative file path of the Artifact. It can be used to locate
+                      the file in the root of the Artifact storage on the local file system of
+                      the controller managing the Source.
+                    type: string
+                  revision:
+                    description: |-
+                      Revision is a human-readable identifier traceable in the origin source
+                      system. It can be a Git commit SHA, Git tag, a Helm chart version, etc.
+                    type: string
+                  size:
+                    description: Size is the number of bytes in the file.
+                    format: int64
+                    type: integer
+                  url:
+                    description: |-
+                      URL is the HTTP address of the Artifact as exposed by the controller
+                      managing the Source. It can be used to retrieve the Artifact for
+                      consumption, e.g. by another controller applying the Artifact contents.
+                    type: string
+                required:
+                - lastUpdateTime
+                - path
+                - revision
+                - url
+                type: object
+              conditions:
+                description: Conditions holds the conditions for the HelmRepository.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
                       description: |-
-                        Revision is a human-readable identifier traceable in the origin source
-                        system. It can be a Git commit SHA, Git tag, a Helm chart version, etc.
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
                       type: string
-                    size:
-                      description: Size is the number of bytes in the file.
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
                       format: int64
+                      minimum: 0
                       type: integer
-                    url:
+                    reason:
                       description: |-
-                        URL is the HTTP address of the Artifact as exposed by the controller
-                        managing the Source. It can be used to retrieve the Artifact for
-                        consumption, e.g. by another controller applying the Artifact contents.
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
                   required:
-                    - lastUpdateTime
-                    - path
-                    - revision
-                    - url
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
                   type: object
-                conditions:
-                  description: Conditions holds the conditions for the HelmRepository.
-                  items:
-                    description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
-                    properties:
-                      lastTransitionTime:
-                        description: |-
-                          lastTransitionTime is the last time the condition transitioned from one status to another.
-                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                        format: date-time
-                        type: string
-                      message:
-                        description: |-
-                          message is a human readable message indicating details about the transition.
-                          This may be an empty string.
-                        maxLength: 32768
-                        type: string
-                      observedGeneration:
-                        description: |-
-                          observedGeneration represents the .metadata.generation that the condition was set based upon.
-                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                          with respect to the current state of the instance.
-                        format: int64
-                        minimum: 0
-                        type: integer
-                      reason:
-                        description: |-
-                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                          Producers of specific condition types may define expected values and meanings for this field,
-                          and whether the values are considered a guaranteed API.
-                          The value should be a CamelCase string.
-                          This field may not be empty.
-                        maxLength: 1024
-                        minLength: 1
-                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                        type: string
-                      status:
-                        description: status of the condition, one of True, False, Unknown.
-                        enum:
-                          - "True"
-                          - "False"
-                          - Unknown
-                        type: string
-                      type:
-                        description: |-
-                          type of condition in CamelCase or in foo.example.com/CamelCase.
-                          ---
-                          Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                          useful (see .node.status.conditions), the ability to deconflict is important.
-                          The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                        maxLength: 316
-                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                        type: string
-                    required:
-                      - lastTransitionTime
-                      - message
-                      - reason
-                      - status
-                      - type
-                    type: object
-                  type: array
-                lastHandledReconcileAt:
-                  description: |-
-                    LastHandledReconcileAt holds the value of the most recent
-                    reconcile request value, so a change of the annotation value
-                    can be detected.
-                  type: string
-                observedGeneration:
-                  description: |-
-                    ObservedGeneration is the last observed generation of the HelmRepository
-                    object.
-                  format: int64
-                  type: integer
-                url:
-                  description: |-
-                    URL is the dynamic fetch link for the latest Artifact.
-                    It is provided on a "best effort" basis, and using the precise
-                    HelmRepositoryStatus.Artifact data is recommended.
-                  type: string
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
-    - additionalPrinterColumns:
-        - jsonPath: .spec.url
-          name: URL
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].status
-          name: Ready
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].message
-          name: Status
-          type: string
-        - jsonPath: .metadata.creationTimestamp
-          name: Age
-          type: date
-      deprecated: true
-      deprecationWarning: v1beta1 HelmRepository is deprecated, upgrade to v1
-      name: v1beta1
-      schema:
-        openAPIV3Schema:
-          description: HelmRepository is the Schema for the helmrepositories API
-          properties:
-            apiVersion:
-              description: |-
-                APIVersion defines the versioned schema of this representation of an object.
-                Servers should convert recognized schemas to the latest internal value, and
-                may reject unrecognized values.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-              type: string
-            kind:
-              description: |-
-                Kind is a string value representing the REST resource this object represents.
-                Servers may infer this from the endpoint the client submits requests to.
-                Cannot be updated.
-                In CamelCase.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: HelmRepositorySpec defines the reference to a Helm repository.
-              properties:
-                accessFrom:
-                  description: AccessFrom defines an Access Control List for allowing
-                    cross-namespace references to this object.
-                  properties:
-                    namespaceSelectors:
+                type: array
+              lastHandledReconcileAt:
+                description: |-
+                  LastHandledReconcileAt holds the value of the most recent
+                  reconcile request value, so a change of the annotation value
+                  can be detected.
+                type: string
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the last observed generation of the HelmRepository
+                  object.
+                format: int64
+                type: integer
+              url:
+                description: |-
+                  URL is the dynamic fetch link for the latest Artifact.
+                  It is provided on a "best effort" basis, and using the precise
+                  HelmRepositoryStatus.Artifact data is recommended.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.url
+      name: URL
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    deprecated: true
+    deprecationWarning: v1beta1 HelmRepository is deprecated, upgrade to v1
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: HelmRepository is the Schema for the helmrepositories API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: HelmRepositorySpec defines the reference to a Helm repository.
+            properties:
+              accessFrom:
+                description: AccessFrom defines an Access Control List for allowing
+                  cross-namespace references to this object.
+                properties:
+                  namespaceSelectors:
+                    description: |-
+                      NamespaceSelectors is the list of namespace selectors to which this ACL applies.
+                      Items in this list are evaluated using a logical OR operation.
+                    items:
                       description: |-
-                        NamespaceSelectors is the list of namespace selectors to which this ACL applies.
-                        Items in this list are evaluated using a logical OR operation.
-                      items:
-                        description: |-
-                          NamespaceSelector selects the namespaces to which this ACL applies.
-                          An empty map of MatchLabels matches all namespaces in a cluster.
-                        properties:
-                          matchLabels:
-                            additionalProperties:
-                              type: string
-                            description: |-
-                              MatchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                              map is equivalent to an element of matchExpressions, whose key field is "key", the
-                              operator is "In", and the values array contains only "value". The requirements are ANDed.
-                            type: object
-                        type: object
-                      type: array
-                  required:
-                    - namespaceSelectors
-                  type: object
-                interval:
-                  description: The interval at which to check the upstream for updates.
-                  type: string
-                passCredentials:
-                  description: |-
-                    PassCredentials allows the credentials from the SecretRef to be passed on to
-                    a host that does not match the host as defined in URL.
-                    This may be required if the host of the advertised chart URLs in the index
-                    differ from the defined URL.
-                    Enabling this should be done with caution, as it can potentially result in
-                    credentials getting stolen in a MITM-attack.
-                  type: boolean
-                secretRef:
-                  description: |-
-                    The name of the secret containing authentication credentials for the Helm
-                    repository.
-                    For HTTP/S basic auth the secret must contain username and
-                    password fields.
-                    For TLS the secret must contain a certFile and keyFile, and/or
-                    caFile fields.
-                  properties:
-                    name:
-                      description: Name of the referent.
-                      type: string
-                  required:
-                    - name
-                  type: object
-                suspend:
-                  description: This flag tells the controller to suspend the reconciliation
-                    of this source.
-                  type: boolean
-                timeout:
-                  default: 60s
-                  description: The timeout of index downloading, defaults to 60s.
-                  type: string
-                url:
-                  description: The Helm repository URL, a valid URL contains at least
-                    a protocol and host.
-                  type: string
-              required:
-                - interval
-                - url
-              type: object
-            status:
-              default:
-                observedGeneration: -1
-              description: HelmRepositoryStatus defines the observed state of the HelmRepository.
-              properties:
-                artifact:
-                  description: Artifact represents the output of the last successful
-                    repository sync.
-                  properties:
-                    checksum:
-                      description: Checksum is the SHA256 checksum of the artifact.
-                      type: string
-                    lastUpdateTime:
-                      description: |-
-                        LastUpdateTime is the timestamp corresponding to the last update of this
-                        artifact.
-                      format: date-time
-                      type: string
-                    path:
-                      description: Path is the relative file path of this artifact.
-                      type: string
-                    revision:
-                      description: |-
-                        Revision is a human readable identifier traceable in the origin source
-                        system. It can be a Git commit SHA, Git tag, a Helm index timestamp, a Helm
-                        chart version, etc.
-                      type: string
-                    url:
-                      description: URL is the HTTP address of this artifact.
-                      type: string
-                  required:
-                    - path
-                    - url
-                  type: object
-                conditions:
-                  description: Conditions holds the conditions for the HelmRepository.
-                  items:
-                    description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
-                    properties:
-                      lastTransitionTime:
-                        description: |-
-                          lastTransitionTime is the last time the condition transitioned from one status to another.
-                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                        format: date-time
-                        type: string
-                      message:
-                        description: |-
-                          message is a human readable message indicating details about the transition.
-                          This may be an empty string.
-                        maxLength: 32768
-                        type: string
-                      observedGeneration:
-                        description: |-
-                          observedGeneration represents the .metadata.generation that the condition was set based upon.
-                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                          with respect to the current state of the instance.
-                        format: int64
-                        minimum: 0
-                        type: integer
-                      reason:
-                        description: |-
-                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                          Producers of specific condition types may define expected values and meanings for this field,
-                          and whether the values are considered a guaranteed API.
-                          The value should be a CamelCase string.
-                          This field may not be empty.
-                        maxLength: 1024
-                        minLength: 1
-                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                        type: string
-                      status:
-                        description: status of the condition, one of True, False, Unknown.
-                        enum:
-                          - "True"
-                          - "False"
-                          - Unknown
-                        type: string
-                      type:
-                        description: |-
-                          type of condition in CamelCase or in foo.example.com/CamelCase.
-                          ---
-                          Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                          useful (see .node.status.conditions), the ability to deconflict is important.
-                          The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                        maxLength: 316
-                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                        type: string
-                    required:
-                      - lastTransitionTime
-                      - message
-                      - reason
-                      - status
-                      - type
-                    type: object
-                  type: array
-                lastHandledReconcileAt:
-                  description: |-
-                    LastHandledReconcileAt holds the value of the most recent
-                    reconcile request value, so a change of the annotation value
-                    can be detected.
-                  type: string
-                observedGeneration:
-                  description: ObservedGeneration is the last observed generation.
-                  format: int64
-                  type: integer
-                url:
-                  description: URL is the download link for the last index fetched.
-                  type: string
-              type: object
-          type: object
-      served: true
-      storage: false
-      subresources:
-        status: {}
-    - additionalPrinterColumns:
-        - jsonPath: .spec.url
-          name: URL
-          type: string
-        - jsonPath: .metadata.creationTimestamp
-          name: Age
-          type: date
-        - jsonPath: .status.conditions[?(@.type=="Ready")].status
-          name: Ready
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].message
-          name: Status
-          type: string
-      deprecated: true
-      deprecationWarning: v1beta2 HelmRepository is deprecated, upgrade to v1
-      name: v1beta2
-      schema:
-        openAPIV3Schema:
-          description: HelmRepository is the Schema for the helmrepositories API.
-          properties:
-            apiVersion:
-              description: |-
-                APIVersion defines the versioned schema of this representation of an object.
-                Servers should convert recognized schemas to the latest internal value, and
-                may reject unrecognized values.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-              type: string
-            kind:
-              description: |-
-                Kind is a string value representing the REST resource this object represents.
-                Servers may infer this from the endpoint the client submits requests to.
-                Cannot be updated.
-                In CamelCase.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: |-
-                HelmRepositorySpec specifies the required configuration to produce an
-                Artifact for a Helm repository index YAML.
-              properties:
-                accessFrom:
-                  description: |-
-                    AccessFrom specifies an Access Control List for allowing cross-namespace
-                    references to this object.
-                    NOTE: Not implemented, provisional as of https://github.com/fluxcd/flux2/pull/2092
-                  properties:
-                    namespaceSelectors:
-                      description: |-
-                        NamespaceSelectors is the list of namespace selectors to which this ACL applies.
-                        Items in this list are evaluated using a logical OR operation.
-                      items:
-                        description: |-
-                          NamespaceSelector selects the namespaces to which this ACL applies.
-                          An empty map of MatchLabels matches all namespaces in a cluster.
-                        properties:
-                          matchLabels:
-                            additionalProperties:
-                              type: string
-                            description: |-
-                              MatchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                              map is equivalent to an element of matchExpressions, whose key field is "key", the
-                              operator is "In", and the values array contains only "value". The requirements are ANDed.
-                            type: object
-                        type: object
-                      type: array
-                  required:
-                    - namespaceSelectors
-                  type: object
-                certSecretRef:
-                  description: |-
-                    CertSecretRef can be given the name of a Secret containing
-                    either or both of
-                    
-                    
-                    - a PEM-encoded client certificate (`tls.crt`) and private
-                    key (`tls.key`);
-                    - a PEM-encoded CA certificate (`ca.crt`)
-                    
-                    
-                    and whichever are supplied, will be used for connecting to the
-                    registry. The client cert and key are useful if you are
-                    authenticating with a certificate; the CA cert is useful if
-                    you are using a self-signed server certificate. The Secret must
-                    be of type `Opaque` or `kubernetes.io/tls`.
-                    
-                    
-                    It takes precedence over the values specified in the Secret referred
-                    to by `.spec.secretRef`.
-                  properties:
-                    name:
-                      description: Name of the referent.
-                      type: string
-                  required:
-                    - name
-                  type: object
-                insecure:
-                  description: |-
-                    Insecure allows connecting to a non-TLS HTTP container registry.
-                    This field is only taken into account if the .spec.type field is set to 'oci'.
-                  type: boolean
-                interval:
-                  description: |-
-                    Interval at which the HelmRepository URL is checked for updates.
-                    This interval is approximate and may be subject to jitter to ensure
-                    efficient use of resources.
-                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                  type: string
-                passCredentials:
-                  description: |-
-                    PassCredentials allows the credentials from the SecretRef to be passed
-                    on to a host that does not match the host as defined in URL.
-                    This may be required if the host of the advertised chart URLs in the
-                    index differ from the defined URL.
-                    Enabling this should be done with caution, as it can potentially result
-                    in credentials getting stolen in a MITM-attack.
-                  type: boolean
-                provider:
-                  default: generic
-                  description: |-
-                    Provider used for authentication, can be 'aws', 'azure', 'gcp' or 'generic'.
-                    This field is optional, and only taken into account if the .spec.type field is set to 'oci'.
-                    When not specified, defaults to 'generic'.
-                  enum:
-                    - generic
-                    - aws
-                    - azure
-                    - gcp
-                  type: string
-                secretRef:
-                  description: |-
-                    SecretRef specifies the Secret containing authentication credentials
-                    for the HelmRepository.
-                    For HTTP/S basic auth the secret must contain 'username' and 'password'
-                    fields.
-                    Support for TLS auth using the 'certFile' and 'keyFile', and/or 'caFile'
-                    keys is deprecated. Please use `.spec.certSecretRef` instead.
-                  properties:
-                    name:
-                      description: Name of the referent.
-                      type: string
-                  required:
-                    - name
-                  type: object
-                suspend:
-                  description: |-
-                    Suspend tells the controller to suspend the reconciliation of this
-                    HelmRepository.
-                  type: boolean
-                timeout:
-                  description: |-
-                    Timeout is used for the index fetch operation for an HTTPS helm repository,
-                    and for remote OCI Repository operations like pulling for an OCI helm
-                    chart by the associated HelmChart.
-                    Its default value is 60s.
-                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
-                  type: string
-                type:
-                  description: |-
-                    Type of the HelmRepository.
-                    When this field is set to  "oci", the URL field value must be prefixed with "oci://".
-                  enum:
-                    - default
-                    - oci
-                  type: string
-                url:
-                  description: |-
-                    URL of the Helm repository, a valid URL contains at least a protocol and
-                    host.
-                  pattern: ^(http|https|oci)://.*$
-                  type: string
-              required:
-                - url
-              type: object
-            status:
-              default:
-                observedGeneration: -1
-              description: HelmRepositoryStatus records the observed state of the HelmRepository.
-              properties:
-                artifact:
-                  description: Artifact represents the last successful HelmRepository
-                    reconciliation.
-                  properties:
-                    digest:
-                      description: Digest is the digest of the file in the form of '<algorithm>:<checksum>'.
-                      pattern: ^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$
-                      type: string
-                    lastUpdateTime:
-                      description: |-
-                        LastUpdateTime is the timestamp corresponding to the last update of the
-                        Artifact.
-                      format: date-time
-                      type: string
-                    metadata:
-                      additionalProperties:
-                        type: string
-                      description: Metadata holds upstream information such as OCI annotations.
+                        NamespaceSelector selects the namespaces to which this ACL applies.
+                        An empty map of MatchLabels matches all namespaces in a cluster.
+                      properties:
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            MatchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
                       type: object
-                    path:
+                    type: array
+                required:
+                - namespaceSelectors
+                type: object
+              interval:
+                description: The interval at which to check the upstream for updates.
+                type: string
+              passCredentials:
+                description: |-
+                  PassCredentials allows the credentials from the SecretRef to be passed on to
+                  a host that does not match the host as defined in URL.
+                  This may be required if the host of the advertised chart URLs in the index
+                  differ from the defined URL.
+                  Enabling this should be done with caution, as it can potentially result in
+                  credentials getting stolen in a MITM-attack.
+                type: boolean
+              secretRef:
+                description: |-
+                  The name of the secret containing authentication credentials for the Helm
+                  repository.
+                  For HTTP/S basic auth the secret must contain username and
+                  password fields.
+                  For TLS the secret must contain a certFile and keyFile, and/or
+                  caFile fields.
+                properties:
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - name
+                type: object
+              suspend:
+                description: This flag tells the controller to suspend the reconciliation
+                  of this source.
+                type: boolean
+              timeout:
+                default: 60s
+                description: The timeout of index downloading, defaults to 60s.
+                type: string
+              url:
+                description: The Helm repository URL, a valid URL contains at least
+                  a protocol and host.
+                type: string
+            required:
+            - interval
+            - url
+            type: object
+          status:
+            default:
+              observedGeneration: -1
+            description: HelmRepositoryStatus defines the observed state of the HelmRepository.
+            properties:
+              artifact:
+                description: Artifact represents the output of the last successful
+                  repository sync.
+                properties:
+                  checksum:
+                    description: Checksum is the SHA256 checksum of the artifact.
+                    type: string
+                  lastUpdateTime:
+                    description: |-
+                      LastUpdateTime is the timestamp corresponding to the last update of this
+                      artifact.
+                    format: date-time
+                    type: string
+                  path:
+                    description: Path is the relative file path of this artifact.
+                    type: string
+                  revision:
+                    description: |-
+                      Revision is a human readable identifier traceable in the origin source
+                      system. It can be a Git commit SHA, Git tag, a Helm index timestamp, a Helm
+                      chart version, etc.
+                    type: string
+                  url:
+                    description: URL is the HTTP address of this artifact.
+                    type: string
+                required:
+                - lastUpdateTime
+                - path
+                - url
+                type: object
+              conditions:
+                description: Conditions holds the conditions for the HelmRepository.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
                       description: |-
-                        Path is the relative file path of the Artifact. It can be used to locate
-                        the file in the root of the Artifact storage on the local file system of
-                        the controller managing the Source.
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
                       type: string
-                    revision:
+                    message:
                       description: |-
-                        Revision is a human-readable identifier traceable in the origin source
-                        system. It can be a Git commit SHA, Git tag, a Helm chart version, etc.
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
                       type: string
-                    size:
-                      description: Size is the number of bytes in the file.
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
                       format: int64
+                      minimum: 0
                       type: integer
-                    url:
+                    reason:
                       description: |-
-                        URL is the HTTP address of the Artifact as exposed by the controller
-                        managing the Source. It can be used to retrieve the Artifact for
-                        consumption, e.g. by another controller applying the Artifact contents.
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
                   required:
-                    - lastUpdateTime
-                    - path
-                    - revision
-                    - url
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
                   type: object
-                conditions:
-                  description: Conditions holds the conditions for the HelmRepository.
-                  items:
-                    description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
-                    properties:
-                      lastTransitionTime:
-                        description: |-
-                          lastTransitionTime is the last time the condition transitioned from one status to another.
-                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                        format: date-time
-                        type: string
-                      message:
-                        description: |-
-                          message is a human readable message indicating details about the transition.
-                          This may be an empty string.
-                        maxLength: 32768
-                        type: string
-                      observedGeneration:
-                        description: |-
-                          observedGeneration represents the .metadata.generation that the condition was set based upon.
-                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                          with respect to the current state of the instance.
-                        format: int64
-                        minimum: 0
-                        type: integer
-                      reason:
-                        description: |-
-                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                          Producers of specific condition types may define expected values and meanings for this field,
-                          and whether the values are considered a guaranteed API.
-                          The value should be a CamelCase string.
-                          This field may not be empty.
-                        maxLength: 1024
-                        minLength: 1
-                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                        type: string
-                      status:
-                        description: status of the condition, one of True, False, Unknown.
-                        enum:
-                          - "True"
-                          - "False"
-                          - Unknown
-                        type: string
-                      type:
-                        description: |-
-                          type of condition in CamelCase or in foo.example.com/CamelCase.
-                          ---
-                          Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                          useful (see .node.status.conditions), the ability to deconflict is important.
-                          The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                        maxLength: 316
-                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                        type: string
-                    required:
-                      - lastTransitionTime
-                      - message
-                      - reason
-                      - status
-                      - type
+                type: array
+              lastHandledReconcileAt:
+                description: |-
+                  LastHandledReconcileAt holds the value of the most recent
+                  reconcile request value, so a change of the annotation value
+                  can be detected.
+                type: string
+              observedGeneration:
+                description: ObservedGeneration is the last observed generation.
+                format: int64
+                type: integer
+              url:
+                description: URL is the download link for the last index fetched.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.url
+      name: URL
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      type: string
+    deprecated: true
+    deprecationWarning: v1beta2 HelmRepository is deprecated, upgrade to v1
+    name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: HelmRepository is the Schema for the helmrepositories API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              HelmRepositorySpec specifies the required configuration to produce an
+              Artifact for a Helm repository index YAML.
+            properties:
+              accessFrom:
+                description: |-
+                  AccessFrom specifies an Access Control List for allowing cross-namespace
+                  references to this object.
+                  NOTE: Not implemented, provisional as of https://github.com/fluxcd/flux2/pull/2092
+                properties:
+                  namespaceSelectors:
+                    description: |-
+                      NamespaceSelectors is the list of namespace selectors to which this ACL applies.
+                      Items in this list are evaluated using a logical OR operation.
+                    items:
+                      description: |-
+                        NamespaceSelector selects the namespaces to which this ACL applies.
+                        An empty map of MatchLabels matches all namespaces in a cluster.
+                      properties:
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            MatchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                    type: array
+                required:
+                - namespaceSelectors
+                type: object
+              certSecretRef:
+                description: |-
+                  CertSecretRef can be given the name of a Secret containing
+                  either or both of
+
+                  - a PEM-encoded client certificate (`tls.crt`) and private
+                  key (`tls.key`);
+                  - a PEM-encoded CA certificate (`ca.crt`)
+
+                  and whichever are supplied, will be used for connecting to the
+                  registry. The client cert and key are useful if you are
+                  authenticating with a certificate; the CA cert is useful if
+                  you are using a self-signed server certificate. The Secret must
+                  be of type `Opaque` or `kubernetes.io/tls`.
+
+                  It takes precedence over the values specified in the Secret referred
+                  to by `.spec.secretRef`.
+                properties:
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - name
+                type: object
+              insecure:
+                description: |-
+                  Insecure allows connecting to a non-TLS HTTP container registry.
+                  This field is only taken into account if the .spec.type field is set to 'oci'.
+                type: boolean
+              interval:
+                description: |-
+                  Interval at which the HelmRepository URL is checked for updates.
+                  This interval is approximate and may be subject to jitter to ensure
+                  efficient use of resources.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                type: string
+              passCredentials:
+                description: |-
+                  PassCredentials allows the credentials from the SecretRef to be passed
+                  on to a host that does not match the host as defined in URL.
+                  This may be required if the host of the advertised chart URLs in the
+                  index differ from the defined URL.
+                  Enabling this should be done with caution, as it can potentially result
+                  in credentials getting stolen in a MITM-attack.
+                type: boolean
+              provider:
+                default: generic
+                description: |-
+                  Provider used for authentication, can be 'aws', 'azure', 'gcp' or 'generic'.
+                  This field is optional, and only taken into account if the .spec.type field is set to 'oci'.
+                  When not specified, defaults to 'generic'.
+                enum:
+                - generic
+                - aws
+                - azure
+                - gcp
+                type: string
+              secretRef:
+                description: |-
+                  SecretRef specifies the Secret containing authentication credentials
+                  for the HelmRepository.
+                  For HTTP/S basic auth the secret must contain 'username' and 'password'
+                  fields.
+                  Support for TLS auth using the 'certFile' and 'keyFile', and/or 'caFile'
+                  keys is deprecated. Please use `.spec.certSecretRef` instead.
+                properties:
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - name
+                type: object
+              suspend:
+                description: |-
+                  Suspend tells the controller to suspend the reconciliation of this
+                  HelmRepository.
+                type: boolean
+              timeout:
+                description: |-
+                  Timeout is used for the index fetch operation for an HTTPS helm repository,
+                  and for remote OCI Repository operations like pulling for an OCI helm
+                  chart by the associated HelmChart.
+                  Its default value is 60s.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
+                type: string
+              type:
+                description: |-
+                  Type of the HelmRepository.
+                  When this field is set to  "oci", the URL field value must be prefixed with "oci://".
+                enum:
+                - default
+                - oci
+                type: string
+              url:
+                description: |-
+                  URL of the Helm repository, a valid URL contains at least a protocol and
+                  host.
+                pattern: ^(http|https|oci)://.*$
+                type: string
+            required:
+            - url
+            type: object
+          status:
+            default:
+              observedGeneration: -1
+            description: HelmRepositoryStatus records the observed state of the HelmRepository.
+            properties:
+              artifact:
+                description: Artifact represents the last successful HelmRepository
+                  reconciliation.
+                properties:
+                  digest:
+                    description: Digest is the digest of the file in the form of '<algorithm>:<checksum>'.
+                    pattern: ^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$
+                    type: string
+                  lastUpdateTime:
+                    description: |-
+                      LastUpdateTime is the timestamp corresponding to the last update of the
+                      Artifact.
+                    format: date-time
+                    type: string
+                  metadata:
+                    additionalProperties:
+                      type: string
+                    description: Metadata holds upstream information such as OCI annotations.
                     type: object
-                  type: array
-                lastHandledReconcileAt:
-                  description: |-
-                    LastHandledReconcileAt holds the value of the most recent
-                    reconcile request value, so a change of the annotation value
-                    can be detected.
-                  type: string
-                observedGeneration:
-                  description: |-
-                    ObservedGeneration is the last observed generation of the HelmRepository
-                    object.
-                  format: int64
-                  type: integer
-                url:
-                  description: |-
-                    URL is the dynamic fetch link for the latest Artifact.
-                    It is provided on a "best effort" basis, and using the precise
-                    HelmRepositoryStatus.Artifact data is recommended.
-                  type: string
-              type: object
-          type: object
-      served: true
-      storage: false
-      subresources:
-        status: {}
+                  path:
+                    description: |-
+                      Path is the relative file path of the Artifact. It can be used to locate
+                      the file in the root of the Artifact storage on the local file system of
+                      the controller managing the Source.
+                    type: string
+                  revision:
+                    description: |-
+                      Revision is a human-readable identifier traceable in the origin source
+                      system. It can be a Git commit SHA, Git tag, a Helm chart version, etc.
+                    type: string
+                  size:
+                    description: Size is the number of bytes in the file.
+                    format: int64
+                    type: integer
+                  url:
+                    description: |-
+                      URL is the HTTP address of the Artifact as exposed by the controller
+                      managing the Source. It can be used to retrieve the Artifact for
+                      consumption, e.g. by another controller applying the Artifact contents.
+                    type: string
+                required:
+                - lastUpdateTime
+                - path
+                - revision
+                - url
+                type: object
+              conditions:
+                description: Conditions holds the conditions for the HelmRepository.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              lastHandledReconcileAt:
+                description: |-
+                  LastHandledReconcileAt holds the value of the most recent
+                  reconcile request value, so a change of the annotation value
+                  can be detected.
+                type: string
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the last observed generation of the HelmRepository
+                  object.
+                format: int64
+                type: integer
+              url:
+                description: |-
+                  URL is the dynamic fetch link for the latest Artifact.
+                  It is provided on a "best effort" basis, and using the precise
+                  HelmRepositoryStatus.Artifact data is recommended.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}

--- a/tools/testcrds/source.toolkit.fluxcd.io_ocirepositories.yaml
+++ b/tools/testcrds/source.toolkit.fluxcd.io_ocirepositories.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.1
   name: ocirepositories.source.toolkit.fluxcd.io
 spec:
   group: source.toolkit.fluxcd.io
@@ -12,422 +12,416 @@ spec:
     listKind: OCIRepositoryList
     plural: ocirepositories
     shortNames:
-      - ocirepo
+    - ocirepo
     singular: ocirepository
   scope: Namespaced
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .spec.url
-          name: URL
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].status
-          name: Ready
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Ready")].message
-          name: Status
-          type: string
-        - jsonPath: .metadata.creationTimestamp
-          name: Age
-          type: date
-      name: v1beta2
-      schema:
-        openAPIV3Schema:
-          description: OCIRepository is the Schema for the ocirepositories API
-          properties:
-            apiVersion:
-              description: |-
-                APIVersion defines the versioned schema of this representation of an object.
-                Servers should convert recognized schemas to the latest internal value, and
-                may reject unrecognized values.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-              type: string
-            kind:
-              description: |-
-                Kind is a string value representing the REST resource this object represents.
-                Servers may infer this from the endpoint the client submits requests to.
-                Cannot be updated.
-                In CamelCase.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: OCIRepositorySpec defines the desired state of OCIRepository
-              properties:
-                certSecretRef:
-                  description: |-
-                    CertSecretRef can be given the name of a Secret containing
-                    either or both of
-                    
-                    
-                    - a PEM-encoded client certificate (`tls.crt`) and private
-                    key (`tls.key`);
-                    - a PEM-encoded CA certificate (`ca.crt`)
-                    
-                    
-                    and whichever are supplied, will be used for connecting to the
-                    registry. The client cert and key are useful if you are
-                    authenticating with a certificate; the CA cert is useful if
-                    you are using a self-signed server certificate. The Secret must
-                    be of type `Opaque` or `kubernetes.io/tls`.
-                    
-                    
-                    Note: Support for the `caFile`, `certFile` and `keyFile` keys have
-                    been deprecated.
-                  properties:
-                    name:
-                      description: Name of the referent.
-                      type: string
-                  required:
-                    - name
-                  type: object
-                ignore:
-                  description: |-
-                    Ignore overrides the set of excluded patterns in the .sourceignore format
-                    (which is the same as .gitignore). If not provided, a default will be used,
-                    consult the documentation for your version to find out what those are.
-                  type: string
-                insecure:
-                  description: Insecure allows connecting to a non-TLS HTTP container
-                    registry.
-                  type: boolean
-                interval:
-                  description: |-
-                    Interval at which the OCIRepository URL is checked for updates.
-                    This interval is approximate and may be subject to jitter to ensure
-                    efficient use of resources.
-                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                  type: string
-                layerSelector:
-                  description: |-
-                    LayerSelector specifies which layer should be extracted from the OCI artifact.
-                    When not specified, the first layer found in the artifact is selected.
-                  properties:
-                    mediaType:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.url
+      name: URL
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: OCIRepository is the Schema for the ocirepositories API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: OCIRepositorySpec defines the desired state of OCIRepository
+            properties:
+              certSecretRef:
+                description: |-
+                  CertSecretRef can be given the name of a Secret containing
+                  either or both of
+
+                  - a PEM-encoded client certificate (`tls.crt`) and private
+                  key (`tls.key`);
+                  - a PEM-encoded CA certificate (`ca.crt`)
+
+                  and whichever are supplied, will be used for connecting to the
+                  registry. The client cert and key are useful if you are
+                  authenticating with a certificate; the CA cert is useful if
+                  you are using a self-signed server certificate. The Secret must
+                  be of type `Opaque` or `kubernetes.io/tls`.
+
+                  Note: Support for the `caFile`, `certFile` and `keyFile` keys have
+                  been deprecated.
+                properties:
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - name
+                type: object
+              ignore:
+                description: |-
+                  Ignore overrides the set of excluded patterns in the .sourceignore format
+                  (which is the same as .gitignore). If not provided, a default will be used,
+                  consult the documentation for your version to find out what those are.
+                type: string
+              insecure:
+                description: Insecure allows connecting to a non-TLS HTTP container
+                  registry.
+                type: boolean
+              interval:
+                description: |-
+                  Interval at which the OCIRepository URL is checked for updates.
+                  This interval is approximate and may be subject to jitter to ensure
+                  efficient use of resources.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                type: string
+              layerSelector:
+                description: |-
+                  LayerSelector specifies which layer should be extracted from the OCI artifact.
+                  When not specified, the first layer found in the artifact is selected.
+                properties:
+                  mediaType:
+                    description: |-
+                      MediaType specifies the OCI media type of the layer
+                      which should be extracted from the OCI Artifact. The
+                      first layer matching this type is selected.
+                    type: string
+                  operation:
+                    description: |-
+                      Operation specifies how the selected layer should be processed.
+                      By default, the layer compressed content is extracted to storage.
+                      When the operation is set to 'copy', the layer compressed content
+                      is persisted to storage as it is.
+                    enum:
+                    - extract
+                    - copy
+                    type: string
+                type: object
+              provider:
+                default: generic
+                description: |-
+                  The provider used for authentication, can be 'aws', 'azure', 'gcp' or 'generic'.
+                  When not specified, defaults to 'generic'.
+                enum:
+                - generic
+                - aws
+                - azure
+                - gcp
+                type: string
+              proxySecretRef:
+                description: |-
+                  ProxySecretRef specifies the Secret containing the proxy configuration
+                  to use while communicating with the container registry.
+                properties:
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - name
+                type: object
+              ref:
+                description: |-
+                  The OCI reference to pull and monitor for changes,
+                  defaults to the latest tag.
+                properties:
+                  digest:
+                    description: |-
+                      Digest is the image digest to pull, takes precedence over SemVer.
+                      The value should be in the format 'sha256:<HASH>'.
+                    type: string
+                  semver:
+                    description: |-
+                      SemVer is the range of tags to pull selecting the latest within
+                      the range, takes precedence over Tag.
+                    type: string
+                  semverFilter:
+                    description: SemverFilter is a regex pattern to filter the tags
+                      within the SemVer range.
+                    type: string
+                  tag:
+                    description: Tag is the image tag to pull, defaults to latest.
+                    type: string
+                type: object
+              secretRef:
+                description: |-
+                  SecretRef contains the secret name containing the registry login
+                  credentials to resolve image metadata.
+                  The secret must be of type kubernetes.io/dockerconfigjson.
+                properties:
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - name
+                type: object
+              serviceAccountName:
+                description: |-
+                  ServiceAccountName is the name of the Kubernetes ServiceAccount used to authenticate
+                  the image pull if the service account has attached pull secrets. For more information:
+                  https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#add-imagepullsecrets-to-a-service-account
+                type: string
+              suspend:
+                description: This flag tells the controller to suspend the reconciliation
+                  of this source.
+                type: boolean
+              timeout:
+                default: 60s
+                description: The timeout for remote OCI Repository operations like
+                  pulling, defaults to 60s.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
+                type: string
+              url:
+                description: |-
+                  URL is a reference to an OCI artifact repository hosted
+                  on a remote container registry.
+                pattern: ^oci://.*$
+                type: string
+              verify:
+                description: |-
+                  Verify contains the secret name containing the trusted public keys
+                  used to verify the signature and specifies which provider to use to check
+                  whether OCI image is authentic.
+                properties:
+                  matchOIDCIdentity:
+                    description: |-
+                      MatchOIDCIdentity specifies the identity matching criteria to use
+                      while verifying an OCI artifact which was signed using Cosign keyless
+                      signing. The artifact's identity is deemed to be verified if any of the
+                      specified matchers match against the identity.
+                    items:
                       description: |-
-                        MediaType specifies the OCI media type of the layer
-                        which should be extracted from the OCI Artifact. The
-                        first layer matching this type is selected.
-                      type: string
-                    operation:
-                      description: |-
-                        Operation specifies how the selected layer should be processed.
-                        By default, the layer compressed content is extracted to storage.
-                        When the operation is set to 'copy', the layer compressed content
-                        is persisted to storage as it is.
-                      enum:
-                        - extract
-                        - copy
-                      type: string
-                  type: object
-                provider:
-                  default: generic
-                  description: |-
-                    The provider used for authentication, can be 'aws', 'azure', 'gcp' or 'generic'.
-                    When not specified, defaults to 'generic'.
-                  enum:
-                    - generic
-                    - aws
-                    - azure
-                    - gcp
-                  type: string
-                ref:
-                  description: |-
-                    The OCI reference to pull and monitor for changes,
-                    defaults to the latest tag.
-                  properties:
-                    digest:
-                      description: |-
-                        Digest is the image digest to pull, takes precedence over SemVer.
-                        The value should be in the format 'sha256:<HASH>'.
-                      type: string
-                    semver:
-                      description: |-
-                        SemVer is the range of tags to pull selecting the latest within
-                        the range, takes precedence over Tag.
-                      type: string
-                    semverFilter:
-                      description: SemverFilter is a regex pattern to filter the tags
-                        within the SemVer range.
-                      type: string
-                    tag:
-                      description: Tag is the image tag to pull, defaults to latest.
-                      type: string
-                  type: object
-                secretRef:
-                  description: |-
-                    SecretRef contains the secret name containing the registry login
-                    credentials to resolve image metadata.
-                    The secret must be of type kubernetes.io/dockerconfigjson.
-                  properties:
-                    name:
-                      description: Name of the referent.
-                      type: string
-                  required:
-                    - name
-                  type: object
-                serviceAccountName:
-                  description: |-
-                    ServiceAccountName is the name of the Kubernetes ServiceAccount used to authenticate
-                    the image pull if the service account has attached pull secrets. For more information:
-                    https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#add-imagepullsecrets-to-a-service-account
-                  type: string
-                suspend:
-                  description: This flag tells the controller to suspend the reconciliation
-                    of this source.
-                  type: boolean
-                timeout:
-                  default: 60s
-                  description: The timeout for remote OCI Repository operations like
-                    pulling, defaults to 60s.
-                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
-                  type: string
-                url:
-                  description: |-
-                    URL is a reference to an OCI artifact repository hosted
-                    on a remote container registry.
-                  pattern: ^oci://.*$
-                  type: string
-                verify:
-                  description: |-
-                    Verify contains the secret name containing the trusted public keys
-                    used to verify the signature and specifies which provider to use to check
-                    whether OCI image is authentic.
-                  properties:
-                    matchOIDCIdentity:
-                      description: |-
-                        MatchOIDCIdentity specifies the identity matching criteria to use
-                        while verifying an OCI artifact which was signed using Cosign keyless
-                        signing. The artifact's identity is deemed to be verified if any of the
-                        specified matchers match against the identity.
-                      items:
-                        description: |-
-                          OIDCIdentityMatch specifies options for verifying the certificate identity,
-                          i.e. the issuer and the subject of the certificate.
-                        properties:
-                          issuer:
-                            description: |-
-                              Issuer specifies the regex pattern to match against to verify
-                              the OIDC issuer in the Fulcio certificate. The pattern must be a
-                              valid Go regular expression.
-                            type: string
-                          subject:
-                            description: |-
-                              Subject specifies the regex pattern to match against to verify
-                              the identity subject in the Fulcio certificate. The pattern must
-                              be a valid Go regular expression.
-                            type: string
-                        required:
-                          - issuer
-                          - subject
-                        type: object
-                      type: array
-                    provider:
-                      default: cosign
-                      description: Provider specifies the technology used to sign the
-                        OCI Artifact.
-                      enum:
-                        - cosign
-                        - notation
-                      type: string
-                    secretRef:
-                      description: |-
-                        SecretRef specifies the Kubernetes Secret containing the
-                        trusted public keys.
+                        OIDCIdentityMatch specifies options for verifying the certificate identity,
+                        i.e. the issuer and the subject of the certificate.
                       properties:
-                        name:
-                          description: Name of the referent.
+                        issuer:
+                          description: |-
+                            Issuer specifies the regex pattern to match against to verify
+                            the OIDC issuer in the Fulcio certificate. The pattern must be a
+                            valid Go regular expression.
+                          type: string
+                        subject:
+                          description: |-
+                            Subject specifies the regex pattern to match against to verify
+                            the identity subject in the Fulcio certificate. The pattern must
+                            be a valid Go regular expression.
                           type: string
                       required:
-                        - name
+                      - issuer
+                      - subject
                       type: object
-                  required:
-                    - provider
-                  type: object
-              required:
-                - interval
-                - url
-              type: object
-            status:
-              default:
-                observedGeneration: -1
-              description: OCIRepositoryStatus defines the observed state of OCIRepository
-              properties:
-                artifact:
-                  description: Artifact represents the output of the last successful
-                    OCI Repository sync.
-                  properties:
-                    digest:
-                      description: Digest is the digest of the file in the form of '<algorithm>:<checksum>'.
-                      pattern: ^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$
-                      type: string
-                    lastUpdateTime:
-                      description: |-
-                        LastUpdateTime is the timestamp corresponding to the last update of the
-                        Artifact.
-                      format: date-time
-                      type: string
-                    metadata:
-                      additionalProperties:
-                        type: string
-                      description: Metadata holds upstream information such as OCI annotations.
-                      type: object
-                    path:
-                      description: |-
-                        Path is the relative file path of the Artifact. It can be used to locate
-                        the file in the root of the Artifact storage on the local file system of
-                        the controller managing the Source.
-                      type: string
-                    revision:
-                      description: |-
-                        Revision is a human-readable identifier traceable in the origin source
-                        system. It can be a Git commit SHA, Git tag, a Helm chart version, etc.
-                      type: string
-                    size:
-                      description: Size is the number of bytes in the file.
-                      format: int64
-                      type: integer
-                    url:
-                      description: |-
-                        URL is the HTTP address of the Artifact as exposed by the controller
-                        managing the Source. It can be used to retrieve the Artifact for
-                        consumption, e.g. by another controller applying the Artifact contents.
-                      type: string
-                  required:
-                    - lastUpdateTime
-                    - path
-                    - revision
-                    - url
-                  type: object
-                conditions:
-                  description: Conditions holds the conditions for the OCIRepository.
-                  items:
-                    description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                    type: array
+                  provider:
+                    default: cosign
+                    description: Provider specifies the technology used to sign the
+                      OCI Artifact.
+                    enum:
+                    - cosign
+                    - notation
+                    type: string
+                  secretRef:
+                    description: |-
+                      SecretRef specifies the Kubernetes Secret containing the
+                      trusted public keys.
                     properties:
-                      lastTransitionTime:
-                        description: |-
-                          lastTransitionTime is the last time the condition transitioned from one status to another.
-                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                        format: date-time
-                        type: string
-                      message:
-                        description: |-
-                          message is a human readable message indicating details about the transition.
-                          This may be an empty string.
-                        maxLength: 32768
-                        type: string
-                      observedGeneration:
-                        description: |-
-                          observedGeneration represents the .metadata.generation that the condition was set based upon.
-                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                          with respect to the current state of the instance.
-                        format: int64
-                        minimum: 0
-                        type: integer
-                      reason:
-                        description: |-
-                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                          Producers of specific condition types may define expected values and meanings for this field,
-                          and whether the values are considered a guaranteed API.
-                          The value should be a CamelCase string.
-                          This field may not be empty.
-                        maxLength: 1024
-                        minLength: 1
-                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                        type: string
-                      status:
-                        description: status of the condition, one of True, False, Unknown.
-                        enum:
-                          - "True"
-                          - "False"
-                          - Unknown
-                        type: string
-                      type:
-                        description: |-
-                          type of condition in CamelCase or in foo.example.com/CamelCase.
-                          ---
-                          Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                          useful (see .node.status.conditions), the ability to deconflict is important.
-                          The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                        maxLength: 316
-                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      name:
+                        description: Name of the referent.
                         type: string
                     required:
-                      - lastTransitionTime
-                      - message
-                      - reason
-                      - status
-                      - type
+                    - name
                     type: object
-                  type: array
-                contentConfigChecksum:
-                  description: |-
-                    ContentConfigChecksum is a checksum of all the configurations related to
-                    the content of the source artifact:
-                     - .spec.ignore
-                     - .spec.layerSelector
-                    observed in .status.observedGeneration version of the object. This can
-                    be used to determine if the content configuration has changed and the
-                    artifact needs to be rebuilt.
-                    It has the format of `<algo>:<checksum>`, for example: `sha256:<checksum>`.
-                    
-                    
-                    Deprecated: Replaced with explicit fields for observed artifact content
-                    config in the status.
-                  type: string
-                lastHandledReconcileAt:
-                  description: |-
-                    LastHandledReconcileAt holds the value of the most recent
-                    reconcile request value, so a change of the annotation value
-                    can be detected.
-                  type: string
-                observedGeneration:
-                  description: ObservedGeneration is the last observed generation.
-                  format: int64
-                  type: integer
-                observedIgnore:
-                  description: |-
-                    ObservedIgnore is the observed exclusion patterns used for constructing
-                    the source artifact.
-                  type: string
-                observedLayerSelector:
-                  description: |-
-                    ObservedLayerSelector is the observed layer selector used for constructing
-                    the source artifact.
+                required:
+                - provider
+                type: object
+            required:
+            - interval
+            - url
+            type: object
+          status:
+            default:
+              observedGeneration: -1
+            description: OCIRepositoryStatus defines the observed state of OCIRepository
+            properties:
+              artifact:
+                description: Artifact represents the output of the last successful
+                  OCI Repository sync.
+                properties:
+                  digest:
+                    description: Digest is the digest of the file in the form of '<algorithm>:<checksum>'.
+                    pattern: ^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$
+                    type: string
+                  lastUpdateTime:
+                    description: |-
+                      LastUpdateTime is the timestamp corresponding to the last update of the
+                      Artifact.
+                    format: date-time
+                    type: string
+                  metadata:
+                    additionalProperties:
+                      type: string
+                    description: Metadata holds upstream information such as OCI annotations.
+                    type: object
+                  path:
+                    description: |-
+                      Path is the relative file path of the Artifact. It can be used to locate
+                      the file in the root of the Artifact storage on the local file system of
+                      the controller managing the Source.
+                    type: string
+                  revision:
+                    description: |-
+                      Revision is a human-readable identifier traceable in the origin source
+                      system. It can be a Git commit SHA, Git tag, a Helm chart version, etc.
+                    type: string
+                  size:
+                    description: Size is the number of bytes in the file.
+                    format: int64
+                    type: integer
+                  url:
+                    description: |-
+                      URL is the HTTP address of the Artifact as exposed by the controller
+                      managing the Source. It can be used to retrieve the Artifact for
+                      consumption, e.g. by another controller applying the Artifact contents.
+                    type: string
+                required:
+                - lastUpdateTime
+                - path
+                - revision
+                - url
+                type: object
+              conditions:
+                description: Conditions holds the conditions for the OCIRepository.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
-                    mediaType:
+                    lastTransitionTime:
                       description: |-
-                        MediaType specifies the OCI media type of the layer
-                        which should be extracted from the OCI Artifact. The
-                        first layer matching this type is selected.
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
                       type: string
-                    operation:
+                    message:
                       description: |-
-                        Operation specifies how the selected layer should be processed.
-                        By default, the layer compressed content is extracted to storage.
-                        When the operation is set to 'copy', the layer compressed content
-                        is persisted to storage as it is.
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
                       enum:
-                        - extract
-                        - copy
+                      - "True"
+                      - "False"
+                      - Unknown
                       type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
                   type: object
-                url:
-                  description: URL is the download link for the artifact output of the
-                    last OCI Repository sync.
-                  type: string
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                type: array
+              contentConfigChecksum:
+                description: |-
+                  ContentConfigChecksum is a checksum of all the configurations related to
+                  the content of the source artifact:
+                   - .spec.ignore
+                   - .spec.layerSelector
+                  observed in .status.observedGeneration version of the object. This can
+                  be used to determine if the content configuration has changed and the
+                  artifact needs to be rebuilt.
+                  It has the format of `<algo>:<checksum>`, for example: `sha256:<checksum>`.
+
+                  Deprecated: Replaced with explicit fields for observed artifact content
+                  config in the status.
+                type: string
+              lastHandledReconcileAt:
+                description: |-
+                  LastHandledReconcileAt holds the value of the most recent
+                  reconcile request value, so a change of the annotation value
+                  can be detected.
+                type: string
+              observedGeneration:
+                description: ObservedGeneration is the last observed generation.
+                format: int64
+                type: integer
+              observedIgnore:
+                description: |-
+                  ObservedIgnore is the observed exclusion patterns used for constructing
+                  the source artifact.
+                type: string
+              observedLayerSelector:
+                description: |-
+                  ObservedLayerSelector is the observed layer selector used for constructing
+                  the source artifact.
+                properties:
+                  mediaType:
+                    description: |-
+                      MediaType specifies the OCI media type of the layer
+                      which should be extracted from the OCI Artifact. The
+                      first layer matching this type is selected.
+                    type: string
+                  operation:
+                    description: |-
+                      Operation specifies how the selected layer should be processed.
+                      By default, the layer compressed content is extracted to storage.
+                      When the operation is set to 'copy', the layer compressed content
+                      is persisted to storage as it is.
+                    enum:
+                    - extract
+                    - copy
+                    type: string
+                type: object
+              url:
+                description: URL is the download link for the artifact output of the
+                  last OCI Repository sync.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}


### PR DESCRIPTION
It seems like most of the Go tests passes when Flux CRDs are bumped to Flux 2.4. I see that we already have moved into "Flux 2.4 land" in the go.mod file. What if we try to head directly for Flux 2.4? We use ww-gitops with Flux 2.4 in our clusters, so at least for the main parts, it works.

/cc @casibbald 