### PR TITLE
Fix proxy-middleware

### DIFF
--- a/.proxyrc.js
+++ b/.proxyrc.js
@@ -8,20 +8,14 @@ const proxyHost = process.env.PROXY_HOST || DEFAULT_PROXY_HOST;
 const secure = process.env.PROXY_SECURE === "true";
 
 module.exports = function (app) {
-  app.use(
-    "/v1",
-    createProxyMiddleware({
-      target: proxyHost,
-      secure,
-      changeOrigin: true,
-    })
-  );
-  app.use(
-    "/oauth2",
-    createProxyMiddleware({
-      target: proxyHost,
-      secure,
-      changeOrigin: true,
-    })
-  );
+  app.use("/v1", createProxyMiddleware({
+    target: proxyHost + "/v1",
+    secure,
+    changeOrigin: true,
+   }));
+  app.use("/oauth2", createProxyMiddleware({
+    target: proxyHost + "/oauth2",
+    secure,
+    changeOrigin: true,
+  }));
 };


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes

<!-- Describe what has changed in this PR -->
**What changed?**

PR [#4413](https://github.com/weaveworks/weave-gitops/pull/4413) moved the proxy-middleware across major versions without migrations being applied to `.proxyrc.js`

This affects redirecting API traffic from the front end to the backend server for both the `/v1` and `/oauth2` endpoints.

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**

To resolve proxying requests to the backend when the backend server is on a different URL

<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**

This commit resolves that break by applying the necessary migration to `.proxyrc.js`

<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**

- run `SKIP_UI_BUILD=1 tilt up` to bring up the backend service
- run `yarn start` to run the front end outside of tilt
- Observe that the UI can be accessed normally without a blank page being present

<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**

N/A - Restores original behaviour

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**

N/A - Restores original behaviour