### PR TITLE
Styling cleanup

### DIFF
--- a/ui/components/Alert.tsx
+++ b/ui/components/Alert.tsx
@@ -1,4 +1,4 @@
-import { AlertTitle, Alert as MaterialAlert } from "@mui/lab";
+import { AlertTitle, Alert as MaterialAlert } from "@mui/material";
 import * as React from "react";
 import styled from "styled-components";
 import { ThemeTypes } from "../contexts/AppContext";

--- a/ui/components/AlertListErrors.tsx
+++ b/ui/components/AlertListErrors.tsx
@@ -1,5 +1,5 @@
-import Alert from "@mui/lab/Alert";
 import { Box, Button, Collapse } from "@mui/material";
+import Alert from "@mui/material/Alert";
 import { sortBy, uniqBy } from "lodash";
 import React, { FC, useEffect, useState } from "react";
 import styled from "styled-components";
@@ -31,7 +31,8 @@ const BoxWrapper = styled(Box)`
   }
   .MuiAlert-icon {
     .MuiSvgIcon-root {
-      display: none;
+      display: inline-flex;
+      color: ${(props) => props.theme.colors.alertMedium};
     }
   }
   .MuiAlert-message {
@@ -43,6 +44,7 @@ const BoxWrapper = styled(Box)`
 `;
 const ErrorText = styled(Text)`
   margin-left: 8px;
+  color: ${(props) => props.theme.colors.alertMedium};
 `;
 const NavButton = styled(Button)`
   padding: 0;
@@ -86,9 +88,9 @@ export const AlertListErrors: FC<{
         {!!filteredErrors[index] && (
           <Alert severity="error" onClose={() => setShow(false)}>
             <Flex align center>
-              <Icon type={IconType.ErrorIcon} size="medium" color="alertDark" />
-              <ErrorText data-testid="error-message" color="black">
-                {filteredErrors[index].clusterName}:&nbsp;
+              <ErrorText data-testid="error-message">
+                {filteredErrors[index].clusterName &&
+                  filteredErrors[index].clusterName + ":&nbsp;"}
                 {filteredErrors[index].message}
               </ErrorText>
             </Flex>

--- a/ui/components/Button.tsx
+++ b/ui/components/Button.tsx
@@ -46,6 +46,9 @@ const Button = styled(UnstyledButton)`
     line-height: 1;
     border-radius: ${(props) => props.theme.borderRadius.soft};
     font-weight: 600;
+    &:hover {
+      background-color: ${(props) => props.theme.colors.blueWithOpacity};
+    }
   }
   &.MuiButton-outlined {
     padding: 8px 12px;
@@ -58,6 +61,9 @@ export const IconButton = styled(UnstyledButton)`
     min-width: 38px;
     height: 38px;
     padding: 0;
+    &:hover {
+      background-color: ${(props) => props.theme.colors.blueWithOpacity};
+    }
   }
   &.MuiButton-text {
     padding: 0;

--- a/ui/components/DagGraph.tsx
+++ b/ui/components/DagGraph.tsx
@@ -43,7 +43,7 @@ const GraphDiv = styled.div`
 
 function DagGraph({ className, nodes }: Props) {
   //zoom
-  const defaultZoomPercent = 85;
+  const defaultZoomPercent = 75;
   const [zoomPercent, setZoomPercent] = React.useState(defaultZoomPercent);
 
   //pan
@@ -192,7 +192,7 @@ export default styled(DagGraph).attrs({ className: DagGraph.name })`
     width: 6px;
   }
   .MuiSlider-vertical .MuiSlider-thumb {
-    margin-left: -9px;
+    margin-left: 0px;
   }
   .MuiSlider-thumb {
     width: 24px;

--- a/ui/components/DarkModeSwitch.tsx
+++ b/ui/components/DarkModeSwitch.tsx
@@ -25,7 +25,12 @@ function DarkModeSwitch({ className, darkModeEnabled }: Props) {
 export default styled(DarkModeSwitch).attrs({
   className: DarkModeSwitch.name,
 })`
-.MuiSwitch-thumb {
+  .MuiSwitch-switchBase {
+    &:hover {
+      background-color: ${(props) => props.theme.colors.blueWithOpacity};
+    }
+  }
+  .MuiSwitch-thumb {
     color: #fff;
     background-image: url(${(props) =>
       props.theme.mode === ThemeTypes.Dark
@@ -34,4 +39,5 @@ export default styled(DarkModeSwitch).attrs({
   }
   .MuiSwitch-track {
     background-color: ${(props) => props.theme.colors.primary};
+  }
 `;

--- a/ui/components/DataTable/__tests__/__snapshots__/DataTable.test.tsx.snap
+++ b/ui/components/DataTable/__tests__/__snapshots__/DataTable.test.tsx.snap
@@ -136,7 +136,7 @@ exports[`DataTable snapshots renders 1`] = `
   background: rbga(255, 255, 255, 0.75);
   height: 100%;
   width: 100%;
-  border-left: 2px solid #d8d8d8;
+  border-left: 2px solid #BDBDBD;
   padding: 24px;
   padding-left: 32px;
 }
@@ -202,7 +202,7 @@ exports[`DataTable snapshots renders 1`] = `
 }
 
 .c1 .MuiTableCell-root {
-  border-color: #d8d8d8;
+  border-color: #BDBDBD;
 }
 
 .c1 table {
@@ -211,7 +211,7 @@ exports[`DataTable snapshots renders 1`] = `
 
 .c1 th {
   padding: 0;
-  background: #F6F7F9;
+  background: #C2C9D7;
 }
 
 .c1 th .MuiCheckbox-root {
@@ -266,7 +266,7 @@ exports[`DataTable snapshots renders 1`] = `
                 className="c5"
               >
                 <button
-                  className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit c6 css-9wcwzo-MuiButtonBase-root-MuiButton-root"
+                  className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit c6 css-1swlott-MuiButtonBase-root-MuiButton-root"
                   disabled={null}
                   id=":r0:"
                   onBlur={[Function]}
@@ -317,7 +317,7 @@ exports[`DataTable snapshots renders 1`] = `
                 className="c5"
               >
                 <button
-                  className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit c6 css-9wcwzo-MuiButtonBase-root-MuiButton-root"
+                  className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit c6 css-1swlott-MuiButtonBase-root-MuiButton-root"
                   disabled={null}
                   id=":r1:"
                   onBlur={[Function]}
@@ -360,7 +360,7 @@ exports[`DataTable snapshots renders 1`] = `
                 className="c5"
               >
                 <button
-                  className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit c6 css-9wcwzo-MuiButtonBase-root-MuiButton-root"
+                  className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit c6 css-1swlott-MuiButtonBase-root-MuiButton-root"
                   disabled={null}
                   id=":r2:"
                   onBlur={[Function]}
@@ -403,7 +403,7 @@ exports[`DataTable snapshots renders 1`] = `
                 className="c5"
               >
                 <button
-                  className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit c6 css-9wcwzo-MuiButtonBase-root-MuiButton-root"
+                  className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit c6 css-1swlott-MuiButtonBase-root-MuiButton-root"
                   disabled={null}
                   id=":r3:"
                   onBlur={[Function]}

--- a/ui/components/ErrorList.tsx
+++ b/ui/components/ErrorList.tsx
@@ -1,5 +1,4 @@
-import { Alert } from "@mui/lab";
-import { Box, Collapse } from "@mui/material";
+import { Alert, Box, Collapse } from "@mui/material";
 import { sortBy, uniqBy } from "lodash";
 import * as React from "react";
 import styled from "styled-components";

--- a/ui/components/Nav.tsx
+++ b/ui/components/Nav.tsx
@@ -1,8 +1,10 @@
 import { ArrowLeft, ArrowRight } from "@mui/icons-material";
 import { IconButton, Tab, Tabs, Tooltip } from "@mui/material";
+import { alpha } from "@mui/material/styles";
 import _ from "lodash";
 import React, { Dispatch, SetStateAction } from "react";
 import styled from "styled-components";
+import { ThemeTypes } from "../contexts/AppContext";
 import { formatURL } from "../lib/nav";
 import { PageRoute, V2Routes } from "../lib/types";
 import { Fade } from "../lib/utils";
@@ -81,7 +83,7 @@ const NavContent = styled.div<{ collapsed: boolean }>`
     //matches .MuiSvgIcon-root
     transition: background-color 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
     &.selected,
-    :hover {
+    &:hover {
       background-color: ${(props) => props.theme.colors.blueWithOpacity};
     }
   }
@@ -107,6 +109,12 @@ const NavContent = styled.div<{ collapsed: boolean }>`
 const CollapseButton = styled(IconButton)`
   &.MuiIconButton-root {
     margin: 0 18px 0 4px;
+    &:hover {
+      background-color: ${(props) =>
+        props.theme.mode === ThemeTypes.Dark
+          ? alpha(props.theme.colors.primary10, 0.2)
+          : alpha(props.theme.colors.primary, 0.1)};
+    }
   }
 `;
 

--- a/ui/components/Nav.tsx
+++ b/ui/components/Nav.tsx
@@ -85,6 +85,16 @@ const NavContent = styled.div<{ collapsed: boolean }>`
       background-color: ${(props) => props.theme.colors.blueWithOpacity};
     }
   }
+
+  .link-flex:hover,
+  .horizontal-tabs:hover {
+    background-color: ${(props) => props.theme.colors.blueWithOpacity};
+  }
+
+  .link-flex span:hover {
+    background-color: transparent;
+  }
+
   .header {
     opacity: ${(props) => (props.collapsed ? 0 : 1)};
     letter-spacing: 1px;

--- a/ui/components/ReconciliationGraph.tsx
+++ b/ui/components/ReconciliationGraph.tsx
@@ -179,7 +179,7 @@ export default styled(ReconciliationGraph)`
     width: 6px;
   }
   .MuiSlider-vertical .MuiSlider-thumb {
-    margin-left: -9px;
+    margin-left: 0px;
   }
   .MuiSlider-thumb {
     width: 24px;

--- a/ui/components/ReconciliationGraph.tsx
+++ b/ui/components/ReconciliationGraph.tsx
@@ -121,7 +121,7 @@ export const Graph = ({
   const links = tree.links();
 
   //zoom
-  const defaultZoomPercent = 85;
+  const defaultZoomPercent = 75;
   const [zoomPercent, setZoomPercent] = React.useState(defaultZoomPercent);
 
   //pan

--- a/ui/components/SearchField.tsx
+++ b/ui/components/SearchField.tsx
@@ -26,10 +26,20 @@ const Expander = styled(
   ),
 )`
   width: 0px;
-  transition: width 0.3s ease-in-out;
+  transition-property: opacity, width;
+  transition-duration: 0.5s;
+  transition-timing-function: cubic-bezier(0.46, 0.03, 0.52, 0.96);
   margin-left: 4px;
+  opacity: 0;
+
   &.expanded {
     width: 200px;
+    opacity: 1;
+  }
+
+  input {
+    padding: 8px 10px;
+    border-bottom: 1px solid ${(props) => props.theme.colors.neutral40};
   }
 `;
 

--- a/ui/components/SubRouterTabs.tsx
+++ b/ui/components/SubRouterTabs.tsx
@@ -108,6 +108,7 @@ export default styled(SubRouterTabs).attrs({ className: SubRouterTabs.name })`
     width: 100%;
     .MuiTabs-flexContainer {
       border-bottom: 3px solid ${(props) => props.theme.colors.neutral20};
+
       .MuiTab-root {
         line-height: 1;
         letter-spacing: 1px;
@@ -118,6 +119,14 @@ export default styled(SubRouterTabs).attrs({ className: SubRouterTabs.name })`
         }
         @media (min-width: 1440px) {
           min-width: 132px;
+        }
+        &:hover {
+          background-color: ${(props) => props.theme.colors.blueWithOpacity};
+          color: ${(props) => props.theme.colors.primary10};
+          font-weight: 600;
+          span {
+            color: ${(props) => props.theme.colors.primary};
+          }
         }
       }
     }

--- a/ui/components/Sync/ResumeIcon.tsx
+++ b/ui/components/Sync/ResumeIcon.tsx
@@ -5,7 +5,7 @@ function ResumeIcon() {
     <svg
       width="24"
       height="24"
-      viewBox="0 0 24 24"
+      viewBox="-2 0 24 24"
       xmlns="http://www.w3.org/2000/svg"
     >
       <path d="M4.08331 18.75V4.75H6.41665V18.75H4.08331ZM8.74998 18.75L20.4166 11.75L8.74998 4.75V18.75Z" />

--- a/ui/components/Sync/SyncControls.tsx
+++ b/ui/components/Sync/SyncControls.tsx
@@ -72,7 +72,7 @@ export const IconButton = styled(Button)`
     height: 32px;
     padding: 0;
 
-    :disabled {
+    &.Mui-disabled {
       svg {
         fill: ${(props) =>
           props.theme.mode === ThemeTypes.Dark
@@ -81,7 +81,7 @@ export const IconButton = styled(Button)`
       }
     }
 
-    :hover {
+    &:hover {
       background-color: ${(props) =>
         props.theme.mode === ThemeTypes.Dark
           ? alpha(props.theme.colors.primary10, 0.2)
@@ -90,6 +90,19 @@ export const IconButton = styled(Button)`
   }
   &.MuiButton-text {
     padding: 0;
+
+    &.Mui-disabled {
+      color: ${(props) =>
+        props.theme.mode === ThemeTypes.Dark
+          ? props.theme.colors.primary30
+          : props.theme.colors.neutral20};
+      svg {
+        fill: ${(props) =>
+          props.theme.mode === ThemeTypes.Dark
+            ? props.theme.colors.primary30
+            : props.theme.colors.neutral20};
+      }
+    }
   }
 `;
 
@@ -230,7 +243,6 @@ export default styled(SyncControls)`
 
   .rotate-icon {
     color: ${(props) => props.theme.colors.primary10};
-
     animation: 1s linear infinite ${rotateAnimation};
   }
 `;

--- a/ui/components/Sync/__tests__/__snapshots__/SyncActions.test.tsx.snap
+++ b/ui/components/Sync/__tests__/__snapshots__/SyncActions.test.tsx.snap
@@ -124,16 +124,24 @@ exports[`SyncActions snapshots hideSyncOptions 1`] = `
   padding: 0;
 }
 
-.c7.MuiButton-root :disabled svg {
+.c7.MuiButton-root.Mui-disabled svg {
   fill: #d8d8d8;
 }
 
-.c7.MuiButton-root :hover {
+.c7.MuiButton-root:hover {
   background-color: rgba(0, 179, 236, 0.1);
 }
 
 .c7.MuiButton-text {
   padding: 0;
+}
+
+.c7.MuiButton-text.Mui-disabled {
+  color: #d8d8d8;
+}
+
+.c7.MuiButton-text.Mui-disabled svg {
+  fill: #d8d8d8;
 }
 
 .c1 .sync-icon-button {
@@ -496,16 +504,24 @@ exports[`SyncActions snapshots non-suspended 1`] = `
   padding: 0;
 }
 
-.c8.MuiButton-root :disabled svg {
+.c8.MuiButton-root.Mui-disabled svg {
   fill: #d8d8d8;
 }
 
-.c8.MuiButton-root :hover {
+.c8.MuiButton-root:hover {
   background-color: rgba(0, 179, 236, 0.1);
 }
 
 .c8.MuiButton-text {
   padding: 0;
+}
+
+.c8.MuiButton-text.Mui-disabled {
+  color: #d8d8d8;
+}
+
+.c8.MuiButton-text.Mui-disabled svg {
+  fill: #d8d8d8;
 }
 
 .c1 .sync-icon-button {
@@ -1011,16 +1027,24 @@ exports[`SyncActions snapshots suspended 1`] = `
   padding: 0;
 }
 
-.c8.MuiButton-root :disabled svg {
+.c8.MuiButton-root.Mui-disabled svg {
   fill: #d8d8d8;
 }
 
-.c8.MuiButton-root :hover {
+.c8.MuiButton-root:hover {
   background-color: rgba(0, 179, 236, 0.1);
 }
 
 .c8.MuiButton-text {
   padding: 0;
+}
+
+.c8.MuiButton-text.Mui-disabled {
+  color: #d8d8d8;
+}
+
+.c8.MuiButton-text.Mui-disabled svg {
+  fill: #d8d8d8;
 }
 
 .c1 .sync-icon-button {

--- a/ui/components/Sync/__tests__/__snapshots__/SyncActions.test.tsx.snap
+++ b/ui/components/Sync/__tests__/__snapshots__/SyncActions.test.tsx.snap
@@ -349,7 +349,7 @@ exports[`SyncActions snapshots hideSyncOptions 1`] = `
       >
         <svg
           height="24"
-          viewBox="0 0 24 24"
+          viewBox="-2 0 24 24"
           width="24"
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -872,7 +872,7 @@ exports[`SyncActions snapshots non-suspended 1`] = `
       >
         <svg
           height="24"
-          viewBox="0 0 24 24"
+          viewBox="-2 0 24 24"
           width="24"
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -1397,7 +1397,7 @@ exports[`SyncActions snapshots suspended 1`] = `
       >
         <svg
           height="24"
-          viewBox="0 0 24 24"
+          viewBox="-2 0 24 24"
           width="24"
           xmlns="http://www.w3.org/2000/svg"
         >

--- a/ui/components/Sync/__tests__/__snapshots__/SyncActions.test.tsx.snap
+++ b/ui/components/Sync/__tests__/__snapshots__/SyncActions.test.tsx.snap
@@ -125,7 +125,7 @@ exports[`SyncActions snapshots hideSyncOptions 1`] = `
 }
 
 .c7.MuiButton-root.Mui-disabled svg {
-  fill: #d8d8d8;
+  fill: #BDBDBD;
 }
 
 .c7.MuiButton-root:hover {
@@ -137,11 +137,11 @@ exports[`SyncActions snapshots hideSyncOptions 1`] = `
 }
 
 .c7.MuiButton-text.Mui-disabled {
-  color: #d8d8d8;
+  color: #BDBDBD;
 }
 
 .c7.MuiButton-text.Mui-disabled svg {
-  fill: #d8d8d8;
+  fill: #BDBDBD;
 }
 
 .c1 .sync-icon-button {
@@ -163,7 +163,7 @@ exports[`SyncActions snapshots hideSyncOptions 1`] = `
   className="c0 c1 c2"
 >
   <button
-    className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation c3 sync-icon-button css-157ho6v-MuiButtonBase-root-MuiButton-root"
+    className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation c3 sync-icon-button css-9buukw-MuiButtonBase-root-MuiButton-root"
     disabled={null}
     id=":rg:"
     onBlur={[Function]}
@@ -218,7 +218,7 @@ exports[`SyncActions snapshots hideSyncOptions 1`] = `
     onTouchStart={[Function]}
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c3 c7 css-1fh7grq-MuiButtonBase-root-MuiButton-root"
+      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c3 c7 css-624mb0-MuiButtonBase-root-MuiButton-root"
       data-testid="sync-button"
       disabled={null}
       id=":ri:"
@@ -271,7 +271,7 @@ exports[`SyncActions snapshots hideSyncOptions 1`] = `
     onTouchStart={[Function]}
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c3 c7 css-1fh7grq-MuiButtonBase-root-MuiButton-root"
+      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c3 c7 css-624mb0-MuiButtonBase-root-MuiButton-root"
       data-testid="suspend-button"
       disabled={null}
       id=":rk:"
@@ -324,7 +324,7 @@ exports[`SyncActions snapshots hideSyncOptions 1`] = `
     onTouchStart={[Function]}
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c3 c7 css-1fh7grq-MuiButtonBase-root-MuiButton-root"
+      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c3 c7 css-624mb0-MuiButtonBase-root-MuiButton-root"
       data-testid="resume-button"
       disabled={true}
       id=":rm:"
@@ -490,7 +490,7 @@ exports[`SyncActions snapshots non-suspended 1`] = `
 }
 
 .c7 .MuiFormControlLabel-label.Mui-disabled {
-  color: #d8d8d8;
+  color: #BDBDBD;
 }
 
 .c7 .MuiTypography-root {
@@ -505,7 +505,7 @@ exports[`SyncActions snapshots non-suspended 1`] = `
 }
 
 .c8.MuiButton-root.Mui-disabled svg {
-  fill: #d8d8d8;
+  fill: #BDBDBD;
 }
 
 .c8.MuiButton-root:hover {
@@ -517,11 +517,11 @@ exports[`SyncActions snapshots non-suspended 1`] = `
 }
 
 .c8.MuiButton-text.Mui-disabled {
-  color: #d8d8d8;
+  color: #BDBDBD;
 }
 
 .c8.MuiButton-text.Mui-disabled svg {
-  fill: #d8d8d8;
+  fill: #BDBDBD;
 }
 
 .c1 .sync-icon-button {
@@ -543,7 +543,7 @@ exports[`SyncActions snapshots non-suspended 1`] = `
   className="c0 c1 c2"
 >
   <button
-    className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation c3 sync-icon-button css-157ho6v-MuiButtonBase-root-MuiButton-root"
+    className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation c3 sync-icon-button css-9buukw-MuiButtonBase-root-MuiButton-root"
     disabled={null}
     id=":r0:"
     onBlur={[Function]}
@@ -598,7 +598,7 @@ exports[`SyncActions snapshots non-suspended 1`] = `
         className="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd c7 css-12f4qvw-MuiFormControlLabel-root"
       >
         <span
-          className="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-checked MuiRadio-root MuiRadio-colorPrimary css-yavd16-MuiButtonBase-root-MuiRadio-root"
+          className="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-checked MuiRadio-root MuiRadio-colorPrimary css-1avr0ra-MuiButtonBase-root-MuiRadio-root"
           onBlur={[Function]}
           onContextMenu={[Function]}
           onDragLeave={[Function]}
@@ -664,7 +664,7 @@ exports[`SyncActions snapshots non-suspended 1`] = `
         className="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd c7 css-12f4qvw-MuiFormControlLabel-root"
       >
         <span
-          className="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary css-yavd16-MuiButtonBase-root-MuiRadio-root"
+          className="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary css-1avr0ra-MuiButtonBase-root-MuiRadio-root"
           onBlur={[Function]}
           onContextMenu={[Function]}
           onDragLeave={[Function]}
@@ -741,7 +741,7 @@ exports[`SyncActions snapshots non-suspended 1`] = `
     onTouchStart={[Function]}
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c3 c8 css-1fh7grq-MuiButtonBase-root-MuiButton-root"
+      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c3 c8 css-624mb0-MuiButtonBase-root-MuiButton-root"
       data-testid="sync-button"
       disabled={null}
       id=":r3:"
@@ -794,7 +794,7 @@ exports[`SyncActions snapshots non-suspended 1`] = `
     onTouchStart={[Function]}
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c3 c8 css-1fh7grq-MuiButtonBase-root-MuiButton-root"
+      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c3 c8 css-624mb0-MuiButtonBase-root-MuiButton-root"
       data-testid="suspend-button"
       disabled={null}
       id=":r5:"
@@ -847,7 +847,7 @@ exports[`SyncActions snapshots non-suspended 1`] = `
     onTouchStart={[Function]}
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c3 c8 css-1fh7grq-MuiButtonBase-root-MuiButton-root"
+      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c3 c8 css-624mb0-MuiButtonBase-root-MuiButton-root"
       data-testid="resume-button"
       disabled={true}
       id=":r7:"
@@ -1013,7 +1013,7 @@ exports[`SyncActions snapshots suspended 1`] = `
 }
 
 .c7 .MuiFormControlLabel-label.Mui-disabled {
-  color: #d8d8d8;
+  color: #BDBDBD;
 }
 
 .c7 .MuiTypography-root {
@@ -1028,7 +1028,7 @@ exports[`SyncActions snapshots suspended 1`] = `
 }
 
 .c8.MuiButton-root.Mui-disabled svg {
-  fill: #d8d8d8;
+  fill: #BDBDBD;
 }
 
 .c8.MuiButton-root:hover {
@@ -1040,11 +1040,11 @@ exports[`SyncActions snapshots suspended 1`] = `
 }
 
 .c8.MuiButton-text.Mui-disabled {
-  color: #d8d8d8;
+  color: #BDBDBD;
 }
 
 .c8.MuiButton-text.Mui-disabled svg {
-  fill: #d8d8d8;
+  fill: #BDBDBD;
 }
 
 .c1 .sync-icon-button {
@@ -1066,7 +1066,7 @@ exports[`SyncActions snapshots suspended 1`] = `
   className="c0 c1 c2"
 >
   <button
-    className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation c3 sync-icon-button css-157ho6v-MuiButtonBase-root-MuiButton-root"
+    className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation c3 sync-icon-button css-9buukw-MuiButtonBase-root-MuiButton-root"
     disabled={true}
     id=":r8:"
     onBlur={[Function]}
@@ -1122,7 +1122,7 @@ exports[`SyncActions snapshots suspended 1`] = `
       >
         <span
           aria-disabled={true}
-          className="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary Mui-disabled PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-checked Mui-disabled MuiRadio-root MuiRadio-colorPrimary css-1mux80u-MuiButtonBase-root-MuiRadio-root"
+          className="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary Mui-disabled PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-checked Mui-disabled MuiRadio-root MuiRadio-colorPrimary css-1a0qp0h-MuiButtonBase-root-MuiRadio-root"
           onBlur={[Function]}
           onContextMenu={[Function]}
           onDragLeave={[Function]}
@@ -1189,7 +1189,7 @@ exports[`SyncActions snapshots suspended 1`] = `
       >
         <span
           aria-disabled={true}
-          className="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary Mui-disabled PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-disabled MuiRadio-root MuiRadio-colorPrimary css-1mux80u-MuiButtonBase-root-MuiRadio-root"
+          className="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary Mui-disabled PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-disabled MuiRadio-root MuiRadio-colorPrimary css-1a0qp0h-MuiButtonBase-root-MuiRadio-root"
           onBlur={[Function]}
           onContextMenu={[Function]}
           onDragLeave={[Function]}
@@ -1266,7 +1266,7 @@ exports[`SyncActions snapshots suspended 1`] = `
     onTouchStart={[Function]}
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c3 c8 css-1fh7grq-MuiButtonBase-root-MuiButton-root"
+      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c3 c8 css-624mb0-MuiButtonBase-root-MuiButton-root"
       data-testid="sync-button"
       disabled={true}
       id=":rb:"
@@ -1319,7 +1319,7 @@ exports[`SyncActions snapshots suspended 1`] = `
     onTouchStart={[Function]}
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c3 c8 css-1fh7grq-MuiButtonBase-root-MuiButton-root"
+      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c3 c8 css-624mb0-MuiButtonBase-root-MuiButton-root"
       data-testid="suspend-button"
       disabled={true}
       id=":rd:"
@@ -1372,7 +1372,7 @@ exports[`SyncActions snapshots suspended 1`] = `
     onTouchStart={[Function]}
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c3 c8 css-1fh7grq-MuiButtonBase-root-MuiButton-root"
+      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c3 c8 css-624mb0-MuiButtonBase-root-MuiButton-root"
       data-testid="resume-button"
       disabled={null}
       id=":rf:"

--- a/ui/components/Sync/__tests__/__snapshots__/SyncActions.test.tsx.snap
+++ b/ui/components/Sync/__tests__/__snapshots__/SyncActions.test.tsx.snap
@@ -113,6 +113,10 @@ exports[`SyncActions snapshots hideSyncOptions 1`] = `
   font-weight: 600;
 }
 
+.c3.MuiButton-root:hover {
+  background-color: rgba(0, 179, 236, 0.1);
+}
+
 .c3.MuiButton-outlined {
   padding: 8px 12px;
 }
@@ -474,6 +478,10 @@ exports[`SyncActions snapshots non-suspended 1`] = `
   line-height: 1;
   border-radius: 2px;
   font-weight: 600;
+}
+
+.c3.MuiButton-root:hover {
+  background-color: rgba(0, 179, 236, 0.1);
 }
 
 .c3.MuiButton-outlined {
@@ -997,6 +1005,10 @@ exports[`SyncActions snapshots suspended 1`] = `
   line-height: 1;
   border-radius: 2px;
   font-weight: 600;
+}
+
+.c3.MuiButton-root:hover {
+  background-color: rgba(0, 179, 236, 0.1);
 }
 
 .c3.MuiButton-outlined {

--- a/ui/components/Sync/__tests__/__snapshots__/SyncControls.test.tsx.snap
+++ b/ui/components/Sync/__tests__/__snapshots__/SyncControls.test.tsx.snap
@@ -504,7 +504,7 @@ exports[`SyncControls snapshots allButtonsDisabled 1`] = `
       >
         <svg
           height="24"
-          viewBox="0 0 24 24"
+          viewBox="-2 0 24 24"
           width="24"
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -1020,7 +1020,7 @@ exports[`SyncControls snapshots hasTooltipSuffix 1`] = `
       >
         <svg
           height="24"
-          viewBox="0 0 24 24"
+          viewBox="-2 0 24 24"
           width="24"
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -1746,7 +1746,7 @@ exports[`SyncControls snapshots hideSyncOptions 1`] = `
       >
         <svg
           height="24"
-          viewBox="0 0 24 24"
+          viewBox="-2 0 24 24"
           width="24"
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -2262,7 +2262,7 @@ exports[`SyncControls snapshots non-suspended 1`] = `
       >
         <svg
           height="24"
-          viewBox="0 0 24 24"
+          viewBox="-2 0 24 24"
           width="24"
           xmlns="http://www.w3.org/2000/svg"
         >

--- a/ui/components/Sync/__tests__/__snapshots__/SyncControls.test.tsx.snap
+++ b/ui/components/Sync/__tests__/__snapshots__/SyncControls.test.tsx.snap
@@ -113,6 +113,10 @@ exports[`SyncControls snapshots allButtonsDisabled 1`] = `
   font-weight: 600;
 }
 
+.c2.MuiButton-root:hover {
+  background-color: rgba(0, 179, 236, 0.1);
+}
+
 .c2.MuiButton-outlined {
   padding: 8px 12px;
 }
@@ -631,6 +635,10 @@ exports[`SyncControls snapshots hasTooltipSuffix 1`] = `
   font-weight: 600;
 }
 
+.c2.MuiButton-root:hover {
+  background-color: rgba(0, 179, 236, 0.1);
+}
+
 .c2.MuiButton-outlined {
   padding: 8px 12px;
 }
@@ -1104,6 +1112,10 @@ exports[`SyncControls snapshots hideSuspend 1`] = `
   font-weight: 600;
 }
 
+.c2.MuiButton-root:hover {
+  background-color: rgba(0, 179, 236, 0.1);
+}
+
 .c2.MuiButton-outlined {
   padding: 8px 12px;
 }
@@ -1517,6 +1529,10 @@ exports[`SyncControls snapshots hideSyncOptions 1`] = `
   font-weight: 600;
 }
 
+.c2.MuiButton-root:hover {
+  background-color: rgba(0, 179, 236, 0.1);
+}
+
 .c2.MuiButton-outlined {
   padding: 8px 12px;
 }
@@ -1871,6 +1887,10 @@ exports[`SyncControls snapshots non-suspended 1`] = `
   line-height: 1;
   border-radius: 2px;
   font-weight: 600;
+}
+
+.c2.MuiButton-root:hover {
+  background-color: rgba(0, 179, 236, 0.1);
 }
 
 .c2.MuiButton-outlined {

--- a/ui/components/Sync/__tests__/__snapshots__/SyncControls.test.tsx.snap
+++ b/ui/components/Sync/__tests__/__snapshots__/SyncControls.test.tsx.snap
@@ -127,7 +127,7 @@ exports[`SyncControls snapshots allButtonsDisabled 1`] = `
 }
 
 .c6 .MuiFormControlLabel-label.Mui-disabled {
-  color: #d8d8d8;
+  color: #BDBDBD;
 }
 
 .c6 .MuiTypography-root {
@@ -142,7 +142,7 @@ exports[`SyncControls snapshots allButtonsDisabled 1`] = `
 }
 
 .c7.MuiButton-root.Mui-disabled svg {
-  fill: #d8d8d8;
+  fill: #BDBDBD;
 }
 
 .c7.MuiButton-root:hover {
@@ -154,11 +154,11 @@ exports[`SyncControls snapshots allButtonsDisabled 1`] = `
 }
 
 .c7.MuiButton-text.Mui-disabled {
-  color: #d8d8d8;
+  color: #BDBDBD;
 }
 
 .c7.MuiButton-text.Mui-disabled svg {
-  fill: #d8d8d8;
+  fill: #BDBDBD;
 }
 
 .c1 .sync-icon-button {
@@ -175,7 +175,7 @@ exports[`SyncControls snapshots allButtonsDisabled 1`] = `
   className="c0 c1"
 >
   <button
-    className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation c2 sync-icon-button css-157ho6v-MuiButtonBase-root-MuiButton-root"
+    className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation c2 sync-icon-button css-9buukw-MuiButtonBase-root-MuiButton-root"
     disabled={true}
     id=":r8:"
     onBlur={[Function]}
@@ -231,7 +231,7 @@ exports[`SyncControls snapshots allButtonsDisabled 1`] = `
       >
         <span
           aria-disabled={true}
-          className="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary Mui-disabled PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-checked Mui-disabled MuiRadio-root MuiRadio-colorPrimary css-1mux80u-MuiButtonBase-root-MuiRadio-root"
+          className="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary Mui-disabled PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-checked Mui-disabled MuiRadio-root MuiRadio-colorPrimary css-1a0qp0h-MuiButtonBase-root-MuiRadio-root"
           onBlur={[Function]}
           onContextMenu={[Function]}
           onDragLeave={[Function]}
@@ -298,7 +298,7 @@ exports[`SyncControls snapshots allButtonsDisabled 1`] = `
       >
         <span
           aria-disabled={true}
-          className="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary Mui-disabled PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-disabled MuiRadio-root MuiRadio-colorPrimary css-1mux80u-MuiButtonBase-root-MuiRadio-root"
+          className="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary Mui-disabled PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-disabled MuiRadio-root MuiRadio-colorPrimary css-1a0qp0h-MuiButtonBase-root-MuiRadio-root"
           onBlur={[Function]}
           onContextMenu={[Function]}
           onDragLeave={[Function]}
@@ -375,7 +375,7 @@ exports[`SyncControls snapshots allButtonsDisabled 1`] = `
     onTouchStart={[Function]}
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-1fh7grq-MuiButtonBase-root-MuiButton-root"
+      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-624mb0-MuiButtonBase-root-MuiButton-root"
       data-testid="sync-button"
       disabled={true}
       id=":rb:"
@@ -428,7 +428,7 @@ exports[`SyncControls snapshots allButtonsDisabled 1`] = `
     onTouchStart={[Function]}
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-1fh7grq-MuiButtonBase-root-MuiButton-root"
+      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-624mb0-MuiButtonBase-root-MuiButton-root"
       data-testid="suspend-button"
       disabled={true}
       id=":rd:"
@@ -480,7 +480,7 @@ exports[`SyncControls snapshots allButtonsDisabled 1`] = `
     onTouchStart={[Function]}
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-1fh7grq-MuiButtonBase-root-MuiButton-root"
+      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation Mui-disabled MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-624mb0-MuiButtonBase-root-MuiButton-root"
       data-testid="resume-button"
       disabled={true}
       id=":rf:"
@@ -645,7 +645,7 @@ exports[`SyncControls snapshots hasTooltipSuffix 1`] = `
 }
 
 .c6 .MuiFormControlLabel-label.Mui-disabled {
-  color: #d8d8d8;
+  color: #BDBDBD;
 }
 
 .c6 .MuiTypography-root {
@@ -660,7 +660,7 @@ exports[`SyncControls snapshots hasTooltipSuffix 1`] = `
 }
 
 .c7.MuiButton-root.Mui-disabled svg {
-  fill: #d8d8d8;
+  fill: #BDBDBD;
 }
 
 .c7.MuiButton-root:hover {
@@ -672,11 +672,11 @@ exports[`SyncControls snapshots hasTooltipSuffix 1`] = `
 }
 
 .c7.MuiButton-text.Mui-disabled {
-  color: #d8d8d8;
+  color: #BDBDBD;
 }
 
 .c7.MuiButton-text.Mui-disabled svg {
-  fill: #d8d8d8;
+  fill: #BDBDBD;
 }
 
 .c1 .sync-icon-button {
@@ -693,7 +693,7 @@ exports[`SyncControls snapshots hasTooltipSuffix 1`] = `
   className="c0 c1"
 >
   <button
-    className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation c2 sync-icon-button css-157ho6v-MuiButtonBase-root-MuiButton-root"
+    className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation c2 sync-icon-button css-9buukw-MuiButtonBase-root-MuiButton-root"
     disabled={null}
     id=":rr:"
     onBlur={[Function]}
@@ -748,7 +748,7 @@ exports[`SyncControls snapshots hasTooltipSuffix 1`] = `
         className="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd c6 css-12f4qvw-MuiFormControlLabel-root"
       >
         <span
-          className="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-checked MuiRadio-root MuiRadio-colorPrimary css-yavd16-MuiButtonBase-root-MuiRadio-root"
+          className="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-checked MuiRadio-root MuiRadio-colorPrimary css-1avr0ra-MuiButtonBase-root-MuiRadio-root"
           onBlur={[Function]}
           onContextMenu={[Function]}
           onDragLeave={[Function]}
@@ -814,7 +814,7 @@ exports[`SyncControls snapshots hasTooltipSuffix 1`] = `
         className="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd c6 css-12f4qvw-MuiFormControlLabel-root"
       >
         <span
-          className="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary css-yavd16-MuiButtonBase-root-MuiRadio-root"
+          className="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary css-1avr0ra-MuiButtonBase-root-MuiRadio-root"
           onBlur={[Function]}
           onContextMenu={[Function]}
           onDragLeave={[Function]}
@@ -891,7 +891,7 @@ exports[`SyncControls snapshots hasTooltipSuffix 1`] = `
     onTouchStart={[Function]}
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-1fh7grq-MuiButtonBase-root-MuiButton-root"
+      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-624mb0-MuiButtonBase-root-MuiButton-root"
       data-testid="sync-button"
       disabled={null}
       id=":ru:"
@@ -944,7 +944,7 @@ exports[`SyncControls snapshots hasTooltipSuffix 1`] = `
     onTouchStart={[Function]}
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-1fh7grq-MuiButtonBase-root-MuiButton-root"
+      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-624mb0-MuiButtonBase-root-MuiButton-root"
       data-testid="suspend-button"
       disabled={null}
       id=":r10:"
@@ -996,7 +996,7 @@ exports[`SyncControls snapshots hasTooltipSuffix 1`] = `
     onTouchStart={[Function]}
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-1fh7grq-MuiButtonBase-root-MuiButton-root"
+      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-624mb0-MuiButtonBase-root-MuiButton-root"
       data-testid="resume-button"
       disabled={null}
       id=":r12:"
@@ -1118,7 +1118,7 @@ exports[`SyncControls snapshots hideSuspend 1`] = `
 }
 
 .c6 .MuiFormControlLabel-label.Mui-disabled {
-  color: #d8d8d8;
+  color: #BDBDBD;
 }
 
 .c6 .MuiTypography-root {
@@ -1133,7 +1133,7 @@ exports[`SyncControls snapshots hideSuspend 1`] = `
 }
 
 .c7.MuiButton-root.Mui-disabled svg {
-  fill: #d8d8d8;
+  fill: #BDBDBD;
 }
 
 .c7.MuiButton-root:hover {
@@ -1145,11 +1145,11 @@ exports[`SyncControls snapshots hideSuspend 1`] = `
 }
 
 .c7.MuiButton-text.Mui-disabled {
-  color: #d8d8d8;
+  color: #BDBDBD;
 }
 
 .c7.MuiButton-text.Mui-disabled svg {
-  fill: #d8d8d8;
+  fill: #BDBDBD;
 }
 
 .c1 .sync-icon-button {
@@ -1166,7 +1166,7 @@ exports[`SyncControls snapshots hideSuspend 1`] = `
   className="c0 c1"
 >
   <button
-    className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation c2 sync-icon-button css-157ho6v-MuiButtonBase-root-MuiButton-root"
+    className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation c2 sync-icon-button css-9buukw-MuiButtonBase-root-MuiButton-root"
     disabled={null}
     id=":rn:"
     onBlur={[Function]}
@@ -1221,7 +1221,7 @@ exports[`SyncControls snapshots hideSuspend 1`] = `
         className="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd c6 css-12f4qvw-MuiFormControlLabel-root"
       >
         <span
-          className="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-checked MuiRadio-root MuiRadio-colorPrimary css-yavd16-MuiButtonBase-root-MuiRadio-root"
+          className="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-checked MuiRadio-root MuiRadio-colorPrimary css-1avr0ra-MuiButtonBase-root-MuiRadio-root"
           onBlur={[Function]}
           onContextMenu={[Function]}
           onDragLeave={[Function]}
@@ -1287,7 +1287,7 @@ exports[`SyncControls snapshots hideSuspend 1`] = `
         className="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd c6 css-12f4qvw-MuiFormControlLabel-root"
       >
         <span
-          className="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary css-yavd16-MuiButtonBase-root-MuiRadio-root"
+          className="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary css-1avr0ra-MuiButtonBase-root-MuiRadio-root"
           onBlur={[Function]}
           onContextMenu={[Function]}
           onDragLeave={[Function]}
@@ -1364,7 +1364,7 @@ exports[`SyncControls snapshots hideSuspend 1`] = `
     onTouchStart={[Function]}
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-1fh7grq-MuiButtonBase-root-MuiButton-root"
+      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-624mb0-MuiButtonBase-root-MuiButton-root"
       data-testid="sync-button"
       disabled={null}
       id=":rq:"
@@ -1529,7 +1529,7 @@ exports[`SyncControls snapshots hideSyncOptions 1`] = `
 }
 
 .c6.MuiButton-root.Mui-disabled svg {
-  fill: #d8d8d8;
+  fill: #BDBDBD;
 }
 
 .c6.MuiButton-root:hover {
@@ -1541,11 +1541,11 @@ exports[`SyncControls snapshots hideSyncOptions 1`] = `
 }
 
 .c6.MuiButton-text.Mui-disabled {
-  color: #d8d8d8;
+  color: #BDBDBD;
 }
 
 .c6.MuiButton-text.Mui-disabled svg {
-  fill: #d8d8d8;
+  fill: #BDBDBD;
 }
 
 .c1 .sync-icon-button {
@@ -1562,7 +1562,7 @@ exports[`SyncControls snapshots hideSyncOptions 1`] = `
   className="c0 c1"
 >
   <button
-    className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation c2 sync-icon-button css-157ho6v-MuiButtonBase-root-MuiButton-root"
+    className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation c2 sync-icon-button css-9buukw-MuiButtonBase-root-MuiButton-root"
     disabled={null}
     id=":rg:"
     onBlur={[Function]}
@@ -1617,7 +1617,7 @@ exports[`SyncControls snapshots hideSyncOptions 1`] = `
     onTouchStart={[Function]}
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c6 css-1fh7grq-MuiButtonBase-root-MuiButton-root"
+      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c6 css-624mb0-MuiButtonBase-root-MuiButton-root"
       data-testid="sync-button"
       disabled={null}
       id=":ri:"
@@ -1670,7 +1670,7 @@ exports[`SyncControls snapshots hideSyncOptions 1`] = `
     onTouchStart={[Function]}
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c6 css-1fh7grq-MuiButtonBase-root-MuiButton-root"
+      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c6 css-624mb0-MuiButtonBase-root-MuiButton-root"
       data-testid="suspend-button"
       disabled={null}
       id=":rk:"
@@ -1722,7 +1722,7 @@ exports[`SyncControls snapshots hideSyncOptions 1`] = `
     onTouchStart={[Function]}
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c6 css-1fh7grq-MuiButtonBase-root-MuiButton-root"
+      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c6 css-624mb0-MuiButtonBase-root-MuiButton-root"
       data-testid="resume-button"
       disabled={null}
       id=":rm:"
@@ -1887,7 +1887,7 @@ exports[`SyncControls snapshots non-suspended 1`] = `
 }
 
 .c6 .MuiFormControlLabel-label.Mui-disabled {
-  color: #d8d8d8;
+  color: #BDBDBD;
 }
 
 .c6 .MuiTypography-root {
@@ -1902,7 +1902,7 @@ exports[`SyncControls snapshots non-suspended 1`] = `
 }
 
 .c7.MuiButton-root.Mui-disabled svg {
-  fill: #d8d8d8;
+  fill: #BDBDBD;
 }
 
 .c7.MuiButton-root:hover {
@@ -1914,11 +1914,11 @@ exports[`SyncControls snapshots non-suspended 1`] = `
 }
 
 .c7.MuiButton-text.Mui-disabled {
-  color: #d8d8d8;
+  color: #BDBDBD;
 }
 
 .c7.MuiButton-text.Mui-disabled svg {
-  fill: #d8d8d8;
+  fill: #BDBDBD;
 }
 
 .c1 .sync-icon-button {
@@ -1935,7 +1935,7 @@ exports[`SyncControls snapshots non-suspended 1`] = `
   className="c0 c1"
 >
   <button
-    className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation c2 sync-icon-button css-157ho6v-MuiButtonBase-root-MuiButton-root"
+    className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-disableElevation c2 sync-icon-button css-9buukw-MuiButtonBase-root-MuiButton-root"
     disabled={null}
     id=":r0:"
     onBlur={[Function]}
@@ -1990,7 +1990,7 @@ exports[`SyncControls snapshots non-suspended 1`] = `
         className="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd c6 css-12f4qvw-MuiFormControlLabel-root"
       >
         <span
-          className="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-checked MuiRadio-root MuiRadio-colorPrimary css-yavd16-MuiButtonBase-root-MuiRadio-root"
+          className="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-checked MuiRadio-root MuiRadio-colorPrimary css-1avr0ra-MuiButtonBase-root-MuiRadio-root"
           onBlur={[Function]}
           onContextMenu={[Function]}
           onDragLeave={[Function]}
@@ -2056,7 +2056,7 @@ exports[`SyncControls snapshots non-suspended 1`] = `
         className="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd c6 css-12f4qvw-MuiFormControlLabel-root"
       >
         <span
-          className="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary css-yavd16-MuiButtonBase-root-MuiRadio-root"
+          className="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary css-1avr0ra-MuiButtonBase-root-MuiRadio-root"
           onBlur={[Function]}
           onContextMenu={[Function]}
           onDragLeave={[Function]}
@@ -2133,7 +2133,7 @@ exports[`SyncControls snapshots non-suspended 1`] = `
     onTouchStart={[Function]}
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-1fh7grq-MuiButtonBase-root-MuiButton-root"
+      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-624mb0-MuiButtonBase-root-MuiButton-root"
       data-testid="sync-button"
       disabled={null}
       id=":r3:"
@@ -2186,7 +2186,7 @@ exports[`SyncControls snapshots non-suspended 1`] = `
     onTouchStart={[Function]}
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-1fh7grq-MuiButtonBase-root-MuiButton-root"
+      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-624mb0-MuiButtonBase-root-MuiButton-root"
       data-testid="suspend-button"
       disabled={null}
       id=":r5:"
@@ -2238,7 +2238,7 @@ exports[`SyncControls snapshots non-suspended 1`] = `
     onTouchStart={[Function]}
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-1fh7grq-MuiButtonBase-root-MuiButton-root"
+      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeLarge MuiButton-outlinedSizeLarge MuiButton-colorPrimary MuiButton-disableElevation c2 c7 css-624mb0-MuiButtonBase-root-MuiButton-root"
       data-testid="resume-button"
       disabled={null}
       id=":r7:"

--- a/ui/components/Sync/__tests__/__snapshots__/SyncControls.test.tsx.snap
+++ b/ui/components/Sync/__tests__/__snapshots__/SyncControls.test.tsx.snap
@@ -141,16 +141,24 @@ exports[`SyncControls snapshots allButtonsDisabled 1`] = `
   padding: 0;
 }
 
-.c7.MuiButton-root :disabled svg {
+.c7.MuiButton-root.Mui-disabled svg {
   fill: #d8d8d8;
 }
 
-.c7.MuiButton-root :hover {
+.c7.MuiButton-root:hover {
   background-color: rgba(0, 179, 236, 0.1);
 }
 
 .c7.MuiButton-text {
   padding: 0;
+}
+
+.c7.MuiButton-text.Mui-disabled {
+  color: #d8d8d8;
+}
+
+.c7.MuiButton-text.Mui-disabled svg {
+  fill: #d8d8d8;
 }
 
 .c1 .sync-icon-button {
@@ -651,16 +659,24 @@ exports[`SyncControls snapshots hasTooltipSuffix 1`] = `
   padding: 0;
 }
 
-.c7.MuiButton-root :disabled svg {
+.c7.MuiButton-root.Mui-disabled svg {
   fill: #d8d8d8;
 }
 
-.c7.MuiButton-root :hover {
+.c7.MuiButton-root:hover {
   background-color: rgba(0, 179, 236, 0.1);
 }
 
 .c7.MuiButton-text {
   padding: 0;
+}
+
+.c7.MuiButton-text.Mui-disabled {
+  color: #d8d8d8;
+}
+
+.c7.MuiButton-text.Mui-disabled svg {
+  fill: #d8d8d8;
 }
 
 .c1 .sync-icon-button {
@@ -1116,16 +1132,24 @@ exports[`SyncControls snapshots hideSuspend 1`] = `
   padding: 0;
 }
 
-.c7.MuiButton-root :disabled svg {
+.c7.MuiButton-root.Mui-disabled svg {
   fill: #d8d8d8;
 }
 
-.c7.MuiButton-root :hover {
+.c7.MuiButton-root:hover {
   background-color: rgba(0, 179, 236, 0.1);
 }
 
 .c7.MuiButton-text {
   padding: 0;
+}
+
+.c7.MuiButton-text.Mui-disabled {
+  color: #d8d8d8;
+}
+
+.c7.MuiButton-text.Mui-disabled svg {
+  fill: #d8d8d8;
 }
 
 .c1 .sync-icon-button {
@@ -1504,16 +1528,24 @@ exports[`SyncControls snapshots hideSyncOptions 1`] = `
   padding: 0;
 }
 
-.c6.MuiButton-root :disabled svg {
+.c6.MuiButton-root.Mui-disabled svg {
   fill: #d8d8d8;
 }
 
-.c6.MuiButton-root :hover {
+.c6.MuiButton-root:hover {
   background-color: rgba(0, 179, 236, 0.1);
 }
 
 .c6.MuiButton-text {
   padding: 0;
+}
+
+.c6.MuiButton-text.Mui-disabled {
+  color: #d8d8d8;
+}
+
+.c6.MuiButton-text.Mui-disabled svg {
+  fill: #d8d8d8;
 }
 
 .c1 .sync-icon-button {
@@ -1869,16 +1901,24 @@ exports[`SyncControls snapshots non-suspended 1`] = `
   padding: 0;
 }
 
-.c7.MuiButton-root :disabled svg {
+.c7.MuiButton-root.Mui-disabled svg {
   fill: #d8d8d8;
 }
 
-.c7.MuiButton-root :hover {
+.c7.MuiButton-root:hover {
   background-color: rgba(0, 179, 236, 0.1);
 }
 
 .c7.MuiButton-text {
   padding: 0;
+}
+
+.c7.MuiButton-text.Mui-disabled {
+  color: #d8d8d8;
+}
+
+.c7.MuiButton-text.Mui-disabled svg {
+  fill: #d8d8d8;
 }
 
 .c1 .sync-icon-button {

--- a/ui/components/UserSettings.tsx
+++ b/ui/components/UserSettings.tsx
@@ -94,7 +94,7 @@ function UserSettings({ className, darkModeEnabled = true }: Props) {
         open={open}
         onClose={handleClose}
         onClick={handleClose}
-        transformOrigin={{ horizontal: 150, vertical: -80 }}
+        transformOrigin={{ horizontal: 90, vertical: -10 }}
       >
         <MenuItem onClick={() => navigate(V2Routes.UserInfo)}>
           Hello, {userInfo?.id}

--- a/ui/components/UserSettings.tsx
+++ b/ui/components/UserSettings.tsx
@@ -39,9 +39,8 @@ const PersonButton = styled(IconButton)<{ open?: boolean }>`
     padding: ${(props) => props.theme.spacing.xs};
     background-color: ${(props) => props.theme.colors.neutralGray};
     color: ${(props) => props.theme.colors.neutral30};
-    :hover {
-      background-color: ${(props) => props.theme.colors.neutral00};
-      color: ${(props) => props.theme.colors.primary10};
+    &:hover {
+      background-color: ${(props) => props.theme.colors.blueWithOpacity};
     }
   }
 `;

--- a/ui/components/YamlView.tsx
+++ b/ui/components/YamlView.tsx
@@ -36,7 +36,7 @@ function UnstyledYamlView({
   const styleProps = {
     customStyle: {
       margin: 0,
-      ...(!dark && { backgroundColor: "transparent" }),
+      backgroundColor: "transparent",
     },
 
     codeTagProps: {

--- a/ui/components/__tests__/__snapshots__/Footer.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/Footer.test.tsx.snap
@@ -73,7 +73,7 @@ exports[`Footer snapshots default 1`] = `
 .c1 {
   max-width: 100%;
   box-sizing: border-box;
-  background: #F6F7F9;
+  background: #C2C9D7;
   color: #737373;
   padding: 24px;
   border-radius: 0 0 8px 8px;
@@ -250,7 +250,7 @@ exports[`Footer snapshots no api version 1`] = `
 .c1 {
   max-width: 100%;
   box-sizing: border-box;
-  background: #F6F7F9;
+  background: #C2C9D7;
   color: #737373;
   padding: 24px;
   border-radius: 0 0 8px 8px;

--- a/ui/components/__tests__/__snapshots__/MessageBox.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/MessageBox.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`MessageBox snapshots renders 1`] = `
   width: 560px;
   padding: 24px 48px 64px;
   border-radius: 10px;
-  background-color: #F6F7F9;
+  background-color: #C2C9D7;
   color: #737373;
 }
 

--- a/ui/components/__tests__/__snapshots__/Metadata.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/Metadata.test.tsx.snap
@@ -113,7 +113,7 @@ exports[`Metadata snapshots renders with data 1`] = `
   padding: 8px 12px;
   border-radius: 15px;
   white-space: nowrap;
-  background-color: #F6F7F9;
+  background-color: #C2C9D7;
 }
 
 .c1 {

--- a/ui/components/__tests__/__snapshots__/Page.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/Page.test.tsx.snap
@@ -125,12 +125,12 @@ exports[`Page snapshots default 1`] = `
 
 .c10.MuiIconButton-root {
   padding: 8px;
-  background-color: #F6F7F9;
+  background-color: #C2C9D7;
   color: #737373;
 }
 
 .c10.MuiIconButton-root :hover {
-  background-color: #ffffff;
+  background-color: #EEEEEE;
   color: #009CCC;
 }
 
@@ -151,7 +151,7 @@ exports[`Page snapshots default 1`] = `
 }
 
 .c15 {
-  background-color: #ffffff;
+  background-color: #EEEEEE;
   border-radius: 10px;
   box-sizing: border-box;
   margin: 0 auto;

--- a/ui/components/__tests__/__snapshots__/Page.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/Page.test.tsx.snap
@@ -114,6 +114,10 @@ exports[`Page snapshots default 1`] = `
   text-overflow: ellipsis;
 }
 
+.c9 .MuiSwitch-switchBase:hover {
+  background-color: rgba(0, 179, 236, 0.1);
+}
+
 .c9 .MuiSwitch-thumb {
   color: #fff;
   background-image: url();
@@ -129,9 +133,8 @@ exports[`Page snapshots default 1`] = `
   color: #737373;
 }
 
-.c10.MuiIconButton-root :hover {
-  background-color: #EEEEEE;
-  color: #009CCC;
+.c10.MuiIconButton-root:hover {
+  background-color: rgba(0, 179, 236, 0.1);
 }
 
 .c13 {

--- a/ui/components/__tests__/__snapshots__/YamlView.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/YamlView.test.tsx.snap
@@ -100,9 +100,9 @@ exports[`YamlView snapshots renders 1`] = `
 }
 
 .c2 {
-  background: #F6F7F9;
+  background: #C2C9D7;
   padding: 12px;
-  border-bottom: 1px solid #d8d8d8;
+  border-bottom: 1px solid #BDBDBD;
   font-family: monospace;
   color: #009CCC;
   text-overflow: ellipsis;
@@ -112,7 +112,7 @@ exports[`YamlView snapshots renders 1`] = `
   margin-bottom: 12px;
   width: 100%;
   font-size: 12px;
-  border: 1px solid #d8d8d8;
+  border: 1px solid #BDBDBD;
   border-radius: 8px;
   overflow: hidden;
 }
@@ -125,7 +125,7 @@ exports[`YamlView snapshots renders 1`] = `
   position: absolute;
   right: 4px;
   top: 8px;
-  background: #F6F7F9;
+  background: #C2C9D7;
   padding: 4px 8px;
   border-radius: 2px;
 }

--- a/ui/lib/theme.ts
+++ b/ui/lib/theme.ts
@@ -118,11 +118,11 @@ export const theme = (mode: ThemeTypes = ThemeTypes.Light): DefaultTheme => {
         alertMedium: "#D58572",
         alertOriginal: "#BC3B1D",
         alertDark: "#9F3119",
-        neutralGray: "#F6F7F9",
+        neutralGray: "#C2C9D7",
         pipelineGray: "#dde1e9",
-        neutral00: "#ffffff",
+        neutral00: "#EEEEEE",
         neutral10: "#f5f5f5",
-        neutral20: "#d8d8d8",
+        neutral20: "#BDBDBD",
         neutral30: "#737373",
         neutral40: "#1a1a1a",
         whiteToPrimary: "#fff",
@@ -171,7 +171,7 @@ export const GlobalStyle = createGlobalStyle`
     background-image: ${(props) =>
       props.theme.mode === ThemeTypes.Dark
         ? `url(${images.bgDark})`
-        : `url(${images.bg}), linear-gradient(to bottom, rgba(85, 105, 145, .1) 5%, rgba(85, 105, 145, .1), rgba(85, 105, 145, .25) 35%)`};
+        : `url(${images.bg}), linear-gradient(to bottom, rgba(85, 105, 145, .35) 5%, rgba(85, 105, 145, .30), rgba(85, 105, 145, .25) 35%)`};
     background-color: ${(props) =>
       props.theme.mode === ThemeTypes.Dark
         ? props.theme.colors.neutralGray

--- a/ui/lib/theme.ts
+++ b/ui/lib/theme.ts
@@ -159,7 +159,7 @@ export const GlobalStyle = createGlobalStyle`
     height: 100%;
     margin: 0;
   }
-  
+
   body {
     font-family: ${(props) => props.theme.fontFamilies.regular};
     font-size: ${(props) => props.theme.fontSizes.medium};
@@ -167,7 +167,7 @@ export const GlobalStyle = createGlobalStyle`
     padding: 0;
     margin: 0;
     min-width: fit-content;
-    background: right bottom no-repeat fixed; 
+    background: right bottom no-repeat fixed;
     background-image: ${(props) =>
       props.theme.mode === ThemeTypes.Dark
         ? `url(${images.bgDark})`
@@ -184,7 +184,7 @@ export const GlobalStyle = createGlobalStyle`
 
 //prevents white autofill background in dark mode
 input:-webkit-autofill,
-input:-webkit-autofill:hover, 
+input:-webkit-autofill:hover,
 input:-webkit-autofill:focus {
     ${(props) =>
       props.theme.mode === ThemeTypes.Dark &&
@@ -242,6 +242,7 @@ export const muiTheme = (colors, mode) =>
           paper: {
             width: "60%",
             minWidth: 600,
+            backgroundColor: colors.neutral00,
           },
         },
       },


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

This PR cleans up a number of stylistic issues I have noticed in the UI.

Each style change is a distinct commit on the PR to aid in isolation and be able to describe what each change is as part of its commit rather than trying to raise each one as a separate PR.

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**

Whilst browsing the UI I have noticed a number of stylistic issues, particularly in Dark mode that in some cases are the result of the switch from Material UI 4 to Material UI 5.

* `6b19b10a6` Button styling fixes
* `2f4024ef1` Link hover states for sidebar and tabs
* `5c8c3ce4f` Search field showed as wrapper to filter button
* `9121cd8a6` Styling changes for light mode to make it less harsh
* `54e909083` YAML sidebar in dark mode
* `d9e5edb43` Fix alerts import and styling
* `44fdac8df` Better placing for User details dropdown
* `4e0db75fc` Better centring for the resume icon
* `01c770cc1` Clean up theming of sync controls
* `98fead114` Set default zoom level down to 75% from 85%
* `49ff2db5f` Set graph thumb to centre on the slider

Each of these commits contains additional information about why the change was made. Please see the commit log for details.

**How did you validate the change?**

Local testing, ensuring close compatibility with existing unit tests, clicking around in the UI

**Release notes**

N/A

**Documentation Changes**

N/A