### PR TITLE
ci: enable Dependabot for GH actions upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,10 +44,3 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    reviewers:
-      - "weaveworks/timber-wolf"
-      - "weaveworks/pesto"
-      - "weaveworks/wild-watermelon"
-      - "weaveworks/tangerine"
-    # Only do security updates not version updates.
-    open-pull-requests-limit: 0


### PR DESCRIPTION
Dependabot is currently only configured for security updates, and some of the used GH actions are lagging on upgrades. Proposing to enable upgrades of GH actions in general and see how it works. Also removing the assigned reviewers which I think are abandoned Weaveworks teams.