### PR TITLE
ci(deps): no YAML alias support in Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
     schedule:
       interval: "daily"
     groups:
-      react: &react-group
+      react:
         patterns:
           - react
           - "@types/react"
@@ -31,7 +31,17 @@ updates:
       docusaurus:
         patterns:
           - "@docusaurus"
-      react: *react-group
+      react:
+        patterns:
+          - react
+          - "@types/react"
+        exclude-patterns:
+          - react-lottie-player
+          - react-markdown
+          - react-router-dom
+          - react-syntax-highlighter
+          - react-toastify
+          - "@testing-library/react-hooks"
   # maintain dependencies for github actions
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes

<!-- Describe what has changed in this PR -->
**What changed?**

Extand YAML aliases since they are not yet supported by Dependabot, ref. https://github.com/dependabot/dependabot-core/issues/1582

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**

Working Dependabot configuration.

<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**


<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**


<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**


<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
