### PR TITLE
ci(release): remove publish to https Helm repository

### DIFF
--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -13,10 +13,6 @@ on:
       - 'charts/**'
   workflow_dispatch:
 
-env:
-  REGISTRY: ghcr.io
-  CHART_LOCATION: weaveworks/charts
-
 permissions:
   contents: read # for actions/checkout to fetch code
 
@@ -89,27 +85,14 @@ jobs:
           echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
       - name: Generate new chart
         run: |
-          URL=https://helm.gitops.weave.works
           mkdir helm-release
           helm package charts/gitops-server/ -d helm-release
-          curl -O $URL/index.yaml
-          helm repo index helm-release --merge=index.yaml --url=$URL
-      - id: auth
-        uses: google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f # v2.1.7
-        with:
-          credentials_json: ${{ secrets.PROD_DOCS_GITOPS_UPLOAD }}
-      - id: upload-file
-        uses: google-github-actions/upload-cloud-storage@386ab77f37fdf51c0e38b3d229fad286861cc0d0 # v2.2.1
-        with:
-          path: helm-release
-          destination: helm.gitops.weave.works
-          parent: false
       - name: Log in to the Container registry
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:
-          registry: ${{ env.REGISTRY }}
+          registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish chart as an OCI image
         run: |
-          helm push helm-release/weave-gitops-${{ steps.new_version.outputs.version }}.tgz oci://${{ env.REGISTRY }}/${{ env.CHART_LOCATION }}
+          helm push helm-release/weave-gitops-${{ steps.new_version.outputs.version }}.tgz oci://ghcr.io/weaveworks/charts

--- a/website/update-screenshots.js
+++ b/website/update-screenshots.js
@@ -49,8 +49,9 @@ metadata:
   name: ww-gitops
   namespace: flux-system
 spec:
-  interval: 1h0m0s
-  url: https://helm.gitops.weave.works
+  type: oci
+  interval: 10m0s
+  url: oci://ghcr.io/weaveworks/charts
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes

<!-- Describe what has changed in this PR -->
**What changed?**

This removes the publishing of the Helm chart to the https Helm repository, leaving OCI as the only option for installing the Helm chart. Also updated the Helm install example in the docs.

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**

We no longer have access to the `helm.gitops.weave.works` domain, and OCI is now the preferred mechanism for publishing Helm charts.

<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**


<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**


<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**


<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
