### PR TITLE
refactor: migrate calls to deprecated NewSimpleClientset

### DIFF
--- a/core/server/suite_test.go
+++ b/core/server/suite_test.go
@@ -171,7 +171,7 @@ func makeServerConfig(fakeClient client.Client, t *testing.T, clusterName string
 		// Pretend the user has access to everything
 		return n, nil
 	}
-	clientset := fake.NewSimpleClientset()
+	clientset := fake.NewClientset()
 
 	cluster := clusterfakes.FakeCluster{}
 

--- a/pkg/services/check/check_test.go
+++ b/pkg/services/check/check_test.go
@@ -18,7 +18,7 @@ func TestKubernetesVersionWithError(t *testing.T) {
 	g := NewWithT(t)
 
 	expectedError := errors.New("an error occurred")
-	fakeClient := fakeclientset.NewSimpleClientset()
+	fakeClient := fakeclientset.NewClientset()
 	fakeClient.Discovery().(*fakediscovery.FakeDiscovery).PrependReactor("*", "*", func(action kubetesting.Action) (handled bool, ret runtime.Object, err error) {
 		return true, nil, expectedError
 	})
@@ -56,7 +56,7 @@ func TestKubernetesVersion(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
-			client := fakeclientset.NewSimpleClientset()
+			client := fakeclientset.NewClientset()
 			fakeDiscovery, ok := client.Discovery().(*fakediscovery.FakeDiscovery)
 			if !ok {
 				t.Fatalf("couldn't convert Discovery() to *FakeDiscovery")


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes

<!-- Describe what has changed in this PR -->
**What changed?**

Migrate calls to the deprecated `NewSimpleClientset `function.

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**

Avoid using deprecated functionality.

<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**


<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**


<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**


<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
