### PR TITLE
ci(dependabot): improve config for release-please

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,11 @@ updates:
     schedule:
       interval: weekly
       day: thursday
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: fix
+      prefix-development: build
+      include: scope
     groups:
       babel:
         patterns:
@@ -43,6 +48,10 @@ updates:
     schedule:
       interval: weekly
       day: tuesday
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: fix
+      include: scope
     groups:
       golang-grpc:
         patterns:
@@ -61,24 +70,37 @@ updates:
     directory: "/website"
     schedule:
       interval: weekly
+    commit-message:
+      prefix: build
+      include: scope
     groups:
-      npm-packages:
-        patterns:
-          - "*"
+      all-website-npm:
+        patterns: ["*"]
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: weekly
+    commit-message:
+      prefix: ci
+      include: scope
+    groups:
+      all-github-actions:
+        patterns: ["*"]
   - package-ecosystem: docker
     directory: "/"
     schedule:
       interval: weekly
       day: friday
+    commit-message:
+      prefix: chore
+      include: scope
   - package-ecosystem: pip
     directory: "/"
     schedule:
       interval: weekly
+    commit-message:
+      prefix: build
+      include: scope
     groups:
-      python-packages:
-        patterns:
-          - "*"
+      all-pip:
+        patterns: ["*"]


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes

<!-- Describe what has changed in this PR -->
**What changed?**

Tune Dependabot configuration with the following goals:
- Conventional commits better aligned with automated release notes generated by release-please.
- More efficient upgrade process. This includes more grouping for non-user-facing dependency upgrades.

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**

I want release-please to propose a new release whenever a production dependency is bumped. I also want the production dependency upgrades to be included in the release notes - without the noise from other dependency upgrades. In addition, I want a bit more efficient dependency upgrade PR process.

<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**


<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**


<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**


<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
