### PR TITLE
ci(release): keyless sign of release artifacts with Cosign

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -77,6 +77,9 @@ jobs:
 
   goreleaser:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # for actions/checkout to fetch code
+      id-token: write # for Cosign to be able to sign release artifacts with GHA token
     needs:
       - publish_npm_package
       - build-and-push-image
@@ -118,6 +121,8 @@ jobs:
           cat > ${{ runner.temp }}/changelog.md <<'END_OF_CHANGELOG'
           ${{ github.event.pull_request.body }}
           END_OF_CHANGELOG
+      - name: Install cosign
+        uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da # v3.7.0
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@9ed2f89a662bf1735a48bc8557fd212fa902bebf # v6.1.0
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -68,3 +68,9 @@ builds:
       - darwin
     goarch:
       - arm64
+signs:
+  - id: cosign-keyless
+    cmd: cosign
+    certificate: "${artifact}.crt"
+    args: ["sign-blob", "--output-signature", "${signature}", "--output-certificate", "${certificate}", "${artifact}", "--yes"]
+    artifacts: all


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes

<!-- Describe what has changed in this PR -->
**What changed?**

Configure Cosign keyless signing of all release artifacts to the (Goreleaser) release workflow. I am not sure this will work, but there is a fair chance it will. Goreleaser docs: https://goreleaser.com/customization/sign/. I searched the Internet for references, and it seems like Chainguard has done something around this. I just copied https://github.com/chainguard-dev/apko/blob/64e3ae0d1cf09e2e83dd384cd5a4f9c06d48e0a4/.goreleaser.yaml#L34-L39, which should end up like this (Assets; example): https://github.com/chainguard-dev/apko/releases/tag/v0.22.6.

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**

Allow our users to verify release artifacts before actually using/installing them.

<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**


<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**


<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**


<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
