### PR TITLE
ci: don't run FOSSA job in forks

### DIFF
--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -17,6 +17,8 @@ permissions:
 jobs:
   fossa:
     name: FOSSA
+    # FOSSA API key secret is not available in forks
+    if: github.secret_source != 'None'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
The FOSSA API key secret is not available in forks, which makes the job fail. To avoid "green" PRs, I suggest adding a conditional to only run this job when in upstream org.