### PR TITLE
ci: cancel PR workflows on new commits

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -11,6 +11,10 @@ on:
       - 'website/**'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read # for actions/checkout to fetch code
 

--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -13,6 +13,10 @@ on:
       - 'charts/**'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read # for actions/checkout to fetch code
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -7,6 +7,10 @@ on:
       - main
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read # for actions/checkout to fetch code
 

--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -11,6 +11,10 @@ on:
     - cron: '0 12 * * 1'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read # for actions/checkout to fetch code
 


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes

<!-- Describe what has changed in this PR -->
**What changed?**

This change should ensure all PR workflows are cancelled when new commits are added to the PR branch. This improvement is already suggested in https://github.com/weaveworks/weave-gitops/pull/3733, but I think the proposed syntax in that PR is incorrect. The PR also has conflicts that need to be resolved.

Close https://github.com/weaveworks/weave-gitops/pull/3733 

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**

I want to add CI that eventually will update release-please PR branches to include doc updates in the release PR. This seems to be the suggested approach, ref. https://github.com/googleapis/release-please/issues/2022#issuecomment-1650651529.

Not wasting workflow resources appears like a good idea.

<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**


<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**


<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**


<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
