### PR TITLE
Revert "fix: bump ts config target to ES2018"

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
         "jsx": "react",
         "resolveJsonModule": true,
         "skipLibCheck": true,
-        "target": "ES2018",
+        "target": "ES5",
         "module": "CommonJS",
     },
     "include": [


### PR DESCRIPTION
Reverts weaveworks/weave-gitops#4437

`
@parcel/core: ui/components/Input.tsx does not export 'InputProps'
  /home/runner/work/weave-gitops/weave-gitops/ui/index.ts:100:890

     99 |   useListFluxRuntimeObjects,
  > 100 |   useListRuntimeObjects,
  >     |                         ^
    101 |   useListRuntimeCrds,
    102 |   useToggleSuspend,
`