### PR TITLE
feat(helm): new value to opt-out from cluster-wide view access to secrets

### DIFF
--- a/charts/gitops-server/templates/role.yaml
+++ b/charts/gitops-server/templates/role.yaml
@@ -15,6 +15,7 @@ rules:
     {{- with .Values.rbac.impersonationResourceNames }}
     resourceNames: {{ . | toJson }}
     {{- end }}
+    {{- if .Values.rbac.viewSecretsEnabled }}
   # Access to enterprise entitlement
   - apiGroups: [""]
     resources: [ "secrets" ]
@@ -25,6 +26,7 @@ rules:
     # or should return the first non-falsy result
     {{- with (or .Values.rbac.viewSecretsResourceNames .Values.rbac.viewSecrets) }}
     resourceNames: {{ . | toJson }}
+    {{- end }}
     {{- end }}
 
   # The service account needs to read namespaces to know where it can query

--- a/charts/gitops-server/values.yaml
+++ b/charts/gitops-server/values.yaml
@@ -63,6 +63,9 @@ rbac:
   impersonationResourceNames: []
   # -- Limit the type of principal that can be impersonated
   impersonationResources: ["users", "groups"]
+  # -- Specifies whether the service account should have cluster-wide view access to secrets.
+  # If enabled, the secrets permitted to read can be limited by name with `viewSecretsResourceNames`.
+  viewSecretsEnabled: true
   # -- If non-empty, this limits the secrets that can be accessed by
   # the service account to the specified ones, e.g. `['weave-gitops-enterprise-credentials']`
   viewSecretsResourceNames: ["cluster-user-auth", "oidc-auth"]


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Relates to https://github.com/weaveworks/weave-gitops/issues/3702

<!-- Describe what has changed in this PR -->
**What changed?**

This adds a new value to the Helm chart that allows opting out from cluster-wide read access to secrets.

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**

It seems like this permission isn't required, at least not in the current community-only version. Let's see what is required when we eventually fold in the enterprise features later on.

<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**


<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**


<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**


<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
