### PR TITLE
ci: new lint-fix make target

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,5 +1,5 @@
 run:
-  timeout: 5m
+  timeout: 10m
 
 linters:
   disable-all: true
@@ -100,3 +100,8 @@ issues:
     - source: "flags.Parse|response.WriteError"
       linters:
         - errcheck
+
+output:
+  formats:
+    - format: colored-line-number
+      path: stdout


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes

<!-- Describe what has changed in this PR -->
**What changed?**

Add a new Makefile target to facilitate fixing lint issues in Go and Proto (API). Also refactoring the setup of these tools a bit. I am not a big fan of one project "dictating" my global installation of tools, so from now on we will use a local bin directory for golangci-lint and protolint binaries. 😉 

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**

Triggered by https://github.com/weaveworks/weave-gitops/pull/4466. Especially for the GCI linter, an auto-fix target is useful for contributors to get imports organized according to the spec.

<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**


<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**


<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**


<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
