### PR TITLE
ci(deps): Dependabot group patterns match prefix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,15 +6,17 @@ updates:
     schedule:
       interval: "daily"
     groups:
-      react:
-        patterns: &react-deps
+      react: &react-group
+        patterns:
           - react
-          - react-dom
-          - react-is
-          - react-test-renderer
           - @types/react
-          - @types/react-dom
-          - @types/react-is
+        exclude-patterns:
+          - react-lottie-player
+          - react-markdown
+          - react-router-dom
+          - react-syntax-highlighter
+          - react-toastify
+          - @testing-library/react-hooks
   # Maintain dependencies for backend
   - package-ecosystem: "gomod"
     directory: "/"
@@ -28,9 +30,8 @@ updates:
     groups:
       docusaurus:
         patterns:
-          - "@docusaurus/*"
-      react:
-        patterns: *react-deps
+          - @docusaurus
+      react: *react-group
   # maintain dependencies for github actions
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes

<!-- Describe what has changed in this PR -->
**What changed?**

https://github.com/weaveworks/weave-gitops/pull/4363 is still borked, and I think Depedabot group patterns are matching on prefix and not exact. Which means we need to use exclude-patterns to ungroup deps we don't want to group with React upgrades.

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**

![image](https://github.com/user-attachments/assets/f0e1b78a-7f78-4575-a2a1-73e05062b4ae)

<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**


<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**


<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**


<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
