### PR TITLE
ci: upload binaries as workflow artifacts

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -91,37 +91,34 @@ jobs:
 
   ci-upload-binary:
     name: Upload Binary - Disabled
-    runs-on: ${{matrix.os}}
+    runs-on: ${{ matrix.os }}
     needs: [ci-go, ci-static, ci-js]
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest]
-    if: github.event_name == 'push'
+    if: ${{ github.event_name != 'pull_request' && github.repository == 'weaveworks/weave-gitops' }}
     steps:
-    - name: Checkout code
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-    - name: Setup Go
-      uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
-      with:
-        go-version-file: go.mod
-    - name: Clean
-      run: make clean
-    - id: gitsha
-      run: |
-        gitsha=$(git rev-parse --short ${{ github.sha }})
-        echo "sha=$gitsha" >> $GITHUB_OUTPUT
-    - name: build
-      run: |
-        make gitops
-#    - name: publish to s3
-#      uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
-#      with:
-#        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-#        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-#        aws-region: us-east-2
-#    - run: |
-#        aws s3 cp bin/gitops s3://weave-gitops/gitops-${{matrix.os}}-${{steps.gitsha.outputs.sha}}
-#        aws s3 cp s3://weave-gitops/gitops-${{matrix.os}}-${{steps.gitsha.outputs.sha}} s3://weave-gitops/gitops-${{matrix.os}}
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Setup Go
+        uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
+        with:
+          go-version-file: go.mod
+      - name: Clean
+        run: make clean
+      - id: gitsha
+        run: |
+          gitsha=$(git rev-parse --short ${{ github.sha }})
+          echo "sha=$gitsha" >> $GITHUB_OUTPUT
+      - name: build
+        run: |
+          make gitops
+      - name: Upload binary
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: gitops-${{ matrix.os }}-${{ steps.gitsha.outputs.sha }}
+          path: bin/gitops
+          overwrite: true
 
   ci-publish-js-lib:
     name: Publish js library


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes

<!-- Describe what has changed in this PR -->
**What changed?**

Slightly improve the upload binary CI job. Since I couldn't find a way to create a "generic" GH package, I suggest starting by replacing the out-commented AWS S3 upload with upload-artifact-action. This will keep the binaries available for the default project retention period (30 days)?

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**

I have accidentally reformatted this code several times in other PR, and in general I am not a big fan of out-commented code. We can always find old things in the Git history. 

<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**


<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**


<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**


<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
