### PR TITLE
test(ui): make footer snapshot test independent of npm module version

### DIFF
--- a/ui/components/__tests__/Footer.test.tsx
+++ b/ui/components/__tests__/Footer.test.tsx
@@ -10,6 +10,14 @@ import {
 } from "../../lib/test-utils";
 import Footer from "../Footer";
 
+jest.mock(
+  "../../../package.json",
+  () => ({
+    version: "x.y.z",
+  }),
+  { virtual: true },
+);
+
 describe("Footer", () => {
   let container;
   beforeEach(() => {

--- a/ui/components/__tests__/__snapshots__/Footer.test.tsx.snap
+++ b/ui/components/__tests__/__snapshots__/Footer.test.tsx.snap
@@ -325,7 +325,7 @@ exports[`Footer snapshots no api version 1`] = `
       />
       <a
         class="c5 Link"
-        href="https://github.com/weaveworks/weave-gitops/releases/tag/v0.39.0-rc.2"
+        href="https://github.com/weaveworks/weave-gitops/releases/tag/vx.y.z"
         rel="noreferrer"
         target="_blank"
       >
@@ -335,7 +335,7 @@ exports[`Footer snapshots no api version 1`] = `
           <span
             class="c10"
           >
-            v0.39.0-rc.2
+            vx.y.z
           </span>
         </span>
       </a>


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes

<!-- Describe what has changed in this PR -->
**What changed?**

Add mocking of the `package.json` version in the footer snapshot UI test.

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**

Done to fix CI in release-please PRs like https://github.com/weaveworks/weave-gitops/pull/4834.

<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**


<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**


<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**


<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
