### PR TITLE
ci(dependabot): reintroduce website group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: "npm"
-    directories:
-      - "/"
-      - "/website"
+    directory: "/"
     schedule:
       interval: "daily"
     # Raised limit temporarily to get all potential upgrades
@@ -14,9 +12,6 @@ updates:
           - "@babel/core"
           - "@babel/preset-env"
           - "@types/babel__preset-env"
-      docusaurus:
-        patterns:
-          - "@docusaurus/*"
       emotion:
         patterns:
           - "@emotion/*"
@@ -62,6 +57,14 @@ updates:
       k8s:
         patterns:
           - "k8s.io/*"
+  - package-ecosystem: "npm"
+    directory: "/website"
+    schedule:
+      interval: weekly
+    groups:
+      npm-packages:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes

<!-- Describe what has changed in this PR -->
**What changed?**

"Smart" revert of https://github.com/weaveworks/weave-gitops/pull/4621: Reintroduce a dedicated Dependabot group for website upgrades, but one PR for all upgrades.

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**

I was not very happy with the way Dependabot supports multiple directories. We should not mix F/E app and doc updates the way Dependabot does.

<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**


<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**


<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**


<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
