### PR TITLE
ci(dependabot): replace excluded dep in react group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -72,7 +72,7 @@ updates:
         exclude-patterns:
           - react-lottie-player
           - react-markdown
-          - react-router-dom
+          - react-router
           - react-syntax-highlighter
           - react-toastify
   # maintain dependencies for github actions


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes

<!-- Describe what has changed in this PR -->
**What changed?**

Replace excluded dependency from the react Depedabot group.

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**

After https://github.com/weaveworks/weave-gitops/pull/4540, we depend on react-router instead of react-router-dom.

<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**


<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**


<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**


<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
