### PR TITLE
chore: remove direct dependency to github.com/pkg/errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,6 @@ require (
 	github.com/onsi/ginkgo/v2 v2.19.0
 	github.com/onsi/gomega v1.33.1
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
-	github.com/pkg/errors v0.9.1
 	github.com/slok/go-http-metrics v0.10.0
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/viper v1.16.0
@@ -103,6 +102,7 @@ require (
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.8 // indirect
 	github.com/pjbgf/sha1cd v0.3.0 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/rs/xid v1.2.1 // indirect
 	github.com/ryszard/goskiplist v0.0.0-20150312221310-2dfbae5fcf46 // indirect
 	github.com/shabbyrobe/gocovmerge v0.0.0-20180507124511-f6ea450bfb63 // indirect

--- a/pkg/kube/kubehttp.go
+++ b/pkg/kube/kubehttp.go
@@ -1,13 +1,10 @@
 package kube
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
-
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	helmv2 "github.com/fluxcd/helm-controller/api/v2"
 	imgautomationv1 "github.com/fluxcd/image-automation-controller/api/v1beta2"
@@ -17,7 +14,6 @@ import (
 	notificationv1b2 "github.com/fluxcd/notification-controller/api/v1beta2"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 	sourcev1b2 "github.com/fluxcd/source-controller/api/v1beta2"
-	"github.com/pkg/errors"
 	pacv2beta2 "github.com/weaveworks/policy-agent/api/v2beta2"
 	appsv1 "k8s.io/api/apps/v1"
 	authv1 "k8s.io/api/authentication/v1"
@@ -26,6 +22,9 @@ import (
 	extensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiruntime "k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func CreateScheme() (*apiruntime.Scheme, error) {
@@ -65,7 +64,7 @@ const (
 
 var (
 	// ErrWegoConfigNotFound indicates weave gitops config could not be found
-	ErrWegoConfigNotFound = errors.New("Wego Config not found")
+	ErrWegoConfigNotFound = errors.New("wego config not found")
 )
 
 // InClusterConfig defines a function for checking if this code is executing in kubernetes.

--- a/pkg/services/auth/jwt.go
+++ b/pkg/services/auth/jwt.go
@@ -1,9 +1,9 @@
 package auth
 
 import (
+	"errors"
+	"fmt"
 	"time"
-
-	"github.com/pkg/errors"
 
 	"github.com/weaveworks/weave-gitops/pkg/gitproviders"
 
@@ -80,7 +80,7 @@ func (i *internalJWTClient) VerifyJWT(accessToken string) (*Claims, error) {
 	)
 
 	if err != nil {
-		return nil, errors.WithMessage(ErrUnauthorizedToken, err.Error())
+		return nil, fmt.Errorf("%w: %w", ErrUnauthorizedToken, err)
 	}
 
 	claims, ok := token.Claims.(*Claims)


### PR DESCRIPTION
The https://github.com/pkg/errors project has been archived for some time in favor of the proposals that landed in the stdlib. We have very few references to this module so I took a stab at migrating it.