### PR TITLE
Revert "build(deps): Bump d3-dag from 0.11.5 to 1.1.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@types/styled-components": "^5.1.34",
     "ansi-styles": "^6.2.1",
     "d3": "^7.9.0",
-    "d3-dag": "^1.1.0",
+    "d3-dag": "^0.11.5",
     "history": "^5.3.0",
     "http-proxy-middleware": "^3.0.3",
     "install": "^0.13.0",

--- a/ui/components/DagGraph.tsx
+++ b/ui/components/DagGraph.tsx
@@ -83,19 +83,17 @@ function DagGraph({ className, nodes }: Props) {
   const linkStrokeWidth = 5;
 
   //use d3 to create DAG structure
-  const builder = d3d.graphStratify();
-  const graph = builder(nodes);
+  const stratify = d3d.dagStratify();
+  const root = stratify(nodes);
   const makeDag = d3d
     .sugiyama()
     .nodeSize(() => [
       nodeSize.width + nodeSize.horizontalSeparation,
       nodeSize.height + nodeSize.verticalSeparation,
     ]);
-  const { width } = makeDag(graph);
-  const root = [...graph.roots()][0];
-
-  const descendants = root ? [...root.descendants()] : [];
-  const links = [...graph.links()];
+  const { width } = makeDag(root);
+  const descendants = root.descendants();
+  const links = root.links();
 
   const graphOffsetX = zoomBox / 2 - width / 2;
   const verticalSeparationHalf = nodeSize.verticalSeparation / 2;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4399,7 +4399,7 @@ __metadata:
     babel-plugin-styled-components: "npm:^2.1.4"
     buffer: "npm:^6.0.3"
     d3: "npm:^7.9.0"
-    d3-dag: "npm:^1.1.0"
+    d3-dag: "npm:^0.11.5"
     eslint: "npm:9.18.0"
     eslint-plugin-import: "npm:^2.31.0"
     history: "npm:^5.3.0"
@@ -5605,21 +5605,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"d3-array@npm:2 - 3, d3-array@npm:2.10.0 - 3, d3-array@npm:2.5.0 - 3, d3-array@npm:3, d3-array@npm:^3.2.0":
+"d3-array@npm:2 - 3, d3-array@npm:2.10.0 - 3, d3-array@npm:2.5.0 - 3, d3-array@npm:3, d3-array@npm:^3.1.6, d3-array@npm:^3.2.0":
   version: 3.2.0
   resolution: "d3-array@npm:3.2.0"
   dependencies:
     internmap: "npm:1 - 2"
   checksum: 10c0/5e3d831b2b4ae3ba1cf50dbdf4f16f794f8aa3013ee327c50970f3206a87849eba612667255f0451685abe599c437fcff65d72fbff3e38ecfb433372f5c27c73
-  languageName: node
-  linkType: hard
-
-"d3-array@npm:^3.2.4":
-  version: 3.2.4
-  resolution: "d3-array@npm:3.2.4"
-  dependencies:
-    internmap: "npm:1 - 2"
-  checksum: 10c0/08b95e91130f98c1375db0e0af718f4371ccacef7d5d257727fe74f79a24383e79aba280b9ffae655483ffbbad4fd1dec4ade0119d88c4749f388641c8bf8c50
   languageName: node
   linkType: hard
 
@@ -5668,15 +5659,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"d3-dag@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "d3-dag@npm:1.1.0"
+"d3-dag@npm:^0.11.5":
+  version: 0.11.5
+  resolution: "d3-dag@npm:0.11.5"
   dependencies:
-    d3-array: "npm:^3.2.4"
+    d3-array: "npm:^3.1.6"
+    fastpriorityqueue: "npm:0.7.2"
     javascript-lp-solver: "npm:0.4.24"
     quadprog: "npm:^1.6.1"
-    stringify-object: "npm:^5.0.0"
-  checksum: 10c0/e4590fe88fc3bb34cf7c9629059b1378da501bfce244e1d3012e123ddf9c413bc7dd9cb77a6737e78d853e1c53a7d3961dbd2d130552a32001bae54da8190f48
+  checksum: 10c0/bdcfd673a56830e297f228919bc38f44aefd104c13f3ee1962bb0c3fa084ab3881844bdfaa9e5024fabf679b536d33052c5a9f05fdf1d28882035767e22b7538
   languageName: node
   linkType: hard
 
@@ -6904,6 +6895,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fastpriorityqueue@npm:0.7.2":
+  version: 0.7.2
+  resolution: "fastpriorityqueue@npm:0.7.2"
+  checksum: 10c0/21ce7c0c25a27f8d266de044aa7a2a755640e7db1419dbd49a744ecd7e949e3074540321008dfc91832f0b16b6db21ed103d5aeab40add28f087b4ebe8526ade
+  languageName: node
+  linkType: hard
+
 "fastq@npm:^1.6.0":
   version: 1.13.0
   resolution: "fastq@npm:1.13.0"
@@ -7166,13 +7164,6 @@ __metadata:
     hasown: "npm:^2.0.2"
     math-intrinsics: "npm:^1.1.0"
   checksum: 10c0/b475dec9f8bff6f7422f51ff4b7b8d0b68e6776ee83a753c1d627e3008c3442090992788038b37eff72e93e43dceed8c1acbdf2d6751672687ec22127933080d
-  languageName: node
-  linkType: hard
-
-"get-own-enumerable-keys@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "get-own-enumerable-keys@npm:1.0.0"
-  checksum: 10c0/3e14fbcf7cbb27a09f4335b3fe28ec4ac73254cd5007c141ff8e248c854fb1f4b44271fcc707c9aec1de7ae889eb28ffbd5b8a82f6abd9adb91df926fb7cec44
   languageName: node
   linkType: hard
 
@@ -8051,13 +8042,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-obj@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "is-obj@npm:3.0.0"
-  checksum: 10c0/48d678fa15c56fd38353634ae2106a538827af9050211b18df13540dba0b38aa25c5cb498648a01311bf493a99ac3ce416576649b8cace10bcce7344611fa56a
-  languageName: node
-  linkType: hard
-
 "is-plain-obj@npm:^4.0.0":
   version: 4.1.0
   resolution: "is-plain-obj@npm:4.1.0"
@@ -8088,13 +8072,6 @@ __metadata:
     has-tostringtag: "npm:^1.0.2"
     hasown: "npm:^2.0.2"
   checksum: 10c0/1d3715d2b7889932349241680032e85d0b492cfcb045acb75ffc2c3085e8d561184f1f7e84b6f8321935b4aea39bc9c6ba74ed595b57ce4881a51dfdbc214e04
-  languageName: node
-  linkType: hard
-
-"is-regexp@npm:^3.1.0":
-  version: 3.1.0
-  resolution: "is-regexp@npm:3.1.0"
-  checksum: 10c0/99dbaea41bddee2205db468c0946f5fee25cc4ae486333cb4d2b8095ab4b0a500e74ba61afd9e6e4f63ececcd55b4df5ae2a555b1c3e26308e516ff53c9533cd
   languageName: node
   linkType: hard
 
@@ -12059,17 +12036,6 @@ __metadata:
     character-entities-html4: "npm:^2.0.0"
     character-entities-legacy: "npm:^3.0.0"
   checksum: 10c0/537c7e656354192406bdd08157d759cd615724e9d0873602d2c9b2f6a5c0a8d0b1d73a0a08677848105c5eebac6db037b57c0b3a4ec86331117fa7319ed50448
-  languageName: node
-  linkType: hard
-
-"stringify-object@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "stringify-object@npm:5.0.0"
-  dependencies:
-    get-own-enumerable-keys: "npm:^1.0.0"
-    is-obj: "npm:^3.0.0"
-    is-regexp: "npm:^3.1.0"
-  checksum: 10c0/f955bb0b41edb0a200bf5ba24d516a2d409c749a01224e14a088ecf07fec3d930ec90da3a681f6798b9d6a1b187cb3bb57f0d17525190006ef3bd609d0300bb9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Reverts weaveworks/weave-gitops#4407

`
2025-01-15T10:47:41.225Z	INFO	gitops	cmd/cmd.go:301	Starting server	{"address": "0.0.0.0:9001"}
2025-01-15T10:47:41.225Z	INFO	gitops	cmd/cmd.go:358	TLS connections disabled
2025-01-15T10:47:41.230Z	INFO	gitops	cmd/cmd.go:326	Starting metrics endpoint	{"address": ":2112"}
2025-01-15T10:47:42.132Z	DEBUG	gitops	middleware/middleware.go:59	request success	{"uri": "/", "status": 200}
2025-01-15T10:47:42.165Z	ERROR	gitops	cmd/cmd.go:304	server exited	{"error": "http: Server closed"}
2025-01-15T10:47:50.814Z	DEBUG	gitops	middleware/middleware.go:59	request success	{"uri": "/", "status": 200}
2025-01-15T10:56:19.908Z	DEBUG	gitops	middleware/middleware.go:59	request success	{"uri": "/", "status": 200}
       → 🚨 Build failed.
       →
       →
       → @parcel/core: node_modules/d3-dag/bundle/d3-dag.esm.min.js does not export
       → 'dagStratify'
       →   /home/app/ui/components/DagGraph.tsx:63:22
       →     62 |
       →   > 63 |   //minimum zoomBox is 1000
       →   >    |                      ^^^^^^^
       →     64 |   const zoomBox = 15000 - 14000 * (zoomPercent / 100);
       →     65 |   //since viewbox is so large, make smaller mouse movements correspond
       →
       → make: *** [Makefile:166: ui] Error 1

     ERROR IN: [ui 15/15] RUN --mount=type=cache,target=/home/app/ui/.parcel-cache make ui

Build Failed: ImageBuild: process "/bin/sh -c make ui" did not complete successfully: exit code: 2
2025-01-15T10:56:29.908Z	DEBUG	gitops	middleware/middleware.go:59	request success	{"uri"
`