### PR TITLE
chore: don't delete *.iml (IDEA module) files on 'make clean'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *~
 bin
 /.idea
+*.iml
 
 .tool-versions
 tools/bin/*

--- a/Makefile
+++ b/Makefile
@@ -100,8 +100,8 @@ gitops-bucket-server: bin/gitops-bucket-server ## Build the GitOps bucket server
 
 # Clean up images and binaries
 clean: ## Clean up images and binaries
-#	Clean up everything. This includes files git has been told to ignore (-x) and directories (-d)
-	git clean -x -d --force --exclude .idea
+	# Clean up everything. This includes files git has been told to ignore (-x) and directories (-d)
+	git clean -xfd -e .idea -e *.iml
 
 fmt: ## Run go fmt against code
 	go fmt ./...


### PR DESCRIPTION
I have now ruined my IDEA Goland setup multiple times because `make clean` deletes the IDEA module file. This adds `*.iml` files to .gitignore and also excludes it when running `make clean`.