### PR TITLE
Replace deprecated testing library in unit tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -23,10 +23,12 @@ const transformIgnorePatterns = [
 const config = {
   preset: "ts-jest",
   moduleNameMapper: {
-    "\\.(jpg|ico|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$":
+    "\\.(jpg|ico|jpeg|png|gif|eot|otf|webp|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$":
       "<rootDir>/ui/lib/fileMock.js",
     "\\.(css|less)$": "<rootDir>/ui/lib/fileMock.js",
+    "^.+\\.svg$": "jest-svg-transformer",
   },
+
   transform: {
     "\\.tsx?$": "ts-jest",
     "\\.jsx?$": [

--- a/jest.config.js
+++ b/jest.config.js
@@ -26,7 +26,7 @@ const config = {
     "\\.(jpg|ico|jpeg|png|gif|eot|otf|webp|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$":
       "<rootDir>/ui/lib/fileMock.js",
     "\\.(css|less)$": "<rootDir>/ui/lib/fileMock.js",
-    "^.+\\.svg$": "jest-svg-transformer",
+    "^.+\\.svg$": "jest-transformer-svg",
   },
 
   transform: {

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "jest-environment-jsdom": "^29.7.0",
     "jest-fail-on-console": "^3.3.1",
     "jest-styled-components": "^7.2.0",
-    "jest-svg-transformer": "^1.0.0",
+    "jest-transformer-svg": "^2.1.0",
     "jest-worker": "^29.7.0",
     "jsdom": "^26.0.0",
     "parcel": "^2.13.3",

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "jest-environment-jsdom": "^29.7.0",
     "jest-fail-on-console": "^3.3.1",
     "jest-styled-components": "^7.2.0",
+    "jest-svg-transformer": "^1.0.0",
     "jest-worker": "^29.7.0",
     "jsdom": "^26.0.0",
     "parcel": "^2.13.3",

--- a/ui/components/DarkModeSwitch.tsx
+++ b/ui/components/DarkModeSwitch.tsx
@@ -3,6 +3,7 @@ import * as React from "react";
 import styled from "styled-components";
 import { AppContext, ThemeTypes } from "../contexts/AppContext";
 import images from "../lib/images";
+import { svgToB64Image } from "../lib/utils";
 
 type Props = {
   className?: string;
@@ -33,9 +34,11 @@ export default styled(DarkModeSwitch).attrs({
   .MuiSwitch-thumb {
     color: #fff;
     background-image: url(${(props) =>
-      props.theme.mode === ThemeTypes.Dark
-        ? images.darkModeIcon
-        : images.lightModeIcon});
+      svgToB64Image(
+        props.theme.mode,
+        images.lightModeIcon,
+        images.darkModeIcon,
+      )});
   }
   .MuiSwitch-track {
     background-color: ${(props) => props.theme.colors.primary};

--- a/ui/components/DataTable/__tests__/DataTable.test.tsx
+++ b/ui/components/DataTable/__tests__/DataTable.test.tsx
@@ -203,7 +203,7 @@ describe("DataTable", () => {
             {},
           ),
         ),
-      ).asFragment().firstChild;
+      ).asFragment();
       expect(tree).toMatchSnapshot();
     });
   });

--- a/ui/components/DataTable/__tests__/DataTable.test.tsx
+++ b/ui/components/DataTable/__tests__/DataTable.test.tsx
@@ -2,7 +2,6 @@ import { screen } from "@testing-library/dom";
 import { fireEvent, render } from "@testing-library/react";
 import "jest-styled-components";
 import React from "react";
-import renderer from "react-test-renderer";
 import { withContext, withTheme } from "../../../lib/test-utils";
 import DataTable from "../DataTable";
 
@@ -196,17 +195,15 @@ describe("DataTable", () => {
 
   describe("snapshots", () => {
     it("renders", () => {
-      const tree = renderer
-        .create(
-          withTheme(
-            withContext(
-              <DataTable fields={fields} rows={rows} />,
-              "/applications",
-              {},
-            ),
+      const tree = render(
+        withTheme(
+          withContext(
+            <DataTable fields={fields} rows={rows} />,
+            "/applications",
+            {},
           ),
-        )
-        .toJSON();
+        ),
+      ).asFragment().firstChild;
       expect(tree).toMatchSnapshot();
     });
   });

--- a/ui/components/DataTable/__tests__/__snapshots__/DataTable.test.tsx.snap
+++ b/ui/components/DataTable/__tests__/__snapshots__/DataTable.test.tsx.snap
@@ -1,7 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DataTable snapshots renders 1`] = `
-.c0 {
+<DocumentFragment>
+  .c0 {
   display: flex;
   flex-direction: column;
   align-items: start;
@@ -234,301 +235,302 @@ exports[`DataTable snapshots renders 1`] = `
 }
 
 <div
-  class="c0 c1"
->
-  <div
-    class="c2 c3"
-  />
-  <div
-    class="c4"
+    class="c0 c1"
   >
     <div
-      class="MuiTableContainer-root css-70zvr5-MuiTableContainer-root"
-    >
-      <table
-        class="MuiTable-root css-wzk8yp-MuiTable-root"
-      >
-        <thead
-          class="MuiTableHead-root css-1a7iywq-MuiTableHead-root"
-        >
-          <tr
-            class="MuiTableRow-root MuiTableRow-head css-h5ctz1-MuiTableRow-root"
-          >
-            <th
-              class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium css-bf3zdk-MuiTableCell-root"
-              scope="col"
-            >
-              <div
-                class="c5"
-              >
-                <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit c6 css-1swlott-MuiButtonBase-root-MuiButton-root"
-                  id=":ri:"
-                  tabindex="0"
-                  type="button"
-                >
-                  <h2
-                    class="selected"
-                  >
-                    Name
-                  </h2>
-                </button>
-                <div
-                  class="c7 c8 downward"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
-                    data-testid="ArrowUpwardIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="m4 12 1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8z"
-                    />
-                  </svg>
-                </div>
-              </div>
-            </th>
-            <th
-              class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium css-bf3zdk-MuiTableCell-root"
-              scope="col"
-            >
-              <div
-                class="c5"
-              >
-                <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit c6 css-1swlott-MuiButtonBase-root-MuiButton-root"
-                  id=":rj:"
-                  tabindex="0"
-                  type="button"
-                >
-                  <h2
-                    class=""
-                  >
-                    Status
-                  </h2>
-                </button>
-                <div
-                  style="width: 16px;"
-                />
-              </div>
-            </th>
-            <th
-              class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium css-bf3zdk-MuiTableCell-root"
-              scope="col"
-            >
-              <div
-                class="c5"
-              >
-                <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit c6 css-1swlott-MuiButtonBase-root-MuiButton-root"
-                  id=":rk:"
-                  tabindex="0"
-                  type="button"
-                >
-                  <h2
-                    class=""
-                  >
-                    Last Updated
-                  </h2>
-                </button>
-                <div
-                  style="width: 16px;"
-                />
-              </div>
-            </th>
-            <th
-              class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium css-bf3zdk-MuiTableCell-root"
-              scope="col"
-            >
-              <div
-                class="c5"
-              >
-                <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit c6 css-1swlott-MuiButtonBase-root-MuiButton-root"
-                  id=":rl:"
-                  tabindex="0"
-                  type="button"
-                >
-                  <h2
-                    class=""
-                  >
-                    Last Synced At
-                  </h2>
-                </button>
-                <div
-                  style="width: 16px;"
-                />
-              </div>
-            </th>
-          </tr>
-        </thead>
-        <tbody
-          class="MuiTableBody-root css-gmh7jj-MuiTableBody-root"
-        >
-          <tr
-            class="MuiTableRow-root css-h5ctz1-MuiTableRow-root"
-          >
-            <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-119gvwi-MuiTableCell-root"
-            >
-              <span
-                class="c9 c10"
-              >
-                <a
-                  href="/some_url"
-                >
-                  nginx
-                </a>
-              </span>
-            </td>
-            <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-119gvwi-MuiTableCell-root"
-            >
-              <span
-                class="c9 c10"
-              >
-                Ready
-              </span>
-            </td>
-            <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-119gvwi-MuiTableCell-root"
-            >
-              <span
-                class="c9 c10"
-              >
-                2004-01-02T15:04:05-0700
-              </span>
-            </td>
-            <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-119gvwi-MuiTableCell-root"
-            >
-              <span
-                class="c9 c10"
-              >
-                3000
-              </span>
-            </td>
-          </tr>
-          <tr
-            class="MuiTableRow-root css-h5ctz1-MuiTableRow-root"
-          >
-            <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-119gvwi-MuiTableCell-root"
-            >
-              <span
-                class="c9 c10"
-              >
-                <a
-                  href="/some_url"
-                >
-                  podinfo
-                </a>
-              </span>
-            </td>
-            <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-119gvwi-MuiTableCell-root"
-            >
-              <span
-                class="c9 c10"
-              >
-                -
-              </span>
-            </td>
-            <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-119gvwi-MuiTableCell-root"
-            >
-              <span
-                class="c9 c10"
-              >
-                2006-01-02T15:04:05-0700
-              </span>
-            </td>
-            <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-119gvwi-MuiTableCell-root"
-            >
-              <span
-                class="c9 c10"
-              >
-                2000
-              </span>
-            </td>
-          </tr>
-          <tr
-            class="MuiTableRow-root css-h5ctz1-MuiTableRow-root"
-          >
-            <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-119gvwi-MuiTableCell-root"
-            >
-              <span
-                class="c9 c10"
-              >
-                <a
-                  href="/some_url"
-                >
-                  the-cool-app
-                </a>
-              </span>
-            </td>
-            <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-119gvwi-MuiTableCell-root"
-            >
-              <span
-                class="c9 c10"
-              />
-            </td>
-            <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-119gvwi-MuiTableCell-root"
-            >
-              <span
-                class="c9 c10"
-              >
-                2005-01-02T15:04:05-0700
-              </span>
-            </td>
-            <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-119gvwi-MuiTableCell-root"
-            >
-              <span
-                class="c9 c10"
-              >
-                1000
-              </span>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
+      class="c2 c3"
+    />
     <div
-      class="c11"
-      data-testid="container"
+      class="c4"
     >
       <div
-        class="c12"
+        class="MuiTableContainer-root css-70zvr5-MuiTableContainer-root"
+      >
+        <table
+          class="MuiTable-root css-wzk8yp-MuiTable-root"
+        >
+          <thead
+            class="MuiTableHead-root css-1a7iywq-MuiTableHead-root"
+          >
+            <tr
+              class="MuiTableRow-root MuiTableRow-head css-h5ctz1-MuiTableRow-root"
+            >
+              <th
+                class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium css-bf3zdk-MuiTableCell-root"
+                scope="col"
+              >
+                <div
+                  class="c5"
+                >
+                  <button
+                    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit c6 css-1swlott-MuiButtonBase-root-MuiButton-root"
+                    id=":ri:"
+                    tabindex="0"
+                    type="button"
+                  >
+                    <h2
+                      class="selected"
+                    >
+                      Name
+                    </h2>
+                  </button>
+                  <div
+                    class="c7 c8 downward"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+                      data-testid="ArrowUpwardIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="m4 12 1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8z"
+                      />
+                    </svg>
+                  </div>
+                </div>
+              </th>
+              <th
+                class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium css-bf3zdk-MuiTableCell-root"
+                scope="col"
+              >
+                <div
+                  class="c5"
+                >
+                  <button
+                    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit c6 css-1swlott-MuiButtonBase-root-MuiButton-root"
+                    id=":rj:"
+                    tabindex="0"
+                    type="button"
+                  >
+                    <h2
+                      class=""
+                    >
+                      Status
+                    </h2>
+                  </button>
+                  <div
+                    style="width: 16px;"
+                  />
+                </div>
+              </th>
+              <th
+                class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium css-bf3zdk-MuiTableCell-root"
+                scope="col"
+              >
+                <div
+                  class="c5"
+                >
+                  <button
+                    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit c6 css-1swlott-MuiButtonBase-root-MuiButton-root"
+                    id=":rk:"
+                    tabindex="0"
+                    type="button"
+                  >
+                    <h2
+                      class=""
+                    >
+                      Last Updated
+                    </h2>
+                  </button>
+                  <div
+                    style="width: 16px;"
+                  />
+                </div>
+              </th>
+              <th
+                class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium css-bf3zdk-MuiTableCell-root"
+                scope="col"
+              >
+                <div
+                  class="c5"
+                >
+                  <button
+                    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit c6 css-1swlott-MuiButtonBase-root-MuiButton-root"
+                    id=":rl:"
+                    tabindex="0"
+                    type="button"
+                  >
+                    <h2
+                      class=""
+                    >
+                      Last Synced At
+                    </h2>
+                  </button>
+                  <div
+                    style="width: 16px;"
+                  />
+                </div>
+              </th>
+            </tr>
+          </thead>
+          <tbody
+            class="MuiTableBody-root css-gmh7jj-MuiTableBody-root"
+          >
+            <tr
+              class="MuiTableRow-root css-h5ctz1-MuiTableRow-root"
+            >
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-119gvwi-MuiTableCell-root"
+              >
+                <span
+                  class="c9 c10"
+                >
+                  <a
+                    href="/some_url"
+                  >
+                    nginx
+                  </a>
+                </span>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-119gvwi-MuiTableCell-root"
+              >
+                <span
+                  class="c9 c10"
+                >
+                  Ready
+                </span>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-119gvwi-MuiTableCell-root"
+              >
+                <span
+                  class="c9 c10"
+                >
+                  2004-01-02T15:04:05-0700
+                </span>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-119gvwi-MuiTableCell-root"
+              >
+                <span
+                  class="c9 c10"
+                >
+                  3000
+                </span>
+              </td>
+            </tr>
+            <tr
+              class="MuiTableRow-root css-h5ctz1-MuiTableRow-root"
+            >
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-119gvwi-MuiTableCell-root"
+              >
+                <span
+                  class="c9 c10"
+                >
+                  <a
+                    href="/some_url"
+                  >
+                    podinfo
+                  </a>
+                </span>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-119gvwi-MuiTableCell-root"
+              >
+                <span
+                  class="c9 c10"
+                >
+                  -
+                </span>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-119gvwi-MuiTableCell-root"
+              >
+                <span
+                  class="c9 c10"
+                >
+                  2006-01-02T15:04:05-0700
+                </span>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-119gvwi-MuiTableCell-root"
+              >
+                <span
+                  class="c9 c10"
+                >
+                  2000
+                </span>
+              </td>
+            </tr>
+            <tr
+              class="MuiTableRow-root css-h5ctz1-MuiTableRow-root"
+            >
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-119gvwi-MuiTableCell-root"
+              >
+                <span
+                  class="c9 c10"
+                >
+                  <a
+                    href="/some_url"
+                  >
+                    the-cool-app
+                  </a>
+                </span>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-119gvwi-MuiTableCell-root"
+              >
+                <span
+                  class="c9 c10"
+                />
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-119gvwi-MuiTableCell-root"
+              >
+                <span
+                  class="c9 c10"
+                >
+                  2005-01-02T15:04:05-0700
+                </span>
+              </td>
+              <td
+                class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-119gvwi-MuiTableCell-root"
+              >
+                <span
+                  class="c9 c10"
+                >
+                  1000
+                </span>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <div
+        class="c11"
+        data-testid="container"
       >
         <div
-          class="c13 c14"
+          class="c12"
         >
           <div
-            class="c15"
+            class="c13 c14"
           >
-            <span
-              class="c9 c16"
+            <div
+              class="c15"
             >
-              Filters
-            </span>
+              <span
+                class="c9 c16"
+              >
+                Filters
+              </span>
+            </div>
+            <form
+              class="ControlledForm"
+            >
+              <ul
+                class="MuiList-root MuiList-padding css-b7dj7n-MuiList-root"
+              />
+            </form>
           </div>
-          <form
-            class="ControlledForm"
-          >
-            <ul
-              class="MuiList-root MuiList-padding css-b7dj7n-MuiList-root"
-            />
-          </form>
         </div>
       </div>
     </div>
   </div>
-</div>
+</DocumentFragment>
 `;

--- a/ui/components/DataTable/__tests__/__snapshots__/DataTable.test.tsx.snap
+++ b/ui/components/DataTable/__tests__/__snapshots__/DataTable.test.tsx.snap
@@ -136,7 +136,7 @@ exports[`DataTable snapshots renders 1`] = `
   background: rbga(255, 255, 255, 0.75);
   height: 100%;
   width: 100%;
-  border-left: 2px solid #d8d8d8;
+  border-left: 2px solid #BDBDBD;
   padding: 24px;
   padding-left: 32px;
 }
@@ -202,7 +202,7 @@ exports[`DataTable snapshots renders 1`] = `
 }
 
 .c1 .MuiTableCell-root {
-  border-color: #d8d8d8;
+  border-color: #BDBDBD;
 }
 
 .c1 table {
@@ -211,7 +211,7 @@ exports[`DataTable snapshots renders 1`] = `
 
 .c1 th {
   padding: 0;
-  background: #F6F7F9;
+  background: #C2C9D7;
 }
 
 .c1 th .MuiCheckbox-root {
@@ -234,69 +234,51 @@ exports[`DataTable snapshots renders 1`] = `
 }
 
 <div
-  className="c0 c1"
+  class="c0 c1"
 >
   <div
-    className="c2 c3"
+    class="c2 c3"
   />
   <div
-    className="c4"
+    class="c4"
   >
     <div
-      className="MuiTableContainer-root css-70zvr5-MuiTableContainer-root"
+      class="MuiTableContainer-root css-70zvr5-MuiTableContainer-root"
     >
       <table
-        className="MuiTable-root css-wzk8yp-MuiTable-root"
-        role={null}
+        class="MuiTable-root css-wzk8yp-MuiTable-root"
       >
         <thead
-          className="MuiTableHead-root css-1a7iywq-MuiTableHead-root"
-          role={null}
+          class="MuiTableHead-root css-1a7iywq-MuiTableHead-root"
         >
           <tr
-            className="MuiTableRow-root MuiTableRow-head css-h5ctz1-MuiTableRow-root"
-            role={null}
+            class="MuiTableRow-root MuiTableRow-head css-h5ctz1-MuiTableRow-root"
           >
             <th
-              aria-sort={null}
-              className="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium css-bf3zdk-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium css-bf3zdk-MuiTableCell-root"
               scope="col"
             >
               <div
-                className="c5"
+                class="c5"
               >
                 <button
-                  className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit c6 css-9wcwzo-MuiButtonBase-root-MuiButton-root"
-                  disabled={null}
-                  id=":r0:"
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onContextMenu={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  tabIndex={0}
+                  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit c6 css-1swlott-MuiButtonBase-root-MuiButton-root"
+                  id=":ri:"
+                  tabindex="0"
                   type="button"
                 >
                   <h2
-                    className="selected"
+                    class="selected"
                   >
                     Name
                   </h2>
                 </button>
                 <div
-                  className="c7 c8 downward"
+                  class="c7 c8 downward"
                 >
                   <svg
-                    aria-hidden={true}
-                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                     data-testid="ArrowUpwardIcon"
                     focusable="false"
                     viewBox="0 0 24 24"
@@ -309,150 +291,90 @@ exports[`DataTable snapshots renders 1`] = `
               </div>
             </th>
             <th
-              aria-sort={null}
-              className="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium css-bf3zdk-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium css-bf3zdk-MuiTableCell-root"
               scope="col"
             >
               <div
-                className="c5"
+                class="c5"
               >
                 <button
-                  className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit c6 css-9wcwzo-MuiButtonBase-root-MuiButton-root"
-                  disabled={null}
-                  id=":r1:"
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onContextMenu={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  tabIndex={0}
+                  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit c6 css-1swlott-MuiButtonBase-root-MuiButton-root"
+                  id=":rj:"
+                  tabindex="0"
                   type="button"
                 >
                   <h2
-                    className=""
+                    class=""
                   >
                     Status
                   </h2>
                 </button>
                 <div
-                  style={
-                    {
-                      "width": "16px",
-                    }
-                  }
+                  style="width: 16px;"
                 />
               </div>
             </th>
             <th
-              aria-sort={null}
-              className="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium css-bf3zdk-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium css-bf3zdk-MuiTableCell-root"
               scope="col"
             >
               <div
-                className="c5"
+                class="c5"
               >
                 <button
-                  className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit c6 css-9wcwzo-MuiButtonBase-root-MuiButton-root"
-                  disabled={null}
-                  id=":r2:"
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onContextMenu={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  tabIndex={0}
+                  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit c6 css-1swlott-MuiButtonBase-root-MuiButton-root"
+                  id=":rk:"
+                  tabindex="0"
                   type="button"
                 >
                   <h2
-                    className=""
+                    class=""
                   >
                     Last Updated
                   </h2>
                 </button>
                 <div
-                  style={
-                    {
-                      "width": "16px",
-                    }
-                  }
+                  style="width: 16px;"
                 />
               </div>
             </th>
             <th
-              aria-sort={null}
-              className="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium css-bf3zdk-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium css-bf3zdk-MuiTableCell-root"
               scope="col"
             >
               <div
-                className="c5"
+                class="c5"
               >
                 <button
-                  className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit c6 css-9wcwzo-MuiButtonBase-root-MuiButton-root"
-                  disabled={null}
-                  id=":r3:"
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onContextMenu={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  tabIndex={0}
+                  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit c6 css-1swlott-MuiButtonBase-root-MuiButton-root"
+                  id=":rl:"
+                  tabindex="0"
                   type="button"
                 >
                   <h2
-                    className=""
+                    class=""
                   >
                     Last Synced At
                   </h2>
                 </button>
                 <div
-                  style={
-                    {
-                      "width": "16px",
-                    }
-                  }
+                  style="width: 16px;"
                 />
               </div>
             </th>
           </tr>
         </thead>
         <tbody
-          className="MuiTableBody-root css-gmh7jj-MuiTableBody-root"
-          role={null}
+          class="MuiTableBody-root css-gmh7jj-MuiTableBody-root"
         >
           <tr
-            className="MuiTableRow-root css-h5ctz1-MuiTableRow-root"
-            role={null}
+            class="MuiTableRow-root css-h5ctz1-MuiTableRow-root"
           >
             <td
-              aria-sort={null}
-              className="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-119gvwi-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-119gvwi-MuiTableCell-root"
             >
               <span
-                className="c9 c10"
+                class="c9 c10"
               >
                 <a
                   href="/some_url"
@@ -462,46 +384,41 @@ exports[`DataTable snapshots renders 1`] = `
               </span>
             </td>
             <td
-              aria-sort={null}
-              className="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-119gvwi-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-119gvwi-MuiTableCell-root"
             >
               <span
-                className="c9 c10"
+                class="c9 c10"
               >
                 Ready
               </span>
             </td>
             <td
-              aria-sort={null}
-              className="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-119gvwi-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-119gvwi-MuiTableCell-root"
             >
               <span
-                className="c9 c10"
+                class="c9 c10"
               >
                 2004-01-02T15:04:05-0700
               </span>
             </td>
             <td
-              aria-sort={null}
-              className="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-119gvwi-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-119gvwi-MuiTableCell-root"
             >
               <span
-                className="c9 c10"
+                class="c9 c10"
               >
                 3000
               </span>
             </td>
           </tr>
           <tr
-            className="MuiTableRow-root css-h5ctz1-MuiTableRow-root"
-            role={null}
+            class="MuiTableRow-root css-h5ctz1-MuiTableRow-root"
           >
             <td
-              aria-sort={null}
-              className="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-119gvwi-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-119gvwi-MuiTableCell-root"
             >
               <span
-                className="c9 c10"
+                class="c9 c10"
               >
                 <a
                   href="/some_url"
@@ -511,46 +428,41 @@ exports[`DataTable snapshots renders 1`] = `
               </span>
             </td>
             <td
-              aria-sort={null}
-              className="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-119gvwi-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-119gvwi-MuiTableCell-root"
             >
               <span
-                className="c9 c10"
+                class="c9 c10"
               >
                 -
               </span>
             </td>
             <td
-              aria-sort={null}
-              className="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-119gvwi-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-119gvwi-MuiTableCell-root"
             >
               <span
-                className="c9 c10"
+                class="c9 c10"
               >
                 2006-01-02T15:04:05-0700
               </span>
             </td>
             <td
-              aria-sort={null}
-              className="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-119gvwi-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-119gvwi-MuiTableCell-root"
             >
               <span
-                className="c9 c10"
+                class="c9 c10"
               >
                 2000
               </span>
             </td>
           </tr>
           <tr
-            className="MuiTableRow-root css-h5ctz1-MuiTableRow-root"
-            role={null}
+            class="MuiTableRow-root css-h5ctz1-MuiTableRow-root"
           >
             <td
-              aria-sort={null}
-              className="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-119gvwi-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-119gvwi-MuiTableCell-root"
             >
               <span
-                className="c9 c10"
+                class="c9 c10"
               >
                 <a
                   href="/some_url"
@@ -560,29 +472,26 @@ exports[`DataTable snapshots renders 1`] = `
               </span>
             </td>
             <td
-              aria-sort={null}
-              className="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-119gvwi-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-119gvwi-MuiTableCell-root"
             >
               <span
-                className="c9 c10"
+                class="c9 c10"
               />
             </td>
             <td
-              aria-sort={null}
-              className="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-119gvwi-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-119gvwi-MuiTableCell-root"
             >
               <span
-                className="c9 c10"
+                class="c9 c10"
               >
                 2005-01-02T15:04:05-0700
               </span>
             </td>
             <td
-              aria-sort={null}
-              className="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-119gvwi-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-119gvwi-MuiTableCell-root"
             >
               <span
-                className="c9 c10"
+                class="c9 c10"
               >
                 1000
               </span>
@@ -592,30 +501,29 @@ exports[`DataTable snapshots renders 1`] = `
       </table>
     </div>
     <div
-      className="c11"
+      class="c11"
       data-testid="container"
     >
       <div
-        className="c12"
+        class="c12"
       >
         <div
-          className="c13 c14"
+          class="c13 c14"
         >
           <div
-            className="c15"
+            class="c15"
           >
             <span
-              className="c9 c16"
+              class="c9 c16"
             >
               Filters
             </span>
           </div>
           <form
-            className="ControlledForm"
-            onSubmit={[Function]}
+            class="ControlledForm"
           >
             <ul
-              className="MuiList-root MuiList-padding css-b7dj7n-MuiList-root"
+              class="MuiList-root MuiList-padding css-b7dj7n-MuiList-root"
             />
           </form>
         </div>

--- a/ui/components/DataTable/__tests__/__snapshots__/DataTable.test.tsx.snap
+++ b/ui/components/DataTable/__tests__/__snapshots__/DataTable.test.tsx.snap
@@ -136,7 +136,7 @@ exports[`DataTable snapshots renders 1`] = `
   background: rbga(255, 255, 255, 0.75);
   height: 100%;
   width: 100%;
-  border-left: 2px solid #BDBDBD;
+  border-left: 2px solid #d8d8d8;
   padding: 24px;
   padding-left: 32px;
 }
@@ -202,7 +202,7 @@ exports[`DataTable snapshots renders 1`] = `
 }
 
 .c1 .MuiTableCell-root {
-  border-color: #BDBDBD;
+  border-color: #d8d8d8;
 }
 
 .c1 table {
@@ -211,7 +211,7 @@ exports[`DataTable snapshots renders 1`] = `
 
 .c1 th {
   padding: 0;
-  background: #C2C9D7;
+  background: #F6F7F9;
 }
 
 .c1 th .MuiCheckbox-root {
@@ -266,7 +266,7 @@ exports[`DataTable snapshots renders 1`] = `
                 className="c5"
               >
                 <button
-                  className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit c6 css-1swlott-MuiButtonBase-root-MuiButton-root"
+                  className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit c6 css-9wcwzo-MuiButtonBase-root-MuiButton-root"
                   disabled={null}
                   id=":r0:"
                   onBlur={[Function]}
@@ -317,7 +317,7 @@ exports[`DataTable snapshots renders 1`] = `
                 className="c5"
               >
                 <button
-                  className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit c6 css-1swlott-MuiButtonBase-root-MuiButton-root"
+                  className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit c6 css-9wcwzo-MuiButtonBase-root-MuiButton-root"
                   disabled={null}
                   id=":r1:"
                   onBlur={[Function]}
@@ -360,7 +360,7 @@ exports[`DataTable snapshots renders 1`] = `
                 className="c5"
               >
                 <button
-                  className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit c6 css-1swlott-MuiButtonBase-root-MuiButton-root"
+                  className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit c6 css-9wcwzo-MuiButtonBase-root-MuiButton-root"
                   disabled={null}
                   id=":r2:"
                   onBlur={[Function]}
@@ -403,7 +403,7 @@ exports[`DataTable snapshots renders 1`] = `
                 className="c5"
               >
                 <button
-                  className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit c6 css-1swlott-MuiButtonBase-root-MuiButton-root"
+                  className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit c6 css-9wcwzo-MuiButtonBase-root-MuiButton-root"
                   disabled={null}
                   id=":r3:"
                   onBlur={[Function]}

--- a/ui/components/Sync/__tests__/SyncActions.test.tsx
+++ b/ui/components/Sync/__tests__/SyncActions.test.tsx
@@ -1,6 +1,6 @@
 import "jest-styled-components";
+import { render } from "@testing-library/react";
 import React from "react";
-import renderer from "react-test-renderer";
 import { CoreClientContext } from "../../../contexts/CoreClientContext";
 import {
   createCoreMockClient,
@@ -14,51 +14,45 @@ describe("SyncActions", () => {
     const mockContext = { api: createCoreMockClient({}), featureFlags: {} };
 
     it("non-suspended", () => {
-      const tree = renderer
-        .create(
-          withTheme(
-            withContext(
-              <CoreClientContext.Provider value={mockContext}>
-                <SyncActions />
-              </CoreClientContext.Provider>,
-              "/",
-              {},
-            ),
+      const tree = render(
+        withTheme(
+          withContext(
+            <CoreClientContext.Provider value={mockContext}>
+              <SyncActions />
+            </CoreClientContext.Provider>,
+            "/",
+            {},
           ),
-        )
-        .toJSON();
+        ),
+      ).asFragment().firstChild;
       expect(tree).toMatchSnapshot();
     });
     it("suspended", () => {
-      const tree = renderer
-        .create(
-          withTheme(
-            withContext(
-              <CoreClientContext.Provider value={mockContext}>
-                <SyncActions suspended />
-              </CoreClientContext.Provider>,
-              "/",
-              {},
-            ),
+      const tree = render(
+        withTheme(
+          withContext(
+            <CoreClientContext.Provider value={mockContext}>
+              <SyncActions suspended />
+            </CoreClientContext.Provider>,
+            "/",
+            {},
           ),
-        )
-        .toJSON();
+        ),
+      ).asFragment().firstChild;
       expect(tree).toMatchSnapshot();
     });
     it("hideSyncOptions", () => {
-      const tree = renderer
-        .create(
-          withTheme(
-            withContext(
-              <CoreClientContext.Provider value={mockContext}>
-                <SyncActions hideSyncOptions />
-              </CoreClientContext.Provider>,
-              "/",
-              {},
-            ),
+      const tree = render(
+        withTheme(
+          withContext(
+            <CoreClientContext.Provider value={mockContext}>
+              <SyncActions hideSyncOptions />
+            </CoreClientContext.Provider>,
+            "/",
+            {},
           ),
-        )
-        .toJSON();
+        ),
+      ).asFragment().firstChild;
       expect(tree).toMatchSnapshot();
     });
   });

--- a/ui/components/Sync/__tests__/SyncActions.test.tsx
+++ b/ui/components/Sync/__tests__/SyncActions.test.tsx
@@ -24,7 +24,7 @@ describe("SyncActions", () => {
             {},
           ),
         ),
-      ).asFragment().firstChild;
+      ).asFragment();
       expect(tree).toMatchSnapshot();
     });
     it("suspended", () => {
@@ -38,7 +38,7 @@ describe("SyncActions", () => {
             {},
           ),
         ),
-      ).asFragment().firstChild;
+      ).asFragment();
       expect(tree).toMatchSnapshot();
     });
     it("hideSyncOptions", () => {
@@ -52,7 +52,7 @@ describe("SyncActions", () => {
             {},
           ),
         ),
-      ).asFragment().firstChild;
+      ).asFragment();
       expect(tree).toMatchSnapshot();
     });
   });

--- a/ui/components/Sync/__tests__/SyncControls.test.tsx
+++ b/ui/components/Sync/__tests__/SyncControls.test.tsx
@@ -24,7 +24,7 @@ describe("SyncControls", () => {
             {},
           ),
         ),
-      ).asFragment().firstChild;
+      ).asFragment();
       expect(tree).toMatchSnapshot();
     });
     it("allButtonsDisabled", () => {
@@ -43,7 +43,7 @@ describe("SyncControls", () => {
             {},
           ),
         ),
-      ).asFragment().firstChild;
+      ).asFragment();
       expect(tree).toMatchSnapshot();
     });
     it("hideSyncOptions", () => {
@@ -57,7 +57,7 @@ describe("SyncControls", () => {
             {},
           ),
         ),
-      ).asFragment().firstChild;
+      ).asFragment();
       expect(tree).toMatchSnapshot();
     });
     it("hideSuspend", () => {
@@ -71,7 +71,7 @@ describe("SyncControls", () => {
             {},
           ),
         ),
-      ).asFragment().firstChild;
+      ).asFragment();
       expect(tree).toMatchSnapshot();
     });
     it("hasTooltipSuffix", () => {
@@ -88,7 +88,7 @@ describe("SyncControls", () => {
             {},
           ),
         ),
-      ).asFragment().firstChild;
+      ).asFragment();
       expect(tree).toMatchSnapshot();
     });
   });

--- a/ui/components/Sync/__tests__/SyncControls.test.tsx
+++ b/ui/components/Sync/__tests__/SyncControls.test.tsx
@@ -1,6 +1,6 @@
 import "jest-styled-components";
+import { render } from "@testing-library/react";
 import React from "react";
-import renderer from "react-test-renderer";
 import { CoreClientContext } from "../../../contexts/CoreClientContext";
 import {
   createCoreMockClient,
@@ -14,91 +14,81 @@ describe("SyncControls", () => {
     const mockContext = { api: createCoreMockClient({}), featureFlags: {} };
 
     it("non-suspended", () => {
-      const tree = renderer
-        .create(
-          withTheme(
-            withContext(
-              <CoreClientContext.Provider value={mockContext}>
-                <SyncControls onSyncClick={() => {}} />
-              </CoreClientContext.Provider>,
-              "/",
-              {},
-            ),
+      const tree = render(
+        withTheme(
+          withContext(
+            <CoreClientContext.Provider value={mockContext}>
+              <SyncControls onSyncClick={() => {}} />
+            </CoreClientContext.Provider>,
+            "/",
+            {},
           ),
-        )
-        .toJSON();
+        ),
+      ).asFragment().firstChild;
       expect(tree).toMatchSnapshot();
     });
     it("allButtonsDisabled", () => {
-      const tree = renderer
-        .create(
-          withTheme(
-            withContext(
-              <CoreClientContext.Provider value={mockContext}>
-                <SyncControls
-                  syncDisabled
-                  suspendDisabled
-                  resumeDisabled
-                  onSyncClick={() => {}}
-                />
-              </CoreClientContext.Provider>,
-              "/",
-              {},
-            ),
+      const tree = render(
+        withTheme(
+          withContext(
+            <CoreClientContext.Provider value={mockContext}>
+              <SyncControls
+                syncDisabled
+                suspendDisabled
+                resumeDisabled
+                onSyncClick={() => {}}
+              />
+            </CoreClientContext.Provider>,
+            "/",
+            {},
           ),
-        )
-        .toJSON();
+        ),
+      ).asFragment().firstChild;
       expect(tree).toMatchSnapshot();
     });
     it("hideSyncOptions", () => {
-      const tree = renderer
-        .create(
-          withTheme(
-            withContext(
-              <CoreClientContext.Provider value={mockContext}>
-                <SyncControls hideSyncOptions onSyncClick={() => {}} />
-              </CoreClientContext.Provider>,
-              "/",
-              {},
-            ),
+      const tree = render(
+        withTheme(
+          withContext(
+            <CoreClientContext.Provider value={mockContext}>
+              <SyncControls hideSyncOptions onSyncClick={() => {}} />
+            </CoreClientContext.Provider>,
+            "/",
+            {},
           ),
-        )
-        .toJSON();
+        ),
+      ).asFragment().firstChild;
       expect(tree).toMatchSnapshot();
     });
     it("hideSuspend", () => {
-      const tree = renderer
-        .create(
-          withTheme(
-            withContext(
-              <CoreClientContext.Provider value={mockContext}>
-                <SyncControls hideSuspend onSyncClick={() => {}} />
-              </CoreClientContext.Provider>,
-              "/",
-              {},
-            ),
+      const tree = render(
+        withTheme(
+          withContext(
+            <CoreClientContext.Provider value={mockContext}>
+              <SyncControls hideSuspend onSyncClick={() => {}} />
+            </CoreClientContext.Provider>,
+            "/",
+            {},
           ),
-        )
-        .toJSON();
+        ),
+      ).asFragment().firstChild;
       expect(tree).toMatchSnapshot();
     });
     it("hasTooltipSuffix", () => {
-      const tree = renderer
-        .create(
-          withTheme(
-            withContext(
-              <CoreClientContext.Provider value={mockContext}>
-                <SyncControls
-                  tooltipSuffix="test suffix"
-                  onSyncClick={() => {}}
-                />
-              </CoreClientContext.Provider>,
-              "/",
-              {},
-            ),
+      const tree = render(
+        withTheme(
+          withContext(
+            <CoreClientContext.Provider value={mockContext}>
+              <SyncControls
+                tooltipSuffix="test suffix"
+                onSyncClick={() => {}}
+              />
+            </CoreClientContext.Provider>,
+            "/",
+            {},
           ),
-        )
-        .toJSON();
+        ),
+      ).asFragment().firstChild;
       expect(tree).toMatchSnapshot();
     });
   });

--- a/ui/components/Sync/__tests__/__snapshots__/SyncActions.test.tsx.snap
+++ b/ui/components/Sync/__tests__/__snapshots__/SyncActions.test.tsx.snap
@@ -113,6 +113,10 @@ exports[`SyncActions snapshots hideSyncOptions 1`] = `
   font-weight: 600;
 }
 
+.c3.MuiButton-root:hover {
+  background-color: rgba(0, 179, 236, 0.1);
+}
+
 .c3.MuiButton-outlined {
   padding: 8px 12px;
 }
@@ -124,16 +128,24 @@ exports[`SyncActions snapshots hideSyncOptions 1`] = `
   padding: 0;
 }
 
-.c7.MuiButton-root :disabled svg {
-  fill: #d8d8d8;
+.c7.MuiButton-root.Mui-disabled svg {
+  fill: #BDBDBD;
 }
 
-.c7.MuiButton-root :hover {
+.c7.MuiButton-root:hover {
   background-color: rgba(0, 179, 236, 0.1);
 }
 
 .c7.MuiButton-text {
   padding: 0;
+}
+
+.c7.MuiButton-text.Mui-disabled {
+  color: #BDBDBD;
+}
+
+.c7.MuiButton-text.Mui-disabled svg {
+  fill: #BDBDBD;
 }
 
 .c1 .sync-icon-button {
@@ -152,36 +164,23 @@ exports[`SyncActions snapshots hideSyncOptions 1`] = `
 }
 
 <div
-  className="c0 c1 c2"
+  class="c0 c1 c2"
 >
   <button
-    className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation c3 sync-icon-button css-157ho6v-MuiButtonBase-root-MuiButton-root"
-    disabled={null}
+    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation c3 sync-icon-button css-9buukw-MuiButtonBase-root-MuiButton-root"
     id=":rg:"
-    onBlur={[Function]}
-    onContextMenu={[Function]}
-    onDragLeave={[Function]}
-    onFocus={[Function]}
-    onKeyDown={[Function]}
-    onKeyUp={[Function]}
-    onMouseDown={[Function]}
-    onMouseLeave={[Function]}
-    onMouseUp={[Function]}
-    onTouchEnd={[Function]}
-    onTouchMove={[Function]}
-    onTouchStart={[Function]}
-    tabIndex={0}
+    tabindex="0"
     type="button"
   >
     <span
-      className="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeMedium css-1v1j2p3-MuiButton-startIcon"
+      class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeMedium css-1v1j2p3-MuiButton-startIcon"
     >
       <div
-        className="c4 c5"
+        class="c4 c5"
       >
         <svg
-          aria-hidden={true}
-          className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
           data-testid="SyncIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -195,47 +194,26 @@ exports[`SyncActions snapshots hideSyncOptions 1`] = `
     Sync
   </button>
   <div
-    className="c6"
+    class="c6"
   />
   <div
     aria-label="Sync"
-    aria-labelledby={null}
-    className=""
-    data-mui-internal-clone-element={true}
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseLeave={[Function]}
-    onMouseOver={[Function]}
-    onTouchEnd={[Function]}
-    onTouchStart={[Function]}
+    class=""
+    data-mui-internal-clone-element="true"
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c3 c7 css-1fh7grq-MuiButtonBase-root-MuiButton-root"
+      class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c3 c7 css-624mb0-MuiButtonBase-root-MuiButton-root"
       data-testid="sync-button"
-      disabled={null}
       id=":ri:"
-      onBlur={[Function]}
-      onClick={[Function]}
-      onContextMenu={[Function]}
-      onDragLeave={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
-      onMouseDown={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      onTouchEnd={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
-      tabIndex={0}
+      tabindex="0"
       type="button"
     >
       <div
-        className="c4 c5"
+        class="c4 c5"
       >
         <svg
-          aria-hidden={true}
-          className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
           data-testid="PlayArrowIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -248,47 +226,26 @@ exports[`SyncActions snapshots hideSyncOptions 1`] = `
     </button>
   </div>
   <div
-    className="c6"
+    class="c6"
   />
   <div
     aria-label="Suspend"
-    aria-labelledby={null}
-    className=""
-    data-mui-internal-clone-element={true}
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseLeave={[Function]}
-    onMouseOver={[Function]}
-    onTouchEnd={[Function]}
-    onTouchStart={[Function]}
+    class=""
+    data-mui-internal-clone-element="true"
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c3 c7 css-1fh7grq-MuiButtonBase-root-MuiButton-root"
+      class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c3 c7 css-624mb0-MuiButtonBase-root-MuiButton-root"
       data-testid="suspend-button"
-      disabled={null}
       id=":rk:"
-      onBlur={[Function]}
-      onClick={[Function]}
-      onContextMenu={[Function]}
-      onDragLeave={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
-      onMouseDown={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      onTouchEnd={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
-      tabIndex={0}
+      tabindex="0"
       type="button"
     >
       <div
-        className="c4 c5"
+        class="c4 c5"
       >
         <svg
-          aria-hidden={true}
-          className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
           data-testid="PauseIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -301,47 +258,27 @@ exports[`SyncActions snapshots hideSyncOptions 1`] = `
     </button>
   </div>
   <div
-    className="c6"
+    class="c6"
   />
   <div
     aria-label="Resume"
-    aria-labelledby={null}
-    className=""
-    data-mui-internal-clone-element={true}
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseLeave={[Function]}
-    onMouseOver={[Function]}
-    onTouchEnd={[Function]}
-    onTouchStart={[Function]}
+    class=""
+    data-mui-internal-clone-element="true"
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c3 c7 css-1fh7grq-MuiButtonBase-root-MuiButton-root"
+      class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c3 c7 css-624mb0-MuiButtonBase-root-MuiButton-root"
       data-testid="resume-button"
-      disabled={true}
+      disabled=""
       id=":rm:"
-      onBlur={[Function]}
-      onClick={[Function]}
-      onContextMenu={[Function]}
-      onDragLeave={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
-      onMouseDown={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      onTouchEnd={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
-      tabIndex={-1}
+      tabindex="-1"
       type="button"
     >
       <div
-        className="c4 c8"
+        class="c4 c8"
       >
         <svg
           height="24"
-          viewBox="0 0 24 24"
+          viewBox="-2 0 24 24"
           width="24"
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -468,6 +405,10 @@ exports[`SyncActions snapshots non-suspended 1`] = `
   font-weight: 600;
 }
 
+.c3.MuiButton-root:hover {
+  background-color: rgba(0, 179, 236, 0.1);
+}
+
 .c3.MuiButton-outlined {
   padding: 8px 12px;
 }
@@ -482,7 +423,7 @@ exports[`SyncActions snapshots non-suspended 1`] = `
 }
 
 .c7 .MuiFormControlLabel-label.Mui-disabled {
-  color: #d8d8d8;
+  color: #BDBDBD;
 }
 
 .c7 .MuiTypography-root {
@@ -496,16 +437,24 @@ exports[`SyncActions snapshots non-suspended 1`] = `
   padding: 0;
 }
 
-.c8.MuiButton-root :disabled svg {
-  fill: #d8d8d8;
+.c8.MuiButton-root.Mui-disabled svg {
+  fill: #BDBDBD;
 }
 
-.c8.MuiButton-root :hover {
+.c8.MuiButton-root:hover {
   background-color: rgba(0, 179, 236, 0.1);
 }
 
 .c8.MuiButton-text {
   padding: 0;
+}
+
+.c8.MuiButton-text.Mui-disabled {
+  color: #BDBDBD;
+}
+
+.c8.MuiButton-text.Mui-disabled svg {
+  fill: #BDBDBD;
 }
 
 .c1 .sync-icon-button {
@@ -524,36 +473,23 @@ exports[`SyncActions snapshots non-suspended 1`] = `
 }
 
 <div
-  className="c0 c1 c2"
+  class="c0 c1 c2"
 >
   <button
-    className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation c3 sync-icon-button css-157ho6v-MuiButtonBase-root-MuiButton-root"
-    disabled={null}
+    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation c3 sync-icon-button css-9buukw-MuiButtonBase-root-MuiButton-root"
     id=":r0:"
-    onBlur={[Function]}
-    onContextMenu={[Function]}
-    onDragLeave={[Function]}
-    onFocus={[Function]}
-    onKeyDown={[Function]}
-    onKeyUp={[Function]}
-    onMouseDown={[Function]}
-    onMouseLeave={[Function]}
-    onMouseUp={[Function]}
-    onTouchEnd={[Function]}
-    onTouchMove={[Function]}
-    onTouchStart={[Function]}
-    tabIndex={0}
+    tabindex="0"
     type="button"
   >
     <span
-      className="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeMedium css-1v1j2p3-MuiButton-startIcon"
+      class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeMedium css-1v1j2p3-MuiButton-startIcon"
     >
       <div
-        className="c4 c5"
+        class="c4 c5"
       >
         <svg
-          aria-hidden={true}
-          className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
           data-testid="SyncIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -567,52 +503,36 @@ exports[`SyncActions snapshots non-suspended 1`] = `
     Sync
   </button>
   <div
-    className="c6"
+    class="c6"
   />
   <div
-    className="MuiFormControl-root css-1iw3t7y-MuiFormControl-root"
+    class="MuiFormControl-root css-1iw3t7y-MuiFormControl-root"
   >
     <div
       aria-labelledby="source-radio-buttons-group-label"
-      className="MuiFormGroup-root MuiFormGroup-row MuiRadioGroup-root MuiRadioGroup-row css-cis11t-MuiFormGroup-root"
+      class="MuiFormGroup-root MuiFormGroup-row MuiRadioGroup-root MuiRadioGroup-row css-cis11t-MuiFormGroup-root"
       data-testid="sync-options"
       role="radiogroup"
     >
       <label
-        className="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd c7 css-12f4qvw-MuiFormControlLabel-root"
+        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd c7 css-12f4qvw-MuiFormControlLabel-root"
       >
         <span
-          className="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-checked MuiRadio-root MuiRadio-colorPrimary css-yavd16-MuiButtonBase-root-MuiRadio-root"
-          onBlur={[Function]}
-          onContextMenu={[Function]}
-          onDragLeave={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseLeave={[Function]}
-          onMouseUp={[Function]}
-          onTouchEnd={[Function]}
-          onTouchMove={[Function]}
-          onTouchStart={[Function]}
-          tabIndex={null}
+          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-checked MuiRadio-root MuiRadio-colorPrimary css-1avr0ra-MuiButtonBase-root-MuiRadio-root"
         >
           <input
-            checked={true}
-            className="PrivateSwitchBase-input css-j8yymo"
-            disabled={false}
+            checked=""
+            class="PrivateSwitchBase-input css-j8yymo"
             name="source-radio-buttons-group"
-            onChange={[Function]}
-            required={false}
             type="radio"
             value="WithSource"
           />
           <span
-            className="css-1qiat4j"
+            class="css-1qiat4j"
           >
             <svg
-              aria-hidden={true}
-              className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bz1rr0-MuiSvgIcon-root"
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bz1rr0-MuiSvgIcon-root"
               data-testid="RadioButtonUncheckedIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -622,8 +542,8 @@ exports[`SyncActions snapshots non-suspended 1`] = `
               />
             </svg>
             <svg
-              aria-hidden={true}
-              className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-z8nmqa-MuiSvgIcon-root"
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-z8nmqa-MuiSvgIcon-root"
               data-testid="RadioButtonCheckedIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -635,50 +555,32 @@ exports[`SyncActions snapshots non-suspended 1`] = `
           </span>
         </span>
         <span
-          className="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1lw54ax-MuiTypography-root"
-          style={{}}
+          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1lw54ax-MuiTypography-root"
         >
           with Source
         </span>
       </label>
       <div
-        className="c6"
+        class="c6"
       />
       <label
-        className="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd c7 css-12f4qvw-MuiFormControlLabel-root"
+        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd c7 css-12f4qvw-MuiFormControlLabel-root"
       >
         <span
-          className="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary css-yavd16-MuiButtonBase-root-MuiRadio-root"
-          onBlur={[Function]}
-          onContextMenu={[Function]}
-          onDragLeave={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseLeave={[Function]}
-          onMouseUp={[Function]}
-          onTouchEnd={[Function]}
-          onTouchMove={[Function]}
-          onTouchStart={[Function]}
-          tabIndex={null}
+          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary css-1avr0ra-MuiButtonBase-root-MuiRadio-root"
         >
           <input
-            checked={false}
-            className="PrivateSwitchBase-input css-j8yymo"
-            disabled={false}
+            class="PrivateSwitchBase-input css-j8yymo"
             name="source-radio-buttons-group"
-            onChange={[Function]}
-            required={false}
             type="radio"
             value="WithoutSource"
           />
           <span
-            className="css-1qiat4j"
+            class="css-1qiat4j"
           >
             <svg
-              aria-hidden={true}
-              className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bz1rr0-MuiSvgIcon-root"
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bz1rr0-MuiSvgIcon-root"
               data-testid="RadioButtonUncheckedIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -688,8 +590,8 @@ exports[`SyncActions snapshots non-suspended 1`] = `
               />
             </svg>
             <svg
-              aria-hidden={true}
-              className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-o8rdeq-MuiSvgIcon-root"
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-o8rdeq-MuiSvgIcon-root"
               data-testid="RadioButtonCheckedIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -701,8 +603,7 @@ exports[`SyncActions snapshots non-suspended 1`] = `
           </span>
         </span>
         <span
-          className="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1lw54ax-MuiTypography-root"
-          style={{}}
+          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1lw54ax-MuiTypography-root"
         >
           without Source
         </span>
@@ -710,47 +611,26 @@ exports[`SyncActions snapshots non-suspended 1`] = `
     </div>
   </div>
   <div
-    className="c6"
+    class="c6"
   />
   <div
     aria-label="Sync"
-    aria-labelledby={null}
-    className=""
-    data-mui-internal-clone-element={true}
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseLeave={[Function]}
-    onMouseOver={[Function]}
-    onTouchEnd={[Function]}
-    onTouchStart={[Function]}
+    class=""
+    data-mui-internal-clone-element="true"
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c3 c8 css-1fh7grq-MuiButtonBase-root-MuiButton-root"
+      class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c3 c8 css-624mb0-MuiButtonBase-root-MuiButton-root"
       data-testid="sync-button"
-      disabled={null}
       id=":r3:"
-      onBlur={[Function]}
-      onClick={[Function]}
-      onContextMenu={[Function]}
-      onDragLeave={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
-      onMouseDown={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      onTouchEnd={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
-      tabIndex={0}
+      tabindex="0"
       type="button"
     >
       <div
-        className="c4 c5"
+        class="c4 c5"
       >
         <svg
-          aria-hidden={true}
-          className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
           data-testid="PlayArrowIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -763,47 +643,26 @@ exports[`SyncActions snapshots non-suspended 1`] = `
     </button>
   </div>
   <div
-    className="c6"
+    class="c6"
   />
   <div
     aria-label="Suspend"
-    aria-labelledby={null}
-    className=""
-    data-mui-internal-clone-element={true}
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseLeave={[Function]}
-    onMouseOver={[Function]}
-    onTouchEnd={[Function]}
-    onTouchStart={[Function]}
+    class=""
+    data-mui-internal-clone-element="true"
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c3 c8 css-1fh7grq-MuiButtonBase-root-MuiButton-root"
+      class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c3 c8 css-624mb0-MuiButtonBase-root-MuiButton-root"
       data-testid="suspend-button"
-      disabled={null}
       id=":r5:"
-      onBlur={[Function]}
-      onClick={[Function]}
-      onContextMenu={[Function]}
-      onDragLeave={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
-      onMouseDown={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      onTouchEnd={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
-      tabIndex={0}
+      tabindex="0"
       type="button"
     >
       <div
-        className="c4 c5"
+        class="c4 c5"
       >
         <svg
-          aria-hidden={true}
-          className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
           data-testid="PauseIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -816,47 +675,27 @@ exports[`SyncActions snapshots non-suspended 1`] = `
     </button>
   </div>
   <div
-    className="c6"
+    class="c6"
   />
   <div
     aria-label="Resume"
-    aria-labelledby={null}
-    className=""
-    data-mui-internal-clone-element={true}
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseLeave={[Function]}
-    onMouseOver={[Function]}
-    onTouchEnd={[Function]}
-    onTouchStart={[Function]}
+    class=""
+    data-mui-internal-clone-element="true"
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c3 c8 css-1fh7grq-MuiButtonBase-root-MuiButton-root"
+      class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c3 c8 css-624mb0-MuiButtonBase-root-MuiButton-root"
       data-testid="resume-button"
-      disabled={true}
+      disabled=""
       id=":r7:"
-      onBlur={[Function]}
-      onClick={[Function]}
-      onContextMenu={[Function]}
-      onDragLeave={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
-      onMouseDown={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      onTouchEnd={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
-      tabIndex={-1}
+      tabindex="-1"
       type="button"
     >
       <div
-        className="c4 c9"
+        class="c4 c9"
       >
         <svg
           height="24"
-          viewBox="0 0 24 24"
+          viewBox="-2 0 24 24"
           width="24"
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -983,6 +822,10 @@ exports[`SyncActions snapshots suspended 1`] = `
   font-weight: 600;
 }
 
+.c3.MuiButton-root:hover {
+  background-color: rgba(0, 179, 236, 0.1);
+}
+
 .c3.MuiButton-outlined {
   padding: 8px 12px;
 }
@@ -997,7 +840,7 @@ exports[`SyncActions snapshots suspended 1`] = `
 }
 
 .c7 .MuiFormControlLabel-label.Mui-disabled {
-  color: #d8d8d8;
+  color: #BDBDBD;
 }
 
 .c7 .MuiTypography-root {
@@ -1011,16 +854,24 @@ exports[`SyncActions snapshots suspended 1`] = `
   padding: 0;
 }
 
-.c8.MuiButton-root :disabled svg {
-  fill: #d8d8d8;
+.c8.MuiButton-root.Mui-disabled svg {
+  fill: #BDBDBD;
 }
 
-.c8.MuiButton-root :hover {
+.c8.MuiButton-root:hover {
   background-color: rgba(0, 179, 236, 0.1);
 }
 
 .c8.MuiButton-text {
   padding: 0;
+}
+
+.c8.MuiButton-text.Mui-disabled {
+  color: #BDBDBD;
+}
+
+.c8.MuiButton-text.Mui-disabled svg {
+  fill: #BDBDBD;
 }
 
 .c1 .sync-icon-button {
@@ -1039,36 +890,24 @@ exports[`SyncActions snapshots suspended 1`] = `
 }
 
 <div
-  className="c0 c1 c2"
+  class="c0 c1 c2"
 >
   <button
-    className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation c3 sync-icon-button css-157ho6v-MuiButtonBase-root-MuiButton-root"
-    disabled={true}
+    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation c3 sync-icon-button css-9buukw-MuiButtonBase-root-MuiButton-root"
+    disabled=""
     id=":r8:"
-    onBlur={[Function]}
-    onContextMenu={[Function]}
-    onDragLeave={[Function]}
-    onFocus={[Function]}
-    onKeyDown={[Function]}
-    onKeyUp={[Function]}
-    onMouseDown={[Function]}
-    onMouseLeave={[Function]}
-    onMouseUp={[Function]}
-    onTouchEnd={[Function]}
-    onTouchMove={[Function]}
-    onTouchStart={[Function]}
-    tabIndex={-1}
+    tabindex="-1"
     type="button"
   >
     <span
-      className="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeMedium css-1v1j2p3-MuiButton-startIcon"
+      class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeMedium css-1v1j2p3-MuiButton-startIcon"
     >
       <div
-        className="c4 c5"
+        class="c4 c5"
       >
         <svg
-          aria-hidden={true}
-          className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
           data-testid="SyncIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -1082,53 +921,39 @@ exports[`SyncActions snapshots suspended 1`] = `
     Sync
   </button>
   <div
-    className="c6"
+    class="c6"
   />
   <div
-    className="MuiFormControl-root css-1iw3t7y-MuiFormControl-root"
+    class="MuiFormControl-root css-1iw3t7y-MuiFormControl-root"
   >
     <div
       aria-labelledby="source-radio-buttons-group-label"
-      className="MuiFormGroup-root MuiFormGroup-row MuiRadioGroup-root MuiRadioGroup-row css-cis11t-MuiFormGroup-root"
+      class="MuiFormGroup-root MuiFormGroup-row MuiRadioGroup-root MuiRadioGroup-row css-cis11t-MuiFormGroup-root"
       data-testid="sync-options"
       role="radiogroup"
     >
       <label
-        className="MuiFormControlLabel-root Mui-disabled MuiFormControlLabel-labelPlacementEnd c7 css-12f4qvw-MuiFormControlLabel-root"
+        class="MuiFormControlLabel-root Mui-disabled MuiFormControlLabel-labelPlacementEnd c7 css-12f4qvw-MuiFormControlLabel-root"
       >
         <span
-          aria-disabled={true}
-          className="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary Mui-disabled PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-checked Mui-disabled MuiRadio-root MuiRadio-colorPrimary css-1mux80u-MuiButtonBase-root-MuiRadio-root"
-          onBlur={[Function]}
-          onContextMenu={[Function]}
-          onDragLeave={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseLeave={[Function]}
-          onMouseUp={[Function]}
-          onTouchEnd={[Function]}
-          onTouchMove={[Function]}
-          onTouchStart={[Function]}
-          tabIndex={-1}
+          aria-disabled="true"
+          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary Mui-disabled PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-checked Mui-disabled MuiRadio-root MuiRadio-colorPrimary css-1a0qp0h-MuiButtonBase-root-MuiRadio-root"
+          tabindex="-1"
         >
           <input
-            checked={true}
-            className="PrivateSwitchBase-input css-j8yymo"
-            disabled={true}
+            checked=""
+            class="PrivateSwitchBase-input css-j8yymo"
+            disabled=""
             name="source-radio-buttons-group"
-            onChange={[Function]}
-            required={false}
             type="radio"
             value="WithSource"
           />
           <span
-            className="css-1qiat4j"
+            class="css-1qiat4j"
           >
             <svg
-              aria-hidden={true}
-              className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bz1rr0-MuiSvgIcon-root"
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bz1rr0-MuiSvgIcon-root"
               data-testid="RadioButtonUncheckedIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -1138,8 +963,8 @@ exports[`SyncActions snapshots suspended 1`] = `
               />
             </svg>
             <svg
-              aria-hidden={true}
-              className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-z8nmqa-MuiSvgIcon-root"
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-z8nmqa-MuiSvgIcon-root"
               data-testid="RadioButtonCheckedIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -1151,51 +976,35 @@ exports[`SyncActions snapshots suspended 1`] = `
           </span>
         </span>
         <span
-          className="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label Mui-disabled css-1lw54ax-MuiTypography-root"
-          style={{}}
+          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label Mui-disabled css-1lw54ax-MuiTypography-root"
         >
           with Source
         </span>
       </label>
       <div
-        className="c6"
+        class="c6"
       />
       <label
-        className="MuiFormControlLabel-root Mui-disabled MuiFormControlLabel-labelPlacementEnd c7 css-12f4qvw-MuiFormControlLabel-root"
+        class="MuiFormControlLabel-root Mui-disabled MuiFormControlLabel-labelPlacementEnd c7 css-12f4qvw-MuiFormControlLabel-root"
       >
         <span
-          aria-disabled={true}
-          className="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary Mui-disabled PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-disabled MuiRadio-root MuiRadio-colorPrimary css-1mux80u-MuiButtonBase-root-MuiRadio-root"
-          onBlur={[Function]}
-          onContextMenu={[Function]}
-          onDragLeave={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseLeave={[Function]}
-          onMouseUp={[Function]}
-          onTouchEnd={[Function]}
-          onTouchMove={[Function]}
-          onTouchStart={[Function]}
-          tabIndex={-1}
+          aria-disabled="true"
+          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary Mui-disabled PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-disabled MuiRadio-root MuiRadio-colorPrimary css-1a0qp0h-MuiButtonBase-root-MuiRadio-root"
+          tabindex="-1"
         >
           <input
-            checked={false}
-            className="PrivateSwitchBase-input css-j8yymo"
-            disabled={true}
+            class="PrivateSwitchBase-input css-j8yymo"
+            disabled=""
             name="source-radio-buttons-group"
-            onChange={[Function]}
-            required={false}
             type="radio"
             value="WithoutSource"
           />
           <span
-            className="css-1qiat4j"
+            class="css-1qiat4j"
           >
             <svg
-              aria-hidden={true}
-              className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bz1rr0-MuiSvgIcon-root"
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bz1rr0-MuiSvgIcon-root"
               data-testid="RadioButtonUncheckedIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -1205,8 +1014,8 @@ exports[`SyncActions snapshots suspended 1`] = `
               />
             </svg>
             <svg
-              aria-hidden={true}
-              className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-o8rdeq-MuiSvgIcon-root"
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-o8rdeq-MuiSvgIcon-root"
               data-testid="RadioButtonCheckedIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -1218,8 +1027,7 @@ exports[`SyncActions snapshots suspended 1`] = `
           </span>
         </span>
         <span
-          className="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label Mui-disabled css-1lw54ax-MuiTypography-root"
-          style={{}}
+          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label Mui-disabled css-1lw54ax-MuiTypography-root"
         >
           without Source
         </span>
@@ -1227,47 +1035,27 @@ exports[`SyncActions snapshots suspended 1`] = `
     </div>
   </div>
   <div
-    className="c6"
+    class="c6"
   />
   <div
     aria-label="Sync"
-    aria-labelledby={null}
-    className=""
-    data-mui-internal-clone-element={true}
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseLeave={[Function]}
-    onMouseOver={[Function]}
-    onTouchEnd={[Function]}
-    onTouchStart={[Function]}
+    class=""
+    data-mui-internal-clone-element="true"
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c3 c8 css-1fh7grq-MuiButtonBase-root-MuiButton-root"
+      class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c3 c8 css-624mb0-MuiButtonBase-root-MuiButton-root"
       data-testid="sync-button"
-      disabled={true}
+      disabled=""
       id=":rb:"
-      onBlur={[Function]}
-      onClick={[Function]}
-      onContextMenu={[Function]}
-      onDragLeave={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
-      onMouseDown={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      onTouchEnd={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
-      tabIndex={-1}
+      tabindex="-1"
       type="button"
     >
       <div
-        className="c4 c5"
+        class="c4 c5"
       >
         <svg
-          aria-hidden={true}
-          className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
           data-testid="PlayArrowIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -1280,47 +1068,27 @@ exports[`SyncActions snapshots suspended 1`] = `
     </button>
   </div>
   <div
-    className="c6"
+    class="c6"
   />
   <div
     aria-label="Suspend"
-    aria-labelledby={null}
-    className=""
-    data-mui-internal-clone-element={true}
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseLeave={[Function]}
-    onMouseOver={[Function]}
-    onTouchEnd={[Function]}
-    onTouchStart={[Function]}
+    class=""
+    data-mui-internal-clone-element="true"
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c3 c8 css-1fh7grq-MuiButtonBase-root-MuiButton-root"
+      class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c3 c8 css-624mb0-MuiButtonBase-root-MuiButton-root"
       data-testid="suspend-button"
-      disabled={true}
+      disabled=""
       id=":rd:"
-      onBlur={[Function]}
-      onClick={[Function]}
-      onContextMenu={[Function]}
-      onDragLeave={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
-      onMouseDown={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      onTouchEnd={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
-      tabIndex={-1}
+      tabindex="-1"
       type="button"
     >
       <div
-        className="c4 c5"
+        class="c4 c5"
       >
         <svg
-          aria-hidden={true}
-          className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
           data-testid="PauseIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -1333,47 +1101,26 @@ exports[`SyncActions snapshots suspended 1`] = `
     </button>
   </div>
   <div
-    className="c6"
+    class="c6"
   />
   <div
     aria-label="Resume"
-    aria-labelledby={null}
-    className=""
-    data-mui-internal-clone-element={true}
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseLeave={[Function]}
-    onMouseOver={[Function]}
-    onTouchEnd={[Function]}
-    onTouchStart={[Function]}
+    class=""
+    data-mui-internal-clone-element="true"
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c3 c8 css-1fh7grq-MuiButtonBase-root-MuiButton-root"
+      class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c3 c8 css-624mb0-MuiButtonBase-root-MuiButton-root"
       data-testid="resume-button"
-      disabled={null}
       id=":rf:"
-      onBlur={[Function]}
-      onClick={[Function]}
-      onContextMenu={[Function]}
-      onDragLeave={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
-      onMouseDown={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      onTouchEnd={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
-      tabIndex={0}
+      tabindex="0"
       type="button"
     >
       <div
-        className="c4 c9"
+        class="c4 c9"
       >
         <svg
           height="24"
-          viewBox="0 0 24 24"
+          viewBox="-2 0 24 24"
           width="24"
           xmlns="http://www.w3.org/2000/svg"
         >

--- a/ui/components/Sync/__tests__/__snapshots__/SyncActions.test.tsx.snap
+++ b/ui/components/Sync/__tests__/__snapshots__/SyncActions.test.tsx.snap
@@ -1,7 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SyncActions snapshots hideSyncOptions 1`] = `
-.c0 {
+<DocumentFragment>
+  .c0 {
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -164,136 +165,138 @@ exports[`SyncActions snapshots hideSyncOptions 1`] = `
 }
 
 <div
-  class="c0 c1 c2"
->
-  <button
-    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation c3 sync-icon-button css-9buukw-MuiButtonBase-root-MuiButton-root"
-    id=":rg:"
-    tabindex="0"
-    type="button"
-  >
-    <span
-      class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeMedium css-1v1j2p3-MuiButton-startIcon"
-    >
-      <div
-        class="c4 c5"
-      >
-        <svg
-          aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
-          data-testid="SyncIcon"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M12 4V1L8 5l4 4V6c3.31 0 6 2.69 6 6 0 1.01-.25 1.97-.7 2.8l1.46 1.46C19.54 15.03 20 13.57 20 12c0-4.42-3.58-8-8-8m0 14c-3.31 0-6-2.69-6-6 0-1.01.25-1.97.7-2.8L5.24 7.74C4.46 8.97 4 10.43 4 12c0 4.42 3.58 8 8 8v3l4-4-4-4z"
-          />
-        </svg>
-      </div>
-    </span>
-    Sync
-  </button>
-  <div
-    class="c6"
-  />
-  <div
-    aria-label="Sync"
-    class=""
-    data-mui-internal-clone-element="true"
+    class="c0 c1 c2"
   >
     <button
-      class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c3 c7 css-624mb0-MuiButtonBase-root-MuiButton-root"
-      data-testid="sync-button"
-      id=":ri:"
+      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation c3 sync-icon-button css-9buukw-MuiButtonBase-root-MuiButton-root"
+      id=":rg:"
       tabindex="0"
       type="button"
     >
-      <div
-        class="c4 c5"
+      <span
+        class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeMedium css-1v1j2p3-MuiButton-startIcon"
       >
-        <svg
-          aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
-          data-testid="PlayArrowIcon"
-          focusable="false"
-          viewBox="0 0 24 24"
+        <div
+          class="c4 c5"
         >
-          <path
-            d="M8 5v14l11-7z"
-          />
-        </svg>
-      </div>
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+            data-testid="SyncIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M12 4V1L8 5l4 4V6c3.31 0 6 2.69 6 6 0 1.01-.25 1.97-.7 2.8l1.46 1.46C19.54 15.03 20 13.57 20 12c0-4.42-3.58-8-8-8m0 14c-3.31 0-6-2.69-6-6 0-1.01.25-1.97.7-2.8L5.24 7.74C4.46 8.97 4 10.43 4 12c0 4.42 3.58 8 8 8v3l4-4-4-4z"
+            />
+          </svg>
+        </div>
+      </span>
+      Sync
     </button>
-  </div>
-  <div
-    class="c6"
-  />
-  <div
-    aria-label="Suspend"
-    class=""
-    data-mui-internal-clone-element="true"
-  >
-    <button
-      class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c3 c7 css-624mb0-MuiButtonBase-root-MuiButton-root"
-      data-testid="suspend-button"
-      id=":rk:"
-      tabindex="0"
-      type="button"
+    <div
+      class="c6"
+    />
+    <div
+      aria-label="Sync"
+      class=""
+      data-mui-internal-clone-element="true"
     >
-      <div
-        class="c4 c5"
+      <button
+        class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c3 c7 css-624mb0-MuiButtonBase-root-MuiButton-root"
+        data-testid="sync-button"
+        id=":ri:"
+        tabindex="0"
+        type="button"
       >
-        <svg
-          aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
-          data-testid="PauseIcon"
-          focusable="false"
-          viewBox="0 0 24 24"
+        <div
+          class="c4 c5"
         >
-          <path
-            d="M6 19h4V5H6zm8-14v14h4V5z"
-          />
-        </svg>
-      </div>
-    </button>
-  </div>
-  <div
-    class="c6"
-  />
-  <div
-    aria-label="Resume"
-    class=""
-    data-mui-internal-clone-element="true"
-  >
-    <button
-      class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c3 c7 css-624mb0-MuiButtonBase-root-MuiButton-root"
-      data-testid="resume-button"
-      disabled=""
-      id=":rm:"
-      tabindex="-1"
-      type="button"
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+            data-testid="PlayArrowIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M8 5v14l11-7z"
+            />
+          </svg>
+        </div>
+      </button>
+    </div>
+    <div
+      class="c6"
+    />
+    <div
+      aria-label="Suspend"
+      class=""
+      data-mui-internal-clone-element="true"
     >
-      <div
-        class="c4 c8"
+      <button
+        class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c3 c7 css-624mb0-MuiButtonBase-root-MuiButton-root"
+        data-testid="suspend-button"
+        id=":rk:"
+        tabindex="0"
+        type="button"
       >
-        <svg
-          height="24"
-          viewBox="-2 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
+        <div
+          class="c4 c5"
         >
-          <path
-            d="M4.08331 18.75V4.75H6.41665V18.75H4.08331ZM8.74998 18.75L20.4166 11.75L8.74998 4.75V18.75Z"
-          />
-        </svg>
-      </div>
-    </button>
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+            data-testid="PauseIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M6 19h4V5H6zm8-14v14h4V5z"
+            />
+          </svg>
+        </div>
+      </button>
+    </div>
+    <div
+      class="c6"
+    />
+    <div
+      aria-label="Resume"
+      class=""
+      data-mui-internal-clone-element="true"
+    >
+      <button
+        class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c3 c7 css-624mb0-MuiButtonBase-root-MuiButton-root"
+        data-testid="resume-button"
+        disabled=""
+        id=":rm:"
+        tabindex="-1"
+        type="button"
+      >
+        <div
+          class="c4 c8"
+        >
+          <svg
+            height="24"
+            viewBox="-2 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M4.08331 18.75V4.75H6.41665V18.75H4.08331ZM8.74998 18.75L20.4166 11.75L8.74998 4.75V18.75Z"
+            />
+          </svg>
+        </div>
+      </button>
+    </div>
   </div>
-</div>
+</DocumentFragment>
 `;
 
 exports[`SyncActions snapshots non-suspended 1`] = `
-.c0 {
+<DocumentFragment>
+  .c0 {
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -473,244 +476,246 @@ exports[`SyncActions snapshots non-suspended 1`] = `
 }
 
 <div
-  class="c0 c1 c2"
->
-  <button
-    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation c3 sync-icon-button css-9buukw-MuiButtonBase-root-MuiButton-root"
-    id=":r0:"
-    tabindex="0"
-    type="button"
+    class="c0 c1 c2"
   >
-    <span
-      class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeMedium css-1v1j2p3-MuiButton-startIcon"
+    <button
+      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation c3 sync-icon-button css-9buukw-MuiButtonBase-root-MuiButton-root"
+      id=":r0:"
+      tabindex="0"
+      type="button"
     >
-      <div
-        class="c4 c5"
+      <span
+        class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeMedium css-1v1j2p3-MuiButton-startIcon"
       >
-        <svg
-          aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
-          data-testid="SyncIcon"
-          focusable="false"
-          viewBox="0 0 24 24"
+        <div
+          class="c4 c5"
         >
-          <path
-            d="M12 4V1L8 5l4 4V6c3.31 0 6 2.69 6 6 0 1.01-.25 1.97-.7 2.8l1.46 1.46C19.54 15.03 20 13.57 20 12c0-4.42-3.58-8-8-8m0 14c-3.31 0-6-2.69-6-6 0-1.01.25-1.97.7-2.8L5.24 7.74C4.46 8.97 4 10.43 4 12c0 4.42 3.58 8 8 8v3l4-4-4-4z"
-          />
-        </svg>
-      </div>
-    </span>
-    Sync
-  </button>
-  <div
-    class="c6"
-  />
-  <div
-    class="MuiFormControl-root css-1iw3t7y-MuiFormControl-root"
-  >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+            data-testid="SyncIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M12 4V1L8 5l4 4V6c3.31 0 6 2.69 6 6 0 1.01-.25 1.97-.7 2.8l1.46 1.46C19.54 15.03 20 13.57 20 12c0-4.42-3.58-8-8-8m0 14c-3.31 0-6-2.69-6-6 0-1.01.25-1.97.7-2.8L5.24 7.74C4.46 8.97 4 10.43 4 12c0 4.42 3.58 8 8 8v3l4-4-4-4z"
+            />
+          </svg>
+        </div>
+      </span>
+      Sync
+    </button>
     <div
-      aria-labelledby="source-radio-buttons-group-label"
-      class="MuiFormGroup-root MuiFormGroup-row MuiRadioGroup-root MuiRadioGroup-row css-cis11t-MuiFormGroup-root"
-      data-testid="sync-options"
-      role="radiogroup"
+      class="c6"
+    />
+    <div
+      class="MuiFormControl-root css-1iw3t7y-MuiFormControl-root"
     >
-      <label
-        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd c7 css-12f4qvw-MuiFormControlLabel-root"
-      >
-        <span
-          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-checked MuiRadio-root MuiRadio-colorPrimary css-1avr0ra-MuiButtonBase-root-MuiRadio-root"
-        >
-          <input
-            checked=""
-            class="PrivateSwitchBase-input css-j8yymo"
-            name="source-radio-buttons-group"
-            type="radio"
-            value="WithSource"
-          />
-          <span
-            class="css-1qiat4j"
-          >
-            <svg
-              aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bz1rr0-MuiSvgIcon-root"
-              data-testid="RadioButtonUncheckedIcon"
-              focusable="false"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
-              />
-            </svg>
-            <svg
-              aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-z8nmqa-MuiSvgIcon-root"
-              data-testid="RadioButtonCheckedIcon"
-              focusable="false"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
-              />
-            </svg>
-          </span>
-        </span>
-        <span
-          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1lw54ax-MuiTypography-root"
-        >
-          with Source
-        </span>
-      </label>
       <div
-        class="c6"
-      />
-      <label
-        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd c7 css-12f4qvw-MuiFormControlLabel-root"
+        aria-labelledby="source-radio-buttons-group-label"
+        class="MuiFormGroup-root MuiFormGroup-row MuiRadioGroup-root MuiRadioGroup-row css-cis11t-MuiFormGroup-root"
+        data-testid="sync-options"
+        role="radiogroup"
       >
-        <span
-          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary css-1avr0ra-MuiButtonBase-root-MuiRadio-root"
+        <label
+          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd c7 css-12f4qvw-MuiFormControlLabel-root"
         >
-          <input
-            class="PrivateSwitchBase-input css-j8yymo"
-            name="source-radio-buttons-group"
-            type="radio"
-            value="WithoutSource"
-          />
           <span
-            class="css-1qiat4j"
+            class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-checked MuiRadio-root MuiRadio-colorPrimary css-1avr0ra-MuiButtonBase-root-MuiRadio-root"
           >
-            <svg
-              aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bz1rr0-MuiSvgIcon-root"
-              data-testid="RadioButtonUncheckedIcon"
-              focusable="false"
-              viewBox="0 0 24 24"
+            <input
+              checked=""
+              class="PrivateSwitchBase-input css-j8yymo"
+              name="source-radio-buttons-group"
+              type="radio"
+              value="WithSource"
+            />
+            <span
+              class="css-1qiat4j"
             >
-              <path
-                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
-              />
-            </svg>
-            <svg
-              aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-o8rdeq-MuiSvgIcon-root"
-              data-testid="RadioButtonCheckedIcon"
-              focusable="false"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
-              />
-            </svg>
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bz1rr0-MuiSvgIcon-root"
+                data-testid="RadioButtonUncheckedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                />
+              </svg>
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-z8nmqa-MuiSvgIcon-root"
+                data-testid="RadioButtonCheckedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+                />
+              </svg>
+            </span>
           </span>
-        </span>
-        <span
-          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1lw54ax-MuiTypography-root"
+          <span
+            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1lw54ax-MuiTypography-root"
+          >
+            with Source
+          </span>
+        </label>
+        <div
+          class="c6"
+        />
+        <label
+          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd c7 css-12f4qvw-MuiFormControlLabel-root"
         >
-          without Source
-        </span>
-      </label>
+          <span
+            class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary css-1avr0ra-MuiButtonBase-root-MuiRadio-root"
+          >
+            <input
+              class="PrivateSwitchBase-input css-j8yymo"
+              name="source-radio-buttons-group"
+              type="radio"
+              value="WithoutSource"
+            />
+            <span
+              class="css-1qiat4j"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bz1rr0-MuiSvgIcon-root"
+                data-testid="RadioButtonUncheckedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                />
+              </svg>
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-o8rdeq-MuiSvgIcon-root"
+                data-testid="RadioButtonCheckedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+                />
+              </svg>
+            </span>
+          </span>
+          <span
+            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1lw54ax-MuiTypography-root"
+          >
+            without Source
+          </span>
+        </label>
+      </div>
+    </div>
+    <div
+      class="c6"
+    />
+    <div
+      aria-label="Sync"
+      class=""
+      data-mui-internal-clone-element="true"
+    >
+      <button
+        class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c3 c8 css-624mb0-MuiButtonBase-root-MuiButton-root"
+        data-testid="sync-button"
+        id=":r3:"
+        tabindex="0"
+        type="button"
+      >
+        <div
+          class="c4 c5"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+            data-testid="PlayArrowIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M8 5v14l11-7z"
+            />
+          </svg>
+        </div>
+      </button>
+    </div>
+    <div
+      class="c6"
+    />
+    <div
+      aria-label="Suspend"
+      class=""
+      data-mui-internal-clone-element="true"
+    >
+      <button
+        class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c3 c8 css-624mb0-MuiButtonBase-root-MuiButton-root"
+        data-testid="suspend-button"
+        id=":r5:"
+        tabindex="0"
+        type="button"
+      >
+        <div
+          class="c4 c5"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+            data-testid="PauseIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M6 19h4V5H6zm8-14v14h4V5z"
+            />
+          </svg>
+        </div>
+      </button>
+    </div>
+    <div
+      class="c6"
+    />
+    <div
+      aria-label="Resume"
+      class=""
+      data-mui-internal-clone-element="true"
+    >
+      <button
+        class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c3 c8 css-624mb0-MuiButtonBase-root-MuiButton-root"
+        data-testid="resume-button"
+        disabled=""
+        id=":r7:"
+        tabindex="-1"
+        type="button"
+      >
+        <div
+          class="c4 c9"
+        >
+          <svg
+            height="24"
+            viewBox="-2 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M4.08331 18.75V4.75H6.41665V18.75H4.08331ZM8.74998 18.75L20.4166 11.75L8.74998 4.75V18.75Z"
+            />
+          </svg>
+        </div>
+      </button>
     </div>
   </div>
-  <div
-    class="c6"
-  />
-  <div
-    aria-label="Sync"
-    class=""
-    data-mui-internal-clone-element="true"
-  >
-    <button
-      class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c3 c8 css-624mb0-MuiButtonBase-root-MuiButton-root"
-      data-testid="sync-button"
-      id=":r3:"
-      tabindex="0"
-      type="button"
-    >
-      <div
-        class="c4 c5"
-      >
-        <svg
-          aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
-          data-testid="PlayArrowIcon"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M8 5v14l11-7z"
-          />
-        </svg>
-      </div>
-    </button>
-  </div>
-  <div
-    class="c6"
-  />
-  <div
-    aria-label="Suspend"
-    class=""
-    data-mui-internal-clone-element="true"
-  >
-    <button
-      class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c3 c8 css-624mb0-MuiButtonBase-root-MuiButton-root"
-      data-testid="suspend-button"
-      id=":r5:"
-      tabindex="0"
-      type="button"
-    >
-      <div
-        class="c4 c5"
-      >
-        <svg
-          aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
-          data-testid="PauseIcon"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M6 19h4V5H6zm8-14v14h4V5z"
-          />
-        </svg>
-      </div>
-    </button>
-  </div>
-  <div
-    class="c6"
-  />
-  <div
-    aria-label="Resume"
-    class=""
-    data-mui-internal-clone-element="true"
-  >
-    <button
-      class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c3 c8 css-624mb0-MuiButtonBase-root-MuiButton-root"
-      data-testid="resume-button"
-      disabled=""
-      id=":r7:"
-      tabindex="-1"
-      type="button"
-    >
-      <div
-        class="c4 c9"
-      >
-        <svg
-          height="24"
-          viewBox="-2 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M4.08331 18.75V4.75H6.41665V18.75H4.08331ZM8.74998 18.75L20.4166 11.75L8.74998 4.75V18.75Z"
-          />
-        </svg>
-      </div>
-    </button>
-  </div>
-</div>
+</DocumentFragment>
 `;
 
 exports[`SyncActions snapshots suspended 1`] = `
-.c0 {
+<DocumentFragment>
+  .c0 {
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -890,246 +895,247 @@ exports[`SyncActions snapshots suspended 1`] = `
 }
 
 <div
-  class="c0 c1 c2"
->
-  <button
-    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation c3 sync-icon-button css-9buukw-MuiButtonBase-root-MuiButton-root"
-    disabled=""
-    id=":r8:"
-    tabindex="-1"
-    type="button"
+    class="c0 c1 c2"
   >
-    <span
-      class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeMedium css-1v1j2p3-MuiButton-startIcon"
+    <button
+      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation c3 sync-icon-button css-9buukw-MuiButtonBase-root-MuiButton-root"
+      disabled=""
+      id=":r8:"
+      tabindex="-1"
+      type="button"
     >
-      <div
-        class="c4 c5"
+      <span
+        class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeMedium css-1v1j2p3-MuiButton-startIcon"
       >
-        <svg
-          aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
-          data-testid="SyncIcon"
-          focusable="false"
-          viewBox="0 0 24 24"
+        <div
+          class="c4 c5"
         >
-          <path
-            d="M12 4V1L8 5l4 4V6c3.31 0 6 2.69 6 6 0 1.01-.25 1.97-.7 2.8l1.46 1.46C19.54 15.03 20 13.57 20 12c0-4.42-3.58-8-8-8m0 14c-3.31 0-6-2.69-6-6 0-1.01.25-1.97.7-2.8L5.24 7.74C4.46 8.97 4 10.43 4 12c0 4.42 3.58 8 8 8v3l4-4-4-4z"
-          />
-        </svg>
-      </div>
-    </span>
-    Sync
-  </button>
-  <div
-    class="c6"
-  />
-  <div
-    class="MuiFormControl-root css-1iw3t7y-MuiFormControl-root"
-  >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+            data-testid="SyncIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M12 4V1L8 5l4 4V6c3.31 0 6 2.69 6 6 0 1.01-.25 1.97-.7 2.8l1.46 1.46C19.54 15.03 20 13.57 20 12c0-4.42-3.58-8-8-8m0 14c-3.31 0-6-2.69-6-6 0-1.01.25-1.97.7-2.8L5.24 7.74C4.46 8.97 4 10.43 4 12c0 4.42 3.58 8 8 8v3l4-4-4-4z"
+            />
+          </svg>
+        </div>
+      </span>
+      Sync
+    </button>
     <div
-      aria-labelledby="source-radio-buttons-group-label"
-      class="MuiFormGroup-root MuiFormGroup-row MuiRadioGroup-root MuiRadioGroup-row css-cis11t-MuiFormGroup-root"
-      data-testid="sync-options"
-      role="radiogroup"
+      class="c6"
+    />
+    <div
+      class="MuiFormControl-root css-1iw3t7y-MuiFormControl-root"
     >
-      <label
-        class="MuiFormControlLabel-root Mui-disabled MuiFormControlLabel-labelPlacementEnd c7 css-12f4qvw-MuiFormControlLabel-root"
-      >
-        <span
-          aria-disabled="true"
-          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary Mui-disabled PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-checked Mui-disabled MuiRadio-root MuiRadio-colorPrimary css-1a0qp0h-MuiButtonBase-root-MuiRadio-root"
-          tabindex="-1"
-        >
-          <input
-            checked=""
-            class="PrivateSwitchBase-input css-j8yymo"
-            disabled=""
-            name="source-radio-buttons-group"
-            type="radio"
-            value="WithSource"
-          />
-          <span
-            class="css-1qiat4j"
-          >
-            <svg
-              aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bz1rr0-MuiSvgIcon-root"
-              data-testid="RadioButtonUncheckedIcon"
-              focusable="false"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
-              />
-            </svg>
-            <svg
-              aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-z8nmqa-MuiSvgIcon-root"
-              data-testid="RadioButtonCheckedIcon"
-              focusable="false"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
-              />
-            </svg>
-          </span>
-        </span>
-        <span
-          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label Mui-disabled css-1lw54ax-MuiTypography-root"
-        >
-          with Source
-        </span>
-      </label>
       <div
-        class="c6"
-      />
-      <label
-        class="MuiFormControlLabel-root Mui-disabled MuiFormControlLabel-labelPlacementEnd c7 css-12f4qvw-MuiFormControlLabel-root"
+        aria-labelledby="source-radio-buttons-group-label"
+        class="MuiFormGroup-root MuiFormGroup-row MuiRadioGroup-root MuiRadioGroup-row css-cis11t-MuiFormGroup-root"
+        data-testid="sync-options"
+        role="radiogroup"
       >
-        <span
-          aria-disabled="true"
-          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary Mui-disabled PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-disabled MuiRadio-root MuiRadio-colorPrimary css-1a0qp0h-MuiButtonBase-root-MuiRadio-root"
-          tabindex="-1"
+        <label
+          class="MuiFormControlLabel-root Mui-disabled MuiFormControlLabel-labelPlacementEnd c7 css-12f4qvw-MuiFormControlLabel-root"
         >
-          <input
-            class="PrivateSwitchBase-input css-j8yymo"
-            disabled=""
-            name="source-radio-buttons-group"
-            type="radio"
-            value="WithoutSource"
-          />
           <span
-            class="css-1qiat4j"
+            aria-disabled="true"
+            class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary Mui-disabled PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-checked Mui-disabled MuiRadio-root MuiRadio-colorPrimary css-1a0qp0h-MuiButtonBase-root-MuiRadio-root"
+            tabindex="-1"
           >
-            <svg
-              aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bz1rr0-MuiSvgIcon-root"
-              data-testid="RadioButtonUncheckedIcon"
-              focusable="false"
-              viewBox="0 0 24 24"
+            <input
+              checked=""
+              class="PrivateSwitchBase-input css-j8yymo"
+              disabled=""
+              name="source-radio-buttons-group"
+              type="radio"
+              value="WithSource"
+            />
+            <span
+              class="css-1qiat4j"
             >
-              <path
-                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
-              />
-            </svg>
-            <svg
-              aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-o8rdeq-MuiSvgIcon-root"
-              data-testid="RadioButtonCheckedIcon"
-              focusable="false"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
-              />
-            </svg>
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bz1rr0-MuiSvgIcon-root"
+                data-testid="RadioButtonUncheckedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                />
+              </svg>
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-z8nmqa-MuiSvgIcon-root"
+                data-testid="RadioButtonCheckedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+                />
+              </svg>
+            </span>
           </span>
-        </span>
-        <span
-          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label Mui-disabled css-1lw54ax-MuiTypography-root"
+          <span
+            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label Mui-disabled css-1lw54ax-MuiTypography-root"
+          >
+            with Source
+          </span>
+        </label>
+        <div
+          class="c6"
+        />
+        <label
+          class="MuiFormControlLabel-root Mui-disabled MuiFormControlLabel-labelPlacementEnd c7 css-12f4qvw-MuiFormControlLabel-root"
         >
-          without Source
-        </span>
-      </label>
+          <span
+            aria-disabled="true"
+            class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary Mui-disabled PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-disabled MuiRadio-root MuiRadio-colorPrimary css-1a0qp0h-MuiButtonBase-root-MuiRadio-root"
+            tabindex="-1"
+          >
+            <input
+              class="PrivateSwitchBase-input css-j8yymo"
+              disabled=""
+              name="source-radio-buttons-group"
+              type="radio"
+              value="WithoutSource"
+            />
+            <span
+              class="css-1qiat4j"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bz1rr0-MuiSvgIcon-root"
+                data-testid="RadioButtonUncheckedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                />
+              </svg>
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-o8rdeq-MuiSvgIcon-root"
+                data-testid="RadioButtonCheckedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+                />
+              </svg>
+            </span>
+          </span>
+          <span
+            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label Mui-disabled css-1lw54ax-MuiTypography-root"
+          >
+            without Source
+          </span>
+        </label>
+      </div>
+    </div>
+    <div
+      class="c6"
+    />
+    <div
+      aria-label="Sync"
+      class=""
+      data-mui-internal-clone-element="true"
+    >
+      <button
+        class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c3 c8 css-624mb0-MuiButtonBase-root-MuiButton-root"
+        data-testid="sync-button"
+        disabled=""
+        id=":rb:"
+        tabindex="-1"
+        type="button"
+      >
+        <div
+          class="c4 c5"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+            data-testid="PlayArrowIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M8 5v14l11-7z"
+            />
+          </svg>
+        </div>
+      </button>
+    </div>
+    <div
+      class="c6"
+    />
+    <div
+      aria-label="Suspend"
+      class=""
+      data-mui-internal-clone-element="true"
+    >
+      <button
+        class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c3 c8 css-624mb0-MuiButtonBase-root-MuiButton-root"
+        data-testid="suspend-button"
+        disabled=""
+        id=":rd:"
+        tabindex="-1"
+        type="button"
+      >
+        <div
+          class="c4 c5"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+            data-testid="PauseIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M6 19h4V5H6zm8-14v14h4V5z"
+            />
+          </svg>
+        </div>
+      </button>
+    </div>
+    <div
+      class="c6"
+    />
+    <div
+      aria-label="Resume"
+      class=""
+      data-mui-internal-clone-element="true"
+    >
+      <button
+        class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c3 c8 css-624mb0-MuiButtonBase-root-MuiButton-root"
+        data-testid="resume-button"
+        id=":rf:"
+        tabindex="0"
+        type="button"
+      >
+        <div
+          class="c4 c9"
+        >
+          <svg
+            height="24"
+            viewBox="-2 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M4.08331 18.75V4.75H6.41665V18.75H4.08331ZM8.74998 18.75L20.4166 11.75L8.74998 4.75V18.75Z"
+            />
+          </svg>
+        </div>
+      </button>
     </div>
   </div>
-  <div
-    class="c6"
-  />
-  <div
-    aria-label="Sync"
-    class=""
-    data-mui-internal-clone-element="true"
-  >
-    <button
-      class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c3 c8 css-624mb0-MuiButtonBase-root-MuiButton-root"
-      data-testid="sync-button"
-      disabled=""
-      id=":rb:"
-      tabindex="-1"
-      type="button"
-    >
-      <div
-        class="c4 c5"
-      >
-        <svg
-          aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
-          data-testid="PlayArrowIcon"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M8 5v14l11-7z"
-          />
-        </svg>
-      </div>
-    </button>
-  </div>
-  <div
-    class="c6"
-  />
-  <div
-    aria-label="Suspend"
-    class=""
-    data-mui-internal-clone-element="true"
-  >
-    <button
-      class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c3 c8 css-624mb0-MuiButtonBase-root-MuiButton-root"
-      data-testid="suspend-button"
-      disabled=""
-      id=":rd:"
-      tabindex="-1"
-      type="button"
-    >
-      <div
-        class="c4 c5"
-      >
-        <svg
-          aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
-          data-testid="PauseIcon"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M6 19h4V5H6zm8-14v14h4V5z"
-          />
-        </svg>
-      </div>
-    </button>
-  </div>
-  <div
-    class="c6"
-  />
-  <div
-    aria-label="Resume"
-    class=""
-    data-mui-internal-clone-element="true"
-  >
-    <button
-      class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c3 c8 css-624mb0-MuiButtonBase-root-MuiButton-root"
-      data-testid="resume-button"
-      id=":rf:"
-      tabindex="0"
-      type="button"
-    >
-      <div
-        class="c4 c9"
-      >
-        <svg
-          height="24"
-          viewBox="-2 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M4.08331 18.75V4.75H6.41665V18.75H4.08331ZM8.74998 18.75L20.4166 11.75L8.74998 4.75V18.75Z"
-          />
-        </svg>
-      </div>
-    </button>
-  </div>
-</div>
+</DocumentFragment>
 `;

--- a/ui/components/Sync/__tests__/__snapshots__/SyncActions.test.tsx.snap
+++ b/ui/components/Sync/__tests__/__snapshots__/SyncActions.test.tsx.snap
@@ -113,10 +113,6 @@ exports[`SyncActions snapshots hideSyncOptions 1`] = `
   font-weight: 600;
 }
 
-.c3.MuiButton-root:hover {
-  background-color: rgba(0, 179, 236, 0.1);
-}
-
 .c3.MuiButton-outlined {
   padding: 8px 12px;
 }
@@ -128,24 +124,16 @@ exports[`SyncActions snapshots hideSyncOptions 1`] = `
   padding: 0;
 }
 
-.c7.MuiButton-root.Mui-disabled svg {
-  fill: #BDBDBD;
+.c7.MuiButton-root :disabled svg {
+  fill: #d8d8d8;
 }
 
-.c7.MuiButton-root:hover {
+.c7.MuiButton-root :hover {
   background-color: rgba(0, 179, 236, 0.1);
 }
 
 .c7.MuiButton-text {
   padding: 0;
-}
-
-.c7.MuiButton-text.Mui-disabled {
-  color: #BDBDBD;
-}
-
-.c7.MuiButton-text.Mui-disabled svg {
-  fill: #BDBDBD;
 }
 
 .c1 .sync-icon-button {
@@ -167,7 +155,7 @@ exports[`SyncActions snapshots hideSyncOptions 1`] = `
   className="c0 c1 c2"
 >
   <button
-    className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation c3 sync-icon-button css-9buukw-MuiButtonBase-root-MuiButton-root"
+    className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation c3 sync-icon-button css-157ho6v-MuiButtonBase-root-MuiButton-root"
     disabled={null}
     id=":rg:"
     onBlur={[Function]}
@@ -222,7 +210,7 @@ exports[`SyncActions snapshots hideSyncOptions 1`] = `
     onTouchStart={[Function]}
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c3 c7 css-624mb0-MuiButtonBase-root-MuiButton-root"
+      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c3 c7 css-1fh7grq-MuiButtonBase-root-MuiButton-root"
       data-testid="sync-button"
       disabled={null}
       id=":ri:"
@@ -275,7 +263,7 @@ exports[`SyncActions snapshots hideSyncOptions 1`] = `
     onTouchStart={[Function]}
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c3 c7 css-624mb0-MuiButtonBase-root-MuiButton-root"
+      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c3 c7 css-1fh7grq-MuiButtonBase-root-MuiButton-root"
       data-testid="suspend-button"
       disabled={null}
       id=":rk:"
@@ -328,7 +316,7 @@ exports[`SyncActions snapshots hideSyncOptions 1`] = `
     onTouchStart={[Function]}
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c3 c7 css-624mb0-MuiButtonBase-root-MuiButton-root"
+      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c3 c7 css-1fh7grq-MuiButtonBase-root-MuiButton-root"
       data-testid="resume-button"
       disabled={true}
       id=":rm:"
@@ -353,7 +341,7 @@ exports[`SyncActions snapshots hideSyncOptions 1`] = `
       >
         <svg
           height="24"
-          viewBox="-2 0 24 24"
+          viewBox="0 0 24 24"
           width="24"
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -480,10 +468,6 @@ exports[`SyncActions snapshots non-suspended 1`] = `
   font-weight: 600;
 }
 
-.c3.MuiButton-root:hover {
-  background-color: rgba(0, 179, 236, 0.1);
-}
-
 .c3.MuiButton-outlined {
   padding: 8px 12px;
 }
@@ -498,7 +482,7 @@ exports[`SyncActions snapshots non-suspended 1`] = `
 }
 
 .c7 .MuiFormControlLabel-label.Mui-disabled {
-  color: #BDBDBD;
+  color: #d8d8d8;
 }
 
 .c7 .MuiTypography-root {
@@ -512,24 +496,16 @@ exports[`SyncActions snapshots non-suspended 1`] = `
   padding: 0;
 }
 
-.c8.MuiButton-root.Mui-disabled svg {
-  fill: #BDBDBD;
+.c8.MuiButton-root :disabled svg {
+  fill: #d8d8d8;
 }
 
-.c8.MuiButton-root:hover {
+.c8.MuiButton-root :hover {
   background-color: rgba(0, 179, 236, 0.1);
 }
 
 .c8.MuiButton-text {
   padding: 0;
-}
-
-.c8.MuiButton-text.Mui-disabled {
-  color: #BDBDBD;
-}
-
-.c8.MuiButton-text.Mui-disabled svg {
-  fill: #BDBDBD;
 }
 
 .c1 .sync-icon-button {
@@ -551,7 +527,7 @@ exports[`SyncActions snapshots non-suspended 1`] = `
   className="c0 c1 c2"
 >
   <button
-    className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation c3 sync-icon-button css-9buukw-MuiButtonBase-root-MuiButton-root"
+    className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation c3 sync-icon-button css-157ho6v-MuiButtonBase-root-MuiButton-root"
     disabled={null}
     id=":r0:"
     onBlur={[Function]}
@@ -606,7 +582,7 @@ exports[`SyncActions snapshots non-suspended 1`] = `
         className="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd c7 css-12f4qvw-MuiFormControlLabel-root"
       >
         <span
-          className="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-checked MuiRadio-root MuiRadio-colorPrimary css-1avr0ra-MuiButtonBase-root-MuiRadio-root"
+          className="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-checked MuiRadio-root MuiRadio-colorPrimary css-yavd16-MuiButtonBase-root-MuiRadio-root"
           onBlur={[Function]}
           onContextMenu={[Function]}
           onDragLeave={[Function]}
@@ -672,7 +648,7 @@ exports[`SyncActions snapshots non-suspended 1`] = `
         className="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd c7 css-12f4qvw-MuiFormControlLabel-root"
       >
         <span
-          className="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary css-1avr0ra-MuiButtonBase-root-MuiRadio-root"
+          className="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary css-yavd16-MuiButtonBase-root-MuiRadio-root"
           onBlur={[Function]}
           onContextMenu={[Function]}
           onDragLeave={[Function]}
@@ -749,7 +725,7 @@ exports[`SyncActions snapshots non-suspended 1`] = `
     onTouchStart={[Function]}
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c3 c8 css-624mb0-MuiButtonBase-root-MuiButton-root"
+      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c3 c8 css-1fh7grq-MuiButtonBase-root-MuiButton-root"
       data-testid="sync-button"
       disabled={null}
       id=":r3:"
@@ -802,7 +778,7 @@ exports[`SyncActions snapshots non-suspended 1`] = `
     onTouchStart={[Function]}
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c3 c8 css-624mb0-MuiButtonBase-root-MuiButton-root"
+      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c3 c8 css-1fh7grq-MuiButtonBase-root-MuiButton-root"
       data-testid="suspend-button"
       disabled={null}
       id=":r5:"
@@ -855,7 +831,7 @@ exports[`SyncActions snapshots non-suspended 1`] = `
     onTouchStart={[Function]}
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c3 c8 css-624mb0-MuiButtonBase-root-MuiButton-root"
+      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c3 c8 css-1fh7grq-MuiButtonBase-root-MuiButton-root"
       data-testid="resume-button"
       disabled={true}
       id=":r7:"
@@ -880,7 +856,7 @@ exports[`SyncActions snapshots non-suspended 1`] = `
       >
         <svg
           height="24"
-          viewBox="-2 0 24 24"
+          viewBox="0 0 24 24"
           width="24"
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -1007,10 +983,6 @@ exports[`SyncActions snapshots suspended 1`] = `
   font-weight: 600;
 }
 
-.c3.MuiButton-root:hover {
-  background-color: rgba(0, 179, 236, 0.1);
-}
-
 .c3.MuiButton-outlined {
   padding: 8px 12px;
 }
@@ -1025,7 +997,7 @@ exports[`SyncActions snapshots suspended 1`] = `
 }
 
 .c7 .MuiFormControlLabel-label.Mui-disabled {
-  color: #BDBDBD;
+  color: #d8d8d8;
 }
 
 .c7 .MuiTypography-root {
@@ -1039,24 +1011,16 @@ exports[`SyncActions snapshots suspended 1`] = `
   padding: 0;
 }
 
-.c8.MuiButton-root.Mui-disabled svg {
-  fill: #BDBDBD;
+.c8.MuiButton-root :disabled svg {
+  fill: #d8d8d8;
 }
 
-.c8.MuiButton-root:hover {
+.c8.MuiButton-root :hover {
   background-color: rgba(0, 179, 236, 0.1);
 }
 
 .c8.MuiButton-text {
   padding: 0;
-}
-
-.c8.MuiButton-text.Mui-disabled {
-  color: #BDBDBD;
-}
-
-.c8.MuiButton-text.Mui-disabled svg {
-  fill: #BDBDBD;
 }
 
 .c1 .sync-icon-button {
@@ -1078,7 +1042,7 @@ exports[`SyncActions snapshots suspended 1`] = `
   className="c0 c1 c2"
 >
   <button
-    className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation c3 sync-icon-button css-9buukw-MuiButtonBase-root-MuiButton-root"
+    className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation c3 sync-icon-button css-157ho6v-MuiButtonBase-root-MuiButton-root"
     disabled={true}
     id=":r8:"
     onBlur={[Function]}
@@ -1134,7 +1098,7 @@ exports[`SyncActions snapshots suspended 1`] = `
       >
         <span
           aria-disabled={true}
-          className="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary Mui-disabled PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-checked Mui-disabled MuiRadio-root MuiRadio-colorPrimary css-1a0qp0h-MuiButtonBase-root-MuiRadio-root"
+          className="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary Mui-disabled PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-checked Mui-disabled MuiRadio-root MuiRadio-colorPrimary css-1mux80u-MuiButtonBase-root-MuiRadio-root"
           onBlur={[Function]}
           onContextMenu={[Function]}
           onDragLeave={[Function]}
@@ -1201,7 +1165,7 @@ exports[`SyncActions snapshots suspended 1`] = `
       >
         <span
           aria-disabled={true}
-          className="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary Mui-disabled PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-disabled MuiRadio-root MuiRadio-colorPrimary css-1a0qp0h-MuiButtonBase-root-MuiRadio-root"
+          className="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary Mui-disabled PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-disabled MuiRadio-root MuiRadio-colorPrimary css-1mux80u-MuiButtonBase-root-MuiRadio-root"
           onBlur={[Function]}
           onContextMenu={[Function]}
           onDragLeave={[Function]}
@@ -1278,7 +1242,7 @@ exports[`SyncActions snapshots suspended 1`] = `
     onTouchStart={[Function]}
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c3 c8 css-624mb0-MuiButtonBase-root-MuiButton-root"
+      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c3 c8 css-1fh7grq-MuiButtonBase-root-MuiButton-root"
       data-testid="sync-button"
       disabled={true}
       id=":rb:"
@@ -1331,7 +1295,7 @@ exports[`SyncActions snapshots suspended 1`] = `
     onTouchStart={[Function]}
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c3 c8 css-624mb0-MuiButtonBase-root-MuiButton-root"
+      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c3 c8 css-1fh7grq-MuiButtonBase-root-MuiButton-root"
       data-testid="suspend-button"
       disabled={true}
       id=":rd:"
@@ -1384,7 +1348,7 @@ exports[`SyncActions snapshots suspended 1`] = `
     onTouchStart={[Function]}
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c3 c8 css-624mb0-MuiButtonBase-root-MuiButton-root"
+      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c3 c8 css-1fh7grq-MuiButtonBase-root-MuiButton-root"
       data-testid="resume-button"
       disabled={null}
       id=":rf:"
@@ -1409,7 +1373,7 @@ exports[`SyncActions snapshots suspended 1`] = `
       >
         <svg
           height="24"
-          viewBox="-2 0 24 24"
+          viewBox="0 0 24 24"
           width="24"
           xmlns="http://www.w3.org/2000/svg"
         >

--- a/ui/components/Sync/__tests__/__snapshots__/SyncControls.test.tsx.snap
+++ b/ui/components/Sync/__tests__/__snapshots__/SyncControls.test.tsx.snap
@@ -1,7 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SyncControls snapshots allButtonsDisabled 1`] = `
-.c0 {
+<DocumentFragment>
+  .c0 {
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -176,253 +177,255 @@ exports[`SyncControls snapshots allButtonsDisabled 1`] = `
 }
 
 <div
-  class="c0 c1"
->
-  <button
-    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation c2 sync-icon-button css-9buukw-MuiButtonBase-root-MuiButton-root"
-    disabled=""
-    id=":r8:"
-    tabindex="-1"
-    type="button"
+    class="c0 c1"
   >
-    <span
-      class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeMedium css-1v1j2p3-MuiButton-startIcon"
+    <button
+      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation c2 sync-icon-button css-9buukw-MuiButtonBase-root-MuiButton-root"
+      disabled=""
+      id=":r8:"
+      tabindex="-1"
+      type="button"
     >
-      <div
-        class="c3 c4"
+      <span
+        class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeMedium css-1v1j2p3-MuiButton-startIcon"
       >
-        <svg
-          aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
-          data-testid="SyncIcon"
-          focusable="false"
-          viewBox="0 0 24 24"
+        <div
+          class="c3 c4"
         >
-          <path
-            d="M12 4V1L8 5l4 4V6c3.31 0 6 2.69 6 6 0 1.01-.25 1.97-.7 2.8l1.46 1.46C19.54 15.03 20 13.57 20 12c0-4.42-3.58-8-8-8m0 14c-3.31 0-6-2.69-6-6 0-1.01.25-1.97.7-2.8L5.24 7.74C4.46 8.97 4 10.43 4 12c0 4.42 3.58 8 8 8v3l4-4-4-4z"
-          />
-        </svg>
-      </div>
-    </span>
-    Sync
-  </button>
-  <div
-    class="c5"
-  />
-  <div
-    class="MuiFormControl-root css-1iw3t7y-MuiFormControl-root"
-  >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+            data-testid="SyncIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M12 4V1L8 5l4 4V6c3.31 0 6 2.69 6 6 0 1.01-.25 1.97-.7 2.8l1.46 1.46C19.54 15.03 20 13.57 20 12c0-4.42-3.58-8-8-8m0 14c-3.31 0-6-2.69-6-6 0-1.01.25-1.97.7-2.8L5.24 7.74C4.46 8.97 4 10.43 4 12c0 4.42 3.58 8 8 8v3l4-4-4-4z"
+            />
+          </svg>
+        </div>
+      </span>
+      Sync
+    </button>
     <div
-      aria-labelledby="source-radio-buttons-group-label"
-      class="MuiFormGroup-root MuiFormGroup-row MuiRadioGroup-root MuiRadioGroup-row css-cis11t-MuiFormGroup-root"
-      data-testid="sync-options"
-      role="radiogroup"
+      class="c5"
+    />
+    <div
+      class="MuiFormControl-root css-1iw3t7y-MuiFormControl-root"
     >
-      <label
-        class="MuiFormControlLabel-root Mui-disabled MuiFormControlLabel-labelPlacementEnd c6 css-12f4qvw-MuiFormControlLabel-root"
-      >
-        <span
-          aria-disabled="true"
-          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary Mui-disabled PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-checked Mui-disabled MuiRadio-root MuiRadio-colorPrimary css-1a0qp0h-MuiButtonBase-root-MuiRadio-root"
-          tabindex="-1"
-        >
-          <input
-            checked=""
-            class="PrivateSwitchBase-input css-j8yymo"
-            disabled=""
-            name="source-radio-buttons-group"
-            type="radio"
-            value="WithSource"
-          />
-          <span
-            class="css-1qiat4j"
-          >
-            <svg
-              aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bz1rr0-MuiSvgIcon-root"
-              data-testid="RadioButtonUncheckedIcon"
-              focusable="false"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
-              />
-            </svg>
-            <svg
-              aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-z8nmqa-MuiSvgIcon-root"
-              data-testid="RadioButtonCheckedIcon"
-              focusable="false"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
-              />
-            </svg>
-          </span>
-        </span>
-        <span
-          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label Mui-disabled css-1lw54ax-MuiTypography-root"
-        >
-          with Source
-        </span>
-      </label>
       <div
-        class="c5"
-      />
-      <label
-        class="MuiFormControlLabel-root Mui-disabled MuiFormControlLabel-labelPlacementEnd c6 css-12f4qvw-MuiFormControlLabel-root"
+        aria-labelledby="source-radio-buttons-group-label"
+        class="MuiFormGroup-root MuiFormGroup-row MuiRadioGroup-root MuiRadioGroup-row css-cis11t-MuiFormGroup-root"
+        data-testid="sync-options"
+        role="radiogroup"
       >
-        <span
-          aria-disabled="true"
-          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary Mui-disabled PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-disabled MuiRadio-root MuiRadio-colorPrimary css-1a0qp0h-MuiButtonBase-root-MuiRadio-root"
-          tabindex="-1"
+        <label
+          class="MuiFormControlLabel-root Mui-disabled MuiFormControlLabel-labelPlacementEnd c6 css-12f4qvw-MuiFormControlLabel-root"
         >
-          <input
-            class="PrivateSwitchBase-input css-j8yymo"
-            disabled=""
-            name="source-radio-buttons-group"
-            type="radio"
-            value="WithoutSource"
-          />
           <span
-            class="css-1qiat4j"
+            aria-disabled="true"
+            class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary Mui-disabled PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-checked Mui-disabled MuiRadio-root MuiRadio-colorPrimary css-1a0qp0h-MuiButtonBase-root-MuiRadio-root"
+            tabindex="-1"
           >
-            <svg
-              aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bz1rr0-MuiSvgIcon-root"
-              data-testid="RadioButtonUncheckedIcon"
-              focusable="false"
-              viewBox="0 0 24 24"
+            <input
+              checked=""
+              class="PrivateSwitchBase-input css-j8yymo"
+              disabled=""
+              name="source-radio-buttons-group"
+              type="radio"
+              value="WithSource"
+            />
+            <span
+              class="css-1qiat4j"
             >
-              <path
-                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
-              />
-            </svg>
-            <svg
-              aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-o8rdeq-MuiSvgIcon-root"
-              data-testid="RadioButtonCheckedIcon"
-              focusable="false"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
-              />
-            </svg>
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bz1rr0-MuiSvgIcon-root"
+                data-testid="RadioButtonUncheckedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                />
+              </svg>
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-z8nmqa-MuiSvgIcon-root"
+                data-testid="RadioButtonCheckedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+                />
+              </svg>
+            </span>
           </span>
-        </span>
-        <span
-          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label Mui-disabled css-1lw54ax-MuiTypography-root"
+          <span
+            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label Mui-disabled css-1lw54ax-MuiTypography-root"
+          >
+            with Source
+          </span>
+        </label>
+        <div
+          class="c5"
+        />
+        <label
+          class="MuiFormControlLabel-root Mui-disabled MuiFormControlLabel-labelPlacementEnd c6 css-12f4qvw-MuiFormControlLabel-root"
         >
-          without Source
-        </span>
-      </label>
+          <span
+            aria-disabled="true"
+            class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary Mui-disabled PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-disabled MuiRadio-root MuiRadio-colorPrimary css-1a0qp0h-MuiButtonBase-root-MuiRadio-root"
+            tabindex="-1"
+          >
+            <input
+              class="PrivateSwitchBase-input css-j8yymo"
+              disabled=""
+              name="source-radio-buttons-group"
+              type="radio"
+              value="WithoutSource"
+            />
+            <span
+              class="css-1qiat4j"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bz1rr0-MuiSvgIcon-root"
+                data-testid="RadioButtonUncheckedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                />
+              </svg>
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-o8rdeq-MuiSvgIcon-root"
+                data-testid="RadioButtonCheckedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+                />
+              </svg>
+            </span>
+          </span>
+          <span
+            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label Mui-disabled css-1lw54ax-MuiTypography-root"
+          >
+            without Source
+          </span>
+        </label>
+      </div>
+    </div>
+    <div
+      class="c5"
+    />
+    <div
+      aria-label="Sync"
+      class=""
+      data-mui-internal-clone-element="true"
+    >
+      <button
+        class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-624mb0-MuiButtonBase-root-MuiButton-root"
+        data-testid="sync-button"
+        disabled=""
+        id=":rb:"
+        tabindex="-1"
+        type="button"
+      >
+        <div
+          class="c3 c4"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+            data-testid="PlayArrowIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M8 5v14l11-7z"
+            />
+          </svg>
+        </div>
+      </button>
+    </div>
+    <div
+      class="c5"
+    />
+    <div
+      aria-label="Suspend"
+      class=""
+      data-mui-internal-clone-element="true"
+    >
+      <button
+        class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-624mb0-MuiButtonBase-root-MuiButton-root"
+        data-testid="suspend-button"
+        disabled=""
+        id=":rd:"
+        tabindex="-1"
+        type="button"
+      >
+        <div
+          class="c3 c4"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+            data-testid="PauseIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M6 19h4V5H6zm8-14v14h4V5z"
+            />
+          </svg>
+        </div>
+      </button>
+    </div>
+    <div
+      class="c5"
+    />
+    <div
+      aria-label="Resume"
+      class=""
+      data-mui-internal-clone-element="true"
+    >
+      <button
+        class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-624mb0-MuiButtonBase-root-MuiButton-root"
+        data-testid="resume-button"
+        disabled=""
+        id=":rf:"
+        tabindex="-1"
+        type="button"
+      >
+        <div
+          class="c3 c8"
+        >
+          <svg
+            height="24"
+            viewBox="-2 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M4.08331 18.75V4.75H6.41665V18.75H4.08331ZM8.74998 18.75L20.4166 11.75L8.74998 4.75V18.75Z"
+            />
+          </svg>
+        </div>
+      </button>
     </div>
   </div>
-  <div
-    class="c5"
-  />
-  <div
-    aria-label="Sync"
-    class=""
-    data-mui-internal-clone-element="true"
-  >
-    <button
-      class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-624mb0-MuiButtonBase-root-MuiButton-root"
-      data-testid="sync-button"
-      disabled=""
-      id=":rb:"
-      tabindex="-1"
-      type="button"
-    >
-      <div
-        class="c3 c4"
-      >
-        <svg
-          aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
-          data-testid="PlayArrowIcon"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M8 5v14l11-7z"
-          />
-        </svg>
-      </div>
-    </button>
-  </div>
-  <div
-    class="c5"
-  />
-  <div
-    aria-label="Suspend"
-    class=""
-    data-mui-internal-clone-element="true"
-  >
-    <button
-      class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-624mb0-MuiButtonBase-root-MuiButton-root"
-      data-testid="suspend-button"
-      disabled=""
-      id=":rd:"
-      tabindex="-1"
-      type="button"
-    >
-      <div
-        class="c3 c4"
-      >
-        <svg
-          aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
-          data-testid="PauseIcon"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M6 19h4V5H6zm8-14v14h4V5z"
-          />
-        </svg>
-      </div>
-    </button>
-  </div>
-  <div
-    class="c5"
-  />
-  <div
-    aria-label="Resume"
-    class=""
-    data-mui-internal-clone-element="true"
-  >
-    <button
-      class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-624mb0-MuiButtonBase-root-MuiButton-root"
-      data-testid="resume-button"
-      disabled=""
-      id=":rf:"
-      tabindex="-1"
-      type="button"
-    >
-      <div
-        class="c3 c8"
-      >
-        <svg
-          height="24"
-          viewBox="-2 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M4.08331 18.75V4.75H6.41665V18.75H4.08331ZM8.74998 18.75L20.4166 11.75L8.74998 4.75V18.75Z"
-          />
-        </svg>
-      </div>
-    </button>
-  </div>
-</div>
+</DocumentFragment>
 `;
 
 exports[`SyncControls snapshots hasTooltipSuffix 1`] = `
-.c0 {
+<DocumentFragment>
+  .c0 {
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -597,243 +600,245 @@ exports[`SyncControls snapshots hasTooltipSuffix 1`] = `
 }
 
 <div
-  class="c0 c1"
->
-  <button
-    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation c2 sync-icon-button css-9buukw-MuiButtonBase-root-MuiButton-root"
-    id=":rr:"
-    tabindex="0"
-    type="button"
+    class="c0 c1"
   >
-    <span
-      class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeMedium css-1v1j2p3-MuiButton-startIcon"
+    <button
+      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation c2 sync-icon-button css-9buukw-MuiButtonBase-root-MuiButton-root"
+      id=":rr:"
+      tabindex="0"
+      type="button"
     >
-      <div
-        class="c3 c4"
+      <span
+        class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeMedium css-1v1j2p3-MuiButton-startIcon"
       >
-        <svg
-          aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
-          data-testid="SyncIcon"
-          focusable="false"
-          viewBox="0 0 24 24"
+        <div
+          class="c3 c4"
         >
-          <path
-            d="M12 4V1L8 5l4 4V6c3.31 0 6 2.69 6 6 0 1.01-.25 1.97-.7 2.8l1.46 1.46C19.54 15.03 20 13.57 20 12c0-4.42-3.58-8-8-8m0 14c-3.31 0-6-2.69-6-6 0-1.01.25-1.97.7-2.8L5.24 7.74C4.46 8.97 4 10.43 4 12c0 4.42 3.58 8 8 8v3l4-4-4-4z"
-          />
-        </svg>
-      </div>
-    </span>
-    Sync
-  </button>
-  <div
-    class="c5"
-  />
-  <div
-    class="MuiFormControl-root css-1iw3t7y-MuiFormControl-root"
-  >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+            data-testid="SyncIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M12 4V1L8 5l4 4V6c3.31 0 6 2.69 6 6 0 1.01-.25 1.97-.7 2.8l1.46 1.46C19.54 15.03 20 13.57 20 12c0-4.42-3.58-8-8-8m0 14c-3.31 0-6-2.69-6-6 0-1.01.25-1.97.7-2.8L5.24 7.74C4.46 8.97 4 10.43 4 12c0 4.42 3.58 8 8 8v3l4-4-4-4z"
+            />
+          </svg>
+        </div>
+      </span>
+      Sync
+    </button>
     <div
-      aria-labelledby="source-radio-buttons-group-label"
-      class="MuiFormGroup-root MuiFormGroup-row MuiRadioGroup-root MuiRadioGroup-row css-cis11t-MuiFormGroup-root"
-      data-testid="sync-options"
-      role="radiogroup"
+      class="c5"
+    />
+    <div
+      class="MuiFormControl-root css-1iw3t7y-MuiFormControl-root"
     >
-      <label
-        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd c6 css-12f4qvw-MuiFormControlLabel-root"
-      >
-        <span
-          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-checked MuiRadio-root MuiRadio-colorPrimary css-1avr0ra-MuiButtonBase-root-MuiRadio-root"
-        >
-          <input
-            checked=""
-            class="PrivateSwitchBase-input css-j8yymo"
-            name="source-radio-buttons-group"
-            type="radio"
-            value="WithSource"
-          />
-          <span
-            class="css-1qiat4j"
-          >
-            <svg
-              aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bz1rr0-MuiSvgIcon-root"
-              data-testid="RadioButtonUncheckedIcon"
-              focusable="false"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
-              />
-            </svg>
-            <svg
-              aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-z8nmqa-MuiSvgIcon-root"
-              data-testid="RadioButtonCheckedIcon"
-              focusable="false"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
-              />
-            </svg>
-          </span>
-        </span>
-        <span
-          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1lw54ax-MuiTypography-root"
-        >
-          with Source
-        </span>
-      </label>
       <div
-        class="c5"
-      />
-      <label
-        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd c6 css-12f4qvw-MuiFormControlLabel-root"
+        aria-labelledby="source-radio-buttons-group-label"
+        class="MuiFormGroup-root MuiFormGroup-row MuiRadioGroup-root MuiRadioGroup-row css-cis11t-MuiFormGroup-root"
+        data-testid="sync-options"
+        role="radiogroup"
       >
-        <span
-          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary css-1avr0ra-MuiButtonBase-root-MuiRadio-root"
+        <label
+          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd c6 css-12f4qvw-MuiFormControlLabel-root"
         >
-          <input
-            class="PrivateSwitchBase-input css-j8yymo"
-            name="source-radio-buttons-group"
-            type="radio"
-            value="WithoutSource"
-          />
           <span
-            class="css-1qiat4j"
+            class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-checked MuiRadio-root MuiRadio-colorPrimary css-1avr0ra-MuiButtonBase-root-MuiRadio-root"
           >
-            <svg
-              aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bz1rr0-MuiSvgIcon-root"
-              data-testid="RadioButtonUncheckedIcon"
-              focusable="false"
-              viewBox="0 0 24 24"
+            <input
+              checked=""
+              class="PrivateSwitchBase-input css-j8yymo"
+              name="source-radio-buttons-group"
+              type="radio"
+              value="WithSource"
+            />
+            <span
+              class="css-1qiat4j"
             >
-              <path
-                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
-              />
-            </svg>
-            <svg
-              aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-o8rdeq-MuiSvgIcon-root"
-              data-testid="RadioButtonCheckedIcon"
-              focusable="false"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
-              />
-            </svg>
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bz1rr0-MuiSvgIcon-root"
+                data-testid="RadioButtonUncheckedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                />
+              </svg>
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-z8nmqa-MuiSvgIcon-root"
+                data-testid="RadioButtonCheckedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+                />
+              </svg>
+            </span>
           </span>
-        </span>
-        <span
-          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1lw54ax-MuiTypography-root"
+          <span
+            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1lw54ax-MuiTypography-root"
+          >
+            with Source
+          </span>
+        </label>
+        <div
+          class="c5"
+        />
+        <label
+          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd c6 css-12f4qvw-MuiFormControlLabel-root"
         >
-          without Source
-        </span>
-      </label>
+          <span
+            class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary css-1avr0ra-MuiButtonBase-root-MuiRadio-root"
+          >
+            <input
+              class="PrivateSwitchBase-input css-j8yymo"
+              name="source-radio-buttons-group"
+              type="radio"
+              value="WithoutSource"
+            />
+            <span
+              class="css-1qiat4j"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bz1rr0-MuiSvgIcon-root"
+                data-testid="RadioButtonUncheckedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                />
+              </svg>
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-o8rdeq-MuiSvgIcon-root"
+                data-testid="RadioButtonCheckedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+                />
+              </svg>
+            </span>
+          </span>
+          <span
+            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1lw54ax-MuiTypography-root"
+          >
+            without Source
+          </span>
+        </label>
+      </div>
+    </div>
+    <div
+      class="c5"
+    />
+    <div
+      aria-label="Synctest suffix"
+      class=""
+      data-mui-internal-clone-element="true"
+    >
+      <button
+        class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-624mb0-MuiButtonBase-root-MuiButton-root"
+        data-testid="sync-button"
+        id=":ru:"
+        tabindex="0"
+        type="button"
+      >
+        <div
+          class="c3 c4"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+            data-testid="PlayArrowIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M8 5v14l11-7z"
+            />
+          </svg>
+        </div>
+      </button>
+    </div>
+    <div
+      class="c5"
+    />
+    <div
+      aria-label="Suspendtest suffix"
+      class=""
+      data-mui-internal-clone-element="true"
+    >
+      <button
+        class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-624mb0-MuiButtonBase-root-MuiButton-root"
+        data-testid="suspend-button"
+        id=":r10:"
+        tabindex="0"
+        type="button"
+      >
+        <div
+          class="c3 c4"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+            data-testid="PauseIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M6 19h4V5H6zm8-14v14h4V5z"
+            />
+          </svg>
+        </div>
+      </button>
+    </div>
+    <div
+      class="c5"
+    />
+    <div
+      aria-label="Resumetest suffix"
+      class=""
+      data-mui-internal-clone-element="true"
+    >
+      <button
+        class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-624mb0-MuiButtonBase-root-MuiButton-root"
+        data-testid="resume-button"
+        id=":r12:"
+        tabindex="0"
+        type="button"
+      >
+        <div
+          class="c3 c8"
+        >
+          <svg
+            height="24"
+            viewBox="-2 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M4.08331 18.75V4.75H6.41665V18.75H4.08331ZM8.74998 18.75L20.4166 11.75L8.74998 4.75V18.75Z"
+            />
+          </svg>
+        </div>
+      </button>
     </div>
   </div>
-  <div
-    class="c5"
-  />
-  <div
-    aria-label="Synctest suffix"
-    class=""
-    data-mui-internal-clone-element="true"
-  >
-    <button
-      class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-624mb0-MuiButtonBase-root-MuiButton-root"
-      data-testid="sync-button"
-      id=":ru:"
-      tabindex="0"
-      type="button"
-    >
-      <div
-        class="c3 c4"
-      >
-        <svg
-          aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
-          data-testid="PlayArrowIcon"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M8 5v14l11-7z"
-          />
-        </svg>
-      </div>
-    </button>
-  </div>
-  <div
-    class="c5"
-  />
-  <div
-    aria-label="Suspendtest suffix"
-    class=""
-    data-mui-internal-clone-element="true"
-  >
-    <button
-      class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-624mb0-MuiButtonBase-root-MuiButton-root"
-      data-testid="suspend-button"
-      id=":r10:"
-      tabindex="0"
-      type="button"
-    >
-      <div
-        class="c3 c4"
-      >
-        <svg
-          aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
-          data-testid="PauseIcon"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M6 19h4V5H6zm8-14v14h4V5z"
-          />
-        </svg>
-      </div>
-    </button>
-  </div>
-  <div
-    class="c5"
-  />
-  <div
-    aria-label="Resumetest suffix"
-    class=""
-    data-mui-internal-clone-element="true"
-  >
-    <button
-      class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-624mb0-MuiButtonBase-root-MuiButton-root"
-      data-testid="resume-button"
-      id=":r12:"
-      tabindex="0"
-      type="button"
-    >
-      <div
-        class="c3 c8"
-      >
-        <svg
-          height="24"
-          viewBox="-2 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M4.08331 18.75V4.75H6.41665V18.75H4.08331ZM8.74998 18.75L20.4166 11.75L8.74998 4.75V18.75Z"
-          />
-        </svg>
-      </div>
-    </button>
-  </div>
-</div>
+</DocumentFragment>
 `;
 
 exports[`SyncControls snapshots hideSuspend 1`] = `
-.c0 {
+<DocumentFragment>
+  .c0 {
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -965,180 +970,182 @@ exports[`SyncControls snapshots hideSuspend 1`] = `
 }
 
 <div
-  class="c0 c1"
->
-  <button
-    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation c2 sync-icon-button css-9buukw-MuiButtonBase-root-MuiButton-root"
-    id=":rn:"
-    tabindex="0"
-    type="button"
-  >
-    <span
-      class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeMedium css-1v1j2p3-MuiButton-startIcon"
-    >
-      <div
-        class="c3 c4"
-      >
-        <svg
-          aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
-          data-testid="SyncIcon"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M12 4V1L8 5l4 4V6c3.31 0 6 2.69 6 6 0 1.01-.25 1.97-.7 2.8l1.46 1.46C19.54 15.03 20 13.57 20 12c0-4.42-3.58-8-8-8m0 14c-3.31 0-6-2.69-6-6 0-1.01.25-1.97.7-2.8L5.24 7.74C4.46 8.97 4 10.43 4 12c0 4.42 3.58 8 8 8v3l4-4-4-4z"
-          />
-        </svg>
-      </div>
-    </span>
-    Sync
-  </button>
-  <div
-    class="c5"
-  />
-  <div
-    class="MuiFormControl-root css-1iw3t7y-MuiFormControl-root"
-  >
-    <div
-      aria-labelledby="source-radio-buttons-group-label"
-      class="MuiFormGroup-root MuiFormGroup-row MuiRadioGroup-root MuiRadioGroup-row css-cis11t-MuiFormGroup-root"
-      data-testid="sync-options"
-      role="radiogroup"
-    >
-      <label
-        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd c6 css-12f4qvw-MuiFormControlLabel-root"
-      >
-        <span
-          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-checked MuiRadio-root MuiRadio-colorPrimary css-1avr0ra-MuiButtonBase-root-MuiRadio-root"
-        >
-          <input
-            checked=""
-            class="PrivateSwitchBase-input css-j8yymo"
-            name="source-radio-buttons-group"
-            type="radio"
-            value="WithSource"
-          />
-          <span
-            class="css-1qiat4j"
-          >
-            <svg
-              aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bz1rr0-MuiSvgIcon-root"
-              data-testid="RadioButtonUncheckedIcon"
-              focusable="false"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
-              />
-            </svg>
-            <svg
-              aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-z8nmqa-MuiSvgIcon-root"
-              data-testid="RadioButtonCheckedIcon"
-              focusable="false"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
-              />
-            </svg>
-          </span>
-        </span>
-        <span
-          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1lw54ax-MuiTypography-root"
-        >
-          with Source
-        </span>
-      </label>
-      <div
-        class="c5"
-      />
-      <label
-        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd c6 css-12f4qvw-MuiFormControlLabel-root"
-      >
-        <span
-          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary css-1avr0ra-MuiButtonBase-root-MuiRadio-root"
-        >
-          <input
-            class="PrivateSwitchBase-input css-j8yymo"
-            name="source-radio-buttons-group"
-            type="radio"
-            value="WithoutSource"
-          />
-          <span
-            class="css-1qiat4j"
-          >
-            <svg
-              aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bz1rr0-MuiSvgIcon-root"
-              data-testid="RadioButtonUncheckedIcon"
-              focusable="false"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
-              />
-            </svg>
-            <svg
-              aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-o8rdeq-MuiSvgIcon-root"
-              data-testid="RadioButtonCheckedIcon"
-              focusable="false"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
-              />
-            </svg>
-          </span>
-        </span>
-        <span
-          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1lw54ax-MuiTypography-root"
-        >
-          without Source
-        </span>
-      </label>
-    </div>
-  </div>
-  <div
-    class="c5"
-  />
-  <div
-    aria-label="Sync"
-    class=""
-    data-mui-internal-clone-element="true"
+    class="c0 c1"
   >
     <button
-      class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-624mb0-MuiButtonBase-root-MuiButton-root"
-      data-testid="sync-button"
-      id=":rq:"
+      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation c2 sync-icon-button css-9buukw-MuiButtonBase-root-MuiButton-root"
+      id=":rn:"
       tabindex="0"
       type="button"
     >
-      <div
-        class="c3 c4"
+      <span
+        class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeMedium css-1v1j2p3-MuiButton-startIcon"
       >
-        <svg
-          aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
-          data-testid="PlayArrowIcon"
-          focusable="false"
-          viewBox="0 0 24 24"
+        <div
+          class="c3 c4"
         >
-          <path
-            d="M8 5v14l11-7z"
-          />
-        </svg>
-      </div>
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+            data-testid="SyncIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M12 4V1L8 5l4 4V6c3.31 0 6 2.69 6 6 0 1.01-.25 1.97-.7 2.8l1.46 1.46C19.54 15.03 20 13.57 20 12c0-4.42-3.58-8-8-8m0 14c-3.31 0-6-2.69-6-6 0-1.01.25-1.97.7-2.8L5.24 7.74C4.46 8.97 4 10.43 4 12c0 4.42 3.58 8 8 8v3l4-4-4-4z"
+            />
+          </svg>
+        </div>
+      </span>
+      Sync
     </button>
+    <div
+      class="c5"
+    />
+    <div
+      class="MuiFormControl-root css-1iw3t7y-MuiFormControl-root"
+    >
+      <div
+        aria-labelledby="source-radio-buttons-group-label"
+        class="MuiFormGroup-root MuiFormGroup-row MuiRadioGroup-root MuiRadioGroup-row css-cis11t-MuiFormGroup-root"
+        data-testid="sync-options"
+        role="radiogroup"
+      >
+        <label
+          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd c6 css-12f4qvw-MuiFormControlLabel-root"
+        >
+          <span
+            class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-checked MuiRadio-root MuiRadio-colorPrimary css-1avr0ra-MuiButtonBase-root-MuiRadio-root"
+          >
+            <input
+              checked=""
+              class="PrivateSwitchBase-input css-j8yymo"
+              name="source-radio-buttons-group"
+              type="radio"
+              value="WithSource"
+            />
+            <span
+              class="css-1qiat4j"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bz1rr0-MuiSvgIcon-root"
+                data-testid="RadioButtonUncheckedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                />
+              </svg>
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-z8nmqa-MuiSvgIcon-root"
+                data-testid="RadioButtonCheckedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+                />
+              </svg>
+            </span>
+          </span>
+          <span
+            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1lw54ax-MuiTypography-root"
+          >
+            with Source
+          </span>
+        </label>
+        <div
+          class="c5"
+        />
+        <label
+          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd c6 css-12f4qvw-MuiFormControlLabel-root"
+        >
+          <span
+            class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary css-1avr0ra-MuiButtonBase-root-MuiRadio-root"
+          >
+            <input
+              class="PrivateSwitchBase-input css-j8yymo"
+              name="source-radio-buttons-group"
+              type="radio"
+              value="WithoutSource"
+            />
+            <span
+              class="css-1qiat4j"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bz1rr0-MuiSvgIcon-root"
+                data-testid="RadioButtonUncheckedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                />
+              </svg>
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-o8rdeq-MuiSvgIcon-root"
+                data-testid="RadioButtonCheckedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+                />
+              </svg>
+            </span>
+          </span>
+          <span
+            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1lw54ax-MuiTypography-root"
+          >
+            without Source
+          </span>
+        </label>
+      </div>
+    </div>
+    <div
+      class="c5"
+    />
+    <div
+      aria-label="Sync"
+      class=""
+      data-mui-internal-clone-element="true"
+    >
+      <button
+        class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-624mb0-MuiButtonBase-root-MuiButton-root"
+        data-testid="sync-button"
+        id=":rq:"
+        tabindex="0"
+        type="button"
+      >
+        <div
+          class="c3 c4"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+            data-testid="PlayArrowIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M8 5v14l11-7z"
+            />
+          </svg>
+        </div>
+      </button>
+    </div>
   </div>
-</div>
+</DocumentFragment>
 `;
 
 exports[`SyncControls snapshots hideSyncOptions 1`] = `
-.c0 {
+<DocumentFragment>
+  .c0 {
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -1296,135 +1303,137 @@ exports[`SyncControls snapshots hideSyncOptions 1`] = `
 }
 
 <div
-  class="c0 c1"
->
-  <button
-    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation c2 sync-icon-button css-9buukw-MuiButtonBase-root-MuiButton-root"
-    id=":rg:"
-    tabindex="0"
-    type="button"
-  >
-    <span
-      class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeMedium css-1v1j2p3-MuiButton-startIcon"
-    >
-      <div
-        class="c3 c4"
-      >
-        <svg
-          aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
-          data-testid="SyncIcon"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M12 4V1L8 5l4 4V6c3.31 0 6 2.69 6 6 0 1.01-.25 1.97-.7 2.8l1.46 1.46C19.54 15.03 20 13.57 20 12c0-4.42-3.58-8-8-8m0 14c-3.31 0-6-2.69-6-6 0-1.01.25-1.97.7-2.8L5.24 7.74C4.46 8.97 4 10.43 4 12c0 4.42 3.58 8 8 8v3l4-4-4-4z"
-          />
-        </svg>
-      </div>
-    </span>
-    Sync
-  </button>
-  <div
-    class="c5"
-  />
-  <div
-    aria-label="Sync"
-    class=""
-    data-mui-internal-clone-element="true"
+    class="c0 c1"
   >
     <button
-      class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c6 css-624mb0-MuiButtonBase-root-MuiButton-root"
-      data-testid="sync-button"
-      id=":ri:"
+      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation c2 sync-icon-button css-9buukw-MuiButtonBase-root-MuiButton-root"
+      id=":rg:"
       tabindex="0"
       type="button"
     >
-      <div
-        class="c3 c4"
+      <span
+        class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeMedium css-1v1j2p3-MuiButton-startIcon"
       >
-        <svg
-          aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
-          data-testid="PlayArrowIcon"
-          focusable="false"
-          viewBox="0 0 24 24"
+        <div
+          class="c3 c4"
         >
-          <path
-            d="M8 5v14l11-7z"
-          />
-        </svg>
-      </div>
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+            data-testid="SyncIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M12 4V1L8 5l4 4V6c3.31 0 6 2.69 6 6 0 1.01-.25 1.97-.7 2.8l1.46 1.46C19.54 15.03 20 13.57 20 12c0-4.42-3.58-8-8-8m0 14c-3.31 0-6-2.69-6-6 0-1.01.25-1.97.7-2.8L5.24 7.74C4.46 8.97 4 10.43 4 12c0 4.42 3.58 8 8 8v3l4-4-4-4z"
+            />
+          </svg>
+        </div>
+      </span>
+      Sync
     </button>
-  </div>
-  <div
-    class="c5"
-  />
-  <div
-    aria-label="Suspend"
-    class=""
-    data-mui-internal-clone-element="true"
-  >
-    <button
-      class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c6 css-624mb0-MuiButtonBase-root-MuiButton-root"
-      data-testid="suspend-button"
-      id=":rk:"
-      tabindex="0"
-      type="button"
+    <div
+      class="c5"
+    />
+    <div
+      aria-label="Sync"
+      class=""
+      data-mui-internal-clone-element="true"
     >
-      <div
-        class="c3 c4"
+      <button
+        class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c6 css-624mb0-MuiButtonBase-root-MuiButton-root"
+        data-testid="sync-button"
+        id=":ri:"
+        tabindex="0"
+        type="button"
       >
-        <svg
-          aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
-          data-testid="PauseIcon"
-          focusable="false"
-          viewBox="0 0 24 24"
+        <div
+          class="c3 c4"
         >
-          <path
-            d="M6 19h4V5H6zm8-14v14h4V5z"
-          />
-        </svg>
-      </div>
-    </button>
-  </div>
-  <div
-    class="c5"
-  />
-  <div
-    aria-label="Resume"
-    class=""
-    data-mui-internal-clone-element="true"
-  >
-    <button
-      class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c6 css-624mb0-MuiButtonBase-root-MuiButton-root"
-      data-testid="resume-button"
-      id=":rm:"
-      tabindex="0"
-      type="button"
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+            data-testid="PlayArrowIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M8 5v14l11-7z"
+            />
+          </svg>
+        </div>
+      </button>
+    </div>
+    <div
+      class="c5"
+    />
+    <div
+      aria-label="Suspend"
+      class=""
+      data-mui-internal-clone-element="true"
     >
-      <div
-        class="c3 c7"
+      <button
+        class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c6 css-624mb0-MuiButtonBase-root-MuiButton-root"
+        data-testid="suspend-button"
+        id=":rk:"
+        tabindex="0"
+        type="button"
       >
-        <svg
-          height="24"
-          viewBox="-2 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
+        <div
+          class="c3 c4"
         >
-          <path
-            d="M4.08331 18.75V4.75H6.41665V18.75H4.08331ZM8.74998 18.75L20.4166 11.75L8.74998 4.75V18.75Z"
-          />
-        </svg>
-      </div>
-    </button>
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+            data-testid="PauseIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M6 19h4V5H6zm8-14v14h4V5z"
+            />
+          </svg>
+        </div>
+      </button>
+    </div>
+    <div
+      class="c5"
+    />
+    <div
+      aria-label="Resume"
+      class=""
+      data-mui-internal-clone-element="true"
+    >
+      <button
+        class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c6 css-624mb0-MuiButtonBase-root-MuiButton-root"
+        data-testid="resume-button"
+        id=":rm:"
+        tabindex="0"
+        type="button"
+      >
+        <div
+          class="c3 c7"
+        >
+          <svg
+            height="24"
+            viewBox="-2 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M4.08331 18.75V4.75H6.41665V18.75H4.08331ZM8.74998 18.75L20.4166 11.75L8.74998 4.75V18.75Z"
+            />
+          </svg>
+        </div>
+      </button>
+    </div>
   </div>
-</div>
+</DocumentFragment>
 `;
 
 exports[`SyncControls snapshots non-suspended 1`] = `
-.c0 {
+<DocumentFragment>
+  .c0 {
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -1599,237 +1608,238 @@ exports[`SyncControls snapshots non-suspended 1`] = `
 }
 
 <div
-  class="c0 c1"
->
-  <button
-    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation c2 sync-icon-button css-9buukw-MuiButtonBase-root-MuiButton-root"
-    id=":r0:"
-    tabindex="0"
-    type="button"
+    class="c0 c1"
   >
-    <span
-      class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeMedium css-1v1j2p3-MuiButton-startIcon"
+    <button
+      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation c2 sync-icon-button css-9buukw-MuiButtonBase-root-MuiButton-root"
+      id=":r0:"
+      tabindex="0"
+      type="button"
     >
-      <div
-        class="c3 c4"
+      <span
+        class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeMedium css-1v1j2p3-MuiButton-startIcon"
       >
-        <svg
-          aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
-          data-testid="SyncIcon"
-          focusable="false"
-          viewBox="0 0 24 24"
+        <div
+          class="c3 c4"
         >
-          <path
-            d="M12 4V1L8 5l4 4V6c3.31 0 6 2.69 6 6 0 1.01-.25 1.97-.7 2.8l1.46 1.46C19.54 15.03 20 13.57 20 12c0-4.42-3.58-8-8-8m0 14c-3.31 0-6-2.69-6-6 0-1.01.25-1.97.7-2.8L5.24 7.74C4.46 8.97 4 10.43 4 12c0 4.42 3.58 8 8 8v3l4-4-4-4z"
-          />
-        </svg>
-      </div>
-    </span>
-    Sync
-  </button>
-  <div
-    class="c5"
-  />
-  <div
-    class="MuiFormControl-root css-1iw3t7y-MuiFormControl-root"
-  >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+            data-testid="SyncIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M12 4V1L8 5l4 4V6c3.31 0 6 2.69 6 6 0 1.01-.25 1.97-.7 2.8l1.46 1.46C19.54 15.03 20 13.57 20 12c0-4.42-3.58-8-8-8m0 14c-3.31 0-6-2.69-6-6 0-1.01.25-1.97.7-2.8L5.24 7.74C4.46 8.97 4 10.43 4 12c0 4.42 3.58 8 8 8v3l4-4-4-4z"
+            />
+          </svg>
+        </div>
+      </span>
+      Sync
+    </button>
     <div
-      aria-labelledby="source-radio-buttons-group-label"
-      class="MuiFormGroup-root MuiFormGroup-row MuiRadioGroup-root MuiRadioGroup-row css-cis11t-MuiFormGroup-root"
-      data-testid="sync-options"
-      role="radiogroup"
+      class="c5"
+    />
+    <div
+      class="MuiFormControl-root css-1iw3t7y-MuiFormControl-root"
     >
-      <label
-        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd c6 css-12f4qvw-MuiFormControlLabel-root"
-      >
-        <span
-          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-checked MuiRadio-root MuiRadio-colorPrimary css-1avr0ra-MuiButtonBase-root-MuiRadio-root"
-        >
-          <input
-            checked=""
-            class="PrivateSwitchBase-input css-j8yymo"
-            name="source-radio-buttons-group"
-            type="radio"
-            value="WithSource"
-          />
-          <span
-            class="css-1qiat4j"
-          >
-            <svg
-              aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bz1rr0-MuiSvgIcon-root"
-              data-testid="RadioButtonUncheckedIcon"
-              focusable="false"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
-              />
-            </svg>
-            <svg
-              aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-z8nmqa-MuiSvgIcon-root"
-              data-testid="RadioButtonCheckedIcon"
-              focusable="false"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
-              />
-            </svg>
-          </span>
-        </span>
-        <span
-          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1lw54ax-MuiTypography-root"
-        >
-          with Source
-        </span>
-      </label>
       <div
-        class="c5"
-      />
-      <label
-        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd c6 css-12f4qvw-MuiFormControlLabel-root"
+        aria-labelledby="source-radio-buttons-group-label"
+        class="MuiFormGroup-root MuiFormGroup-row MuiRadioGroup-root MuiRadioGroup-row css-cis11t-MuiFormGroup-root"
+        data-testid="sync-options"
+        role="radiogroup"
       >
-        <span
-          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary css-1avr0ra-MuiButtonBase-root-MuiRadio-root"
+        <label
+          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd c6 css-12f4qvw-MuiFormControlLabel-root"
         >
-          <input
-            class="PrivateSwitchBase-input css-j8yymo"
-            name="source-radio-buttons-group"
-            type="radio"
-            value="WithoutSource"
-          />
           <span
-            class="css-1qiat4j"
+            class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-checked MuiRadio-root MuiRadio-colorPrimary css-1avr0ra-MuiButtonBase-root-MuiRadio-root"
           >
-            <svg
-              aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bz1rr0-MuiSvgIcon-root"
-              data-testid="RadioButtonUncheckedIcon"
-              focusable="false"
-              viewBox="0 0 24 24"
+            <input
+              checked=""
+              class="PrivateSwitchBase-input css-j8yymo"
+              name="source-radio-buttons-group"
+              type="radio"
+              value="WithSource"
+            />
+            <span
+              class="css-1qiat4j"
             >
-              <path
-                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
-              />
-            </svg>
-            <svg
-              aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-o8rdeq-MuiSvgIcon-root"
-              data-testid="RadioButtonCheckedIcon"
-              focusable="false"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
-              />
-            </svg>
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bz1rr0-MuiSvgIcon-root"
+                data-testid="RadioButtonUncheckedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                />
+              </svg>
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-z8nmqa-MuiSvgIcon-root"
+                data-testid="RadioButtonCheckedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+                />
+              </svg>
+            </span>
           </span>
-        </span>
-        <span
-          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1lw54ax-MuiTypography-root"
+          <span
+            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1lw54ax-MuiTypography-root"
+          >
+            with Source
+          </span>
+        </label>
+        <div
+          class="c5"
+        />
+        <label
+          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd c6 css-12f4qvw-MuiFormControlLabel-root"
         >
-          without Source
-        </span>
-      </label>
+          <span
+            class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary css-1avr0ra-MuiButtonBase-root-MuiRadio-root"
+          >
+            <input
+              class="PrivateSwitchBase-input css-j8yymo"
+              name="source-radio-buttons-group"
+              type="radio"
+              value="WithoutSource"
+            />
+            <span
+              class="css-1qiat4j"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bz1rr0-MuiSvgIcon-root"
+                data-testid="RadioButtonUncheckedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                />
+              </svg>
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-o8rdeq-MuiSvgIcon-root"
+                data-testid="RadioButtonCheckedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+                />
+              </svg>
+            </span>
+          </span>
+          <span
+            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1lw54ax-MuiTypography-root"
+          >
+            without Source
+          </span>
+        </label>
+      </div>
+    </div>
+    <div
+      class="c5"
+    />
+    <div
+      aria-label="Sync"
+      class=""
+      data-mui-internal-clone-element="true"
+    >
+      <button
+        class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-624mb0-MuiButtonBase-root-MuiButton-root"
+        data-testid="sync-button"
+        id=":r3:"
+        tabindex="0"
+        type="button"
+      >
+        <div
+          class="c3 c4"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+            data-testid="PlayArrowIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M8 5v14l11-7z"
+            />
+          </svg>
+        </div>
+      </button>
+    </div>
+    <div
+      class="c5"
+    />
+    <div
+      aria-label="Suspend"
+      class=""
+      data-mui-internal-clone-element="true"
+    >
+      <button
+        class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-624mb0-MuiButtonBase-root-MuiButton-root"
+        data-testid="suspend-button"
+        id=":r5:"
+        tabindex="0"
+        type="button"
+      >
+        <div
+          class="c3 c4"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+            data-testid="PauseIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M6 19h4V5H6zm8-14v14h4V5z"
+            />
+          </svg>
+        </div>
+      </button>
+    </div>
+    <div
+      class="c5"
+    />
+    <div
+      aria-label="Resume"
+      class=""
+      data-mui-internal-clone-element="true"
+    >
+      <button
+        class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-624mb0-MuiButtonBase-root-MuiButton-root"
+        data-testid="resume-button"
+        id=":r7:"
+        tabindex="0"
+        type="button"
+      >
+        <div
+          class="c3 c8"
+        >
+          <svg
+            height="24"
+            viewBox="-2 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M4.08331 18.75V4.75H6.41665V18.75H4.08331ZM8.74998 18.75L20.4166 11.75L8.74998 4.75V18.75Z"
+            />
+          </svg>
+        </div>
+      </button>
     </div>
   </div>
-  <div
-    class="c5"
-  />
-  <div
-    aria-label="Sync"
-    class=""
-    data-mui-internal-clone-element="true"
-  >
-    <button
-      class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-624mb0-MuiButtonBase-root-MuiButton-root"
-      data-testid="sync-button"
-      id=":r3:"
-      tabindex="0"
-      type="button"
-    >
-      <div
-        class="c3 c4"
-      >
-        <svg
-          aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
-          data-testid="PlayArrowIcon"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M8 5v14l11-7z"
-          />
-        </svg>
-      </div>
-    </button>
-  </div>
-  <div
-    class="c5"
-  />
-  <div
-    aria-label="Suspend"
-    class=""
-    data-mui-internal-clone-element="true"
-  >
-    <button
-      class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-624mb0-MuiButtonBase-root-MuiButton-root"
-      data-testid="suspend-button"
-      id=":r5:"
-      tabindex="0"
-      type="button"
-    >
-      <div
-        class="c3 c4"
-      >
-        <svg
-          aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
-          data-testid="PauseIcon"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M6 19h4V5H6zm8-14v14h4V5z"
-          />
-        </svg>
-      </div>
-    </button>
-  </div>
-  <div
-    class="c5"
-  />
-  <div
-    aria-label="Resume"
-    class=""
-    data-mui-internal-clone-element="true"
-  >
-    <button
-      class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-624mb0-MuiButtonBase-root-MuiButton-root"
-      data-testid="resume-button"
-      id=":r7:"
-      tabindex="0"
-      type="button"
-    >
-      <div
-        class="c3 c8"
-      >
-        <svg
-          height="24"
-          viewBox="-2 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M4.08331 18.75V4.75H6.41665V18.75H4.08331ZM8.74998 18.75L20.4166 11.75L8.74998 4.75V18.75Z"
-          />
-        </svg>
-      </div>
-    </button>
-  </div>
-</div>
+</DocumentFragment>
 `;

--- a/ui/components/Sync/__tests__/__snapshots__/SyncControls.test.tsx.snap
+++ b/ui/components/Sync/__tests__/__snapshots__/SyncControls.test.tsx.snap
@@ -113,10 +113,6 @@ exports[`SyncControls snapshots allButtonsDisabled 1`] = `
   font-weight: 600;
 }
 
-.c2.MuiButton-root:hover {
-  background-color: rgba(0, 179, 236, 0.1);
-}
-
 .c2.MuiButton-outlined {
   padding: 8px 12px;
 }
@@ -131,7 +127,7 @@ exports[`SyncControls snapshots allButtonsDisabled 1`] = `
 }
 
 .c6 .MuiFormControlLabel-label.Mui-disabled {
-  color: #BDBDBD;
+  color: #d8d8d8;
 }
 
 .c6 .MuiTypography-root {
@@ -145,24 +141,16 @@ exports[`SyncControls snapshots allButtonsDisabled 1`] = `
   padding: 0;
 }
 
-.c7.MuiButton-root.Mui-disabled svg {
-  fill: #BDBDBD;
+.c7.MuiButton-root :disabled svg {
+  fill: #d8d8d8;
 }
 
-.c7.MuiButton-root:hover {
+.c7.MuiButton-root :hover {
   background-color: rgba(0, 179, 236, 0.1);
 }
 
 .c7.MuiButton-text {
   padding: 0;
-}
-
-.c7.MuiButton-text.Mui-disabled {
-  color: #BDBDBD;
-}
-
-.c7.MuiButton-text.Mui-disabled svg {
-  fill: #BDBDBD;
 }
 
 .c1 .sync-icon-button {
@@ -179,7 +167,7 @@ exports[`SyncControls snapshots allButtonsDisabled 1`] = `
   className="c0 c1"
 >
   <button
-    className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation c2 sync-icon-button css-9buukw-MuiButtonBase-root-MuiButton-root"
+    className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation c2 sync-icon-button css-157ho6v-MuiButtonBase-root-MuiButton-root"
     disabled={true}
     id=":r8:"
     onBlur={[Function]}
@@ -235,7 +223,7 @@ exports[`SyncControls snapshots allButtonsDisabled 1`] = `
       >
         <span
           aria-disabled={true}
-          className="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary Mui-disabled PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-checked Mui-disabled MuiRadio-root MuiRadio-colorPrimary css-1a0qp0h-MuiButtonBase-root-MuiRadio-root"
+          className="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary Mui-disabled PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-checked Mui-disabled MuiRadio-root MuiRadio-colorPrimary css-1mux80u-MuiButtonBase-root-MuiRadio-root"
           onBlur={[Function]}
           onContextMenu={[Function]}
           onDragLeave={[Function]}
@@ -302,7 +290,7 @@ exports[`SyncControls snapshots allButtonsDisabled 1`] = `
       >
         <span
           aria-disabled={true}
-          className="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary Mui-disabled PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-disabled MuiRadio-root MuiRadio-colorPrimary css-1a0qp0h-MuiButtonBase-root-MuiRadio-root"
+          className="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary Mui-disabled PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-disabled MuiRadio-root MuiRadio-colorPrimary css-1mux80u-MuiButtonBase-root-MuiRadio-root"
           onBlur={[Function]}
           onContextMenu={[Function]}
           onDragLeave={[Function]}
@@ -379,7 +367,7 @@ exports[`SyncControls snapshots allButtonsDisabled 1`] = `
     onTouchStart={[Function]}
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-624mb0-MuiButtonBase-root-MuiButton-root"
+      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-1fh7grq-MuiButtonBase-root-MuiButton-root"
       data-testid="sync-button"
       disabled={true}
       id=":rb:"
@@ -432,7 +420,7 @@ exports[`SyncControls snapshots allButtonsDisabled 1`] = `
     onTouchStart={[Function]}
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-624mb0-MuiButtonBase-root-MuiButton-root"
+      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-1fh7grq-MuiButtonBase-root-MuiButton-root"
       data-testid="suspend-button"
       disabled={true}
       id=":rd:"
@@ -484,7 +472,7 @@ exports[`SyncControls snapshots allButtonsDisabled 1`] = `
     onTouchStart={[Function]}
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-624mb0-MuiButtonBase-root-MuiButton-root"
+      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-1fh7grq-MuiButtonBase-root-MuiButton-root"
       data-testid="resume-button"
       disabled={true}
       id=":rf:"
@@ -508,7 +496,7 @@ exports[`SyncControls snapshots allButtonsDisabled 1`] = `
       >
         <svg
           height="24"
-          viewBox="-2 0 24 24"
+          viewBox="0 0 24 24"
           width="24"
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -635,10 +623,6 @@ exports[`SyncControls snapshots hasTooltipSuffix 1`] = `
   font-weight: 600;
 }
 
-.c2.MuiButton-root:hover {
-  background-color: rgba(0, 179, 236, 0.1);
-}
-
 .c2.MuiButton-outlined {
   padding: 8px 12px;
 }
@@ -653,7 +637,7 @@ exports[`SyncControls snapshots hasTooltipSuffix 1`] = `
 }
 
 .c6 .MuiFormControlLabel-label.Mui-disabled {
-  color: #BDBDBD;
+  color: #d8d8d8;
 }
 
 .c6 .MuiTypography-root {
@@ -667,24 +651,16 @@ exports[`SyncControls snapshots hasTooltipSuffix 1`] = `
   padding: 0;
 }
 
-.c7.MuiButton-root.Mui-disabled svg {
-  fill: #BDBDBD;
+.c7.MuiButton-root :disabled svg {
+  fill: #d8d8d8;
 }
 
-.c7.MuiButton-root:hover {
+.c7.MuiButton-root :hover {
   background-color: rgba(0, 179, 236, 0.1);
 }
 
 .c7.MuiButton-text {
   padding: 0;
-}
-
-.c7.MuiButton-text.Mui-disabled {
-  color: #BDBDBD;
-}
-
-.c7.MuiButton-text.Mui-disabled svg {
-  fill: #BDBDBD;
 }
 
 .c1 .sync-icon-button {
@@ -701,7 +677,7 @@ exports[`SyncControls snapshots hasTooltipSuffix 1`] = `
   className="c0 c1"
 >
   <button
-    className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation c2 sync-icon-button css-9buukw-MuiButtonBase-root-MuiButton-root"
+    className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation c2 sync-icon-button css-157ho6v-MuiButtonBase-root-MuiButton-root"
     disabled={null}
     id=":rr:"
     onBlur={[Function]}
@@ -756,7 +732,7 @@ exports[`SyncControls snapshots hasTooltipSuffix 1`] = `
         className="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd c6 css-12f4qvw-MuiFormControlLabel-root"
       >
         <span
-          className="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-checked MuiRadio-root MuiRadio-colorPrimary css-1avr0ra-MuiButtonBase-root-MuiRadio-root"
+          className="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-checked MuiRadio-root MuiRadio-colorPrimary css-yavd16-MuiButtonBase-root-MuiRadio-root"
           onBlur={[Function]}
           onContextMenu={[Function]}
           onDragLeave={[Function]}
@@ -822,7 +798,7 @@ exports[`SyncControls snapshots hasTooltipSuffix 1`] = `
         className="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd c6 css-12f4qvw-MuiFormControlLabel-root"
       >
         <span
-          className="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary css-1avr0ra-MuiButtonBase-root-MuiRadio-root"
+          className="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary css-yavd16-MuiButtonBase-root-MuiRadio-root"
           onBlur={[Function]}
           onContextMenu={[Function]}
           onDragLeave={[Function]}
@@ -899,7 +875,7 @@ exports[`SyncControls snapshots hasTooltipSuffix 1`] = `
     onTouchStart={[Function]}
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-624mb0-MuiButtonBase-root-MuiButton-root"
+      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-1fh7grq-MuiButtonBase-root-MuiButton-root"
       data-testid="sync-button"
       disabled={null}
       id=":ru:"
@@ -952,7 +928,7 @@ exports[`SyncControls snapshots hasTooltipSuffix 1`] = `
     onTouchStart={[Function]}
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-624mb0-MuiButtonBase-root-MuiButton-root"
+      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-1fh7grq-MuiButtonBase-root-MuiButton-root"
       data-testid="suspend-button"
       disabled={null}
       id=":r10:"
@@ -1004,7 +980,7 @@ exports[`SyncControls snapshots hasTooltipSuffix 1`] = `
     onTouchStart={[Function]}
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-624mb0-MuiButtonBase-root-MuiButton-root"
+      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-1fh7grq-MuiButtonBase-root-MuiButton-root"
       data-testid="resume-button"
       disabled={null}
       id=":r12:"
@@ -1028,7 +1004,7 @@ exports[`SyncControls snapshots hasTooltipSuffix 1`] = `
       >
         <svg
           height="24"
-          viewBox="-2 0 24 24"
+          viewBox="0 0 24 24"
           width="24"
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -1112,10 +1088,6 @@ exports[`SyncControls snapshots hideSuspend 1`] = `
   font-weight: 600;
 }
 
-.c2.MuiButton-root:hover {
-  background-color: rgba(0, 179, 236, 0.1);
-}
-
 .c2.MuiButton-outlined {
   padding: 8px 12px;
 }
@@ -1130,7 +1102,7 @@ exports[`SyncControls snapshots hideSuspend 1`] = `
 }
 
 .c6 .MuiFormControlLabel-label.Mui-disabled {
-  color: #BDBDBD;
+  color: #d8d8d8;
 }
 
 .c6 .MuiTypography-root {
@@ -1144,24 +1116,16 @@ exports[`SyncControls snapshots hideSuspend 1`] = `
   padding: 0;
 }
 
-.c7.MuiButton-root.Mui-disabled svg {
-  fill: #BDBDBD;
+.c7.MuiButton-root :disabled svg {
+  fill: #d8d8d8;
 }
 
-.c7.MuiButton-root:hover {
+.c7.MuiButton-root :hover {
   background-color: rgba(0, 179, 236, 0.1);
 }
 
 .c7.MuiButton-text {
   padding: 0;
-}
-
-.c7.MuiButton-text.Mui-disabled {
-  color: #BDBDBD;
-}
-
-.c7.MuiButton-text.Mui-disabled svg {
-  fill: #BDBDBD;
 }
 
 .c1 .sync-icon-button {
@@ -1178,7 +1142,7 @@ exports[`SyncControls snapshots hideSuspend 1`] = `
   className="c0 c1"
 >
   <button
-    className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation c2 sync-icon-button css-9buukw-MuiButtonBase-root-MuiButton-root"
+    className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation c2 sync-icon-button css-157ho6v-MuiButtonBase-root-MuiButton-root"
     disabled={null}
     id=":rn:"
     onBlur={[Function]}
@@ -1233,7 +1197,7 @@ exports[`SyncControls snapshots hideSuspend 1`] = `
         className="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd c6 css-12f4qvw-MuiFormControlLabel-root"
       >
         <span
-          className="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-checked MuiRadio-root MuiRadio-colorPrimary css-1avr0ra-MuiButtonBase-root-MuiRadio-root"
+          className="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-checked MuiRadio-root MuiRadio-colorPrimary css-yavd16-MuiButtonBase-root-MuiRadio-root"
           onBlur={[Function]}
           onContextMenu={[Function]}
           onDragLeave={[Function]}
@@ -1299,7 +1263,7 @@ exports[`SyncControls snapshots hideSuspend 1`] = `
         className="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd c6 css-12f4qvw-MuiFormControlLabel-root"
       >
         <span
-          className="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary css-1avr0ra-MuiButtonBase-root-MuiRadio-root"
+          className="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary css-yavd16-MuiButtonBase-root-MuiRadio-root"
           onBlur={[Function]}
           onContextMenu={[Function]}
           onDragLeave={[Function]}
@@ -1376,7 +1340,7 @@ exports[`SyncControls snapshots hideSuspend 1`] = `
     onTouchStart={[Function]}
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-624mb0-MuiButtonBase-root-MuiButton-root"
+      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-1fh7grq-MuiButtonBase-root-MuiButton-root"
       data-testid="sync-button"
       disabled={null}
       id=":rq:"
@@ -1529,10 +1493,6 @@ exports[`SyncControls snapshots hideSyncOptions 1`] = `
   font-weight: 600;
 }
 
-.c2.MuiButton-root:hover {
-  background-color: rgba(0, 179, 236, 0.1);
-}
-
 .c2.MuiButton-outlined {
   padding: 8px 12px;
 }
@@ -1544,24 +1504,16 @@ exports[`SyncControls snapshots hideSyncOptions 1`] = `
   padding: 0;
 }
 
-.c6.MuiButton-root.Mui-disabled svg {
-  fill: #BDBDBD;
+.c6.MuiButton-root :disabled svg {
+  fill: #d8d8d8;
 }
 
-.c6.MuiButton-root:hover {
+.c6.MuiButton-root :hover {
   background-color: rgba(0, 179, 236, 0.1);
 }
 
 .c6.MuiButton-text {
   padding: 0;
-}
-
-.c6.MuiButton-text.Mui-disabled {
-  color: #BDBDBD;
-}
-
-.c6.MuiButton-text.Mui-disabled svg {
-  fill: #BDBDBD;
 }
 
 .c1 .sync-icon-button {
@@ -1578,7 +1530,7 @@ exports[`SyncControls snapshots hideSyncOptions 1`] = `
   className="c0 c1"
 >
   <button
-    className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation c2 sync-icon-button css-9buukw-MuiButtonBase-root-MuiButton-root"
+    className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation c2 sync-icon-button css-157ho6v-MuiButtonBase-root-MuiButton-root"
     disabled={null}
     id=":rg:"
     onBlur={[Function]}
@@ -1633,7 +1585,7 @@ exports[`SyncControls snapshots hideSyncOptions 1`] = `
     onTouchStart={[Function]}
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c6 css-624mb0-MuiButtonBase-root-MuiButton-root"
+      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c6 css-1fh7grq-MuiButtonBase-root-MuiButton-root"
       data-testid="sync-button"
       disabled={null}
       id=":ri:"
@@ -1686,7 +1638,7 @@ exports[`SyncControls snapshots hideSyncOptions 1`] = `
     onTouchStart={[Function]}
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c6 css-624mb0-MuiButtonBase-root-MuiButton-root"
+      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c6 css-1fh7grq-MuiButtonBase-root-MuiButton-root"
       data-testid="suspend-button"
       disabled={null}
       id=":rk:"
@@ -1738,7 +1690,7 @@ exports[`SyncControls snapshots hideSyncOptions 1`] = `
     onTouchStart={[Function]}
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c6 css-624mb0-MuiButtonBase-root-MuiButton-root"
+      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c6 css-1fh7grq-MuiButtonBase-root-MuiButton-root"
       data-testid="resume-button"
       disabled={null}
       id=":rm:"
@@ -1762,7 +1714,7 @@ exports[`SyncControls snapshots hideSyncOptions 1`] = `
       >
         <svg
           height="24"
-          viewBox="-2 0 24 24"
+          viewBox="0 0 24 24"
           width="24"
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -1889,10 +1841,6 @@ exports[`SyncControls snapshots non-suspended 1`] = `
   font-weight: 600;
 }
 
-.c2.MuiButton-root:hover {
-  background-color: rgba(0, 179, 236, 0.1);
-}
-
 .c2.MuiButton-outlined {
   padding: 8px 12px;
 }
@@ -1907,7 +1855,7 @@ exports[`SyncControls snapshots non-suspended 1`] = `
 }
 
 .c6 .MuiFormControlLabel-label.Mui-disabled {
-  color: #BDBDBD;
+  color: #d8d8d8;
 }
 
 .c6 .MuiTypography-root {
@@ -1921,24 +1869,16 @@ exports[`SyncControls snapshots non-suspended 1`] = `
   padding: 0;
 }
 
-.c7.MuiButton-root.Mui-disabled svg {
-  fill: #BDBDBD;
+.c7.MuiButton-root :disabled svg {
+  fill: #d8d8d8;
 }
 
-.c7.MuiButton-root:hover {
+.c7.MuiButton-root :hover {
   background-color: rgba(0, 179, 236, 0.1);
 }
 
 .c7.MuiButton-text {
   padding: 0;
-}
-
-.c7.MuiButton-text.Mui-disabled {
-  color: #BDBDBD;
-}
-
-.c7.MuiButton-text.Mui-disabled svg {
-  fill: #BDBDBD;
 }
 
 .c1 .sync-icon-button {
@@ -1955,7 +1895,7 @@ exports[`SyncControls snapshots non-suspended 1`] = `
   className="c0 c1"
 >
   <button
-    className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation c2 sync-icon-button css-9buukw-MuiButtonBase-root-MuiButton-root"
+    className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation c2 sync-icon-button css-157ho6v-MuiButtonBase-root-MuiButton-root"
     disabled={null}
     id=":r0:"
     onBlur={[Function]}
@@ -2010,7 +1950,7 @@ exports[`SyncControls snapshots non-suspended 1`] = `
         className="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd c6 css-12f4qvw-MuiFormControlLabel-root"
       >
         <span
-          className="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-checked MuiRadio-root MuiRadio-colorPrimary css-1avr0ra-MuiButtonBase-root-MuiRadio-root"
+          className="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-checked MuiRadio-root MuiRadio-colorPrimary css-yavd16-MuiButtonBase-root-MuiRadio-root"
           onBlur={[Function]}
           onContextMenu={[Function]}
           onDragLeave={[Function]}
@@ -2076,7 +2016,7 @@ exports[`SyncControls snapshots non-suspended 1`] = `
         className="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd c6 css-12f4qvw-MuiFormControlLabel-root"
       >
         <span
-          className="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary css-1avr0ra-MuiButtonBase-root-MuiRadio-root"
+          className="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary css-yavd16-MuiButtonBase-root-MuiRadio-root"
           onBlur={[Function]}
           onContextMenu={[Function]}
           onDragLeave={[Function]}
@@ -2153,7 +2093,7 @@ exports[`SyncControls snapshots non-suspended 1`] = `
     onTouchStart={[Function]}
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-624mb0-MuiButtonBase-root-MuiButton-root"
+      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-1fh7grq-MuiButtonBase-root-MuiButton-root"
       data-testid="sync-button"
       disabled={null}
       id=":r3:"
@@ -2206,7 +2146,7 @@ exports[`SyncControls snapshots non-suspended 1`] = `
     onTouchStart={[Function]}
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-624mb0-MuiButtonBase-root-MuiButton-root"
+      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-1fh7grq-MuiButtonBase-root-MuiButton-root"
       data-testid="suspend-button"
       disabled={null}
       id=":r5:"
@@ -2258,7 +2198,7 @@ exports[`SyncControls snapshots non-suspended 1`] = `
     onTouchStart={[Function]}
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-624mb0-MuiButtonBase-root-MuiButton-root"
+      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-1fh7grq-MuiButtonBase-root-MuiButton-root"
       data-testid="resume-button"
       disabled={null}
       id=":r7:"
@@ -2282,7 +2222,7 @@ exports[`SyncControls snapshots non-suspended 1`] = `
       >
         <svg
           height="24"
-          viewBox="-2 0 24 24"
+          viewBox="0 0 24 24"
           width="24"
           xmlns="http://www.w3.org/2000/svg"
         >

--- a/ui/components/Sync/__tests__/__snapshots__/SyncControls.test.tsx.snap
+++ b/ui/components/Sync/__tests__/__snapshots__/SyncControls.test.tsx.snap
@@ -113,6 +113,10 @@ exports[`SyncControls snapshots allButtonsDisabled 1`] = `
   font-weight: 600;
 }
 
+.c2.MuiButton-root:hover {
+  background-color: rgba(0, 179, 236, 0.1);
+}
+
 .c2.MuiButton-outlined {
   padding: 8px 12px;
 }
@@ -127,7 +131,7 @@ exports[`SyncControls snapshots allButtonsDisabled 1`] = `
 }
 
 .c6 .MuiFormControlLabel-label.Mui-disabled {
-  color: #d8d8d8;
+  color: #BDBDBD;
 }
 
 .c6 .MuiTypography-root {
@@ -141,16 +145,24 @@ exports[`SyncControls snapshots allButtonsDisabled 1`] = `
   padding: 0;
 }
 
-.c7.MuiButton-root :disabled svg {
-  fill: #d8d8d8;
+.c7.MuiButton-root.Mui-disabled svg {
+  fill: #BDBDBD;
 }
 
-.c7.MuiButton-root :hover {
+.c7.MuiButton-root:hover {
   background-color: rgba(0, 179, 236, 0.1);
 }
 
 .c7.MuiButton-text {
   padding: 0;
+}
+
+.c7.MuiButton-text.Mui-disabled {
+  color: #BDBDBD;
+}
+
+.c7.MuiButton-text.Mui-disabled svg {
+  fill: #BDBDBD;
 }
 
 .c1 .sync-icon-button {
@@ -164,36 +176,24 @@ exports[`SyncControls snapshots allButtonsDisabled 1`] = `
 }
 
 <div
-  className="c0 c1"
+  class="c0 c1"
 >
   <button
-    className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation c2 sync-icon-button css-157ho6v-MuiButtonBase-root-MuiButton-root"
-    disabled={true}
+    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation c2 sync-icon-button css-9buukw-MuiButtonBase-root-MuiButton-root"
+    disabled=""
     id=":r8:"
-    onBlur={[Function]}
-    onContextMenu={[Function]}
-    onDragLeave={[Function]}
-    onFocus={[Function]}
-    onKeyDown={[Function]}
-    onKeyUp={[Function]}
-    onMouseDown={[Function]}
-    onMouseLeave={[Function]}
-    onMouseUp={[Function]}
-    onTouchEnd={[Function]}
-    onTouchMove={[Function]}
-    onTouchStart={[Function]}
-    tabIndex={-1}
+    tabindex="-1"
     type="button"
   >
     <span
-      className="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeMedium css-1v1j2p3-MuiButton-startIcon"
+      class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeMedium css-1v1j2p3-MuiButton-startIcon"
     >
       <div
-        className="c3 c4"
+        class="c3 c4"
       >
         <svg
-          aria-hidden={true}
-          className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
           data-testid="SyncIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -207,53 +207,39 @@ exports[`SyncControls snapshots allButtonsDisabled 1`] = `
     Sync
   </button>
   <div
-    className="c5"
+    class="c5"
   />
   <div
-    className="MuiFormControl-root css-1iw3t7y-MuiFormControl-root"
+    class="MuiFormControl-root css-1iw3t7y-MuiFormControl-root"
   >
     <div
       aria-labelledby="source-radio-buttons-group-label"
-      className="MuiFormGroup-root MuiFormGroup-row MuiRadioGroup-root MuiRadioGroup-row css-cis11t-MuiFormGroup-root"
+      class="MuiFormGroup-root MuiFormGroup-row MuiRadioGroup-root MuiRadioGroup-row css-cis11t-MuiFormGroup-root"
       data-testid="sync-options"
       role="radiogroup"
     >
       <label
-        className="MuiFormControlLabel-root Mui-disabled MuiFormControlLabel-labelPlacementEnd c6 css-12f4qvw-MuiFormControlLabel-root"
+        class="MuiFormControlLabel-root Mui-disabled MuiFormControlLabel-labelPlacementEnd c6 css-12f4qvw-MuiFormControlLabel-root"
       >
         <span
-          aria-disabled={true}
-          className="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary Mui-disabled PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-checked Mui-disabled MuiRadio-root MuiRadio-colorPrimary css-1mux80u-MuiButtonBase-root-MuiRadio-root"
-          onBlur={[Function]}
-          onContextMenu={[Function]}
-          onDragLeave={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseLeave={[Function]}
-          onMouseUp={[Function]}
-          onTouchEnd={[Function]}
-          onTouchMove={[Function]}
-          onTouchStart={[Function]}
-          tabIndex={-1}
+          aria-disabled="true"
+          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary Mui-disabled PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-checked Mui-disabled MuiRadio-root MuiRadio-colorPrimary css-1a0qp0h-MuiButtonBase-root-MuiRadio-root"
+          tabindex="-1"
         >
           <input
-            checked={true}
-            className="PrivateSwitchBase-input css-j8yymo"
-            disabled={true}
+            checked=""
+            class="PrivateSwitchBase-input css-j8yymo"
+            disabled=""
             name="source-radio-buttons-group"
-            onChange={[Function]}
-            required={false}
             type="radio"
             value="WithSource"
           />
           <span
-            className="css-1qiat4j"
+            class="css-1qiat4j"
           >
             <svg
-              aria-hidden={true}
-              className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bz1rr0-MuiSvgIcon-root"
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bz1rr0-MuiSvgIcon-root"
               data-testid="RadioButtonUncheckedIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -263,8 +249,8 @@ exports[`SyncControls snapshots allButtonsDisabled 1`] = `
               />
             </svg>
             <svg
-              aria-hidden={true}
-              className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-z8nmqa-MuiSvgIcon-root"
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-z8nmqa-MuiSvgIcon-root"
               data-testid="RadioButtonCheckedIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -276,51 +262,35 @@ exports[`SyncControls snapshots allButtonsDisabled 1`] = `
           </span>
         </span>
         <span
-          className="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label Mui-disabled css-1lw54ax-MuiTypography-root"
-          style={{}}
+          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label Mui-disabled css-1lw54ax-MuiTypography-root"
         >
           with Source
         </span>
       </label>
       <div
-        className="c5"
+        class="c5"
       />
       <label
-        className="MuiFormControlLabel-root Mui-disabled MuiFormControlLabel-labelPlacementEnd c6 css-12f4qvw-MuiFormControlLabel-root"
+        class="MuiFormControlLabel-root Mui-disabled MuiFormControlLabel-labelPlacementEnd c6 css-12f4qvw-MuiFormControlLabel-root"
       >
         <span
-          aria-disabled={true}
-          className="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary Mui-disabled PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-disabled MuiRadio-root MuiRadio-colorPrimary css-1mux80u-MuiButtonBase-root-MuiRadio-root"
-          onBlur={[Function]}
-          onContextMenu={[Function]}
-          onDragLeave={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseLeave={[Function]}
-          onMouseUp={[Function]}
-          onTouchEnd={[Function]}
-          onTouchMove={[Function]}
-          onTouchStart={[Function]}
-          tabIndex={-1}
+          aria-disabled="true"
+          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary Mui-disabled PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-disabled MuiRadio-root MuiRadio-colorPrimary css-1a0qp0h-MuiButtonBase-root-MuiRadio-root"
+          tabindex="-1"
         >
           <input
-            checked={false}
-            className="PrivateSwitchBase-input css-j8yymo"
-            disabled={true}
+            class="PrivateSwitchBase-input css-j8yymo"
+            disabled=""
             name="source-radio-buttons-group"
-            onChange={[Function]}
-            required={false}
             type="radio"
             value="WithoutSource"
           />
           <span
-            className="css-1qiat4j"
+            class="css-1qiat4j"
           >
             <svg
-              aria-hidden={true}
-              className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bz1rr0-MuiSvgIcon-root"
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bz1rr0-MuiSvgIcon-root"
               data-testid="RadioButtonUncheckedIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -330,8 +300,8 @@ exports[`SyncControls snapshots allButtonsDisabled 1`] = `
               />
             </svg>
             <svg
-              aria-hidden={true}
-              className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-o8rdeq-MuiSvgIcon-root"
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-o8rdeq-MuiSvgIcon-root"
               data-testid="RadioButtonCheckedIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -343,8 +313,7 @@ exports[`SyncControls snapshots allButtonsDisabled 1`] = `
           </span>
         </span>
         <span
-          className="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label Mui-disabled css-1lw54ax-MuiTypography-root"
-          style={{}}
+          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label Mui-disabled css-1lw54ax-MuiTypography-root"
         >
           without Source
         </span>
@@ -352,47 +321,27 @@ exports[`SyncControls snapshots allButtonsDisabled 1`] = `
     </div>
   </div>
   <div
-    className="c5"
+    class="c5"
   />
   <div
     aria-label="Sync"
-    aria-labelledby={null}
-    className=""
-    data-mui-internal-clone-element={true}
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseLeave={[Function]}
-    onMouseOver={[Function]}
-    onTouchEnd={[Function]}
-    onTouchStart={[Function]}
+    class=""
+    data-mui-internal-clone-element="true"
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-1fh7grq-MuiButtonBase-root-MuiButton-root"
+      class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-624mb0-MuiButtonBase-root-MuiButton-root"
       data-testid="sync-button"
-      disabled={true}
+      disabled=""
       id=":rb:"
-      onBlur={[Function]}
-      onClick={[Function]}
-      onContextMenu={[Function]}
-      onDragLeave={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
-      onMouseDown={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      onTouchEnd={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
-      tabIndex={-1}
+      tabindex="-1"
       type="button"
     >
       <div
-        className="c3 c4"
+        class="c3 c4"
       >
         <svg
-          aria-hidden={true}
-          className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
           data-testid="PlayArrowIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -405,46 +354,27 @@ exports[`SyncControls snapshots allButtonsDisabled 1`] = `
     </button>
   </div>
   <div
-    className="c5"
+    class="c5"
   />
   <div
     aria-label="Suspend"
-    aria-labelledby={null}
-    className=""
-    data-mui-internal-clone-element={true}
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseLeave={[Function]}
-    onMouseOver={[Function]}
-    onTouchEnd={[Function]}
-    onTouchStart={[Function]}
+    class=""
+    data-mui-internal-clone-element="true"
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-1fh7grq-MuiButtonBase-root-MuiButton-root"
+      class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-624mb0-MuiButtonBase-root-MuiButton-root"
       data-testid="suspend-button"
-      disabled={true}
+      disabled=""
       id=":rd:"
-      onBlur={[Function]}
-      onContextMenu={[Function]}
-      onDragLeave={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
-      onMouseDown={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      onTouchEnd={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
-      tabIndex={-1}
+      tabindex="-1"
       type="button"
     >
       <div
-        className="c3 c4"
+        class="c3 c4"
       >
         <svg
-          aria-hidden={true}
-          className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
           data-testid="PauseIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -457,46 +387,27 @@ exports[`SyncControls snapshots allButtonsDisabled 1`] = `
     </button>
   </div>
   <div
-    className="c5"
+    class="c5"
   />
   <div
     aria-label="Resume"
-    aria-labelledby={null}
-    className=""
-    data-mui-internal-clone-element={true}
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseLeave={[Function]}
-    onMouseOver={[Function]}
-    onTouchEnd={[Function]}
-    onTouchStart={[Function]}
+    class=""
+    data-mui-internal-clone-element="true"
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-1fh7grq-MuiButtonBase-root-MuiButton-root"
+      class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-624mb0-MuiButtonBase-root-MuiButton-root"
       data-testid="resume-button"
-      disabled={true}
+      disabled=""
       id=":rf:"
-      onBlur={[Function]}
-      onContextMenu={[Function]}
-      onDragLeave={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
-      onMouseDown={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      onTouchEnd={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
-      tabIndex={-1}
+      tabindex="-1"
       type="button"
     >
       <div
-        className="c3 c8"
+        class="c3 c8"
       >
         <svg
           height="24"
-          viewBox="0 0 24 24"
+          viewBox="-2 0 24 24"
           width="24"
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -623,6 +534,10 @@ exports[`SyncControls snapshots hasTooltipSuffix 1`] = `
   font-weight: 600;
 }
 
+.c2.MuiButton-root:hover {
+  background-color: rgba(0, 179, 236, 0.1);
+}
+
 .c2.MuiButton-outlined {
   padding: 8px 12px;
 }
@@ -637,7 +552,7 @@ exports[`SyncControls snapshots hasTooltipSuffix 1`] = `
 }
 
 .c6 .MuiFormControlLabel-label.Mui-disabled {
-  color: #d8d8d8;
+  color: #BDBDBD;
 }
 
 .c6 .MuiTypography-root {
@@ -651,16 +566,24 @@ exports[`SyncControls snapshots hasTooltipSuffix 1`] = `
   padding: 0;
 }
 
-.c7.MuiButton-root :disabled svg {
-  fill: #d8d8d8;
+.c7.MuiButton-root.Mui-disabled svg {
+  fill: #BDBDBD;
 }
 
-.c7.MuiButton-root :hover {
+.c7.MuiButton-root:hover {
   background-color: rgba(0, 179, 236, 0.1);
 }
 
 .c7.MuiButton-text {
   padding: 0;
+}
+
+.c7.MuiButton-text.Mui-disabled {
+  color: #BDBDBD;
+}
+
+.c7.MuiButton-text.Mui-disabled svg {
+  fill: #BDBDBD;
 }
 
 .c1 .sync-icon-button {
@@ -674,36 +597,23 @@ exports[`SyncControls snapshots hasTooltipSuffix 1`] = `
 }
 
 <div
-  className="c0 c1"
+  class="c0 c1"
 >
   <button
-    className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation c2 sync-icon-button css-157ho6v-MuiButtonBase-root-MuiButton-root"
-    disabled={null}
+    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation c2 sync-icon-button css-9buukw-MuiButtonBase-root-MuiButton-root"
     id=":rr:"
-    onBlur={[Function]}
-    onContextMenu={[Function]}
-    onDragLeave={[Function]}
-    onFocus={[Function]}
-    onKeyDown={[Function]}
-    onKeyUp={[Function]}
-    onMouseDown={[Function]}
-    onMouseLeave={[Function]}
-    onMouseUp={[Function]}
-    onTouchEnd={[Function]}
-    onTouchMove={[Function]}
-    onTouchStart={[Function]}
-    tabIndex={0}
+    tabindex="0"
     type="button"
   >
     <span
-      className="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeMedium css-1v1j2p3-MuiButton-startIcon"
+      class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeMedium css-1v1j2p3-MuiButton-startIcon"
     >
       <div
-        className="c3 c4"
+        class="c3 c4"
       >
         <svg
-          aria-hidden={true}
-          className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
           data-testid="SyncIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -717,52 +627,36 @@ exports[`SyncControls snapshots hasTooltipSuffix 1`] = `
     Sync
   </button>
   <div
-    className="c5"
+    class="c5"
   />
   <div
-    className="MuiFormControl-root css-1iw3t7y-MuiFormControl-root"
+    class="MuiFormControl-root css-1iw3t7y-MuiFormControl-root"
   >
     <div
       aria-labelledby="source-radio-buttons-group-label"
-      className="MuiFormGroup-root MuiFormGroup-row MuiRadioGroup-root MuiRadioGroup-row css-cis11t-MuiFormGroup-root"
+      class="MuiFormGroup-root MuiFormGroup-row MuiRadioGroup-root MuiRadioGroup-row css-cis11t-MuiFormGroup-root"
       data-testid="sync-options"
       role="radiogroup"
     >
       <label
-        className="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd c6 css-12f4qvw-MuiFormControlLabel-root"
+        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd c6 css-12f4qvw-MuiFormControlLabel-root"
       >
         <span
-          className="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-checked MuiRadio-root MuiRadio-colorPrimary css-yavd16-MuiButtonBase-root-MuiRadio-root"
-          onBlur={[Function]}
-          onContextMenu={[Function]}
-          onDragLeave={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseLeave={[Function]}
-          onMouseUp={[Function]}
-          onTouchEnd={[Function]}
-          onTouchMove={[Function]}
-          onTouchStart={[Function]}
-          tabIndex={null}
+          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-checked MuiRadio-root MuiRadio-colorPrimary css-1avr0ra-MuiButtonBase-root-MuiRadio-root"
         >
           <input
-            checked={true}
-            className="PrivateSwitchBase-input css-j8yymo"
-            disabled={false}
+            checked=""
+            class="PrivateSwitchBase-input css-j8yymo"
             name="source-radio-buttons-group"
-            onChange={[Function]}
-            required={false}
             type="radio"
             value="WithSource"
           />
           <span
-            className="css-1qiat4j"
+            class="css-1qiat4j"
           >
             <svg
-              aria-hidden={true}
-              className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bz1rr0-MuiSvgIcon-root"
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bz1rr0-MuiSvgIcon-root"
               data-testid="RadioButtonUncheckedIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -772,8 +666,8 @@ exports[`SyncControls snapshots hasTooltipSuffix 1`] = `
               />
             </svg>
             <svg
-              aria-hidden={true}
-              className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-z8nmqa-MuiSvgIcon-root"
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-z8nmqa-MuiSvgIcon-root"
               data-testid="RadioButtonCheckedIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -785,50 +679,32 @@ exports[`SyncControls snapshots hasTooltipSuffix 1`] = `
           </span>
         </span>
         <span
-          className="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1lw54ax-MuiTypography-root"
-          style={{}}
+          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1lw54ax-MuiTypography-root"
         >
           with Source
         </span>
       </label>
       <div
-        className="c5"
+        class="c5"
       />
       <label
-        className="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd c6 css-12f4qvw-MuiFormControlLabel-root"
+        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd c6 css-12f4qvw-MuiFormControlLabel-root"
       >
         <span
-          className="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary css-yavd16-MuiButtonBase-root-MuiRadio-root"
-          onBlur={[Function]}
-          onContextMenu={[Function]}
-          onDragLeave={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseLeave={[Function]}
-          onMouseUp={[Function]}
-          onTouchEnd={[Function]}
-          onTouchMove={[Function]}
-          onTouchStart={[Function]}
-          tabIndex={null}
+          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary css-1avr0ra-MuiButtonBase-root-MuiRadio-root"
         >
           <input
-            checked={false}
-            className="PrivateSwitchBase-input css-j8yymo"
-            disabled={false}
+            class="PrivateSwitchBase-input css-j8yymo"
             name="source-radio-buttons-group"
-            onChange={[Function]}
-            required={false}
             type="radio"
             value="WithoutSource"
           />
           <span
-            className="css-1qiat4j"
+            class="css-1qiat4j"
           >
             <svg
-              aria-hidden={true}
-              className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bz1rr0-MuiSvgIcon-root"
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bz1rr0-MuiSvgIcon-root"
               data-testid="RadioButtonUncheckedIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -838,8 +714,8 @@ exports[`SyncControls snapshots hasTooltipSuffix 1`] = `
               />
             </svg>
             <svg
-              aria-hidden={true}
-              className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-o8rdeq-MuiSvgIcon-root"
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-o8rdeq-MuiSvgIcon-root"
               data-testid="RadioButtonCheckedIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -851,8 +727,7 @@ exports[`SyncControls snapshots hasTooltipSuffix 1`] = `
           </span>
         </span>
         <span
-          className="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1lw54ax-MuiTypography-root"
-          style={{}}
+          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1lw54ax-MuiTypography-root"
         >
           without Source
         </span>
@@ -860,47 +735,26 @@ exports[`SyncControls snapshots hasTooltipSuffix 1`] = `
     </div>
   </div>
   <div
-    className="c5"
+    class="c5"
   />
   <div
     aria-label="Synctest suffix"
-    aria-labelledby={null}
-    className=""
-    data-mui-internal-clone-element={true}
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseLeave={[Function]}
-    onMouseOver={[Function]}
-    onTouchEnd={[Function]}
-    onTouchStart={[Function]}
+    class=""
+    data-mui-internal-clone-element="true"
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-1fh7grq-MuiButtonBase-root-MuiButton-root"
+      class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-624mb0-MuiButtonBase-root-MuiButton-root"
       data-testid="sync-button"
-      disabled={null}
       id=":ru:"
-      onBlur={[Function]}
-      onClick={[Function]}
-      onContextMenu={[Function]}
-      onDragLeave={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
-      onMouseDown={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      onTouchEnd={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
-      tabIndex={0}
+      tabindex="0"
       type="button"
     >
       <div
-        className="c3 c4"
+        class="c3 c4"
       >
         <svg
-          aria-hidden={true}
-          className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
           data-testid="PlayArrowIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -913,46 +767,26 @@ exports[`SyncControls snapshots hasTooltipSuffix 1`] = `
     </button>
   </div>
   <div
-    className="c5"
+    class="c5"
   />
   <div
     aria-label="Suspendtest suffix"
-    aria-labelledby={null}
-    className=""
-    data-mui-internal-clone-element={true}
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseLeave={[Function]}
-    onMouseOver={[Function]}
-    onTouchEnd={[Function]}
-    onTouchStart={[Function]}
+    class=""
+    data-mui-internal-clone-element="true"
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-1fh7grq-MuiButtonBase-root-MuiButton-root"
+      class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-624mb0-MuiButtonBase-root-MuiButton-root"
       data-testid="suspend-button"
-      disabled={null}
       id=":r10:"
-      onBlur={[Function]}
-      onContextMenu={[Function]}
-      onDragLeave={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
-      onMouseDown={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      onTouchEnd={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
-      tabIndex={0}
+      tabindex="0"
       type="button"
     >
       <div
-        className="c3 c4"
+        class="c3 c4"
       >
         <svg
-          aria-hidden={true}
-          className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
           data-testid="PauseIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -965,46 +799,26 @@ exports[`SyncControls snapshots hasTooltipSuffix 1`] = `
     </button>
   </div>
   <div
-    className="c5"
+    class="c5"
   />
   <div
     aria-label="Resumetest suffix"
-    aria-labelledby={null}
-    className=""
-    data-mui-internal-clone-element={true}
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseLeave={[Function]}
-    onMouseOver={[Function]}
-    onTouchEnd={[Function]}
-    onTouchStart={[Function]}
+    class=""
+    data-mui-internal-clone-element="true"
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-1fh7grq-MuiButtonBase-root-MuiButton-root"
+      class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-624mb0-MuiButtonBase-root-MuiButton-root"
       data-testid="resume-button"
-      disabled={null}
       id=":r12:"
-      onBlur={[Function]}
-      onContextMenu={[Function]}
-      onDragLeave={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
-      onMouseDown={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      onTouchEnd={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
-      tabIndex={0}
+      tabindex="0"
       type="button"
     >
       <div
-        className="c3 c8"
+        class="c3 c8"
       >
         <svg
           height="24"
-          viewBox="0 0 24 24"
+          viewBox="-2 0 24 24"
           width="24"
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -1088,6 +902,10 @@ exports[`SyncControls snapshots hideSuspend 1`] = `
   font-weight: 600;
 }
 
+.c2.MuiButton-root:hover {
+  background-color: rgba(0, 179, 236, 0.1);
+}
+
 .c2.MuiButton-outlined {
   padding: 8px 12px;
 }
@@ -1102,7 +920,7 @@ exports[`SyncControls snapshots hideSuspend 1`] = `
 }
 
 .c6 .MuiFormControlLabel-label.Mui-disabled {
-  color: #d8d8d8;
+  color: #BDBDBD;
 }
 
 .c6 .MuiTypography-root {
@@ -1116,16 +934,24 @@ exports[`SyncControls snapshots hideSuspend 1`] = `
   padding: 0;
 }
 
-.c7.MuiButton-root :disabled svg {
-  fill: #d8d8d8;
+.c7.MuiButton-root.Mui-disabled svg {
+  fill: #BDBDBD;
 }
 
-.c7.MuiButton-root :hover {
+.c7.MuiButton-root:hover {
   background-color: rgba(0, 179, 236, 0.1);
 }
 
 .c7.MuiButton-text {
   padding: 0;
+}
+
+.c7.MuiButton-text.Mui-disabled {
+  color: #BDBDBD;
+}
+
+.c7.MuiButton-text.Mui-disabled svg {
+  fill: #BDBDBD;
 }
 
 .c1 .sync-icon-button {
@@ -1139,36 +965,23 @@ exports[`SyncControls snapshots hideSuspend 1`] = `
 }
 
 <div
-  className="c0 c1"
+  class="c0 c1"
 >
   <button
-    className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation c2 sync-icon-button css-157ho6v-MuiButtonBase-root-MuiButton-root"
-    disabled={null}
+    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation c2 sync-icon-button css-9buukw-MuiButtonBase-root-MuiButton-root"
     id=":rn:"
-    onBlur={[Function]}
-    onContextMenu={[Function]}
-    onDragLeave={[Function]}
-    onFocus={[Function]}
-    onKeyDown={[Function]}
-    onKeyUp={[Function]}
-    onMouseDown={[Function]}
-    onMouseLeave={[Function]}
-    onMouseUp={[Function]}
-    onTouchEnd={[Function]}
-    onTouchMove={[Function]}
-    onTouchStart={[Function]}
-    tabIndex={0}
+    tabindex="0"
     type="button"
   >
     <span
-      className="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeMedium css-1v1j2p3-MuiButton-startIcon"
+      class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeMedium css-1v1j2p3-MuiButton-startIcon"
     >
       <div
-        className="c3 c4"
+        class="c3 c4"
       >
         <svg
-          aria-hidden={true}
-          className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
           data-testid="SyncIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -1182,52 +995,36 @@ exports[`SyncControls snapshots hideSuspend 1`] = `
     Sync
   </button>
   <div
-    className="c5"
+    class="c5"
   />
   <div
-    className="MuiFormControl-root css-1iw3t7y-MuiFormControl-root"
+    class="MuiFormControl-root css-1iw3t7y-MuiFormControl-root"
   >
     <div
       aria-labelledby="source-radio-buttons-group-label"
-      className="MuiFormGroup-root MuiFormGroup-row MuiRadioGroup-root MuiRadioGroup-row css-cis11t-MuiFormGroup-root"
+      class="MuiFormGroup-root MuiFormGroup-row MuiRadioGroup-root MuiRadioGroup-row css-cis11t-MuiFormGroup-root"
       data-testid="sync-options"
       role="radiogroup"
     >
       <label
-        className="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd c6 css-12f4qvw-MuiFormControlLabel-root"
+        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd c6 css-12f4qvw-MuiFormControlLabel-root"
       >
         <span
-          className="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-checked MuiRadio-root MuiRadio-colorPrimary css-yavd16-MuiButtonBase-root-MuiRadio-root"
-          onBlur={[Function]}
-          onContextMenu={[Function]}
-          onDragLeave={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseLeave={[Function]}
-          onMouseUp={[Function]}
-          onTouchEnd={[Function]}
-          onTouchMove={[Function]}
-          onTouchStart={[Function]}
-          tabIndex={null}
+          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-checked MuiRadio-root MuiRadio-colorPrimary css-1avr0ra-MuiButtonBase-root-MuiRadio-root"
         >
           <input
-            checked={true}
-            className="PrivateSwitchBase-input css-j8yymo"
-            disabled={false}
+            checked=""
+            class="PrivateSwitchBase-input css-j8yymo"
             name="source-radio-buttons-group"
-            onChange={[Function]}
-            required={false}
             type="radio"
             value="WithSource"
           />
           <span
-            className="css-1qiat4j"
+            class="css-1qiat4j"
           >
             <svg
-              aria-hidden={true}
-              className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bz1rr0-MuiSvgIcon-root"
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bz1rr0-MuiSvgIcon-root"
               data-testid="RadioButtonUncheckedIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -1237,8 +1034,8 @@ exports[`SyncControls snapshots hideSuspend 1`] = `
               />
             </svg>
             <svg
-              aria-hidden={true}
-              className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-z8nmqa-MuiSvgIcon-root"
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-z8nmqa-MuiSvgIcon-root"
               data-testid="RadioButtonCheckedIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -1250,50 +1047,32 @@ exports[`SyncControls snapshots hideSuspend 1`] = `
           </span>
         </span>
         <span
-          className="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1lw54ax-MuiTypography-root"
-          style={{}}
+          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1lw54ax-MuiTypography-root"
         >
           with Source
         </span>
       </label>
       <div
-        className="c5"
+        class="c5"
       />
       <label
-        className="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd c6 css-12f4qvw-MuiFormControlLabel-root"
+        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd c6 css-12f4qvw-MuiFormControlLabel-root"
       >
         <span
-          className="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary css-yavd16-MuiButtonBase-root-MuiRadio-root"
-          onBlur={[Function]}
-          onContextMenu={[Function]}
-          onDragLeave={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseLeave={[Function]}
-          onMouseUp={[Function]}
-          onTouchEnd={[Function]}
-          onTouchMove={[Function]}
-          onTouchStart={[Function]}
-          tabIndex={null}
+          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary css-1avr0ra-MuiButtonBase-root-MuiRadio-root"
         >
           <input
-            checked={false}
-            className="PrivateSwitchBase-input css-j8yymo"
-            disabled={false}
+            class="PrivateSwitchBase-input css-j8yymo"
             name="source-radio-buttons-group"
-            onChange={[Function]}
-            required={false}
             type="radio"
             value="WithoutSource"
           />
           <span
-            className="css-1qiat4j"
+            class="css-1qiat4j"
           >
             <svg
-              aria-hidden={true}
-              className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bz1rr0-MuiSvgIcon-root"
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bz1rr0-MuiSvgIcon-root"
               data-testid="RadioButtonUncheckedIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -1303,8 +1082,8 @@ exports[`SyncControls snapshots hideSuspend 1`] = `
               />
             </svg>
             <svg
-              aria-hidden={true}
-              className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-o8rdeq-MuiSvgIcon-root"
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-o8rdeq-MuiSvgIcon-root"
               data-testid="RadioButtonCheckedIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -1316,8 +1095,7 @@ exports[`SyncControls snapshots hideSuspend 1`] = `
           </span>
         </span>
         <span
-          className="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1lw54ax-MuiTypography-root"
-          style={{}}
+          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1lw54ax-MuiTypography-root"
         >
           without Source
         </span>
@@ -1325,47 +1103,26 @@ exports[`SyncControls snapshots hideSuspend 1`] = `
     </div>
   </div>
   <div
-    className="c5"
+    class="c5"
   />
   <div
     aria-label="Sync"
-    aria-labelledby={null}
-    className=""
-    data-mui-internal-clone-element={true}
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseLeave={[Function]}
-    onMouseOver={[Function]}
-    onTouchEnd={[Function]}
-    onTouchStart={[Function]}
+    class=""
+    data-mui-internal-clone-element="true"
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-1fh7grq-MuiButtonBase-root-MuiButton-root"
+      class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-624mb0-MuiButtonBase-root-MuiButton-root"
       data-testid="sync-button"
-      disabled={null}
       id=":rq:"
-      onBlur={[Function]}
-      onClick={[Function]}
-      onContextMenu={[Function]}
-      onDragLeave={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
-      onMouseDown={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      onTouchEnd={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
-      tabIndex={0}
+      tabindex="0"
       type="button"
     >
       <div
-        className="c3 c4"
+        class="c3 c4"
       >
         <svg
-          aria-hidden={true}
-          className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
           data-testid="PlayArrowIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -1493,6 +1250,10 @@ exports[`SyncControls snapshots hideSyncOptions 1`] = `
   font-weight: 600;
 }
 
+.c2.MuiButton-root:hover {
+  background-color: rgba(0, 179, 236, 0.1);
+}
+
 .c2.MuiButton-outlined {
   padding: 8px 12px;
 }
@@ -1504,16 +1265,24 @@ exports[`SyncControls snapshots hideSyncOptions 1`] = `
   padding: 0;
 }
 
-.c6.MuiButton-root :disabled svg {
-  fill: #d8d8d8;
+.c6.MuiButton-root.Mui-disabled svg {
+  fill: #BDBDBD;
 }
 
-.c6.MuiButton-root :hover {
+.c6.MuiButton-root:hover {
   background-color: rgba(0, 179, 236, 0.1);
 }
 
 .c6.MuiButton-text {
   padding: 0;
+}
+
+.c6.MuiButton-text.Mui-disabled {
+  color: #BDBDBD;
+}
+
+.c6.MuiButton-text.Mui-disabled svg {
+  fill: #BDBDBD;
 }
 
 .c1 .sync-icon-button {
@@ -1527,36 +1296,23 @@ exports[`SyncControls snapshots hideSyncOptions 1`] = `
 }
 
 <div
-  className="c0 c1"
+  class="c0 c1"
 >
   <button
-    className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation c2 sync-icon-button css-157ho6v-MuiButtonBase-root-MuiButton-root"
-    disabled={null}
+    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation c2 sync-icon-button css-9buukw-MuiButtonBase-root-MuiButton-root"
     id=":rg:"
-    onBlur={[Function]}
-    onContextMenu={[Function]}
-    onDragLeave={[Function]}
-    onFocus={[Function]}
-    onKeyDown={[Function]}
-    onKeyUp={[Function]}
-    onMouseDown={[Function]}
-    onMouseLeave={[Function]}
-    onMouseUp={[Function]}
-    onTouchEnd={[Function]}
-    onTouchMove={[Function]}
-    onTouchStart={[Function]}
-    tabIndex={0}
+    tabindex="0"
     type="button"
   >
     <span
-      className="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeMedium css-1v1j2p3-MuiButton-startIcon"
+      class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeMedium css-1v1j2p3-MuiButton-startIcon"
     >
       <div
-        className="c3 c4"
+        class="c3 c4"
       >
         <svg
-          aria-hidden={true}
-          className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
           data-testid="SyncIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -1570,47 +1326,26 @@ exports[`SyncControls snapshots hideSyncOptions 1`] = `
     Sync
   </button>
   <div
-    className="c5"
+    class="c5"
   />
   <div
     aria-label="Sync"
-    aria-labelledby={null}
-    className=""
-    data-mui-internal-clone-element={true}
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseLeave={[Function]}
-    onMouseOver={[Function]}
-    onTouchEnd={[Function]}
-    onTouchStart={[Function]}
+    class=""
+    data-mui-internal-clone-element="true"
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c6 css-1fh7grq-MuiButtonBase-root-MuiButton-root"
+      class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c6 css-624mb0-MuiButtonBase-root-MuiButton-root"
       data-testid="sync-button"
-      disabled={null}
       id=":ri:"
-      onBlur={[Function]}
-      onClick={[Function]}
-      onContextMenu={[Function]}
-      onDragLeave={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
-      onMouseDown={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      onTouchEnd={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
-      tabIndex={0}
+      tabindex="0"
       type="button"
     >
       <div
-        className="c3 c4"
+        class="c3 c4"
       >
         <svg
-          aria-hidden={true}
-          className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
           data-testid="PlayArrowIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -1623,46 +1358,26 @@ exports[`SyncControls snapshots hideSyncOptions 1`] = `
     </button>
   </div>
   <div
-    className="c5"
+    class="c5"
   />
   <div
     aria-label="Suspend"
-    aria-labelledby={null}
-    className=""
-    data-mui-internal-clone-element={true}
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseLeave={[Function]}
-    onMouseOver={[Function]}
-    onTouchEnd={[Function]}
-    onTouchStart={[Function]}
+    class=""
+    data-mui-internal-clone-element="true"
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c6 css-1fh7grq-MuiButtonBase-root-MuiButton-root"
+      class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c6 css-624mb0-MuiButtonBase-root-MuiButton-root"
       data-testid="suspend-button"
-      disabled={null}
       id=":rk:"
-      onBlur={[Function]}
-      onContextMenu={[Function]}
-      onDragLeave={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
-      onMouseDown={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      onTouchEnd={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
-      tabIndex={0}
+      tabindex="0"
       type="button"
     >
       <div
-        className="c3 c4"
+        class="c3 c4"
       >
         <svg
-          aria-hidden={true}
-          className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
           data-testid="PauseIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -1675,46 +1390,26 @@ exports[`SyncControls snapshots hideSyncOptions 1`] = `
     </button>
   </div>
   <div
-    className="c5"
+    class="c5"
   />
   <div
     aria-label="Resume"
-    aria-labelledby={null}
-    className=""
-    data-mui-internal-clone-element={true}
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseLeave={[Function]}
-    onMouseOver={[Function]}
-    onTouchEnd={[Function]}
-    onTouchStart={[Function]}
+    class=""
+    data-mui-internal-clone-element="true"
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c6 css-1fh7grq-MuiButtonBase-root-MuiButton-root"
+      class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c6 css-624mb0-MuiButtonBase-root-MuiButton-root"
       data-testid="resume-button"
-      disabled={null}
       id=":rm:"
-      onBlur={[Function]}
-      onContextMenu={[Function]}
-      onDragLeave={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
-      onMouseDown={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      onTouchEnd={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
-      tabIndex={0}
+      tabindex="0"
       type="button"
     >
       <div
-        className="c3 c7"
+        class="c3 c7"
       >
         <svg
           height="24"
-          viewBox="0 0 24 24"
+          viewBox="-2 0 24 24"
           width="24"
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -1841,6 +1536,10 @@ exports[`SyncControls snapshots non-suspended 1`] = `
   font-weight: 600;
 }
 
+.c2.MuiButton-root:hover {
+  background-color: rgba(0, 179, 236, 0.1);
+}
+
 .c2.MuiButton-outlined {
   padding: 8px 12px;
 }
@@ -1855,7 +1554,7 @@ exports[`SyncControls snapshots non-suspended 1`] = `
 }
 
 .c6 .MuiFormControlLabel-label.Mui-disabled {
-  color: #d8d8d8;
+  color: #BDBDBD;
 }
 
 .c6 .MuiTypography-root {
@@ -1869,16 +1568,24 @@ exports[`SyncControls snapshots non-suspended 1`] = `
   padding: 0;
 }
 
-.c7.MuiButton-root :disabled svg {
-  fill: #d8d8d8;
+.c7.MuiButton-root.Mui-disabled svg {
+  fill: #BDBDBD;
 }
 
-.c7.MuiButton-root :hover {
+.c7.MuiButton-root:hover {
   background-color: rgba(0, 179, 236, 0.1);
 }
 
 .c7.MuiButton-text {
   padding: 0;
+}
+
+.c7.MuiButton-text.Mui-disabled {
+  color: #BDBDBD;
+}
+
+.c7.MuiButton-text.Mui-disabled svg {
+  fill: #BDBDBD;
 }
 
 .c1 .sync-icon-button {
@@ -1892,36 +1599,23 @@ exports[`SyncControls snapshots non-suspended 1`] = `
 }
 
 <div
-  className="c0 c1"
+  class="c0 c1"
 >
   <button
-    className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation c2 sync-icon-button css-157ho6v-MuiButtonBase-root-MuiButton-root"
-    disabled={null}
+    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation c2 sync-icon-button css-9buukw-MuiButtonBase-root-MuiButton-root"
     id=":r0:"
-    onBlur={[Function]}
-    onContextMenu={[Function]}
-    onDragLeave={[Function]}
-    onFocus={[Function]}
-    onKeyDown={[Function]}
-    onKeyUp={[Function]}
-    onMouseDown={[Function]}
-    onMouseLeave={[Function]}
-    onMouseUp={[Function]}
-    onTouchEnd={[Function]}
-    onTouchMove={[Function]}
-    onTouchStart={[Function]}
-    tabIndex={0}
+    tabindex="0"
     type="button"
   >
     <span
-      className="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeMedium css-1v1j2p3-MuiButton-startIcon"
+      class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeMedium css-1v1j2p3-MuiButton-startIcon"
     >
       <div
-        className="c3 c4"
+        class="c3 c4"
       >
         <svg
-          aria-hidden={true}
-          className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
           data-testid="SyncIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -1935,52 +1629,36 @@ exports[`SyncControls snapshots non-suspended 1`] = `
     Sync
   </button>
   <div
-    className="c5"
+    class="c5"
   />
   <div
-    className="MuiFormControl-root css-1iw3t7y-MuiFormControl-root"
+    class="MuiFormControl-root css-1iw3t7y-MuiFormControl-root"
   >
     <div
       aria-labelledby="source-radio-buttons-group-label"
-      className="MuiFormGroup-root MuiFormGroup-row MuiRadioGroup-root MuiRadioGroup-row css-cis11t-MuiFormGroup-root"
+      class="MuiFormGroup-root MuiFormGroup-row MuiRadioGroup-root MuiRadioGroup-row css-cis11t-MuiFormGroup-root"
       data-testid="sync-options"
       role="radiogroup"
     >
       <label
-        className="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd c6 css-12f4qvw-MuiFormControlLabel-root"
+        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd c6 css-12f4qvw-MuiFormControlLabel-root"
       >
         <span
-          className="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-checked MuiRadio-root MuiRadio-colorPrimary css-yavd16-MuiButtonBase-root-MuiRadio-root"
-          onBlur={[Function]}
-          onContextMenu={[Function]}
-          onDragLeave={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseLeave={[Function]}
-          onMouseUp={[Function]}
-          onTouchEnd={[Function]}
-          onTouchMove={[Function]}
-          onTouchStart={[Function]}
-          tabIndex={null}
+          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-checked MuiRadio-root MuiRadio-colorPrimary css-1avr0ra-MuiButtonBase-root-MuiRadio-root"
         >
           <input
-            checked={true}
-            className="PrivateSwitchBase-input css-j8yymo"
-            disabled={false}
+            checked=""
+            class="PrivateSwitchBase-input css-j8yymo"
             name="source-radio-buttons-group"
-            onChange={[Function]}
-            required={false}
             type="radio"
             value="WithSource"
           />
           <span
-            className="css-1qiat4j"
+            class="css-1qiat4j"
           >
             <svg
-              aria-hidden={true}
-              className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bz1rr0-MuiSvgIcon-root"
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bz1rr0-MuiSvgIcon-root"
               data-testid="RadioButtonUncheckedIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -1990,8 +1668,8 @@ exports[`SyncControls snapshots non-suspended 1`] = `
               />
             </svg>
             <svg
-              aria-hidden={true}
-              className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-z8nmqa-MuiSvgIcon-root"
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-z8nmqa-MuiSvgIcon-root"
               data-testid="RadioButtonCheckedIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -2003,50 +1681,32 @@ exports[`SyncControls snapshots non-suspended 1`] = `
           </span>
         </span>
         <span
-          className="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1lw54ax-MuiTypography-root"
-          style={{}}
+          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1lw54ax-MuiTypography-root"
         >
           with Source
         </span>
       </label>
       <div
-        className="c5"
+        class="c5"
       />
       <label
-        className="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd c6 css-12f4qvw-MuiFormControlLabel-root"
+        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd c6 css-12f4qvw-MuiFormControlLabel-root"
       >
         <span
-          className="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary css-yavd16-MuiButtonBase-root-MuiRadio-root"
-          onBlur={[Function]}
-          onContextMenu={[Function]}
-          onDragLeave={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseLeave={[Function]}
-          onMouseUp={[Function]}
-          onTouchEnd={[Function]}
-          onTouchMove={[Function]}
-          onTouchStart={[Function]}
-          tabIndex={null}
+          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary css-1avr0ra-MuiButtonBase-root-MuiRadio-root"
         >
           <input
-            checked={false}
-            className="PrivateSwitchBase-input css-j8yymo"
-            disabled={false}
+            class="PrivateSwitchBase-input css-j8yymo"
             name="source-radio-buttons-group"
-            onChange={[Function]}
-            required={false}
             type="radio"
             value="WithoutSource"
           />
           <span
-            className="css-1qiat4j"
+            class="css-1qiat4j"
           >
             <svg
-              aria-hidden={true}
-              className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bz1rr0-MuiSvgIcon-root"
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1bz1rr0-MuiSvgIcon-root"
               data-testid="RadioButtonUncheckedIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -2056,8 +1716,8 @@ exports[`SyncControls snapshots non-suspended 1`] = `
               />
             </svg>
             <svg
-              aria-hidden={true}
-              className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-o8rdeq-MuiSvgIcon-root"
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-o8rdeq-MuiSvgIcon-root"
               data-testid="RadioButtonCheckedIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -2069,8 +1729,7 @@ exports[`SyncControls snapshots non-suspended 1`] = `
           </span>
         </span>
         <span
-          className="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1lw54ax-MuiTypography-root"
-          style={{}}
+          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1lw54ax-MuiTypography-root"
         >
           without Source
         </span>
@@ -2078,47 +1737,26 @@ exports[`SyncControls snapshots non-suspended 1`] = `
     </div>
   </div>
   <div
-    className="c5"
+    class="c5"
   />
   <div
     aria-label="Sync"
-    aria-labelledby={null}
-    className=""
-    data-mui-internal-clone-element={true}
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseLeave={[Function]}
-    onMouseOver={[Function]}
-    onTouchEnd={[Function]}
-    onTouchStart={[Function]}
+    class=""
+    data-mui-internal-clone-element="true"
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-1fh7grq-MuiButtonBase-root-MuiButton-root"
+      class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-624mb0-MuiButtonBase-root-MuiButton-root"
       data-testid="sync-button"
-      disabled={null}
       id=":r3:"
-      onBlur={[Function]}
-      onClick={[Function]}
-      onContextMenu={[Function]}
-      onDragLeave={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
-      onMouseDown={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      onTouchEnd={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
-      tabIndex={0}
+      tabindex="0"
       type="button"
     >
       <div
-        className="c3 c4"
+        class="c3 c4"
       >
         <svg
-          aria-hidden={true}
-          className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
           data-testid="PlayArrowIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -2131,46 +1769,26 @@ exports[`SyncControls snapshots non-suspended 1`] = `
     </button>
   </div>
   <div
-    className="c5"
+    class="c5"
   />
   <div
     aria-label="Suspend"
-    aria-labelledby={null}
-    className=""
-    data-mui-internal-clone-element={true}
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseLeave={[Function]}
-    onMouseOver={[Function]}
-    onTouchEnd={[Function]}
-    onTouchStart={[Function]}
+    class=""
+    data-mui-internal-clone-element="true"
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-1fh7grq-MuiButtonBase-root-MuiButton-root"
+      class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-624mb0-MuiButtonBase-root-MuiButton-root"
       data-testid="suspend-button"
-      disabled={null}
       id=":r5:"
-      onBlur={[Function]}
-      onContextMenu={[Function]}
-      onDragLeave={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
-      onMouseDown={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      onTouchEnd={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
-      tabIndex={0}
+      tabindex="0"
       type="button"
     >
       <div
-        className="c3 c4"
+        class="c3 c4"
       >
         <svg
-          aria-hidden={true}
-          className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
           data-testid="PauseIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -2183,46 +1801,26 @@ exports[`SyncControls snapshots non-suspended 1`] = `
     </button>
   </div>
   <div
-    className="c5"
+    class="c5"
   />
   <div
     aria-label="Resume"
-    aria-labelledby={null}
-    className=""
-    data-mui-internal-clone-element={true}
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseLeave={[Function]}
-    onMouseOver={[Function]}
-    onTouchEnd={[Function]}
-    onTouchStart={[Function]}
+    class=""
+    data-mui-internal-clone-element="true"
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-1fh7grq-MuiButtonBase-root-MuiButton-root"
+      class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-624mb0-MuiButtonBase-root-MuiButton-root"
       data-testid="resume-button"
-      disabled={null}
       id=":r7:"
-      onBlur={[Function]}
-      onContextMenu={[Function]}
-      onDragLeave={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
-      onMouseDown={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      onTouchEnd={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
-      tabIndex={0}
+      tabindex="0"
       type="button"
     >
       <div
-        className="c3 c8"
+        class="c3 c8"
       >
         <svg
           height="24"
-          viewBox="0 0 24 24"
+          viewBox="-2 0 24 24"
           width="24"
           xmlns="http://www.w3.org/2000/svg"
         >

--- a/ui/components/__tests__/Flex.test.tsx
+++ b/ui/components/__tests__/Flex.test.tsx
@@ -6,15 +6,15 @@ import Flex from "../Flex";
 describe("Flex", () => {
   describe("snapshots", () => {
     it("wide", () => {
-      const tree = render(<Flex wide>My Text</Flex>).asFragment().firstChild;
+      const tree = render(<Flex wide>My Text</Flex>).asFragment();
       expect(tree).toMatchSnapshot();
     });
     it("center", () => {
-      const tree = render(<Flex center>My Text</Flex>).asFragment().firstChild;
+      const tree = render(<Flex center>My Text</Flex>).asFragment();
       expect(tree).toMatchSnapshot();
     });
     it("align", () => {
-      const tree = render(<Flex align>My Text</Flex>).asFragment().firstChild;
+      const tree = render(<Flex align>My Text</Flex>).asFragment();
       expect(tree).toMatchSnapshot();
     });
     it("wide center align", () => {
@@ -22,7 +22,7 @@ describe("Flex", () => {
         <Flex wide center align>
           My Text
         </Flex>,
-      ).asFragment().firstChild;
+      ).asFragment();
       expect(tree).toMatchSnapshot();
     });
   });

--- a/ui/components/__tests__/Flex.test.tsx
+++ b/ui/components/__tests__/Flex.test.tsx
@@ -1,30 +1,28 @@
 import "jest-styled-components";
+import { render } from "@testing-library/react";
 import React from "react";
-import renderer from "react-test-renderer";
 import Flex from "../Flex";
 
 describe("Flex", () => {
   describe("snapshots", () => {
     it("wide", () => {
-      const tree = renderer.create(<Flex wide>My Text</Flex>).toJSON();
+      const tree = render(<Flex wide>My Text</Flex>).asFragment().firstChild;
       expect(tree).toMatchSnapshot();
     });
     it("center", () => {
-      const tree = renderer.create(<Flex center>My Text</Flex>).toJSON();
+      const tree = render(<Flex center>My Text</Flex>).asFragment().firstChild;
       expect(tree).toMatchSnapshot();
     });
     it("align", () => {
-      const tree = renderer.create(<Flex align>My Text</Flex>).toJSON();
+      const tree = render(<Flex align>My Text</Flex>).asFragment().firstChild;
       expect(tree).toMatchSnapshot();
     });
     it("wide center align", () => {
-      const tree = renderer
-        .create(
-          <Flex wide center align>
-            My Text
-          </Flex>,
-        )
-        .toJSON();
+      const tree = render(
+        <Flex wide center align>
+          My Text
+        </Flex>,
+      ).asFragment().firstChild;
       expect(tree).toMatchSnapshot();
     });
   });

--- a/ui/components/__tests__/KubeStatusIndicator.test.tsx
+++ b/ui/components/__tests__/KubeStatusIndicator.test.tsx
@@ -208,7 +208,7 @@ describe("KubeStatusIndicator", () => {
       ];
       const tree = render(
         withTheme(<KubeStatusIndicator conditions={conditions} />),
-      ).asFragment().firstChild;
+      ).asFragment();
       expect(tree).toMatchSnapshot();
     });
     it("renders error", () => {
@@ -223,7 +223,7 @@ describe("KubeStatusIndicator", () => {
       ];
       const tree = render(
         withTheme(<KubeStatusIndicator conditions={conditions} short />),
-      ).asFragment().firstChild;
+      ).asFragment();
       expect(tree).toMatchSnapshot();
     });
     it("renders with noText prop", () => {
@@ -238,7 +238,7 @@ describe("KubeStatusIndicator", () => {
       ];
       const tree = render(
         withTheme(<KubeStatusIndicator conditions={conditions} noText />),
-      ).asFragment().firstChild;
+      ).asFragment();
       expect(tree).toMatchSnapshot();
     });
   });

--- a/ui/components/__tests__/KubeStatusIndicator.test.tsx
+++ b/ui/components/__tests__/KubeStatusIndicator.test.tsx
@@ -2,7 +2,6 @@ import { screen } from "@testing-library/dom";
 import { render } from "@testing-library/react";
 import "jest-styled-components";
 import React from "react";
-import renderer from "react-test-renderer";
 import { withTheme } from "../../lib/test-utils";
 import KubeStatusIndicator, {
   createSyntheticCondition,
@@ -207,9 +206,9 @@ describe("KubeStatusIndicator", () => {
           timestamp: "2022-03-03 17:00:38 +0000 UTC",
         },
       ];
-      const tree = renderer
-        .create(withTheme(<KubeStatusIndicator conditions={conditions} />))
-        .toJSON();
+      const tree = render(
+        withTheme(<KubeStatusIndicator conditions={conditions} />),
+      ).asFragment().firstChild;
       expect(tree).toMatchSnapshot();
     });
     it("renders error", () => {
@@ -222,11 +221,9 @@ describe("KubeStatusIndicator", () => {
           timestamp: "2022-03-03 17:00:38 +0000 UTC",
         },
       ];
-      const tree = renderer
-        .create(
-          withTheme(<KubeStatusIndicator conditions={conditions} short />),
-        )
-        .toJSON();
+      const tree = render(
+        withTheme(<KubeStatusIndicator conditions={conditions} short />),
+      ).asFragment().firstChild;
       expect(tree).toMatchSnapshot();
     });
     it("renders with noText prop", () => {
@@ -239,11 +236,9 @@ describe("KubeStatusIndicator", () => {
           timestamp: "2022-03-03 17:00:38 +0000 UTC",
         },
       ];
-      const tree = renderer
-        .create(
-          withTheme(<KubeStatusIndicator conditions={conditions} noText />),
-        )
-        .toJSON();
+      const tree = render(
+        withTheme(<KubeStatusIndicator conditions={conditions} noText />),
+      ).asFragment().firstChild;
       expect(tree).toMatchSnapshot();
     });
   });

--- a/ui/components/__tests__/Logo.test.tsx
+++ b/ui/components/__tests__/Logo.test.tsx
@@ -9,13 +9,13 @@ describe("Logo", () => {
     it("renders open view", () => {
       const tree = render(
         withTheme(withContext(<Logo collapsed={false} />, "", {})),
-      ).asFragment().firstChild;
+      ).asFragment();
       expect(tree).toMatchSnapshot();
     });
     it("renders collapsed view", () => {
       const tree = render(
         withTheme(withContext(<Logo collapsed={true} />, "", {})),
-      ).asFragment().firstChild;
+      ).asFragment();
       expect(tree).toMatchSnapshot();
     });
   });

--- a/ui/components/__tests__/Logo.test.tsx
+++ b/ui/components/__tests__/Logo.test.tsx
@@ -1,21 +1,21 @@
 import "jest-styled-components";
+import { render } from "@testing-library/react";
 import React from "react";
-import renderer from "react-test-renderer";
 import { withContext, withTheme } from "../../lib/test-utils";
 import Logo from "../Logo";
 
 describe("Logo", () => {
   describe("snapshots", () => {
     it("renders open view", () => {
-      const tree = renderer
-        .create(withTheme(withContext(<Logo collapsed={false} />, "", {})))
-        .toJSON();
+      const tree = render(
+        withTheme(withContext(<Logo collapsed={false} />, "", {})),
+      ).asFragment().firstChild;
       expect(tree).toMatchSnapshot();
     });
     it("renders collapsed view", () => {
-      const tree = renderer
-        .create(withTheme(withContext(<Logo collapsed={true} />, "", {})))
-        .toJSON();
+      const tree = render(
+        withTheme(withContext(<Logo collapsed={true} />, "", {})),
+      ).asFragment().firstChild;
       expect(tree).toMatchSnapshot();
     });
   });

--- a/ui/components/__tests__/MessageBox.test.tsx
+++ b/ui/components/__tests__/MessageBox.test.tsx
@@ -1,17 +1,15 @@
 import "jest-styled-components";
+import { render } from "@testing-library/react";
 import React from "react";
-import renderer from "react-test-renderer";
 import { withTheme } from "../../lib/test-utils";
 import MessageBox from "../MessageBox";
 
 describe("MessageBox", () => {
   describe("snapshots", () => {
     it("renders", () => {
-      const tree = renderer
-        .create(
-          withTheme(<MessageBox align>Column and items centered.</MessageBox>),
-        )
-        .toJSON();
+      const tree = render(
+        withTheme(<MessageBox align>Column and items centered.</MessageBox>),
+      ).asFragment().firstChild;
       expect(tree).toMatchSnapshot();
     });
   });

--- a/ui/components/__tests__/MessageBox.test.tsx
+++ b/ui/components/__tests__/MessageBox.test.tsx
@@ -9,7 +9,7 @@ describe("MessageBox", () => {
     it("renders", () => {
       const tree = render(
         withTheme(<MessageBox align>Column and items centered.</MessageBox>),
-      ).asFragment().firstChild;
+      ).asFragment();
       expect(tree).toMatchSnapshot();
     });
   });

--- a/ui/components/__tests__/Metadata.test.tsx
+++ b/ui/components/__tests__/Metadata.test.tsx
@@ -1,43 +1,41 @@
 import "jest-styled-components";
+import { render } from "@testing-library/react";
 import React from "react";
-import renderer from "react-test-renderer";
 import { withTheme } from "../../lib/test-utils";
 import Metadata from "../Metadata";
 
 describe("Metadata", () => {
   describe("snapshots", () => {
     it("renders with data", () => {
-      const tree = renderer
-        .create(
-          withTheme(
-            <Metadata
-              metadata={[
-                ["CreatedBy", "Value 4"],
-                ["Version", "some version"],
-                ["created-by", "Value 2"],
-                ["createdBy", "Value 3"],
-                ["description", "Value 1"],
-                ["html", "<p><b>html</b></p>"],
-                ["link-to-google", "https://google.com"],
-                ["multi-lines", "This is first line\nThis is second line\n"],
-              ]}
-              artifactMetadata={[
-                ["description", "Value 1"],
-                ["html", "<p><b>html</b></p>"],
-                ["link-to-google", "https://google.com"],
-              ]}
-              labels={[
-                ["label", "label"],
-                ["goose", "goose"],
-              ]}
-            />,
-          ),
-        )
-        .toJSON();
+      const tree = render(
+        withTheme(
+          <Metadata
+            metadata={[
+              ["CreatedBy", "Value 4"],
+              ["Version", "some version"],
+              ["created-by", "Value 2"],
+              ["createdBy", "Value 3"],
+              ["description", "Value 1"],
+              ["html", "<p><b>html</b></p>"],
+              ["link-to-google", "https://google.com"],
+              ["multi-lines", "This is first line\nThis is second line\n"],
+            ]}
+            artifactMetadata={[
+              ["description", "Value 1"],
+              ["html", "<p><b>html</b></p>"],
+              ["link-to-google", "https://google.com"],
+            ]}
+            labels={[
+              ["label", "label"],
+              ["goose", "goose"],
+            ]}
+          />,
+        ),
+      ).asFragment().firstChild;
       expect(tree).toMatchSnapshot();
     });
     it("renders nothing without data", () => {
-      const tree = renderer.create(withTheme(<Metadata />)).toJSON();
+      const tree = render(withTheme(<Metadata />)).asFragment().firstChild;
       expect(tree).toMatchSnapshot();
     });
   });

--- a/ui/components/__tests__/Metadata.test.tsx
+++ b/ui/components/__tests__/Metadata.test.tsx
@@ -31,11 +31,11 @@ describe("Metadata", () => {
             ]}
           />,
         ),
-      ).asFragment().firstChild;
+      ).asFragment();
       expect(tree).toMatchSnapshot();
     });
     it("renders nothing without data", () => {
-      const tree = render(withTheme(<Metadata />)).asFragment().firstChild;
+      const tree = render(withTheme(<Metadata />)).asFragment();
       expect(tree).toMatchSnapshot();
     });
   });

--- a/ui/components/__tests__/Page.test.tsx
+++ b/ui/components/__tests__/Page.test.tsx
@@ -26,7 +26,7 @@ describe("Page", () => {
           ),
         ),
       );
-      expect(tree.container.firstChild).toMatchSnapshot();
+      expect(tree.container).toMatchSnapshot();
     });
   });
 });

--- a/ui/components/__tests__/Page.test.tsx
+++ b/ui/components/__tests__/Page.test.tsx
@@ -1,7 +1,7 @@
 import "jest-canvas-mock";
 import "jest-styled-components";
+import { render } from "@testing-library/react";
 import React from "react";
-import renderer from "react-test-renderer";
 import { CoreClientContext } from "../../contexts/CoreClientContext";
 import {
   createCoreMockClient,
@@ -13,21 +13,19 @@ import Page from "../Page";
 describe("Page", () => {
   describe("snapshots", () => {
     it("default", () => {
-      const tree = renderer
-        .create(
-          withTheme(
-            withContext(
-              <CoreClientContext.Provider
-                value={{ api: createCoreMockClient({}), featureFlags: {} }}
-              >
-                <Page path={[{ label: "test" }]} />
-              </CoreClientContext.Provider>,
-              "/",
-              {},
-            ),
+      const tree = render(
+        withTheme(
+          withContext(
+            <CoreClientContext.Provider
+              value={{ api: createCoreMockClient({}), featureFlags: {} }}
+            >
+              <Page path={[{ label: "test" }]} />
+            </CoreClientContext.Provider>,
+            "/",
+            {},
           ),
-        )
-        .toJSON();
+        ),
+      ).asFragment().firstChild;
       expect(tree).toMatchSnapshot();
     });
   });

--- a/ui/components/__tests__/Page.test.tsx
+++ b/ui/components/__tests__/Page.test.tsx
@@ -25,8 +25,8 @@ describe("Page", () => {
             {},
           ),
         ),
-      ).asFragment().firstChild;
-      expect(tree).toMatchSnapshot();
+      );
+      expect(tree.container.firstChild).toMatchSnapshot();
     });
   });
 });

--- a/ui/components/__tests__/Text.test.tsx
+++ b/ui/components/__tests__/Text.test.tsx
@@ -1,25 +1,25 @@
 import "jest-styled-components";
+import { render } from "@testing-library/react";
 import React from "react";
-import renderer from "react-test-renderer";
 import { withTheme } from "../../lib/test-utils";
 import Text from "../Text";
 
 describe("Text", () => {
   describe("snapshots", () => {
     it("normal", () => {
-      const tree = renderer.create(withTheme(<Text>some text</Text>)).toJSON();
+      const tree = render(withTheme(<Text>some text</Text>)).asFragment()
+        .firstChild;
       expect(tree).toMatchSnapshot();
     });
     it("bold", () => {
-      const tree = renderer
-        .create(withTheme(<Text bold>some text</Text>))
-        .toJSON();
+      const tree = render(withTheme(<Text bold>some text</Text>)).asFragment()
+        .firstChild;
       expect(tree).toMatchSnapshot();
     });
     it("with color", () => {
-      const tree = renderer
-        .create(withTheme(<Text color="successOriginal">some text</Text>))
-        .toJSON();
+      const tree = render(
+        withTheme(<Text color="successOriginal">some text</Text>),
+      ).asFragment().firstChild;
       expect(tree).toMatchSnapshot();
     });
   });

--- a/ui/components/__tests__/Text.test.tsx
+++ b/ui/components/__tests__/Text.test.tsx
@@ -7,19 +7,17 @@ import Text from "../Text";
 describe("Text", () => {
   describe("snapshots", () => {
     it("normal", () => {
-      const tree = render(withTheme(<Text>some text</Text>)).asFragment()
-        .firstChild;
+      const tree = render(withTheme(<Text>some text</Text>)).asFragment();
       expect(tree).toMatchSnapshot();
     });
     it("bold", () => {
-      const tree = render(withTheme(<Text bold>some text</Text>)).asFragment()
-        .firstChild;
+      const tree = render(withTheme(<Text bold>some text</Text>)).asFragment();
       expect(tree).toMatchSnapshot();
     });
     it("with color", () => {
       const tree = render(
         withTheme(<Text color="successOriginal">some text</Text>),
-      ).asFragment().firstChild;
+      ).asFragment();
       expect(tree).toMatchSnapshot();
     });
   });

--- a/ui/components/__tests__/Version.test.tsx
+++ b/ui/components/__tests__/Version.test.tsx
@@ -15,7 +15,7 @@ describe("Version", () => {
         withTheme(
           <Version productName={productName} appVersion={{ versionText }} />,
         ),
-      ).asFragment().firstChild;
+      ).asFragment();
       expect(tree).toMatchSnapshot();
     });
     it("renders a link with version text and version href", () => {
@@ -26,7 +26,7 @@ describe("Version", () => {
             appVersion={{ versionText, versionHref }}
           />,
         ),
-      ).asFragment().firstChild;
+      ).asFragment();
       expect(tree).toMatchSnapshot();
     });
     it("renders a dash without version text and without version href", () => {
@@ -37,7 +37,7 @@ describe("Version", () => {
             appVersion={{ versionText: "" }}
           />,
         ),
-      ).asFragment().firstChild;
+      ).asFragment();
       expect(tree).toMatchSnapshot();
     });
     it("renders a dash as plain text without version text and with version href", () => {
@@ -48,7 +48,7 @@ describe("Version", () => {
             appVersion={{ versionText: "", versionHref }}
           />,
         ),
-      ).asFragment().firstChild;
+      ).asFragment();
       expect(tree).toMatchSnapshot();
     });
   });

--- a/ui/components/__tests__/Version.test.tsx
+++ b/ui/components/__tests__/Version.test.tsx
@@ -1,6 +1,6 @@
 import "jest-styled-components";
+import { render } from "@testing-library/react";
 import React from "react";
-import renderer from "react-test-renderer";
 import { withTheme } from "../../lib/test-utils";
 import Version from "../Version";
 
@@ -11,52 +11,44 @@ const versionHref = "https://github.com/weaveworks/weave-gitops";
 describe("Version", () => {
   describe("snapshots", () => {
     it("renders plain text with version text and without version href", () => {
-      const tree = renderer
-        .create(
-          withTheme(
-            <Version productName={productName} appVersion={{ versionText }} />,
-          ),
-        )
-        .toJSON();
+      const tree = render(
+        withTheme(
+          <Version productName={productName} appVersion={{ versionText }} />,
+        ),
+      ).asFragment().firstChild;
       expect(tree).toMatchSnapshot();
     });
     it("renders a link with version text and version href", () => {
-      const tree = renderer
-        .create(
-          withTheme(
-            <Version
-              productName={productName}
-              appVersion={{ versionText, versionHref }}
-            />,
-          ),
-        )
-        .toJSON();
+      const tree = render(
+        withTheme(
+          <Version
+            productName={productName}
+            appVersion={{ versionText, versionHref }}
+          />,
+        ),
+      ).asFragment().firstChild;
       expect(tree).toMatchSnapshot();
     });
     it("renders a dash without version text and without version href", () => {
-      const tree = renderer
-        .create(
-          withTheme(
-            <Version
-              productName={productName}
-              appVersion={{ versionText: "" }}
-            />,
-          ),
-        )
-        .toJSON();
+      const tree = render(
+        withTheme(
+          <Version
+            productName={productName}
+            appVersion={{ versionText: "" }}
+          />,
+        ),
+      ).asFragment().firstChild;
       expect(tree).toMatchSnapshot();
     });
     it("renders a dash as plain text without version text and with version href", () => {
-      const tree = renderer
-        .create(
-          withTheme(
-            <Version
-              productName={productName}
-              appVersion={{ versionText: "", versionHref }}
-            />,
-          ),
-        )
-        .toJSON();
+      const tree = render(
+        withTheme(
+          <Version
+            productName={productName}
+            appVersion={{ versionText: "", versionHref }}
+          />,
+        ),
+      ).asFragment().firstChild;
       expect(tree).toMatchSnapshot();
     });
   });

--- a/ui/components/__tests__/YamlView.test.tsx
+++ b/ui/components/__tests__/YamlView.test.tsx
@@ -1,6 +1,6 @@
 import "jest-styled-components";
+import { render } from "@testing-library/react";
 import React from "react";
-import renderer from "react-test-renderer";
 import { Kind } from "../../lib/api/core/types.pb";
 import { withContext, withTheme } from "../../lib/test-utils";
 import { createYamlCommand } from "../../lib/utils";
@@ -9,24 +9,22 @@ import YamlView from "../YamlView";
 describe("YamlView", () => {
   describe("snapshots", () => {
     it("renders", () => {
-      const tree = renderer
-        .create(
-          withTheme(
-            withContext(
-              <YamlView
-                header={createYamlCommand(
-                  Kind.Kustomization,
-                  "podinfo",
-                  "flux-system",
-                )}
-                yaml="yaml\nyaml\nyaml\n"
-              />,
-              "",
-              {},
-            ),
+      const tree = render(
+        withTheme(
+          withContext(
+            <YamlView
+              header={createYamlCommand(
+                Kind.Kustomization,
+                "podinfo",
+                "flux-system",
+              )}
+              yaml="yaml\nyaml\nyaml\n"
+            />,
+            "",
+            {},
           ),
-        )
-        .toJSON();
+        ),
+      ).asFragment().firstChild;
       expect(tree).toMatchSnapshot();
     });
   });

--- a/ui/components/__tests__/YamlView.test.tsx
+++ b/ui/components/__tests__/YamlView.test.tsx
@@ -24,7 +24,7 @@ describe("YamlView", () => {
             {},
           ),
         ),
-      ).asFragment().firstChild;
+      ).asFragment();
       expect(tree).toMatchSnapshot();
     });
   });

--- a/ui/components/__tests__/__snapshots__/Flex.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/Flex.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`Flex snapshots align 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   My Text
 </div>
@@ -23,7 +23,7 @@ exports[`Flex snapshots center 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   My Text
 </div>
@@ -38,7 +38,7 @@ exports[`Flex snapshots wide 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   My Text
 </div>
@@ -54,7 +54,7 @@ exports[`Flex snapshots wide center align 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   My Text
 </div>

--- a/ui/components/__tests__/__snapshots__/Flex.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/Flex.test.tsx.snap
@@ -1,21 +1,24 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Flex snapshots align 1`] = `
-.c0 {
+<DocumentFragment>
+  .c0 {
   display: flex;
   flex-direction: row;
   align-items: center;
 }
 
 <div
-  class="c0"
->
-  My Text
-</div>
+    class="c0"
+  >
+    My Text
+  </div>
+</DocumentFragment>
 `;
 
 exports[`Flex snapshots center 1`] = `
-.c0 {
+<DocumentFragment>
+  .c0 {
   display: flex;
   flex-direction: row;
   align-items: start;
@@ -23,14 +26,16 @@ exports[`Flex snapshots center 1`] = `
 }
 
 <div
-  class="c0"
->
-  My Text
-</div>
+    class="c0"
+  >
+    My Text
+  </div>
+</DocumentFragment>
 `;
 
 exports[`Flex snapshots wide 1`] = `
-.c0 {
+<DocumentFragment>
+  .c0 {
   display: flex;
   flex-direction: row;
   align-items: start;
@@ -38,14 +43,16 @@ exports[`Flex snapshots wide 1`] = `
 }
 
 <div
-  class="c0"
->
-  My Text
-</div>
+    class="c0"
+  >
+    My Text
+  </div>
+</DocumentFragment>
 `;
 
 exports[`Flex snapshots wide center align 1`] = `
-.c0 {
+<DocumentFragment>
+  .c0 {
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -54,8 +61,9 @@ exports[`Flex snapshots wide center align 1`] = `
 }
 
 <div
-  class="c0"
->
-  My Text
-</div>
+    class="c0"
+  >
+    My Text
+  </div>
+</DocumentFragment>
 `;

--- a/ui/components/__tests__/__snapshots__/KubeStatusIndicator.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/KubeStatusIndicator.test.tsx.snap
@@ -1,7 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`KubeStatusIndicator snapshots renders error 1`] = `
-.c0 {
+<DocumentFragment>
+  .c0 {
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -77,33 +78,35 @@ exports[`KubeStatusIndicator snapshots renders error 1`] = `
 }
 
 <div
-  class="c0 c1 KubeStatusIndicator"
->
-  <div
-    class="c2 c3 c4"
+    class="c0 c1 KubeStatusIndicator"
   >
-    <svg
-      aria-hidden="true"
-      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
-      data-testid="ErrorIcon"
-      focusable="false"
-      viewBox="0 0 24 24"
+    <div
+      class="c2 c3 c4"
     >
-      <path
-        d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m1 15h-2v-2h2zm0-4h-2V7h2z"
-      />
-    </svg>
-    <span
-      class="c5 c6"
-    >
-      Not Ready
-    </span>
+      <svg
+        aria-hidden="true"
+        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+        data-testid="ErrorIcon"
+        focusable="false"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m1 15h-2v-2h2zm0-4h-2V7h2z"
+        />
+      </svg>
+      <span
+        class="c5 c6"
+      >
+        Not Ready
+      </span>
+    </div>
   </div>
-</div>
+</DocumentFragment>
 `;
 
 exports[`KubeStatusIndicator snapshots renders success 1`] = `
-.c0 {
+<DocumentFragment>
+  .c0 {
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -179,33 +182,35 @@ exports[`KubeStatusIndicator snapshots renders success 1`] = `
 }
 
 <div
-  class="c0 c1 KubeStatusIndicator"
->
-  <div
-    class="c2 c3 c4"
+    class="c0 c1 KubeStatusIndicator"
   >
-    <svg
-      aria-hidden="true"
-      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
-      data-testid="CheckCircleIcon"
-      focusable="false"
-      viewBox="0 0 24 24"
+    <div
+      class="c2 c3 c4"
     >
-      <path
-        d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m-2 15-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8z"
-      />
-    </svg>
-    <span
-      class="c5 c6"
-    >
-      Applied revision: main/a3a54ef4a87f8963b14915639f032aa6ec1b8161
-    </span>
+      <svg
+        aria-hidden="true"
+        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+        data-testid="CheckCircleIcon"
+        focusable="false"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m-2 15-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8z"
+        />
+      </svg>
+      <span
+        class="c5 c6"
+      >
+        Applied revision: main/a3a54ef4a87f8963b14915639f032aa6ec1b8161
+      </span>
+    </div>
   </div>
-</div>
+</DocumentFragment>
 `;
 
 exports[`KubeStatusIndicator snapshots renders with noText prop 1`] = `
-.c0 {
+<DocumentFragment>
+  .c0 {
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -262,22 +267,23 @@ exports[`KubeStatusIndicator snapshots renders with noText prop 1`] = `
 }
 
 <div
-  class="c0 KubeStatusIndicator"
->
-  <div
-    class="c1 c2"
+    class="c0 KubeStatusIndicator"
   >
-    <svg
-      aria-hidden="true"
-      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
-      data-testid="ErrorIcon"
-      focusable="false"
-      viewBox="0 0 24 24"
+    <div
+      class="c1 c2"
     >
-      <path
-        d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m1 15h-2v-2h2zm0-4h-2V7h2z"
-      />
-    </svg>
+      <svg
+        aria-hidden="true"
+        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+        data-testid="ErrorIcon"
+        focusable="false"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m1 15h-2v-2h2zm0-4h-2V7h2z"
+        />
+      </svg>
+    </div>
   </div>
-</div>
+</DocumentFragment>
 `;

--- a/ui/components/__tests__/__snapshots__/KubeStatusIndicator.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/KubeStatusIndicator.test.tsx.snap
@@ -77,14 +77,14 @@ exports[`KubeStatusIndicator snapshots renders error 1`] = `
 }
 
 <div
-  className="c0 c1 KubeStatusIndicator"
+  class="c0 c1 KubeStatusIndicator"
 >
   <div
-    className="c2 c3 c4"
+    class="c2 c3 c4"
   >
     <svg
-      aria-hidden={true}
-      className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+      aria-hidden="true"
+      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
       data-testid="ErrorIcon"
       focusable="false"
       viewBox="0 0 24 24"
@@ -94,7 +94,7 @@ exports[`KubeStatusIndicator snapshots renders error 1`] = `
       />
     </svg>
     <span
-      className="c5 c6"
+      class="c5 c6"
     >
       Not Ready
     </span>
@@ -179,14 +179,14 @@ exports[`KubeStatusIndicator snapshots renders success 1`] = `
 }
 
 <div
-  className="c0 c1 KubeStatusIndicator"
+  class="c0 c1 KubeStatusIndicator"
 >
   <div
-    className="c2 c3 c4"
+    class="c2 c3 c4"
   >
     <svg
-      aria-hidden={true}
-      className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+      aria-hidden="true"
+      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
       data-testid="CheckCircleIcon"
       focusable="false"
       viewBox="0 0 24 24"
@@ -196,7 +196,7 @@ exports[`KubeStatusIndicator snapshots renders success 1`] = `
       />
     </svg>
     <span
-      className="c5 c6"
+      class="c5 c6"
     >
       Applied revision: main/a3a54ef4a87f8963b14915639f032aa6ec1b8161
     </span>
@@ -262,14 +262,14 @@ exports[`KubeStatusIndicator snapshots renders with noText prop 1`] = `
 }
 
 <div
-  className="c0 KubeStatusIndicator"
+  class="c0 KubeStatusIndicator"
 >
   <div
-    className="c1 c2"
+    class="c1 c2"
   >
     <svg
-      aria-hidden={true}
-      className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+      aria-hidden="true"
+      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
       data-testid="ErrorIcon"
       focusable="false"
       viewBox="0 0 24 24"

--- a/ui/components/__tests__/__snapshots__/Logo.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/Logo.test.tsx.snap
@@ -41,28 +41,22 @@ exports[`Logo snapshots renders collapsed view 1`] = `
 }
 
 <div
-  className="c0 c1"
+  class="c0 c1"
 >
   <a
     data-discover="true"
     href="/applications"
-    onClick={[Function]}
   >
-    <img
-      src=""
-    />
+    <img />
   </a>
   <div
-    className="c2 c3"
+    class="c2 c3"
   >
     <a
       data-discover="true"
       href="/applications"
-      onClick={[Function]}
     >
-      <img
-        src=""
-      />
+      <img />
     </a>
   </div>
 </div>
@@ -108,28 +102,22 @@ exports[`Logo snapshots renders open view 1`] = `
 }
 
 <div
-  className="c0 c1"
+  class="c0 c1"
 >
   <a
     data-discover="true"
     href="/applications"
-    onClick={[Function]}
   >
-    <img
-      src=""
-    />
+    <img />
   </a>
   <div
-    className="c2 c3"
+    class="c2 c3"
   >
     <a
       data-discover="true"
       href="/applications"
-      onClick={[Function]}
     >
-      <img
-        src=""
-      />
+      <img />
     </a>
   </div>
 </div>

--- a/ui/components/__tests__/__snapshots__/Logo.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/Logo.test.tsx.snap
@@ -1,7 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Logo snapshots renders collapsed view 1`] = `
-.c0 {
+<DocumentFragment>
+  .c0 {
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -41,18 +42,7 @@ exports[`Logo snapshots renders collapsed view 1`] = `
 }
 
 <div
-  class="c0 c1"
->
-  <a
-    data-discover="true"
-    href="/applications"
-  >
-    <img
-      src="[object Object]"
-    />
-  </a>
-  <div
-    class="c2 c3"
+    class="c0 c1"
   >
     <a
       data-discover="true"
@@ -62,12 +52,25 @@ exports[`Logo snapshots renders collapsed view 1`] = `
         src="[object Object]"
       />
     </a>
+    <div
+      class="c2 c3"
+    >
+      <a
+        data-discover="true"
+        href="/applications"
+      >
+        <img
+          src="[object Object]"
+        />
+      </a>
+    </div>
   </div>
-</div>
+</DocumentFragment>
 `;
 
 exports[`Logo snapshots renders open view 1`] = `
-.c0 {
+<DocumentFragment>
+  .c0 {
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -106,18 +109,7 @@ exports[`Logo snapshots renders open view 1`] = `
 }
 
 <div
-  class="c0 c1"
->
-  <a
-    data-discover="true"
-    href="/applications"
-  >
-    <img
-      src="[object Object]"
-    />
-  </a>
-  <div
-    class="c2 c3"
+    class="c0 c1"
   >
     <a
       data-discover="true"
@@ -127,6 +119,18 @@ exports[`Logo snapshots renders open view 1`] = `
         src="[object Object]"
       />
     </a>
+    <div
+      class="c2 c3"
+    >
+      <a
+        data-discover="true"
+        href="/applications"
+      >
+        <img
+          src="[object Object]"
+        />
+      </a>
+    </div>
   </div>
-</div>
+</DocumentFragment>
 `;

--- a/ui/components/__tests__/__snapshots__/Logo.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/Logo.test.tsx.snap
@@ -47,7 +47,9 @@ exports[`Logo snapshots renders collapsed view 1`] = `
     data-discover="true"
     href="/applications"
   >
-    <img />
+    <img
+      src="[object Object]"
+    />
   </a>
   <div
     class="c2 c3"
@@ -56,7 +58,9 @@ exports[`Logo snapshots renders collapsed view 1`] = `
       data-discover="true"
       href="/applications"
     >
-      <img />
+      <img
+        src="[object Object]"
+      />
     </a>
   </div>
 </div>
@@ -108,7 +112,9 @@ exports[`Logo snapshots renders open view 1`] = `
     data-discover="true"
     href="/applications"
   >
-    <img />
+    <img
+      src="[object Object]"
+    />
   </a>
   <div
     class="c2 c3"
@@ -117,7 +123,9 @@ exports[`Logo snapshots renders open view 1`] = `
       data-discover="true"
       href="/applications"
     >
-      <img />
+      <img
+        src="[object Object]"
+      />
     </a>
   </div>
 </div>

--- a/ui/components/__tests__/__snapshots__/MessageBox.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/MessageBox.test.tsx.snap
@@ -1,7 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`MessageBox snapshots renders 1`] = `
-.c0 {
+<DocumentFragment>
+  .c0 {
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -18,8 +19,9 @@ exports[`MessageBox snapshots renders 1`] = `
 }
 
 <div
-  class="c0 c1"
->
-  Column and items centered.
-</div>
+    class="c0 c1"
+  >
+    Column and items centered.
+  </div>
+</DocumentFragment>
 `;

--- a/ui/components/__tests__/__snapshots__/MessageBox.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/MessageBox.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`MessageBox snapshots renders 1`] = `
 }
 
 <div
-  className="c0 c1"
+  class="c0 c1"
 >
   Column and items centered.
 </div>

--- a/ui/components/__tests__/__snapshots__/Metadata.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/Metadata.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`Metadata snapshots renders nothing without data 1`] = `
 }
 
 <div
-  className="c0 c1 Metadata"
+  class="c0 c1 Metadata"
 />
 `;
 
@@ -121,120 +121,114 @@ exports[`Metadata snapshots renders with data 1`] = `
 }
 
 <div
-  className="c0 c1 Metadata"
+  class="c0 c1 Metadata"
 >
   <div
-    className="c2"
+    class="c2"
   >
     <span
-      className="c3"
+      class="c3"
     >
       Metadata
     </span>
     <div
-      className="c4"
+      class="c4"
     >
       <div
-        className="c5"
+        class="c5"
         data-testid="Created By"
       >
         <span
-          className="c6"
+          class="c6"
         >
-          Created By
-          :
+          Created By:
         </span>
         <span
-          className="c7"
+          class="c7"
         >
           Value 2
         </span>
       </div>
       <div
-        className="c5"
+        class="c5"
         data-testid="CreatedBy"
       >
         <span
-          className="c6"
+          class="c6"
         >
-          CreatedBy
-          :
+          CreatedBy:
         </span>
         <span
-          className="c7"
+          class="c7"
         >
           Value 3
         </span>
       </div>
       <div
-        className="c5"
+        class="c5"
         data-testid="CreatedBy"
       >
         <span
-          className="c6"
+          class="c6"
         >
-          CreatedBy
-          :
+          CreatedBy:
         </span>
         <span
-          className="c7"
+          class="c7"
         >
           Value 4
         </span>
       </div>
       <div
-        className="c5"
+        class="c5"
         data-testid="Description"
       >
         <span
-          className="c6"
+          class="c6"
         >
-          Description
-          :
+          Description:
         </span>
         <span
-          className="c7"
+          class="c7"
         >
           Value 1
         </span>
       </div>
       <div
-        className="c5"
+        class="c5"
         data-testid="Html"
       >
         <span
-          className="c6"
+          class="c6"
         >
-          Html
-          :
+          Html:
         </span>
         <span
-          className="c7"
+          class="c7"
         >
           &lt;p&gt;&lt;b&gt;html&lt;/b&gt;&lt;/p&gt;
         </span>
       </div>
       <div
-        className="c5"
+        class="c5"
         data-testid="Link To Google"
       >
         <span
-          className="c6"
+          class="c6"
         >
-          Link To Google
-          :
+          Link To Google:
         </span>
         <span
-          className="c7"
+          class="c7"
         >
           <a
-            className="c8 Link"
+            class="c8 Link"
             href="https://google.com"
             rel="noreferrer"
             target="_blank"
           >
             <span
-              className="c9"
+              class="c9"
             >
               https://google.com
             </span>
@@ -242,17 +236,16 @@ exports[`Metadata snapshots renders with data 1`] = `
         </span>
       </div>
       <div
-        className="c5"
+        class="c5"
         data-testid="Multi Lines"
       >
         <span
-          className="c6"
+          class="c6"
         >
-          Multi Lines
-          :
+          Multi Lines:
         </span>
         <span
-          className="c7"
+          class="c7"
         >
           This is first line
 This is second line
@@ -260,17 +253,16 @@ This is second line
         </span>
       </div>
       <div
-        className="c5"
+        class="c5"
         data-testid="Version"
       >
         <span
-          className="c6"
+          class="c6"
         >
-          Version
-          :
+          Version:
         </span>
         <span
-          className="c7"
+          class="c7"
         >
           some version
         </span>
@@ -278,69 +270,66 @@ This is second line
     </div>
   </div>
   <div
-    className="c2"
+    class="c2"
   >
     <span
-      className="c3"
+      class="c3"
     >
       Artifact Metadata
     </span>
     <div
-      className="c4"
+      class="c4"
     >
       <div
-        className="c5"
+        class="c5"
         data-testid="Description"
       >
         <span
-          className="c6"
+          class="c6"
         >
-          Description
-          :
+          Description:
         </span>
         <span
-          className="c7"
+          class="c7"
         >
           Value 1
         </span>
       </div>
       <div
-        className="c5"
+        class="c5"
         data-testid="Html"
       >
         <span
-          className="c6"
+          class="c6"
         >
-          Html
-          :
+          Html:
         </span>
         <span
-          className="c7"
+          class="c7"
         >
           &lt;p&gt;&lt;b&gt;html&lt;/b&gt;&lt;/p&gt;
         </span>
       </div>
       <div
-        className="c5"
+        class="c5"
         data-testid="Link To Google"
       >
         <span
-          className="c6"
+          class="c6"
         >
-          Link To Google
-          :
+          Link To Google:
         </span>
         <span
-          className="c7"
+          class="c7"
         >
           <a
-            className="c8 Link"
+            class="c8 Link"
             href="https://google.com"
             rel="noreferrer"
             target="_blank"
           >
             <span
-              className="c9"
+              class="c9"
             >
               https://google.com
             </span>
@@ -350,29 +339,25 @@ This is second line
     </div>
   </div>
   <div
-    className="c2"
+    class="c2"
   >
     <span
-      className="c3"
+      class="c3"
     >
       Labels
     </span>
     <div
-      className="c10"
+      class="c10"
     >
       <span
-        className="c11 c12"
+        class="c11 c12"
       >
-        label
-        : 
-        label
+        label: label
       </span>
       <span
-        className="c11 c12"
+        class="c11 c12"
       >
-        goose
-        : 
-        goose
+        goose: goose
       </span>
     </div>
   </div>

--- a/ui/components/__tests__/__snapshots__/Metadata.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/Metadata.test.tsx.snap
@@ -1,7 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Metadata snapshots renders nothing without data 1`] = `
-.c0 {
+<DocumentFragment>
+  .c0 {
   display: flex;
   flex-direction: column;
   align-items: start;
@@ -14,12 +15,14 @@ exports[`Metadata snapshots renders nothing without data 1`] = `
 }
 
 <div
-  class="c0 c1 Metadata"
-/>
+    class="c0 c1 Metadata"
+  />
+</DocumentFragment>
 `;
 
 exports[`Metadata snapshots renders with data 1`] = `
-.c0 {
+<DocumentFragment>
+  .c0 {
   display: flex;
   flex-direction: column;
   align-items: start;
@@ -121,245 +124,246 @@ exports[`Metadata snapshots renders with data 1`] = `
 }
 
 <div
-  class="c0 c1 Metadata"
->
-  <div
-    class="c2"
+    class="c0 c1 Metadata"
   >
-    <span
-      class="c3"
-    >
-      Metadata
-    </span>
     <div
-      class="c4"
+      class="c2"
     >
-      <div
-        class="c5"
-        data-testid="Created By"
+      <span
+        class="c3"
       >
-        <span
-          class="c6"
-        >
-          Created By:
-        </span>
-        <span
-          class="c7"
-        >
-          Value 2
-        </span>
-      </div>
+        Metadata
+      </span>
       <div
-        class="c5"
-        data-testid="CreatedBy"
+        class="c4"
       >
-        <span
-          class="c6"
+        <div
+          class="c5"
+          data-testid="Created By"
         >
-          CreatedBy:
-        </span>
-        <span
-          class="c7"
-        >
-          Value 3
-        </span>
-      </div>
-      <div
-        class="c5"
-        data-testid="CreatedBy"
-      >
-        <span
-          class="c6"
-        >
-          CreatedBy:
-        </span>
-        <span
-          class="c7"
-        >
-          Value 4
-        </span>
-      </div>
-      <div
-        class="c5"
-        data-testid="Description"
-      >
-        <span
-          class="c6"
-        >
-          Description:
-        </span>
-        <span
-          class="c7"
-        >
-          Value 1
-        </span>
-      </div>
-      <div
-        class="c5"
-        data-testid="Html"
-      >
-        <span
-          class="c6"
-        >
-          Html:
-        </span>
-        <span
-          class="c7"
-        >
-          &lt;p&gt;&lt;b&gt;html&lt;/b&gt;&lt;/p&gt;
-        </span>
-      </div>
-      <div
-        class="c5"
-        data-testid="Link To Google"
-      >
-        <span
-          class="c6"
-        >
-          Link To Google:
-        </span>
-        <span
-          class="c7"
-        >
-          <a
-            class="c8 Link"
-            href="https://google.com"
-            rel="noreferrer"
-            target="_blank"
+          <span
+            class="c6"
           >
-            <span
-              class="c9"
+            Created By:
+          </span>
+          <span
+            class="c7"
+          >
+            Value 2
+          </span>
+        </div>
+        <div
+          class="c5"
+          data-testid="CreatedBy"
+        >
+          <span
+            class="c6"
+          >
+            CreatedBy:
+          </span>
+          <span
+            class="c7"
+          >
+            Value 3
+          </span>
+        </div>
+        <div
+          class="c5"
+          data-testid="CreatedBy"
+        >
+          <span
+            class="c6"
+          >
+            CreatedBy:
+          </span>
+          <span
+            class="c7"
+          >
+            Value 4
+          </span>
+        </div>
+        <div
+          class="c5"
+          data-testid="Description"
+        >
+          <span
+            class="c6"
+          >
+            Description:
+          </span>
+          <span
+            class="c7"
+          >
+            Value 1
+          </span>
+        </div>
+        <div
+          class="c5"
+          data-testid="Html"
+        >
+          <span
+            class="c6"
+          >
+            Html:
+          </span>
+          <span
+            class="c7"
+          >
+            &lt;p&gt;&lt;b&gt;html&lt;/b&gt;&lt;/p&gt;
+          </span>
+        </div>
+        <div
+          class="c5"
+          data-testid="Link To Google"
+        >
+          <span
+            class="c6"
+          >
+            Link To Google:
+          </span>
+          <span
+            class="c7"
+          >
+            <a
+              class="c8 Link"
+              href="https://google.com"
+              rel="noreferrer"
+              target="_blank"
             >
-              https://google.com
-            </span>
-          </a>
-        </span>
-      </div>
-      <div
-        class="c5"
-        data-testid="Multi Lines"
-      >
-        <span
-          class="c6"
+              <span
+                class="c9"
+              >
+                https://google.com
+              </span>
+            </a>
+          </span>
+        </div>
+        <div
+          class="c5"
+          data-testid="Multi Lines"
         >
-          Multi Lines:
-        </span>
-        <span
-          class="c7"
-        >
-          This is first line
+          <span
+            class="c6"
+          >
+            Multi Lines:
+          </span>
+          <span
+            class="c7"
+          >
+            This is first line
 This is second line
 
-        </span>
-      </div>
-      <div
-        class="c5"
-        data-testid="Version"
-      >
-        <span
-          class="c6"
+          </span>
+        </div>
+        <div
+          class="c5"
+          data-testid="Version"
         >
-          Version:
-        </span>
-        <span
-          class="c7"
-        >
-          some version
-        </span>
-      </div>
-    </div>
-  </div>
-  <div
-    class="c2"
-  >
-    <span
-      class="c3"
-    >
-      Artifact Metadata
-    </span>
-    <div
-      class="c4"
-    >
-      <div
-        class="c5"
-        data-testid="Description"
-      >
-        <span
-          class="c6"
-        >
-          Description:
-        </span>
-        <span
-          class="c7"
-        >
-          Value 1
-        </span>
-      </div>
-      <div
-        class="c5"
-        data-testid="Html"
-      >
-        <span
-          class="c6"
-        >
-          Html:
-        </span>
-        <span
-          class="c7"
-        >
-          &lt;p&gt;&lt;b&gt;html&lt;/b&gt;&lt;/p&gt;
-        </span>
-      </div>
-      <div
-        class="c5"
-        data-testid="Link To Google"
-      >
-        <span
-          class="c6"
-        >
-          Link To Google:
-        </span>
-        <span
-          class="c7"
-        >
-          <a
-            class="c8 Link"
-            href="https://google.com"
-            rel="noreferrer"
-            target="_blank"
+          <span
+            class="c6"
           >
-            <span
-              class="c9"
+            Version:
+          </span>
+          <span
+            class="c7"
+          >
+            some version
+          </span>
+        </div>
+      </div>
+    </div>
+    <div
+      class="c2"
+    >
+      <span
+        class="c3"
+      >
+        Artifact Metadata
+      </span>
+      <div
+        class="c4"
+      >
+        <div
+          class="c5"
+          data-testid="Description"
+        >
+          <span
+            class="c6"
+          >
+            Description:
+          </span>
+          <span
+            class="c7"
+          >
+            Value 1
+          </span>
+        </div>
+        <div
+          class="c5"
+          data-testid="Html"
+        >
+          <span
+            class="c6"
+          >
+            Html:
+          </span>
+          <span
+            class="c7"
+          >
+            &lt;p&gt;&lt;b&gt;html&lt;/b&gt;&lt;/p&gt;
+          </span>
+        </div>
+        <div
+          class="c5"
+          data-testid="Link To Google"
+        >
+          <span
+            class="c6"
+          >
+            Link To Google:
+          </span>
+          <span
+            class="c7"
+          >
+            <a
+              class="c8 Link"
+              href="https://google.com"
+              rel="noreferrer"
+              target="_blank"
             >
-              https://google.com
-            </span>
-          </a>
+              <span
+                class="c9"
+              >
+                https://google.com
+              </span>
+            </a>
+          </span>
+        </div>
+      </div>
+    </div>
+    <div
+      class="c2"
+    >
+      <span
+        class="c3"
+      >
+        Labels
+      </span>
+      <div
+        class="c10"
+      >
+        <span
+          class="c11 c12"
+        >
+          label: label
+        </span>
+        <span
+          class="c11 c12"
+        >
+          goose: goose
         </span>
       </div>
     </div>
   </div>
-  <div
-    class="c2"
-  >
-    <span
-      class="c3"
-    >
-      Labels
-    </span>
-    <div
-      class="c10"
-    >
-      <span
-        class="c11 c12"
-      >
-        label: label
-      </span>
-      <span
-        class="c11 c12"
-      >
-        goose: goose
-      </span>
-    </div>
-  </div>
-</div>
+</DocumentFragment>
 `;

--- a/ui/components/__tests__/__snapshots__/Page.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/Page.test.tsx.snap
@@ -180,117 +180,119 @@ exports[`Page snapshots default 1`] = `
   width: 100%;
 }
 
-<div
-  class="c0 c1"
->
+<div>
   <div
-    class="c2 c3"
+    class="c0 c1"
   >
     <div
-      class="c4"
+      class="c2 c3"
     >
       <div
         class="c4"
       >
-        <span
-          aria-label="test"
-          class="c5 c6 c7 ellipsis"
-          data-mui-internal-clone-element="true"
-          data-testid="text-test"
+        <div
+          class="c4"
         >
-          test
+          <span
+            aria-label="test"
+            class="c5 c6 c7 ellipsis"
+            data-mui-internal-clone-element="true"
+            data-testid="text-test"
+          >
+            test
+          </span>
+        </div>
+      </div>
+      <div
+        class="c8 "
+      >
+        <span
+          class="MuiSwitch-root MuiSwitch-sizeMedium c9 DarkModeSwitch css-rehya9-MuiSwitch-root"
+        >
+          <span
+            class="MuiButtonBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary PrivateSwitchBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary css-n2qy4p-MuiButtonBase-root-MuiSwitch-switchBase"
+          >
+            <input
+              class="PrivateSwitchBase-input MuiSwitch-input css-j8yymo"
+              type="checkbox"
+            />
+            <span
+              class="MuiSwitch-thumb css-17jyosd-MuiSwitch-thumb"
+            />
+          </span>
+          <span
+            class="MuiSwitch-track css-tj8d99-MuiSwitch-track"
+          />
         </span>
+        <a
+          aria-label="Docs"
+          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium c10 c11 Link css-53g0n7-MuiButtonBase-root-MuiIconButton-root"
+          data-mui-internal-clone-element="true"
+          href="https://docs.gitops.weaveworks.org/"
+          id=":r2:"
+          rel="noreferrer"
+          tabindex="0"
+          target="_blank"
+        >
+          <span
+            class="MuiIconButton-loadingIndicator css-165vu30-MuiIconButton-loadingIndicator"
+          />
+          <div
+            class="c4 c12"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+              data-testid="FindInPageIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M20 19.59V8l-6-6H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c.45 0 .85-.15 1.19-.4l-4.43-4.43c-.8.52-1.74.83-2.76.83-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5c0 1.02-.31 1.96-.83 2.75zM9 13c0 1.66 1.34 3 3 3s3-1.34 3-3-1.34-3-3-3-3 1.34-3 3"
+              />
+            </svg>
+          </div>
+        </a>
+        <button
+          aria-haspopup="true"
+          aria-label="Account settings"
+          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium c10 css-53g0n7-MuiButtonBase-root-MuiIconButton-root"
+          data-mui-internal-clone-element="true"
+          id=":r4:"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="MuiIconButton-loadingIndicator css-165vu30-MuiIconButton-loadingIndicator"
+          />
+          <div
+            class="c4 c12"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+              data-testid="PersonIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4m0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4"
+              />
+            </svg>
+          </div>
+        </button>
       </div>
     </div>
     <div
-      class="c8 "
-    >
-      <span
-        class="MuiSwitch-root MuiSwitch-sizeMedium c9 DarkModeSwitch css-rehya9-MuiSwitch-root"
-      >
-        <span
-          class="MuiButtonBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary PrivateSwitchBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary css-n2qy4p-MuiButtonBase-root-MuiSwitch-switchBase"
-        >
-          <input
-            class="PrivateSwitchBase-input MuiSwitch-input css-j8yymo"
-            type="checkbox"
-          />
-          <span
-            class="MuiSwitch-thumb css-17jyosd-MuiSwitch-thumb"
-          />
-        </span>
-        <span
-          class="MuiSwitch-track css-tj8d99-MuiSwitch-track"
-        />
-      </span>
-      <a
-        aria-label="Docs"
-        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium c10 c11 Link css-53g0n7-MuiButtonBase-root-MuiIconButton-root"
-        data-mui-internal-clone-element="true"
-        href="https://docs.gitops.weaveworks.org/"
-        id=":r2:"
-        rel="noreferrer"
-        tabindex="0"
-        target="_blank"
-      >
-        <span
-          class="MuiIconButton-loadingIndicator css-165vu30-MuiIconButton-loadingIndicator"
-        />
-        <div
-          class="c4 c12"
-        >
-          <svg
-            aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
-            data-testid="FindInPageIcon"
-            focusable="false"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="M20 19.59V8l-6-6H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c.45 0 .85-.15 1.19-.4l-4.43-4.43c-.8.52-1.74.83-2.76.83-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5c0 1.02-.31 1.96-.83 2.75zM9 13c0 1.66 1.34 3 3 3s3-1.34 3-3-1.34-3-3-3-3 1.34-3 3"
-            />
-          </svg>
-        </div>
-      </a>
-      <button
-        aria-haspopup="true"
-        aria-label="Account settings"
-        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium c10 css-53g0n7-MuiButtonBase-root-MuiIconButton-root"
-        data-mui-internal-clone-element="true"
-        id=":r4:"
-        tabindex="0"
-        type="button"
-      >
-        <span
-          class="MuiIconButton-loadingIndicator css-165vu30-MuiIconButton-loadingIndicator"
-        />
-        <div
-          class="c4 c12"
-        >
-          <svg
-            aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
-            data-testid="PersonIcon"
-            focusable="false"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4m0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4"
-            />
-          </svg>
-        </div>
-      </button>
-    </div>
-  </div>
-  <div
-    class="c13"
-  >
-    <div
-      class="c14 c15 c16"
+      class="c13"
     >
       <div
-        class="c17 c18"
-      />
+        class="c14 c15 c16"
+      >
+        <div
+          class="c17 c18"
+        />
+      </div>
     </div>
   </div>
 </div>

--- a/ui/components/__tests__/__snapshots__/Page.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/Page.test.tsx.snap
@@ -181,104 +181,67 @@ exports[`Page snapshots default 1`] = `
 }
 
 <div
-  className="c0 c1"
+  class="c0 c1"
 >
   <div
-    className="c2 c3"
+    class="c2 c3"
   >
     <div
-      className="c4"
+      class="c4"
     >
       <div
-        className="c4"
+        class="c4"
       >
         <span
           aria-label="test"
-          aria-labelledby={null}
-          className="c5 c6 c7 ellipsis"
-          data-mui-internal-clone-element={true}
+          class="c5 c6 c7 ellipsis"
+          data-mui-internal-clone-element="true"
           data-testid="text-test"
-          onBlur={[Function]}
-          onFocus={[Function]}
-          onMouseLeave={[Function]}
-          onMouseOver={[Function]}
-          onTouchEnd={[Function]}
-          onTouchStart={[Function]}
         >
           test
         </span>
       </div>
     </div>
     <div
-      className="c8 "
+      class="c8 "
     >
       <span
-        className="MuiSwitch-root MuiSwitch-sizeMedium c9 DarkModeSwitch css-rehya9-MuiSwitch-root"
+        class="MuiSwitch-root MuiSwitch-sizeMedium c9 DarkModeSwitch css-rehya9-MuiSwitch-root"
       >
         <span
-          className="MuiButtonBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary PrivateSwitchBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary css-n2qy4p-MuiButtonBase-root-MuiSwitch-switchBase"
-          onBlur={[Function]}
-          onContextMenu={[Function]}
-          onDragLeave={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseLeave={[Function]}
-          onMouseUp={[Function]}
-          onTouchEnd={[Function]}
-          onTouchMove={[Function]}
-          onTouchStart={[Function]}
-          tabIndex={null}
+          class="MuiButtonBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary PrivateSwitchBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary css-n2qy4p-MuiButtonBase-root-MuiSwitch-switchBase"
         >
           <input
-            checked={false}
-            className="PrivateSwitchBase-input MuiSwitch-input css-j8yymo"
-            onChange={[Function]}
-            required={false}
+            class="PrivateSwitchBase-input MuiSwitch-input css-j8yymo"
             type="checkbox"
           />
           <span
-            className="MuiSwitch-thumb css-17jyosd-MuiSwitch-thumb"
+            class="MuiSwitch-thumb css-17jyosd-MuiSwitch-thumb"
           />
         </span>
         <span
-          className="MuiSwitch-track css-tj8d99-MuiSwitch-track"
+          class="MuiSwitch-track css-tj8d99-MuiSwitch-track"
         />
       </span>
       <a
         aria-label="Docs"
-        aria-labelledby={null}
-        className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium c10 c11 Link css-53g0n7-MuiButtonBase-root-MuiIconButton-root"
-        data-mui-internal-clone-element={true}
+        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium c10 c11 Link css-53g0n7-MuiButtonBase-root-MuiIconButton-root"
+        data-mui-internal-clone-element="true"
         href="https://docs.gitops.weaveworks.org/"
         id=":r2:"
-        onBlur={[Function]}
-        onContextMenu={[Function]}
-        onDragLeave={[Function]}
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseLeave={[Function]}
-        onMouseOver={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
         rel="noreferrer"
-        tabIndex={0}
+        tabindex="0"
         target="_blank"
       >
         <span
-          className="MuiIconButton-loadingIndicator css-165vu30-MuiIconButton-loadingIndicator"
+          class="MuiIconButton-loadingIndicator css-165vu30-MuiIconButton-loadingIndicator"
         />
         <div
-          className="c4 c12"
+          class="c4 c12"
         >
           <svg
-            aria-hidden={true}
-            className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
             data-testid="FindInPageIcon"
             focusable="false"
             viewBox="0 0 24 24"
@@ -292,38 +255,21 @@ exports[`Page snapshots default 1`] = `
       <button
         aria-haspopup="true"
         aria-label="Account settings"
-        aria-labelledby={null}
-        className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium c10 css-53g0n7-MuiButtonBase-root-MuiIconButton-root"
-        data-mui-internal-clone-element={true}
-        disabled={false}
+        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium c10 css-53g0n7-MuiButtonBase-root-MuiIconButton-root"
+        data-mui-internal-clone-element="true"
         id=":r4:"
-        onBlur={[Function]}
-        onClick={[Function]}
-        onContextMenu={[Function]}
-        onDragLeave={[Function]}
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseLeave={[Function]}
-        onMouseOver={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        open={false}
-        tabIndex={0}
+        tabindex="0"
         type="button"
       >
         <span
-          className="MuiIconButton-loadingIndicator css-165vu30-MuiIconButton-loadingIndicator"
+          class="MuiIconButton-loadingIndicator css-165vu30-MuiIconButton-loadingIndicator"
         />
         <div
-          className="c4 c12"
+          class="c4 c12"
         >
           <svg
-            aria-hidden={true}
-            className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
             data-testid="PersonIcon"
             focusable="false"
             viewBox="0 0 24 24"
@@ -337,13 +283,13 @@ exports[`Page snapshots default 1`] = `
     </div>
   </div>
   <div
-    className="c13"
+    class="c13"
   >
     <div
-      className="c14 c15 c16"
+      class="c14 c15 c16"
     >
       <div
-        className="c17 c18"
+        class="c17 c18"
       />
     </div>
   </div>

--- a/ui/components/__tests__/__snapshots__/Page.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/Page.test.tsx.snap
@@ -120,7 +120,7 @@ exports[`Page snapshots default 1`] = `
 
 .c9 .MuiSwitch-thumb {
   color: #fff;
-  background-image: url();
+  background-image: url(data:image/svg+xml;base64,W29iamVjdCBPYmplY3Rd);
 }
 
 .c9 .MuiSwitch-track {

--- a/ui/components/__tests__/__snapshots__/Text.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/Text.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`Text snapshots bold 1`] = `
 }
 
 <span
-  className="c0"
+  class="c0"
 >
   some text
 </span>
@@ -26,7 +26,7 @@ exports[`Text snapshots normal 1`] = `
 }
 
 <span
-  className="c0"
+  class="c0"
 >
   some text
 </span>
@@ -43,7 +43,7 @@ exports[`Text snapshots with color 1`] = `
 }
 
 <span
-  className="c0"
+  class="c0"
 >
   some text
 </span>

--- a/ui/components/__tests__/__snapshots__/Text.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/Text.test.tsx.snap
@@ -1,7 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Text snapshots bold 1`] = `
-.c0 {
+<DocumentFragment>
+  .c0 {
   font-family: 'proxima-nova',Helvetica,Arial,sans-serif;
   font-size: 14px;
   font-weight: 800;
@@ -10,14 +11,16 @@ exports[`Text snapshots bold 1`] = `
 }
 
 <span
-  class="c0"
->
-  some text
-</span>
+    class="c0"
+  >
+    some text
+  </span>
+</DocumentFragment>
 `;
 
 exports[`Text snapshots normal 1`] = `
-.c0 {
+<DocumentFragment>
+  .c0 {
   font-family: 'proxima-nova',Helvetica,Arial,sans-serif;
   font-size: 14px;
   font-weight: 400;
@@ -26,14 +29,16 @@ exports[`Text snapshots normal 1`] = `
 }
 
 <span
-  class="c0"
->
-  some text
-</span>
+    class="c0"
+  >
+    some text
+  </span>
+</DocumentFragment>
 `;
 
 exports[`Text snapshots with color 1`] = `
-.c0 {
+<DocumentFragment>
+  .c0 {
   font-family: 'proxima-nova',Helvetica,Arial,sans-serif;
   font-size: 14px;
   font-weight: 400;
@@ -43,8 +48,9 @@ exports[`Text snapshots with color 1`] = `
 }
 
 <span
-  class="c0"
->
-  some text
-</span>
+    class="c0"
+  >
+    some text
+  </span>
+</DocumentFragment>
 `;

--- a/ui/components/__tests__/__snapshots__/Version.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/Version.test.tsx.snap
@@ -29,19 +29,18 @@ exports[`Version snapshots renders a dash as plain text without version text and
 }
 
 <div
-  className="c0 Version"
+  class="c0 Version"
 >
   <span
-    className="c1"
+    class="c1"
   >
-    product name
-    :
+    product name:
   </span>
   <div
-    className="c2"
+    class="c2"
   />
   <span
-    className="c3"
+    class="c3"
   >
     -
   </span>
@@ -77,19 +76,18 @@ exports[`Version snapshots renders a dash without version text and without versi
 }
 
 <div
-  className="c0 Version"
+  class="c0 Version"
 >
   <span
-    className="c1"
+    class="c1"
   >
-    product name
-    :
+    product name:
   </span>
   <div
-    className="c2"
+    class="c2"
   />
   <span
-    className="c3"
+    class="c3"
   >
     -
   </span>
@@ -138,28 +136,27 @@ exports[`Version snapshots renders a link with version text and version href 1`]
 }
 
 <div
-  className="c0 Version"
+  class="c0 Version"
 >
   <span
-    className="c1"
+    class="c1"
   >
-    product name
-    :
+    product name:
   </span>
   <div
-    className="c2"
+    class="c2"
   />
   <a
-    className="c3 Link"
+    class="c3 Link"
     href="https://github.com/weaveworks/weave-gitops"
     rel="noreferrer"
     target="_blank"
   >
     <span
-      className="c4"
+      class="c4"
     >
       <span
-        className="c5"
+        class="c5"
       >
         version text
       </span>
@@ -197,19 +194,18 @@ exports[`Version snapshots renders plain text with version text and without vers
 }
 
 <div
-  className="c0 Version"
+  class="c0 Version"
 >
   <span
-    className="c1"
+    class="c1"
   >
-    product name
-    :
+    product name:
   </span>
   <div
-    className="c2"
+    class="c2"
   />
   <span
-    className="c3"
+    class="c3"
   >
     version text
   </span>

--- a/ui/components/__tests__/__snapshots__/Version.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/Version.test.tsx.snap
@@ -1,7 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Version snapshots renders a dash as plain text without version text and with version href 1`] = `
-.c0 {
+<DocumentFragment>
+  .c0 {
   display: flex;
   flex-direction: row;
   align-items: start;
@@ -29,26 +30,28 @@ exports[`Version snapshots renders a dash as plain text without version text and
 }
 
 <div
-  class="c0 Version"
->
-  <span
-    class="c1"
+    class="c0 Version"
   >
-    product name:
-  </span>
-  <div
-    class="c2"
-  />
-  <span
-    class="c3"
-  >
-    -
-  </span>
-</div>
+    <span
+      class="c1"
+    >
+      product name:
+    </span>
+    <div
+      class="c2"
+    />
+    <span
+      class="c3"
+    >
+      -
+    </span>
+  </div>
+</DocumentFragment>
 `;
 
 exports[`Version snapshots renders a dash without version text and without version href 1`] = `
-.c0 {
+<DocumentFragment>
+  .c0 {
   display: flex;
   flex-direction: row;
   align-items: start;
@@ -76,26 +79,28 @@ exports[`Version snapshots renders a dash without version text and without versi
 }
 
 <div
-  class="c0 Version"
->
-  <span
-    class="c1"
+    class="c0 Version"
   >
-    product name:
-  </span>
-  <div
-    class="c2"
-  />
-  <span
-    class="c3"
-  >
-    -
-  </span>
-</div>
+    <span
+      class="c1"
+    >
+      product name:
+    </span>
+    <div
+      class="c2"
+    />
+    <span
+      class="c3"
+    >
+      -
+    </span>
+  </div>
+</DocumentFragment>
 `;
 
 exports[`Version snapshots renders a link with version text and version href 1`] = `
-.c0 {
+<DocumentFragment>
+  .c0 {
   display: flex;
   flex-direction: row;
   align-items: start;
@@ -136,37 +141,39 @@ exports[`Version snapshots renders a link with version text and version href 1`]
 }
 
 <div
-  class="c0 Version"
->
-  <span
-    class="c1"
-  >
-    product name:
-  </span>
-  <div
-    class="c2"
-  />
-  <a
-    class="c3 Link"
-    href="https://github.com/weaveworks/weave-gitops"
-    rel="noreferrer"
-    target="_blank"
+    class="c0 Version"
   >
     <span
-      class="c4"
+      class="c1"
+    >
+      product name:
+    </span>
+    <div
+      class="c2"
+    />
+    <a
+      class="c3 Link"
+      href="https://github.com/weaveworks/weave-gitops"
+      rel="noreferrer"
+      target="_blank"
     >
       <span
-        class="c5"
+        class="c4"
       >
-        version text
+        <span
+          class="c5"
+        >
+          version text
+        </span>
       </span>
-    </span>
-  </a>
-</div>
+    </a>
+  </div>
+</DocumentFragment>
 `;
 
 exports[`Version snapshots renders plain text with version text and without version href 1`] = `
-.c0 {
+<DocumentFragment>
+  .c0 {
   display: flex;
   flex-direction: row;
   align-items: start;
@@ -194,20 +201,21 @@ exports[`Version snapshots renders plain text with version text and without vers
 }
 
 <div
-  class="c0 Version"
->
-  <span
-    class="c1"
+    class="c0 Version"
   >
-    product name:
-  </span>
-  <div
-    class="c2"
-  />
-  <span
-    class="c3"
-  >
-    version text
-  </span>
-</div>
+    <span
+      class="c1"
+    >
+      product name:
+    </span>
+    <div
+      class="c2"
+    />
+    <span
+      class="c3"
+    >
+      version text
+    </span>
+  </div>
+</DocumentFragment>
 `;

--- a/ui/components/__tests__/__snapshots__/YamlView.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/YamlView.test.tsx.snap
@@ -135,26 +135,21 @@ exports[`YamlView snapshots renders 1`] = `
 }
 
 <div
-  className="c0 UnstyledYamlView"
+  class="c0 UnstyledYamlView"
 >
   <div
-    className="c1 c2"
+    class="c1 c2"
   >
     kubectl get kustomization podinfo -n flux-system -o yaml
     <div
-      onClick={[Function]}
-      style={
-        {
-          "cursor": "pointer",
-        }
-      }
+      style="cursor: pointer;"
     >
       <div
-        className="c3 c4"
+        class="c3 c4"
       >
         <svg
-          aria-hidden={true}
-          className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
           data-testid="FileCopyOutlinedIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -167,25 +162,20 @@ exports[`YamlView snapshots renders 1`] = `
     </div>
   </div>
   <div
-    className="code-wrapper"
+    class="code-wrapper"
   >
     <div
-      className="copy-wrapper"
+      class="copy-wrapper"
     >
       <div
-        onClick={[Function]}
-        style={
-          {
-            "cursor": "pointer",
-          }
-        }
+        style="cursor: pointer;"
       >
         <div
-          className="c3 c5"
+          class="c3 c5"
         >
           <svg
-            aria-hidden={true}
-            className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
             data-testid="FileCopyOutlinedIcon"
             focusable="false"
             viewBox="0 0 24 24"
@@ -198,66 +188,21 @@ exports[`YamlView snapshots renders 1`] = `
       </div>
     </div>
     <pre
-      style={
-        {
-          "MozHyphens": "none",
-          "MozTabSize": "4",
-          "OTabSize": "4",
-          "WebkitHyphens": "none",
-          "background": "#f5f2f0",
-          "backgroundColor": "transparent",
-          "color": "black",
-          "fontFamily": "Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace",
-          "fontSize": "1em",
-          "hyphens": "none",
-          "lineHeight": "1.5",
-          "margin": 0,
-          "msHyphens": "none",
-          "overflow": "auto",
-          "padding": "1em",
-          "tabSize": "4",
-          "textAlign": "left",
-          "textShadow": "0 1px white",
-          "whiteSpace": "pre",
-          "wordBreak": "normal",
-          "wordSpacing": "normal",
-          "wordWrap": "normal",
-        }
-      }
+      style="color: black; background: rgb(245, 242, 240); text-shadow: 0 1px white; font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace; font-size: 1em; text-align: left; white-space: pre; word-spacing: normal; word-break: normal; word-wrap: normal; line-height: 1.5; tab-size: 4; hyphens: none; padding: 1em; margin: 0px; overflow: auto; background-color: transparent;"
     >
       <code
-        style={
-          {
-            "whiteSpace": "pre",
-            "wordBreak": "break-word",
-          }
-        }
+        style="white-space: pre; word-break: break-word;"
       >
         <span
-          style={
-            {
-              "textWrap": "wrap",
-            }
-          }
+          style="text-wrap: wrap;"
         >
           <span
-            className="linenumber react-syntax-highlighter-line-number"
-            style={
-              {
-                "color": "slategray",
-                "display": "inline-block",
-                "minWidth": "1.25em",
-                "paddingRight": "1em",
-                "textAlign": "right",
-                "userSelect": "none",
-              }
-            }
+            class="linenumber react-syntax-highlighter-line-number"
+            style="display: inline-block; min-width: 1.25em; padding-right: 1em; text-align: right; user-select: none; color: slategray;"
           >
             1
           </span>
-          <span
-            style={{}}
-          >
+          <span>
             yaml\\nyaml\\nyaml\\n
           </span>
         </span>

--- a/ui/components/__tests__/__snapshots__/YamlView.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/YamlView.test.tsx.snap
@@ -1,7 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`YamlView snapshots renders 1`] = `
-.c1 {
+<DocumentFragment>
+  .c1 {
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -135,43 +136,17 @@ exports[`YamlView snapshots renders 1`] = `
 }
 
 <div
-  class="c0 UnstyledYamlView"
->
-  <div
-    class="c1 c2"
-  >
-    kubectl get kustomization podinfo -n flux-system -o yaml
-    <div
-      style="cursor: pointer;"
-    >
-      <div
-        class="c3 c4"
-      >
-        <svg
-          aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
-          data-testid="FileCopyOutlinedIcon"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12zm-1 4H8c-1.1 0-1.99.9-1.99 2L6 21c0 1.1.89 2 1.99 2H19c1.1 0 2-.9 2-2V11zM8 21V7h6v5h5v9z"
-          />
-        </svg>
-      </div>
-    </div>
-  </div>
-  <div
-    class="code-wrapper"
+    class="c0 UnstyledYamlView"
   >
     <div
-      class="copy-wrapper"
+      class="c1 c2"
     >
+      kubectl get kustomization podinfo -n flux-system -o yaml
       <div
         style="cursor: pointer;"
       >
         <div
-          class="c3 c5"
+          class="c3 c4"
         >
           <svg
             aria-hidden="true"
@@ -187,27 +162,54 @@ exports[`YamlView snapshots renders 1`] = `
         </div>
       </div>
     </div>
-    <pre
-      style="color: black; background: rgb(245, 242, 240); text-shadow: 0 1px white; font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace; font-size: 1em; text-align: left; white-space: pre; word-spacing: normal; word-break: normal; word-wrap: normal; line-height: 1.5; tab-size: 4; hyphens: none; padding: 1em; margin: 0px; overflow: auto; background-color: transparent;"
+    <div
+      class="code-wrapper"
     >
-      <code
-        style="white-space: pre; word-break: break-word;"
+      <div
+        class="copy-wrapper"
       >
-        <span
-          style="text-wrap: wrap;"
+        <div
+          style="cursor: pointer;"
+        >
+          <div
+            class="c3 c5"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+              data-testid="FileCopyOutlinedIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12zm-1 4H8c-1.1 0-1.99.9-1.99 2L6 21c0 1.1.89 2 1.99 2H19c1.1 0 2-.9 2-2V11zM8 21V7h6v5h5v9z"
+              />
+            </svg>
+          </div>
+        </div>
+      </div>
+      <pre
+        style="color: black; background: rgb(245, 242, 240); text-shadow: 0 1px white; font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace; font-size: 1em; text-align: left; white-space: pre; word-spacing: normal; word-break: normal; word-wrap: normal; line-height: 1.5; tab-size: 4; hyphens: none; padding: 1em; margin: 0px; overflow: auto; background-color: transparent;"
+      >
+        <code
+          style="white-space: pre; word-break: break-word;"
         >
           <span
-            class="linenumber react-syntax-highlighter-line-number"
-            style="display: inline-block; min-width: 1.25em; padding-right: 1em; text-align: right; user-select: none; color: slategray;"
+            style="text-wrap: wrap;"
           >
-            1
+            <span
+              class="linenumber react-syntax-highlighter-line-number"
+              style="display: inline-block; min-width: 1.25em; padding-right: 1em; text-align: right; user-select: none; color: slategray;"
+            >
+              1
+            </span>
+            <span>
+              yaml\\nyaml\\nyaml\\n
+            </span>
           </span>
-          <span>
-            yaml\\nyaml\\nyaml\\n
-          </span>
-        </span>
-      </code>
-    </pre>
+        </code>
+      </pre>
+    </div>
   </div>
-</div>
+</DocumentFragment>
 `;

--- a/ui/contexts/__tests__/CoreClientContext.test.tsx
+++ b/ui/contexts/__tests__/CoreClientContext.test.tsx
@@ -1,6 +1,6 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render } from "@testing-library/react";
 import * as React from "react";
-import renderer from "react-test-renderer";
 import { Core } from "../../lib/api/core/core.pb";
 import CoreClientContextProvider, {
   CoreClientContext,
@@ -19,7 +19,7 @@ describe("CoreContextProvider", () => {
 
     const queryClient = new QueryClient();
 
-    renderer.create(
+    render(
       <QueryClientProvider client={queryClient}>
         <CoreClientContextProvider api={Core}>
           <TestComponent />

--- a/ui/lib/utils.ts
+++ b/ui/lib/utils.ts
@@ -6,6 +6,7 @@ import styled from "styled-components";
 import Flex from "../components/Flex";
 import { computeReady, ReadyType } from "../components/KubeStatusIndicator";
 import { AppVersion, repoUrl } from "../components/Version";
+import { ThemeTypes } from "../contexts/AppContext";
 import { AuthRoutes } from "../contexts/AuthContext";
 import { GetVersionResponse } from "./api/core/core.pb";
 import { Condition, Kind, ObjectRef } from "./api/core/types.pb";
@@ -298,4 +299,10 @@ export function stripBasePath(pathname: string) {
   }
 
   return pathname;
+}
+
+export function svgToB64Image(mode, light, dark) {
+  const img = mode === ThemeTypes.Dark ? dark : light;
+  const str = decodeURIComponent(img.toString().replace(/data:image.*,/, ""));
+  return "data:image/svg+xml;base64," + Buffer.from(str).toString("base64");
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4446,6 +4446,7 @@ __metadata:
     jest-environment-jsdom: "npm:^29.7.0"
     jest-fail-on-console: "npm:^3.3.1"
     jest-styled-components: "npm:^7.2.0"
+    jest-svg-transformer: "npm:^1.0.0"
     jest-worker: "npm:^29.7.0"
     js-sha3: "npm:0.9.3"
     js-yaml: "npm:^4.1.0"
@@ -8823,6 +8824,16 @@ __metadata:
   peerDependencies:
     styled-components: ">= 5"
   checksum: 10c0/44eecf73cd1ee50686c9c16517222e2c012422dd7d90a07813f82f3ccce4059563e620d25aed60274e05d31fe6375b1f31a3486033aa39ea5e82fd94afcfa32f
+  languageName: node
+  linkType: hard
+
+"jest-svg-transformer@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "jest-svg-transformer@npm:1.0.0"
+  peerDependencies:
+    jest: ">22"
+    react: ">=16"
+  checksum: 10c0/71688f9ae8647353d07fdc9bd4da20845df7472a7004c0ebb305ac0fd6a879936c43c874eaa1b68ed7b35ad4b5dfb759025c186e5f879e5de23ab201c42d9982
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4446,7 +4446,7 @@ __metadata:
     jest-environment-jsdom: "npm:^29.7.0"
     jest-fail-on-console: "npm:^3.3.1"
     jest-styled-components: "npm:^7.2.0"
-    jest-svg-transformer: "npm:^1.0.0"
+    jest-transformer-svg: "npm:^2.1.0"
     jest-worker: "npm:^29.7.0"
     js-sha3: "npm:0.9.3"
     js-yaml: "npm:^4.1.0"
@@ -8827,13 +8827,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-svg-transformer@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "jest-svg-transformer@npm:1.0.0"
+"jest-transformer-svg@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "jest-transformer-svg@npm:2.1.0"
   peerDependencies:
-    jest: ">22"
-    react: ">=16"
-  checksum: 10c0/71688f9ae8647353d07fdc9bd4da20845df7472a7004c0ebb305ac0fd6a879936c43c874eaa1b68ed7b35ad4b5dfb759025c186e5f879e5de23ab201c42d9982
+    jest: ">= 28.1.0"
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 10c0/f654d383acde11160800603ad5b365edbf3e2a60047959e9fb451cc80420195edd9c416c8803a2b22804f695d9a4e37799aef3f60c3fe709f10e0f91aff5cf21
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**What changed?**

This commit upgrades the testing library from `react-test-renderer` to `@testing-library/react`.

This largely results in changes to `renderer.create().toJSON()` becoming `render().asFragment()`. To ensure minimal snapshot changes were recorded, I used `firstChild` from the fragment so the fragment wrapper was not added to the snapshots.

**Why was this change made?**

This change was made to replace the deprecated `react-test-renderer` with a more modern equivelent which is compatible with future versions of React framework

**Side effects**

During testing, a large number of failure messages such as:

```plaintext
An empty string ("") was passed to the src attribute
```

This message would cause tests to fail and is the result of `svg` images being passed to the fileMock in `ui/lib/fileMock.js`

To resolve this, I have replaced `svg` management with `jest-transformer-svg`  and introduced a helper method to convert imported `svg` images to a usable base64 encoded version for use in CSS styling