### PR TITLE
fix: add ocirepositories to nsaccess rules

### DIFF
--- a/core/nsaccess/nsaccess.go
+++ b/core/nsaccess/nsaccess.go
@@ -18,8 +18,13 @@ import (
 var DefautltWegoAppRules = []rbacv1.PolicyRule{
 	{
 		APIGroups: []string{""},
-		Resources: []string{"secrets", "pods", "events"},
+		Resources: []string{"pods", "secrets"},
 		Verbs:     []string{"get", "list"},
+	},
+	{
+		APIGroups: []string{""},
+		Resources: []string{"events"},
+		Verbs:     []string{"get", "list", "watch"},
 	},
 	{
 		APIGroups: []string{"apps"},
@@ -38,13 +43,8 @@ var DefautltWegoAppRules = []rbacv1.PolicyRule{
 	},
 	{
 		APIGroups: []string{"source.toolkit.fluxcd.io"},
-		Resources: []string{"buckets", "helmcharts", "gitrepositories", "helmrepositories"},
+		Resources: []string{"buckets", "helmcharts", "helmrepositories", "gitrepositories", "ocirepositories"},
 		Verbs:     []string{"get", "list"},
-	},
-	{
-		APIGroups: []string{""},
-		Resources: []string{"events"},
-		Verbs:     []string{"get", "list", "watch"},
 	},
 }
 


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Relates to https://github.com/weaveworks/weave-gitops/issues/3702

<!-- Describe what has changed in this PR -->
**What changed?**

The primary change in this PR is to add `ocirepositories` to the `source.toolkit.fluxcd.io` in the required RBAC rules. This should be part of the requirements alongside the other Flux source types - as weave-gitops is able to list source resources. I did **not** add any requirement for access to the Flux API groups `notification.toolkit.fluxcd.io` or `image.toolkit.fluxcd.io` - even if I think it's strange that this is not a requirement.

I have also organized the required rules better:

- Grouped by API group in list of requirements.
- Fixed the semi-duplicated requirements for events.
- Sorted resources in rules alphabetically.

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**

Before starting on the simpler nsaccess checker suggested in https://github.com/weaveworks/weave-gitops/issues/3702#issuecomment-2626524896, I would like to correct the code currently used.

<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**


<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**


<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**


<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
