### PR TITLE
chore(go): enable race detector in tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ unit-tests: ## Run unit tests
 	@go install github.com/onsi/ginkgo/v2/ginkgo
 	# This tool doesn't have releases - it also is only a shim
 	@go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
-	KUBEBUILDER_ASSETS=$$(setup-envtest use -p path 1.32.0) CGO_ENABLED=0 ginkgo $(TEST_V) -tags unittest $(TEST_TO_RUN)
+	KUBEBUILDER_ASSETS=$$(setup-envtest use -p path 1.32.0) CGO_ENABLED=1 ginkgo $(TEST_V) -race -tags unittest $(TEST_TO_RUN)
 
 local-kind-cluster-with-registry:
 	./tools/kind-with-registry.sh

--- a/core/clustersmngr/factory.go
+++ b/core/clustersmngr/factory.go
@@ -391,7 +391,7 @@ func (cf *clustersManager) updateNamespacesWithClient(ctx context.Context, creat
 }
 
 func (cf *clustersManager) GetClustersNamespaces() map[string][]v1.Namespace {
-	return cf.clustersNamespaces.namespaces
+	return cf.clustersNamespaces.GetAll()
 }
 
 func (cf *clustersManager) syncCaches() {
@@ -544,7 +544,7 @@ func (cf *clustersManager) GetServerClient(ctx context.Context) (Client, error) 
 		result = multierror.Append(result, err)
 	}
 
-	return NewClient(pool, cf.clustersNamespaces.namespaces, cf.log), result.ErrorOrNil()
+	return NewClient(pool, cf.clustersNamespaces.GetAll(), cf.log), result.ErrorOrNil()
 }
 
 func (cf *clustersManager) UpdateUserNamespaces(ctx context.Context, user *auth.UserPrincipal) {

--- a/core/clustersmngr/factory_caches.go
+++ b/core/clustersmngr/factory_caches.go
@@ -2,6 +2,7 @@ package clustersmngr
 
 import (
 	"fmt"
+	"maps"
 	"sort"
 	"strings"
 	"sync"
@@ -114,6 +115,16 @@ func (cn *ClustersNamespaces) Get(cluster string) []v1.Namespace {
 	defer cn.Unlock()
 
 	return cn.namespaces[cluster]
+}
+
+func (cn *ClustersNamespaces) GetAll() map[string][]v1.Namespace {
+	cn.Lock()
+	defer cn.Unlock()
+
+	m := make(map[string][]v1.Namespace, len(cn.namespaces))
+	maps.Copy(m, cn.namespaces)
+
+	return m
 }
 
 type UsersNamespaces struct {


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes

<!-- Describe what has changed in this PR -->
**What changed?**

- Enable Go [race detector](https://go.dev/doc/articles/race_detector) for Go testing (which requires `CGO_ENABLED=1`)
- Fix a race detected by the detector when running tests.

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**

I am trying to figure out why the Go tests sometimes blocks "forever" in CI. Example: https://github.com/weaveworks/weave-gitops/actions/runs/12973902776/job/36183126193. And I have a feeling this problem is related to Goroutines, missing error handling and/or races. I want to eliminate the latter, so I suggest we enable the race detector for the tests.

<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**


<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**


<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**


<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
