### PR TITLE
ci: Disable upgrade-flux workflow in forks

### DIFF
--- a/.github/workflows/upgrade-flux.yaml
+++ b/.github/workflows/upgrade-flux.yaml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   has-new-flux:
     runs-on: ubuntu-latest
+    if: "${{ github.repository_owner == 'weaveworks' && github.ref_name == 'main'}}"
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:

--- a/.github/workflows/upgrade-flux.yaml
+++ b/.github/workflows/upgrade-flux.yaml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   has-new-flux:
     runs-on: ubuntu-latest
-    if: "${{ github.repository_owner == 'weaveworks' && github.ref_name == 'main'}}"
+    if: "${{ github.repository_owner == 'weaveworks' && github.ref_name == 'main' }}"
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes

<!-- Describe what has changed in this PR -->
**What changed?**

Disable the upgrade-flux workflow in forks. It should only run in the main repo, as it will fail in "any" fork.

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**

I was getting failing runs in my fork after Flux 2.5 was released.


<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**


<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**


<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**


<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
