### PR TITLE
ci: improve/fix golangci-lint config

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,13 +1,12 @@
 run:
   timeout: 5m
-  go: '1.23.2'
 
 linters:
   disable-all: true
   enable:
     #- containedctx
     #- contextcheck
-    #- depguard
+    - depguard
     - errcheck
     #- errchkjson
     #- errname
@@ -39,11 +38,12 @@ linters:
 
 linters-settings:
   depguard:
-    list-type: blacklist
-    packages:
-      - k8s.io/kubernetes
-    packages-with-error-messages:
-      k8s.io/kubernetes: "do not use k8s.io/kubernetes directly"
+    rules:
+      prevent_kubernetes_dependency:
+        list-mode: lax # allow unless explicitly denied
+        deny:
+          - pkg: k8s.io/kubernetes
+            desc: "do not use k8s.io/kubernetes directly"
   errcheck:
     exclude-functions:
       - encoding/json.Marshal
@@ -83,12 +83,13 @@ linters-settings:
       - performance
       - style
   gofumpt:
-    lang-version: "1.23.2"
     extra-rules: true
   lll:
     line-length: 150
 
 issues:
+  exclude-dirs:
+    - tilt_modules
   exclude-rules:
     # ignore errcheck for code under a /test folder
     - path: "test/*"

--- a/Makefile
+++ b/Makefile
@@ -110,8 +110,8 @@ vet: ## Run go vet against code
 	go vet ./...
 
 lint: ## Run linters against code
-	@go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.62.0
-	golangci-lint run --out-format=github-actions --timeout 600s --skip-files "tilt_modules"
+	@go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.62.2
+	golangci-lint run --out-format=colored-line-number --timeout 600s
 	@go install github.com/yoheimuta/protolint/cmd/protolint@latest
 	protolint lint -config_path=.protolint.yaml ./api
 


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes

<!-- Describe what has changed in this PR -->
**What changed?**

While running `make lint` I noticed a couple of deprecation warnings that I wanted to fix. In addition, I removed the hard-coded Go version from the lint config. golangci-lint will by default use the Go version specified in `go.mod`.

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**

Eliminate warnings when running lint. Deprecated features will eventually be removed. Also nice to avoid having to bump Go version in multiple files.

<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**


<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**


<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**


<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
