### PR TITLE
refactor: migrate calls to deprecated grpc.Dial

### DIFF
--- a/core/server/suite_test.go
+++ b/core/server/suite_test.go
@@ -109,9 +109,8 @@ func makeGRPCServer(cfg *rest.Config, t *testing.T) pb.CoreClient {
 		}
 	}(t)
 
-	//nolint:staticcheck // Ignore SA1019 deprecation warning for grpc.Dial
-	conn, err := grpc.Dial(
-		"bufnet",
+	conn, err := grpc.NewClient(
+		"passthrough://bufnet",
 		grpc.WithContextDialer(dialer),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 	)
@@ -237,9 +236,8 @@ func dialBufnet(t *testing.T, lis *bufconn.Listener) *grpc.ClientConn {
 		return lis.Dial()
 	}
 
-	//nolint:staticcheck // Ignore SA1019 deprecation warning for grpc.Dial
-	conn, err := grpc.Dial(
-		"bufnet", // The address is ignored when using WithContextDialer
+	conn, err := grpc.NewClient(
+		"passthrough://bufnet",
 		grpc.WithContextDialer(dialer),
 		grpc.WithTransportCredentials(insecure.NewCredentials()), // Insecure for testing
 	)


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes

<!-- Describe what has changed in this PR -->
**What changed?**

Migrate the use of the deprecated `Dial` function to the `NewClient` replacement.

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**

Avoid using deprecated code.

<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**


<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**


<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**


<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
