### PR TITLE
Fix: Broken image links for container images

### DIFF
--- a/ui/components/ImageAutomation/repositories/ImageAutomationRepoDetails.tsx
+++ b/ui/components/ImageAutomation/repositories/ImageAutomationRepoDetails.tsx
@@ -5,6 +5,7 @@ import { useGetObject } from "../../../hooks/objects";
 import { Kind } from "../../../lib/api/core/types.pb";
 import { ImageRepository } from "../../../lib/objects";
 import { V2Routes } from "../../../lib/types";
+import { convertImage } from "../../../lib/utils";
 import Button from "../../Button";
 import ClusterDashboardLink from "../../ClusterDashboardLink";
 import Interval from "../../Interval";
@@ -68,7 +69,7 @@ function ImageAutomationRepoDetails({
             {
               rowkey: "Image",
               children: (
-                <Link newTab={true} to={data.obj?.spec?.image}>
+                <Link newTab={true} href={convertImage(data.obj?.spec?.image)}>
                   {data.obj?.spec?.image}
                 </Link>
               ),


### PR DESCRIPTION
Whilst testing the react router change, I observed that links to container images on docker.io, ghcr and others resulted in a broken URL that didn't resolve to anywhere.

It is likely that this functionality never worked as the image URL was never resolved back to its upstream counterpart as implemented in the `convertImage` function.

This change is necessary to ensure container images link out to the correct location to engineers can better understand the continers running inside their cluster workloads.

This change addresses the need by: wrapping container image links in the `convertImage` function