### PR TITLE
ci(deps): improve react Dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,10 +7,14 @@ updates:
       interval: "daily"
     groups:
       react:
-        patterns:
+        patterns: &react-deps
           - react
-          - react-*
-          - "@*/react-*"
+          - react-dom
+          - react-is
+          - react-test-renderer
+          - @types/react
+          - @types/react-dom
+          - @types/react-is
   # Maintain dependencies for backend
   - package-ecosystem: "gomod"
     directory: "/"
@@ -23,10 +27,7 @@ updates:
       interval: "daily"
     groups:
       react:
-        patterns:
-          - react
-          - react-*
-          - "@*/react-*"
+        patterns: *react-deps
   # maintain dependencies for github actions
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes

<!-- Describe what has changed in this PR -->
**What changed?**

The current react Dependabot group is too wide, making https://github.com/weaveworks/weave-gitops/pull/4363 worthless.
This PR improves the group definition by looking at the proposed versions in https://github.com/weaveworks/weave-gitops/pull/4363. Over time, I think that will be a better approach. I will try to follow up deps that might be missing from the group.


<!-- Tell your future self why have you made these changes -->
**Why was this change made?**

Create mergeable Dependabot PRs.

<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**


<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**


<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**


<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
