### PR TITLE
ci: add missing permission to Trivy scan job

### DIFF
--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -36,6 +36,8 @@ jobs:
   trivy:
     name: Trivy
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write # for Trivy to write security events
     steps:
       - name: Checkout code
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0


### PR DESCRIPTION
Hopefully, this should fix the current error on the main branch:

````
RequestError [HttpError]: Resource not accessible by integration
    at /home/runner/work/_actions/github/codeql-action/04daf0[14](https://github.com/weaveworks/weave-gitops/actions/runs/12536344145/job/34959246645#step:4:15)b50eaf774287bf3f0f1869d4b4c4b913/node_modules/@octokit/request/dist-node/index.js:86:21
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async requestWithGraphqlErrorHandling (/home/runner/work/_actions/github/codeql-action/04daf014b50eaf774287bf3f0f1869d4b4c4b913/node_modules/@octokit/plugin-retry/dist-node/index.js:71:20)
    at async Job.doExecute (/home/runner/work/_actions/github/codeql-action/04daf014b50eaf774287bf3f0f1869d4b4c4b913/node_modules/bottleneck/light.js:405:18) {
  status: 403,
  response: {
    url: 'https://api.github.com/repos/weaveworks/weave-gitops/code-scanning/analysis/status',
    status: 403,
````

The permission granted in this PR is the same as the one given to the CodeQL scanning job. I have a feeling the two jobs require the same permissions.