### PR TITLE
test(go): remove unused controller-runtime Manager

### DIFF
--- a/core/server/suite_test.go
+++ b/core/server/suite_test.go
@@ -44,14 +44,13 @@ func TestMain(m *testing.M) {
 		"../../tools/testcrds",
 	})
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to start test environment: %v\n", err)
-		os.Exit(1)
+		panic(err)
 	}
 
 	code := m.Run()
-	if k8sEnv != nil {
-		k8sEnv.Stop() // No return value to handle here
-	}
+
+	k8sEnv.Stop()
+
 	os.Exit(code)
 }
 

--- a/pkg/run/install/install_suite_test.go
+++ b/pkg/run/install/install_suite_test.go
@@ -33,3 +33,7 @@ var _ = BeforeSuite(func() {
 	cleanupK8s = k8sEnv.Stop
 	k8sClient = k8sEnv.Client
 })
+
+var _ = AfterSuite(func() {
+	cleanupK8s()
+})

--- a/pkg/run/run_suite_test.go
+++ b/pkg/run/run_suite_test.go
@@ -33,3 +33,7 @@ var _ = BeforeSuite(func() {
 	cleanupK8s = k8sEnv.Stop
 	k8sClient = k8sEnv.Client
 })
+
+var _ = AfterSuite(func() {
+	cleanupK8s()
+})

--- a/pkg/server/auth/auth_test.go
+++ b/pkg/server/auth/auth_test.go
@@ -346,9 +346,9 @@ func TestRateLimit(t *testing.T) {
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(res1).To(HaveHTTPStatus(http.StatusOK))
 
-	res2, err := http.Post(s.URL+"/oauth2/sign_in", "application/json", bytes.NewReader([]byte(`{"password":"my-secret-password"}`)))
-	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(res2).To(HaveHTTPStatus(http.StatusTooManyRequests))
+	g.Eventually(func() (*http.Response, error) {
+		return http.Post(s.URL+"/oauth2/sign_in", "application/json", bytes.NewReader([]byte(`{"password":"my-secret-password"}`)))
+	}).Should(HaveHTTPStatus(http.StatusTooManyRequests))
 
 	time.Sleep(time.Second)
 

--- a/pkg/testutils/testutils.go
+++ b/pkg/testutils/testutils.go
@@ -9,20 +9,13 @@ import (
 	"log"
 	"net/http"
 	"net/http/httptest"
-	"os"
-	"strings"
 	"testing"
 	"time"
 
-	kustomizev2 "github.com/fluxcd/kustomize-controller/api/v1"
-	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 	"github.com/go-jose/go-jose/v4"
 	"github.com/go-jose/go-jose/v4/jwt"
-	"github.com/go-logr/logr"
 	"github.com/onsi/gomega"
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/discovery"
@@ -31,15 +24,11 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/restmapper"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 
 	"github.com/weaveworks/weave-gitops/pkg/kube"
-	"github.com/weaveworks/weave-gitops/pkg/vendorfakes/fakelogr"
 )
-
-const BaseURI = "https://weave.works/api"
 
 var k8sEnv *K8sTestEnv
 
@@ -80,38 +69,8 @@ func StartK8sTestEnvironment(crdPaths []string) (*K8sTestEnv, error) {
 		return nil, fmt.Errorf("could not create scheme: %w", err)
 	}
 
-	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
-		Client: client.Options{
-			Cache: &client.CacheOptions{
-				DisableFor: []client.Object{
-					&corev1.Namespace{},
-					&corev1.Secret{},
-					&appsv1.Deployment{},
-					&corev1.ConfigMap{},
-					&kustomizev2.Kustomization{},
-					&sourcev1.GitRepository{},
-					&v1.CustomResourceDefinition{},
-				},
-			},
-			Scheme: scheme,
-		},
-	})
-	if err != nil {
-		return nil, fmt.Errorf("could not create controller manager: %w", err)
-	}
-
-	ctrlCtx, ctrlCancel := context.WithCancel(context.Background())
-
-	go func() {
-		err := k8sManager.Start(ctrlCtx)
-		if err != nil {
-			log.Fatal(err.Error())
-		}
-	}()
-
 	dc, err := discovery.NewDiscoveryClientForConfig(cfg)
 	if err != nil {
-		ctrlCancel()
 		return nil, fmt.Errorf("failed to initialize discovery client: %w", err)
 	}
 
@@ -119,18 +78,21 @@ func StartK8sTestEnvironment(crdPaths []string) (*K8sTestEnv, error) {
 
 	dyn, err := dynamic.NewForConfig(cfg)
 	if err != nil {
-		ctrlCancel()
 		return nil, fmt.Errorf("failed to initialize dynamic client: %w", err)
+	}
+
+	k8sClient, err := client.New(cfg, client.Options{Scheme: scheme})
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize client: %w", err)
 	}
 
 	k8sEnv = &K8sTestEnv{
 		Env:        testEnv,
-		Client:     k8sManager.GetClient(),
+		Client:     k8sClient,
 		DynClient:  dyn,
 		RestMapper: mapper,
 		Rest:       cfg,
 		Stop: func() {
-			ctrlCancel()
 			err := testEnv.Stop()
 			if err != nil {
 				log.Fatal(err.Error())
@@ -139,33 +101,6 @@ func StartK8sTestEnvironment(crdPaths []string) (*K8sTestEnv, error) {
 	}
 
 	return k8sEnv, nil
-}
-
-// MakeFakeLogr returns an API compliant logr object that can be used for unit testing.
-func MakeFakeLogr() (logr.Logger, *fakelogr.LogSink) {
-	sink := &fakelogr.LogSink{}
-	sink.WithValuesStub = func(i ...interface{}) logr.LogSink {
-		return sink
-	}
-	sink.EnabledStub = func(i int) bool {
-		return true
-	}
-
-	return logr.New(sink), sink
-}
-
-func Setenv(k, v string) func() {
-	prev := os.Environ()
-	os.Setenv(k, v)
-
-	return func() {
-		os.Unsetenv(k)
-
-		for _, kv := range prev {
-			parts := strings.SplitN(kv, "=", 2)
-			os.Setenv(parts[0], parts[1])
-		}
-	}
 }
 
 // MakeRSAPrivateKey generates and returns an RSA Private Key.


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes

<!-- Describe what has changed in this PR -->
**What changed?**

The primary change in this PR is removing an unused controller-runtime `Manager`. I have no idea why the test setup was created this way, but we don't need to create a Manager (heavy) just to create a controller-runtime `Client`.

In addition, I made all use of the test-helper consistent (stopping testEnv).

Also improving a flaky test with Ginkgo `Eventually` - as it was bugging me while verifying this change. 🤠 

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**

Still trying to dig into the occasionally blocked tests.

<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**


<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**


<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**


<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
