### PR TITLE
Fix `create dashboard` command

### DIFF
--- a/pkg/run/install/install_dashboard.go
+++ b/pkg/run/install/install_dashboard.go
@@ -157,18 +157,10 @@ func GetInstalledDashboard(ctx context.Context, kubeClient client.Client, namesp
 	dashboardName := ""
 
 	for _, helmRelease := range helmReleaseList.Items {
-		chart := helmRelease.Spec.Chart
-
-		if shouldDetectEnterpriseDashboard && chart != nil && chart.Spec.Chart == enterpriseDashboardHelmChartName &&
-			chart.Spec.SourceRef.Name == enterpriseDashboardHelmRepositoryName {
-			return DashboardTypeEnterprise, helmRelease.Name, nil
+		var chartSpec helmv2.HelmChartTemplateSpec
+		if helmRelease.Spec.Chart != nil {
+			chartSpec = helmRelease.Spec.Chart.Spec
 		}
-
-		if shouldDetectOSSDashboard && chart == nil {
-			return DashboardTypeOSS, dashboardName, nil
-		}
-
-		chartSpec := helmRelease.Spec.Chart.Spec
 
 		if shouldDetectEnterpriseDashboard && chartSpec.Chart == enterpriseDashboardHelmChartName &&
 			chartSpec.SourceRef.Name == enterpriseDashboardHelmRepositoryName {

--- a/pkg/run/install/install_dashboard_test.go
+++ b/pkg/run/install/install_dashboard_test.go
@@ -194,11 +194,11 @@ var _ = Describe("InstallDashboard", func() {
 
 var _ = Describe("GetInstalledDashboard", func() {
 	var (
-		fakeContext context.Context
-		// fakeClientWithHelmReleases client.WithWatch
-		fakeClientWithDeployments client.WithWatch
-		blankClient               client.WithWatch
-		errorClient               ErroringFakeClient
+		fakeContext                context.Context
+		fakeClientWithHelmReleases client.WithWatch
+		fakeClientWithDeployments  client.WithWatch
+		blankClient                client.WithWatch
+		errorClient                ErroringFakeClient
 	)
 
 	BeforeEach(func() {
@@ -206,39 +206,39 @@ var _ = Describe("GetInstalledDashboard", func() {
 		scheme, err := kube.CreateScheme()
 		Expect(err).NotTo(HaveOccurred())
 
-		// fakeClientWithHelmReleases = fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(helmReleaseFixtures...).Build()
+		fakeClientWithHelmReleases = fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(helmReleaseFixtures...).Build()
 		fakeClientWithDeployments = fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(deploymentFixtures...).Build()
 		blankClient = fake.NewClientBuilder().WithScheme(scheme).Build()
 		errorClient = ErroringFakeClient{}
 	})
 
-	// It("returns the oss dashboard type if the dashboard is installed with a helmrelease", func() {
-	//	dashboardType, dashboardName, err := GetInstalledDashboard(fakeContext, fakeClientWithHelmReleases, testNamespace, map[DashboardType]bool{
-	//		DashboardTypeOSS: true,
-	//	})
-	//	Expect(err).ToNot(HaveOccurred())
-	//	Expect(dashboardType).To(Equal(DashboardTypeOSS))
-	//	Expect(dashboardName).To(Equal("dashboard-2"))
-	// })
-	//
-	// It("returns the enterprise dashboard type if the dashboard is installed with a helmrelease", func() {
-	//	dashboardType, dashboardName, err := GetInstalledDashboard(fakeContext, fakeClientWithHelmReleases, testNamespace, map[DashboardType]bool{
-	//		DashboardTypeEnterprise: true,
-	//	})
-	//	Expect(err).ToNot(HaveOccurred())
-	//	Expect(dashboardType).To(Equal(DashboardTypeEnterprise))
-	//	Expect(dashboardName).To(Equal("dashboard-3"))
-	// })
-	//
-	// It("returns the enterprise dashboard type if both dashboards are installed with a helmrelease", func() {
-	//	dashboardType, dashboardName, err := GetInstalledDashboard(fakeContext, fakeClientWithHelmReleases, testNamespace, map[DashboardType]bool{
-	//		DashboardTypeOSS:        true,
-	//		DashboardTypeEnterprise: true,
-	//	})
-	//	Expect(err).ToNot(HaveOccurred())
-	//	Expect(dashboardType).To(Equal(DashboardTypeEnterprise))
-	//	Expect(dashboardName).To(Equal("dashboard-3"))
-	// })
+	It("returns the oss dashboard type if the dashboard is installed with a helmrelease", func() {
+		dashboardType, dashboardName, err := GetInstalledDashboard(fakeContext, fakeClientWithHelmReleases, testNamespace, map[DashboardType]bool{
+			DashboardTypeOSS: true,
+		})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(dashboardType).To(Equal(DashboardTypeOSS))
+		Expect(dashboardName).To(Equal("dashboard-2"))
+	})
+
+	It("returns the enterprise dashboard type if the dashboard is installed with a helmrelease", func() {
+		dashboardType, dashboardName, err := GetInstalledDashboard(fakeContext, fakeClientWithHelmReleases, testNamespace, map[DashboardType]bool{
+			DashboardTypeEnterprise: true,
+		})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(dashboardType).To(Equal(DashboardTypeEnterprise))
+		Expect(dashboardName).To(Equal("dashboard-3"))
+	})
+
+	It("returns the enterprise dashboard type if both dashboards are installed with a helmrelease", func() {
+		dashboardType, dashboardName, err := GetInstalledDashboard(fakeContext, fakeClientWithHelmReleases, testNamespace, map[DashboardType]bool{
+			DashboardTypeOSS:        true,
+			DashboardTypeEnterprise: true,
+		})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(dashboardType).To(Equal(DashboardTypeEnterprise))
+		Expect(dashboardName).To(Equal("dashboard-3"))
+	})
 
 	It("returns the oss dashboard type if the dashboard is installed with a deployment only", func() {
 		dashboardType, dashboardName, err := GetInstalledDashboard(fakeContext, fakeClientWithDeployments, testNamespace, map[DashboardType]bool{


### PR DESCRIPTION
The code to detect an already installed dashboard was broken in 379395c30eb8d3d4368ed4fa97a98d4d5323d9b2. This commit fixes the `GetInstalledDashboard` function to properly detect an installed dashboard and re-enables the tests that have been commented out in that same commit.
