### PR TITLE
ci: migrate deprecated set-output commands

### DIFF
--- a/.github/workflows/chart.yaml
+++ b/.github/workflows/chart.yaml
@@ -34,13 +34,13 @@ jobs:
         id: new-version
         run: |
           NEW_VERSION=$(yq e '.version' charts/gitops-server/Chart.yaml)
-          echo "::set-output name=version::$NEW_VERSION"
+          echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
       - name: Find old version
         id: old-version
         run: |
           git checkout ${{ github.event.pull_request.base.sha || github.event.before }}
           OLD_VERSION=$(yq e '.version' charts/gitops-server/Chart.yaml)
-          echo "::set-output name=version::$OLD_VERSION"
+          echo "version=$OLD_VERSION" >> $GITHUB_OUTPUT
 
   helm-will-release:
     runs-on: ubuntu-latest
@@ -59,7 +59,7 @@ jobs:
           git log --exit-code $last_revision...${{ github.event.pull_request.base.sha }} charts/gitops-server
           unreleased_commits=$?
           if [[ $unreleased_commits == 1 ]]; then
-              echo "::set-output name=unreleased-commits::The last chart was last released in $last_revision and there have been other changes in the chart since"
+              echo "unreleased-commits=The last chart was last released in $last_revision and there have been other changes in the chart since" >> $GITHUB_OUTPUT
           fi
       - name: Let user know merging will cause a release
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
@@ -86,7 +86,7 @@ jobs:
         id: new_version
         run: |
           NEW_VERSION=$(yq e '.version' charts/gitops-server/Chart.yaml)
-          echo "::set-output name=version::$NEW_VERSION"
+          echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
       - name: Generate new chart
         run: |
           URL=https://helm.gitops.weave.works

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -80,7 +80,7 @@ jobs:
       tag: ${{ steps.generate-tag.outputs.tag }}
     steps:
       - id: generate-tag
-        run: echo "::set-output name=tag::$(date -u +%s)-${{ github.sha }}"
+        run: echo "tag=$(date -u +%s)-${{ github.sha }}" >> $GITHUB_OUTPUT
 
   ci-build-gitops-image:
     name: CI Build Gitops Docker Image
@@ -171,7 +171,7 @@ jobs:
     - id: gitsha
       run: |
         gitsha=$(git rev-parse --short ${{ github.sha }})
-        echo "::set-output name=sha::$gitsha"
+        echo "sha=$gitsha" >> $GITHUB_OUTPUT
     - name: build
       run: |
         make gitops
@@ -216,7 +216,7 @@ jobs:
         id: package-version
         run: |
           GITOPS_VERSION=$(git describe)
-          echo "::set-output name=js-version::$GITOPS_VERSION"
+          echo "js-version=$GITOPS_VERSION" >> $GITHUB_OUTPUT
           jq '.version = "'$GITOPS_VERSION'" | .name = "@weaveworks/weave-gitops-main"' < dist/package.json > dist/package-new.json
           mv dist/package-new.json dist/package.json
           cp .npmrc dist

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,7 +31,7 @@ jobs:
           GITHUB_EVENT_PULL_REQUEST_HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           version=$(echo $GITHUB_EVENT_PULL_REQUEST_HEAD_REF | cut -d'/' -f2)
-          echo "::set-output name=version::$version"
+          echo "version=$version" >> $GITHUB_OUTPUT
       - name: Set tag
         run: |
           git config user.name weave-gitops-bot

--- a/.github/workflows/upgrade-flux.yaml
+++ b/.github/workflows/upgrade-flux.yaml
@@ -23,7 +23,7 @@ jobs:
           new_version="$(curl -s --request GET --url "https://api.github.com/repos/fluxcd/flux2/releases?per_page=1" | jq . | jq '.[0] | .tag_name' | jq -r | sed -e 's/v//')"
 
           if [[ "$old_version" != "$new_version" ]]; then
-              echo "::set-output name=version::$new_version"
+              echo "version=$new_version" >> $GITHUB_OUTPUT
           fi
   upgrade-flux:
     needs:


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why was this change made?**

Migrate use of the deprecated GHA set-output commands. Ref. https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**

While looking through the CI logs, I noticed warnings around this:

![image](https://github.com/user-attachments/assets/e197ebab-2363-4de8-a262-00c3cded3173)


<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**


<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**


<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
