### PR TITLE
ci: Don't require specific casing in PR title

### DIFF
--- a/.github/workflows/lint-pr.yaml
+++ b/.github/workflows/lint-pr.yaml
@@ -17,12 +17,6 @@ jobs:
     steps:
       - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5.5.3
         id: lint_pr_title
-        with:
-          # Ensure the subject doesn't start with an uppercase character.
-          subjectPattern: ^(?![a-z]).+$
-          subjectPatternError: |
-            Please ensure the subject in the pull request title ("{subject}")
-            doesn't start with an lowercase character.
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -39,7 +33,6 @@ jobs:
             [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
             and it looks like your proposed title needs to be adjusted.
             
-            While the specification does not require a specific casing, it recommends being consistent.
             We use the pull request title in automated release changelog updates, and would like our
             changelogs to look nice.
 


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes

<!-- Describe what has changed in this PR -->
**What changed?**

This PR removes the strict requirement for an initial uppercase character in the (convention commit) PR title.


<!-- Tell your future self why have you made these changes -->
**Why was this change made?**

This will add less "fuzz" to the general contribution process, which has already annoyed me. 😉 But after discovering that release-please has a [plugin to ensure nice release notes](https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md#sentence-case), even with mixed case subjects, I don't think this strict requirement is required anymore.

Relates to https://github.com/weaveworks/weave-gitops/pull/4824.

<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**


<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**


<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**


<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
