### PR TITLE
ci: avoid failing jobs when syncing fork

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -50,7 +50,7 @@ jobs:
           retention-days: 90
 
   deploy:
-    if: "${{ github.repository_owner == 'weaveworks' && !github.event.pull_request.head.repo.fork && github.ref_name == 'main'}}"
+    if: "${{ github.repository_owner == 'weaveworks' && github.ref_name == 'main'}}"
     permissions:
       statuses: write
       pull-requests: write

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -189,7 +189,7 @@ jobs:
   ci-publish-js-lib:
     name: Publish js library
     runs-on: ubuntu-latest
-    if: ${{ !github.event.pull_request.head.repo.fork }}
+    if: "${{ github.repository_owner == 'weaveworks' && github.ref_name == 'main'}}"
     needs: [ci-js]
     permissions:
       packages: write

--- a/.github/workflows/trigger.yaml
+++ b/.github/workflows/trigger.yaml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   trigger-enterprise-workflow:
     runs-on: ubuntu-latest
-   # if: github.event_name == 'pull_request' && github.event.pull_request.merged == true
+    if: "${{ github.repository_owner == 'weaveworks' && github.ref_name == 'main'}}"
     steps:
       - name: Trigger Workflow
         uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3.0.0


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes

<!-- Describe what has changed in this PR -->
**What changed?**

Tuning conditions for specific jobs that should only run on the `main` branch in the upstream repo.

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**

Since I've now started using codespaces, I need to keep my fork up-to-date. Every time I resync my fork, I get emails about failing jobs. This is annoying.

<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**


<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**


<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**


<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
