### PR TITLE
Revert "ci: add dependency review job to PR workflow"

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -69,13 +69,6 @@ jobs:
       - name: Check that make fakes has been run
         run: git diff --no-ext-diff --exit-code
 
-  ci-dependency-review:
-    name: CI Dependency Review
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions/dependency-review-action@3b139cfc5fae8b618d3eae3675e383bb1769c019 # v4.5.0
-
   build-push-image:
     name: CI Build Image
     uses: ./.github/workflows/build-push-image.yaml


### PR DESCRIPTION
Reverts weaveworks/weave-gitops#4631

It seems like this action is made to only run on pull requests, and it's failing on the main branch now.