### PR TITLE
Disable scope hoisting for production

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     }
   },
   "scripts": {
-    "build": "parcel build --target default",
+    "build": "parcel build --target default --no-scope-hoist",
     "build:lib": "parcel build --target lib",
     "typedefs": "tsc --declaration --skipLibCheck --emitDeclarationOnly --outDir dist -p .",
     "start": "parcel serve --port 4567 ui/index.html",


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
<!-- Describe what has changed in this PR -->
**What changed?**

Parcel [scope hoisting](https://parceljs.org/features/scope-hoisting) was temporarily disabled.

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**
Currently there is a problem with production build. No errors during build time, but in a browser there is an error in JS console. And as a result, no UI is being rendered. 

The error:
```
Uncaught ReferenceError: $36eaa93a700aaadd$import$3c7b5cc2d282a88c is not defined
```

Cause of the issue is the [recent Parcel configuration change](https://github.com/weaveworks/weave-gitops/commit/f4e177b3c49f67b28c69566d9a311ac52e7b79e4). [Package exports](https://parceljs.org/features/dependency-resolution/#package-exports) support was enabled and alias for `yaml` package was deleted. It works as expected, `yaml` and other packages that have `exports` in their `package.json` are being resolved correctly, but Parcel's scope hoisting breaks production builds. Further investigation is needed, but as a temporal solution, hoisting was disabled in this PR.
