### PR TITLE
ci: upgrade golangci-lint to v2

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,8 +1,8 @@
+version: "2"
 run:
   timeout: 10m
-
 linters:
-  disable-all: true
+  default: none
   enable:
     - containedctx
     #- contextcheck
@@ -12,14 +12,11 @@ linters:
     #- errname
     - errorlint
     #- gochecknoinits
-    - gci
     #- goconst
     - gocritic
     #- gocyclo
     #- godot
-    - gofumpt
     - gosec
-    - gosimple
     - govet
     - ineffassign
     #- lll
@@ -28,88 +25,86 @@ linters:
     - nolintlint
     - prealloc
     - staticcheck
-    - stylecheck
-    - tenv
     - thelper
     #- tparallel
-    - typecheck
     - unconvert
     - unparam
     - unused
+    - usetesting
     - whitespace
-
-linters-settings:
-  depguard:
+  settings:
+    depguard:
+      rules:
+        prevent_kubernetes_dependency:
+          list-mode: lax # allow unless explicitly denied
+          deny:
+            - pkg: k8s.io/kubernetes
+              desc: do not use k8s.io/kubernetes directly
+    errcheck:
+      exclude-functions:
+        - encoding/json.Marshal
+        - encoding/json.MarshalIndent
+    errchkjson:
+      check-error-free-encoding: true
+    gocritic:
+      disabled-checks:
+        - appendAssign
+        - appendCombine
+        - commentedOutCode
+        - equalFold
+        - exposedSyncMutex
+        - httpNoBody
+        - hugeParam
+        - ifElseChain
+        - importShadow
+        - methodExprCall
+        - nestingReduce
+        - preferStringWriter
+        - rangeValCopy
+        - singleCaseSwitch
+        - stringConcatSimplify
+        - unlabelStmt
+        - unnamedResult
+        - whyNoLint
+      enabled-tags:
+        - diagnostic
+        - experimental
+        - opinionated
+        - performance
+        - style
+    gosec:
+      excludes:
+        - G110
+        - G115
+        - G204
+        - G306
+    lll:
+      line-length: 150
+    usetesting:
+      context-background: false
+      context-todo: false
+  exclusions:
+    presets:
+      - common-false-positives
+      - legacy
+      - std-error-handling
     rules:
-      prevent_kubernetes_dependency:
-        list-mode: lax # allow unless explicitly denied
-        deny:
-          - pkg: k8s.io/kubernetes
-            desc: "do not use k8s.io/kubernetes directly"
-  errcheck:
-    exclude-functions:
-      - encoding/json.Marshal
-      - encoding/json.MarshalIndent
-  errchkjson:
-    check-error-free-encoding: true
-  gci:
-    sections:
-      - Standard
-      - Default
-      - Prefix(github.com/weaveworks)
-      - Prefix(github.com/weaveworks/weave-gitops)
-  gocritic:
-    disabled-checks:
-      - appendAssign
-      - appendCombine
-      - commentedOutCode
-      - equalFold
-      - exposedSyncMutex
-      - httpNoBody
-      - hugeParam
-      - ifElseChain
-      - importShadow
-      - methodExprCall
-      - nestingReduce
-      - preferStringWriter
-      - rangeValCopy
-      - singleCaseSwitch
-      - stringConcatSimplify
-      - unlabelStmt
-      - unnamedResult
-      - whyNoLint
-    enabled-tags:
-      - diagnostic
-      - experimental
-      - opinionated
-      - performance
-      - style
-  gofumpt:
-    extra-rules: true
-  gosec:
-    excludes:
-      - G110
-      - G115
-      - G204
-      - G306
-  lll:
-    line-length: 150
-
-issues:
-  exclude-dirs:
-    - tilt_modules
-  exclude-rules:
-    # ignore errcheck for code under a /test folder
-    - path: "test/*"
-      linters:
-        - errcheck
-    # ignore errcheck for flags.Parse (it is expected that we flag.ExitOnError)
-    # ignore response.WriteError as it always returns the err it was passed
-    - source: "flags.Parse|response.WriteError"
-      linters:
-        - errcheck
-
-output:
-  formats:
-    - format: colored-line-number
-      path: stdout
+      - linters:
+          - errcheck
+        path: test/*
+      - linters:
+          - errcheck
+        source: flags.Parse|response.WriteError
+formatters:
+  enable:
+    - gci
+    - gofumpt
+  settings:
+    gci:
+      sections:
+        - Standard
+        - Default
+        - Prefix(github.com/weaveworks)
+        - Prefix(github.com/weaveworks/weave-gitops)
+    gofumpt:
+      extra-rules: true

--- a/Makefile
+++ b/Makefile
@@ -232,7 +232,7 @@ endif
 
 ## Tool Binaries
 
-GOLANGCI_LINT_VERSION ?= v1.63.4
+GOLANGCI_LINT_VERSION ?= v2.1.6
 PROTOLINT_VERSION ?= v0.52.0
 
 LOCALBIN ?= $(shell pwd)/bin
@@ -242,7 +242,7 @@ $(LOCALBIN):
 GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT):
-	GOBIN=$(LOCALBIN) go install github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}
+	GOBIN=$(LOCALBIN) go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}
 
 PROTOLINT = $(LOCALBIN)/protolint
 protolint: $(PROTOLINT) ## Download protolint locally if necessary.

--- a/core/server/events.go
+++ b/core/server/events.go
@@ -69,7 +69,7 @@ func (cs *coreServer) ListEvents(ctx context.Context, msg *pb.ListEventsRequest)
 				events = append(events, &pb.Event{
 					Type:      e.Type,
 					Component: e.Source.Component,
-					Name:      e.ObjectMeta.Name,
+					Name:      e.Name,
 					Reason:    e.Reason,
 					Message:   e.Message,
 					Timestamp: e.LastTimestamp.Format(time.RFC3339),

--- a/pkg/run/watch/forward_port.go
+++ b/pkg/run/watch/forward_port.go
@@ -51,12 +51,13 @@ func ParsePortForwardSpec(spec string) (*PortForwardSpec, error) {
 			return nil, fmt.Errorf("invalid port forward spec: %s", spec)
 		}
 
-		if kv[0] == "port" {
+		switch kv[0] {
+		case "port":
 			// split into port and host port
 			portAndHostPort := strings.Split(kv[1], ":")
 			specMap.HostPort = portAndHostPort[0]
 			specMap.ContainerPort = portAndHostPort[1]
-		} else if kv[0] == "resource" {
+		case "resource":
 			// specMap["resource"] = kv[1]
 			// split kv[1] into kind and name
 			kindAndName := strings.Split(kv[1], "/")
@@ -65,9 +66,9 @@ func ParsePortForwardSpec(spec string) (*PortForwardSpec, error) {
 			}
 			specMap.Kind = generalizeKind(kindAndName[0])
 			specMap.Name = kindAndName[1]
-		} else if kv[0] == "namespace" {
+		case "namespace":
 			specMap.Namespace = kv[1]
-		} else {
+		default:
 			specMap.Map[kv[0]] = kv[1]
 		}
 	}

--- a/pkg/s3/auth_middleware.go
+++ b/pkg/s3/auth_middleware.go
@@ -151,8 +151,8 @@ func getCanonicalHeaders(req http.Request, signedHeaders string) string {
 		buf.WriteString(k)
 		buf.WriteByte(':')
 
-		switch {
-		case k == "host":
+		switch k {
+		case "host":
 			buf.WriteString(getHostAddr(&req))
 			buf.WriteByte('\n')
 		default:

--- a/pkg/services/auth/jwt.go
+++ b/pkg/services/auth/jwt.go
@@ -56,7 +56,7 @@ func (i *internalJWTClient) GenerateJWT(expirationTime time.Duration, providerNa
 		// It is possible for the GitLab backend to specify an `expires_in` of 0.
 		// Edit the `Expire access tokens` setting to enable/disable expiring tokens.
 		// Gitlab defaults to 2 hour expiration, so replicate it here I guess?
-		claims.RegisteredClaims.ExpiresAt = jwt.NewNumericDate(time.Now().Add(2 * time.Hour))
+		claims.ExpiresAt = jwt.NewNumericDate(time.Now().Add(2 * time.Hour))
 	}
 
 	token := jwt.NewWithClaims(jwt.SigningMethodHS512, claims)

--- a/pkg/sourceignore/sourceignore_test.go
+++ b/pkg/sourceignore/sourceignore_test.go
@@ -60,11 +60,10 @@ func TestReadPatterns(t *testing.T) {
 }
 
 func TestReadIgnoreFile(t *testing.T) {
-	f, err := os.CreateTemp("", IgnoreFilename)
+	f, err := os.CreateTemp(t.TempDir(), IgnoreFilename)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.Remove(f.Name())
 	if _, err = f.Write([]byte(`# .sourceignore
 ignore-this.txt`)); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes

<!-- Describe what has changed in this PR -->
**What changed?**

Upgrade golangci-lint to v2 by first running the provided migration `golangci-lint migrate`, but since this migration doesn't port comments, I have tried to port them manually to the correct location. The set of linters available has changed a little with v2. As an example, `tenv` is removed and replaced by `usetesting`. I didn't want to change too much code, so I disabled some checks in this new linter. These should probably be enabled as a follow-up.

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**

To follow the evolution of golangci-lint. I had plans adding some new linters first, but figured out they required golangci-lint v2.

<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**


<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**


<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**


<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
