### PR TITLE
chore: fully enable the usetesting Go linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -80,9 +80,6 @@ linters:
         - G306
     lll:
       line-length: 150
-    usetesting:
-      context-background: false
-      context-todo: false
   exclusions:
     presets:
       - common-false-positives

--- a/core/clustersmngr/client_test.go
+++ b/core/clustersmngr/client_test.go
@@ -53,7 +53,7 @@ func TestClientGet(t *testing.T) {
 			},
 		},
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	g.Expect(k8sEnv.Client.Create(ctx, kust)).To(Succeed())
 
 	k := &kustomizev1.Kustomization{}
@@ -89,7 +89,7 @@ func TestClientClusteredList(t *testing.T) {
 			},
 		},
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	g.Expect(k8sEnv.Client.Create(ctx, kust)).To(Succeed())
 
 	cklist := clustersmngr.NewClusteredList(func() client.ObjectList {
@@ -131,7 +131,7 @@ func TestClientClusteredList(t *testing.T) {
 
 func TestClientClusteredListPagination(t *testing.T) {
 	g := NewGomegaWithT(t)
-	ctx := context.Background()
+	ctx := t.Context()
 	ns1 := createNamespace(g)
 	ns2 := createNamespace(g)
 	namespaced := true
@@ -150,7 +150,7 @@ func TestClientClusteredListPagination(t *testing.T) {
 				},
 			},
 		}
-		ctx := context.Background()
+		ctx := t.Context()
 		g.Expect(k8sEnv.Client.Create(ctx, kust)).To(Succeed())
 	}
 
@@ -240,7 +240,7 @@ func TestClientClusteredListClusterScoped(t *testing.T) {
 		},
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	g.Expect(k8sEnv.Client.Create(ctx, &clusterRole)).To(Succeed())
 
 	cklist := clustersmngr.NewClusteredList(func() client.ObjectList {
@@ -277,7 +277,7 @@ func TestClientCLusteredListErrors(t *testing.T) {
 		"foo": "@invalid",
 	}
 
-	cerr := clustersClient.ClusteredList(context.Background(), cklist, true, labels)
+	cerr := clustersClient.ClusteredList(t.Context(), cklist, true, labels)
 	g.Expect(cerr).ToNot(BeNil())
 
 	var errs clustersmngr.ClusteredListError
@@ -311,7 +311,7 @@ func TestClientList(t *testing.T) {
 			},
 		},
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	g.Expect(k8sEnv.Client.Create(ctx, kust)).To(Succeed())
 
 	list := &kustomizev1.KustomizationList{}
@@ -348,7 +348,7 @@ func TestClientCreate(t *testing.T) {
 			},
 		},
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 
 	g.Expect(clustersClient.Create(ctx, clusterName, kust)).To(Succeed())
 
@@ -383,7 +383,7 @@ func TestClientDelete(t *testing.T) {
 			},
 		},
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 
 	g.Expect(k8sEnv.Client.Create(ctx, kust)).To(Succeed())
 
@@ -417,7 +417,7 @@ func TestClientUpdate(t *testing.T) {
 			},
 		},
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	g.Expect(k8sEnv.Client.Create(ctx, kust)).To(Succeed())
 
 	kust.Spec.Path = "/bar"
@@ -460,7 +460,7 @@ func TestClientPatch(t *testing.T) {
 		},
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	opt := []client.PatchOption{
 		client.ForceOwnership,
 		client.FieldOwner("test"),

--- a/core/clustersmngr/cluster/delegating_cache_test.go
+++ b/core/clustersmngr/cluster/delegating_cache_test.go
@@ -21,7 +21,7 @@ func TestDelegatingCacheGet(t *testing.T) {
 	cache, err := cache.New(k8sEnv.Rest, cache.Options{})
 	g.Expect(err).To(BeNil())
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 1*time.Second)
 	defer cancel()
 
 	go cache.Start(ctx)
@@ -56,7 +56,7 @@ func TestDelegatingCacheList(t *testing.T) {
 	cache, err := cache.New(k8sEnv.Rest, cache.Options{})
 	g.Expect(err).To(BeNil())
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 1*time.Second)
 	defer cancel()
 
 	go cache.Start(ctx)

--- a/core/clustersmngr/factory_test.go
+++ b/core/clustersmngr/factory_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/go-logr/logr"
 	. "github.com/onsi/gomega"
-	"golang.org/x/net/context"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 
@@ -25,8 +24,7 @@ func TestGetImpersonatedClient(t *testing.T) {
 	g := NewGomegaWithT(t)
 	logger := logr.Discard()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	ns1 := createNamespace(g)
 	ns2 := createNamespace(g)
@@ -74,8 +72,7 @@ func TestUseUserClientForNamespaces(t *testing.T) {
 	g := NewGomegaWithT(t)
 	logger := logr.Discard()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	ns1 := createNamespace(g)
 	ns2 := createNamespace(g)
@@ -126,8 +123,7 @@ func TestGetImpersonatedDiscoveryClient(t *testing.T) {
 	g := NewGomegaWithT(t)
 	logger := logr.Discard()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	ns1 := createNamespace(g)
 
@@ -157,8 +153,7 @@ func TestUpdateNamespaces(t *testing.T) {
 	g := NewGomegaWithT(t)
 	logger := logr.Discard()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	nsChecker := &nsaccessfakes.FakeChecker{}
 	clustersFetcher := new(clustersmngrfakes.FakeClusterFetcher)
@@ -219,8 +214,7 @@ func TestUpdateUserNamespaces(t *testing.T) {
 	g := NewGomegaWithT(t)
 	logger := logr.Discard()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	nsChecker := &nsaccessfakes.FakeChecker{}
 	clustersFetcher := new(clustersmngrfakes.FakeClusterFetcher)
@@ -265,8 +259,7 @@ func TestUpdateUserNamespacesFailsToConnect(t *testing.T) {
 	g := NewGomegaWithT(t)
 	logger := logr.Discard()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	nsChecker := nsaccess.NewChecker(nil)
 	clustersFetcher := new(clustersmngrfakes.FakeClusterFetcher)
@@ -299,8 +292,7 @@ func TestGetClusters(t *testing.T) {
 	g := NewGomegaWithT(t)
 	logger := logr.Discard()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	nsChecker := nsaccess.NewChecker(nil)
 	clustersFetcher := new(clustersmngrfakes.FakeClusterFetcher)
@@ -335,8 +327,7 @@ func TestUpdateClusters(t *testing.T) {
 	g := NewGomegaWithT(t)
 	logger := logr.Discard()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	nsChecker := &nsaccessfakes.FakeChecker{}
 
@@ -451,8 +442,7 @@ func TestClientCaching(t *testing.T) {
 	g := NewGomegaWithT(t)
 	logger := logr.Discard()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	ns1 := createNamespace(g)
 

--- a/core/clustersmngr/fetcher/single_test.go
+++ b/core/clustersmngr/fetcher/single_test.go
@@ -1,7 +1,6 @@
 package fetcher_test
 
 import (
-	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -25,7 +24,7 @@ func TestSingleFetcher(t *testing.T) {
 
 	fetcher := fetcher.NewSingleClusterFetcher(cluster)
 
-	clusters, err := fetcher.Fetch(context.TODO())
+	clusters, err := fetcher.Fetch(t.Context())
 	g.Expect(err).To(BeNil())
 
 	g.Expect(clusters[0].GetName()).To(Equal("Default"))

--- a/core/fluxsync/adapters_test.go
+++ b/core/fluxsync/adapters_test.go
@@ -1,7 +1,6 @@
 package fluxsync
 
 import (
-	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -105,7 +104,7 @@ func TestAsClientObjectCompatibilityWithTestClient(t *testing.T) {
 		},
 	}
 
-	err := cl.Create(context.TODO(), obj.AsClientObject())
+	err := cl.Create(t.Context(), obj.AsClientObject())
 	g.Expect(err).NotTo(HaveOccurred())
 
 	retrieved := &UnstructuredAdapter{
@@ -116,7 +115,7 @@ func TestAsClientObjectCompatibilityWithTestClient(t *testing.T) {
 			},
 		},
 	}
-	err = cl.Get(context.TODO(), client.ObjectKey{Namespace: "default", Name: "test-cm"}, retrieved.AsClientObject())
+	err = cl.Get(t.Context(), client.ObjectKey{Namespace: "default", Name: "test-cm"}, retrieved.AsClientObject())
 	g.Expect(err).NotTo(HaveOccurred())
 
 	// check the data key

--- a/core/nsaccess/nsaccess_test.go
+++ b/core/nsaccess/nsaccess_test.go
@@ -25,7 +25,7 @@ var userName = "test-user"
 
 func TestFilterAccessibleNamespaces(t *testing.T) {
 	g := NewGomegaWithT(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	testEnv := &envtest.Environment{}
 	testEnv.ControlPlane.GetAPIServer().Configure().Append("--authorization-mode=RBAC")
@@ -104,7 +104,7 @@ func TestFilterAccessibleNamespaces(t *testing.T) {
 	})
 	t.Run("filters out namespaces that do not have the right resources", func(t *testing.T) {
 		g := NewGomegaWithT(t)
-		ns := newNamespace(context.Background(), adminClient, NewGomegaWithT(t))
+		ns := newNamespace(t.Context(), adminClient, NewGomegaWithT(t))
 		defer removeNs(t, adminClient, ns)
 
 		roleName := makeRole(ns)
@@ -139,7 +139,7 @@ func TestFilterAccessibleNamespaces(t *testing.T) {
 	})
 	t.Run("filters out namespaces that do not have the right verbs", func(t *testing.T) {
 		g := NewGomegaWithT(t)
-		ns := newNamespace(context.Background(), adminClient, NewGomegaWithT(t))
+		ns := newNamespace(t.Context(), adminClient, NewGomegaWithT(t))
 		defer removeNs(t, adminClient, ns)
 
 		roleName := makeRole(ns)
@@ -174,7 +174,7 @@ func TestFilterAccessibleNamespaces(t *testing.T) {
 	})
 	t.Run("filters out namespaces that do not have the right resources (multiple required rules)", func(t *testing.T) {
 		g := NewGomegaWithT(t)
-		ns := newNamespace(context.Background(), adminClient, NewGomegaWithT(t))
+		ns := newNamespace(t.Context(), adminClient, NewGomegaWithT(t))
 		defer removeNs(t, adminClient, ns)
 
 		roleName := makeRole(ns)
@@ -213,7 +213,7 @@ func TestFilterAccessibleNamespaces(t *testing.T) {
 	})
 	t.Run("filters out namespaces that do not have the right verbs (multiple required rules)", func(t *testing.T) {
 		g := NewGomegaWithT(t)
-		ns := newNamespace(context.Background(), adminClient, NewGomegaWithT(t))
+		ns := newNamespace(t.Context(), adminClient, NewGomegaWithT(t))
 		defer removeNs(t, adminClient, ns)
 
 		roleName := makeRole(ns)
@@ -252,7 +252,7 @@ func TestFilterAccessibleNamespaces(t *testing.T) {
 	})
 	t.Run("works when api groups are defined in multiple roles", func(t *testing.T) {
 		g := NewGomegaWithT(t)
-		ns := newNamespace(context.Background(), adminClient, NewGomegaWithT(t))
+		ns := newNamespace(t.Context(), adminClient, NewGomegaWithT(t))
 		defer removeNs(t, adminClient, ns)
 
 		roleName := makeRole(ns)
@@ -291,7 +291,7 @@ func TestFilterAccessibleNamespaces(t *testing.T) {
 	})
 	t.Run("works when api groups are defined in multiple roles (multiple required rules)", func(t *testing.T) {
 		g := NewGomegaWithT(t)
-		ns := newNamespace(context.Background(), adminClient, NewGomegaWithT(t))
+		ns := newNamespace(t.Context(), adminClient, NewGomegaWithT(t))
 		defer removeNs(t, adminClient, ns)
 
 		roleName := makeRole(ns)
@@ -375,7 +375,7 @@ func TestFilterAccessibleNamespaces(t *testing.T) {
 		for name, roleRules := range testCases {
 			t.Run(name, func(t *testing.T) {
 				g := NewGomegaWithT(t)
-				ns := newNamespace(context.Background(), adminClient, NewGomegaWithT(t))
+				ns := newNamespace(t.Context(), adminClient, NewGomegaWithT(t))
 				defer removeNs(t, adminClient, ns)
 
 				userName = userName + "-" + rand.String(5)
@@ -424,7 +424,7 @@ func createRole(t *testing.T, cl client.Client, key types.NamespacedName, rules 
 		ObjectMeta: metav1.ObjectMeta{Name: "test-role", Namespace: key.Namespace},
 		Rules:      rules,
 	}
-	if err := cl.Create(context.TODO(), role); err != nil {
+	if err := cl.Create(t.Context(), role); err != nil {
 		t.Fatalf("failed to write role: %s", err)
 	}
 
@@ -446,7 +446,7 @@ func createRole(t *testing.T, cl client.Client, key types.NamespacedName, rules 
 		},
 	}
 
-	if err := cl.Create(context.TODO(), binding); err != nil {
+	if err := cl.Create(t.Context(), binding); err != nil {
 		t.Fatalf("failed to write role-binding: %s", err)
 	}
 }
@@ -490,7 +490,7 @@ func newRestConfigWithRole(t *testing.T, testCfg *rest.Config, roleName types.Na
 func removeNs(t *testing.T, k client.Client, ns *corev1.Namespace) {
 	t.Helper()
 
-	if err := k.Delete(context.Background(), ns); err != nil {
+	if err := k.Delete(t.Context(), ns); err != nil {
 		t.Error(err)
 	}
 }

--- a/core/server/crd_test.go
+++ b/core/server/crd_test.go
@@ -17,7 +17,7 @@ import (
 func TestIsAvailable(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	c := makeGRPCServer(ctx, t, k8sEnv.Rest)
 

--- a/core/server/events_test.go
+++ b/core/server/events_test.go
@@ -21,7 +21,7 @@ import (
 func TestListEvents(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	c := makeGRPCServer(ctx, t, k8sEnv.Rest)
 

--- a/core/server/featureflags_test.go
+++ b/core/server/featureflags_test.go
@@ -1,7 +1,6 @@
 package server_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -22,7 +21,7 @@ import (
 func TestGetFeatureFlags(t *testing.T) {
 	RegisterFailHandler(Fail)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	featureflags.Set("this is a flag", "you won't find it anywhere else")
 
@@ -47,7 +46,7 @@ func TestGetFeatureFlags(t *testing.T) {
 	coreSrv, err := server.NewCoreServer(ctx, cfg)
 	Expect(err).NotTo(HaveOccurred())
 
-	resp, err := coreSrv.GetFeatureFlags(context.Background(), &pb.GetFeatureFlagsRequest{})
+	resp, err := coreSrv.GetFeatureFlags(t.Context(), &pb.GetFeatureFlagsRequest{})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(resp.Flags).To(HaveKeyWithValue("this is a flag", "you won't find it anywhere else"))
 }

--- a/core/server/fluxruntime_test.go
+++ b/core/server/fluxruntime_test.go
@@ -1,7 +1,6 @@
 package server_test
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -30,7 +29,7 @@ import (
 func TestGetReconciledObjects(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	c := makeGRPCServer(ctx, t, k8sEnv.Rest)
 
@@ -196,7 +195,7 @@ func TestGetReconciledObjects(t *testing.T) {
 func TestGetReconciledObjectsWithSecret(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	c := makeGRPCServer(ctx, t, k8sEnv.Rest)
 
@@ -247,7 +246,7 @@ func TestGetReconciledObjectsWithSecret(t *testing.T) {
 func TestGetChildObjects(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	automationName := "my-automation"
 
@@ -333,7 +332,7 @@ func TestGetChildObjects(t *testing.T) {
 func TestListFluxRuntimeObjects(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	tests := []struct {
 		description string
@@ -397,7 +396,7 @@ func TestListFluxRuntimeObjects(t *testing.T) {
 func TestListRuntimeObjects(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	tests := []struct {
 		description string
@@ -495,7 +494,7 @@ func newDeployment(name, ns string, labels map[string]string) *appsv1.Deployment
 func TestListFluxCrds(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	crd1 := &apiextensions.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{
 		Name:   "crd1",
@@ -539,7 +538,7 @@ func TestListFluxCrds(t *testing.T) {
 
 func TestListRuntimeCrds(t *testing.T) {
 	g := NewGomegaWithT(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	tests := []struct {
 		description string

--- a/core/server/inventory_internal_test.go
+++ b/core/server/inventory_internal_test.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"context"
 	"testing"
 
 	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1"
@@ -17,7 +16,7 @@ import (
 func TestGetFluxLikeInventory(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	ks := &kustomizev1.Kustomization{
 		ObjectMeta: metav1.ObjectMeta{

--- a/core/server/inventory_test.go
+++ b/core/server/inventory_test.go
@@ -1,7 +1,6 @@
 package server_test
 
 import (
-	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -29,7 +28,7 @@ import (
 func TestGetInventoryKustomization(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	automationName := "my-automation"
 
@@ -145,7 +144,7 @@ func TestGetInventoryKustomization(t *testing.T) {
 func TestGetBlankInventoryKustomization(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	automationName := "my-automation"
 	ns := "test-namespace"
@@ -216,7 +215,7 @@ func TestGetInventoryHelmRelease(t *testing.T) {
 	scheme, err := kube.CreateScheme()
 	g.Expect(err).NotTo(HaveOccurred())
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -295,7 +294,7 @@ func TestGetInventoryHelmReleaseNoNSResources(t *testing.T) {
 	scheme, err := kube.CreateScheme()
 	g.Expect(err).NotTo(HaveOccurred())
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -384,7 +383,7 @@ func TestGetInventoryHelmReleaseWithKubeconfig(t *testing.T) {
 	scheme, err := kube.CreateScheme()
 	g.Expect(err).NotTo(HaveOccurred())
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{

--- a/core/server/objects_test.go
+++ b/core/server/objects_test.go
@@ -3,7 +3,6 @@ package server_test
 import (
 	"bytes"
 	"compress/gzip"
-	"context"
 	"encoding/base64"
 	"encoding/json"
 	"testing"
@@ -27,7 +26,7 @@ import (
 func TestGetObject(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	scheme, err := kube.CreateScheme()
 	g.Expect(err).To(BeNil())
@@ -102,7 +101,7 @@ func TestGetObject(t *testing.T) {
 func TestGetObjectOtherKinds(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	ns := corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -155,7 +154,7 @@ func TestGetObject_HelmReleaseWithInventory(t *testing.T) {
 	scheme, err := kube.CreateScheme()
 	g.Expect(err).NotTo(HaveOccurred())
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -238,7 +237,7 @@ func TestGetObject_HelmReleaseWithCompressedInventory(t *testing.T) {
 	scheme, err := kube.CreateScheme()
 	g.Expect(err).NotTo(HaveOccurred())
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -304,7 +303,7 @@ func TestGetObject_HelmReleaseCantGetSecret(t *testing.T) {
 	scheme, err := kube.CreateScheme()
 	g.Expect(err).NotTo(HaveOccurred())
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -365,7 +364,7 @@ func TestGetObjectSecret(t *testing.T) {
 			"key": []byte("value"),
 		},
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 
 	scheme, err := kube.CreateScheme()
 	g.Expect(err).To(BeNil())
@@ -395,7 +394,7 @@ func TestGetObjectSecret(t *testing.T) {
 func TestListObjectSingle(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	scheme, err := kube.CreateScheme()
 	g.Expect(err).To(BeNil())
@@ -437,7 +436,7 @@ func TestListObjectSingle(t *testing.T) {
 func TestListObjectMultiple(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	scheme, err := kube.CreateScheme()
 	g.Expect(err).To(BeNil())
@@ -488,7 +487,7 @@ func TestListObjectMultiple(t *testing.T) {
 func TestListObjectSingleWithClusterName(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	scheme, err := kube.CreateScheme()
 	g.Expect(err).To(BeNil())
@@ -531,7 +530,7 @@ func TestListObjectSingleWithClusterName(t *testing.T) {
 func TestListObjectMultipleWithClusterName(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	scheme, err := kube.CreateScheme()
 	g.Expect(err).To(BeNil())
@@ -586,7 +585,7 @@ func TestListObject_HelmReleaseWithInventory(t *testing.T) {
 	scheme, err := kube.CreateScheme()
 	g.Expect(err).NotTo(HaveOccurred())
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -645,7 +644,7 @@ func TestListObject_HelmReleaseWithInventoryHistory(t *testing.T) {
 	scheme, err := kube.CreateScheme()
 	g.Expect(err).NotTo(HaveOccurred())
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -707,7 +706,7 @@ func TestListObject_HelmReleaseCantGetSecret(t *testing.T) {
 	scheme, err := kube.CreateScheme()
 	g.Expect(err).NotTo(HaveOccurred())
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -767,7 +766,7 @@ func TestListObjectsSecret(t *testing.T) {
 			"key": []byte("value"),
 		},
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 
 	scheme, err := kube.CreateScheme()
 	g.Expect(err).To(BeNil())
@@ -820,7 +819,7 @@ func TestListObjectsLabels(t *testing.T) {
 		},
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	scheme, err := kube.CreateScheme()
 	g.Expect(err).To(BeNil())
@@ -854,7 +853,7 @@ func TestListObjectsGitOpsRunSessions(t *testing.T) {
 		testCluster = "test-cluster"
 	)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	scheme, err := kube.CreateScheme()
 	g.Expect(err).To(BeNil())
@@ -921,7 +920,7 @@ func TestGetObjectSessionObjects(t *testing.T) {
 		testCluster = "test-cluster"
 	)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	scheme, err := kube.CreateScheme()
 	g.Expect(err).To(BeNil())

--- a/core/server/policies_test.go
+++ b/core/server/policies_test.go
@@ -1,7 +1,6 @@
 package server_test
 
 import (
-	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -17,7 +16,7 @@ import (
 func TestListPolicies(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	scheme, err := kube.CreateScheme()
 	g.Expect(err).To(BeNil())
@@ -72,7 +71,7 @@ func TestListPolicies(t *testing.T) {
 func TestGetPolicy(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	scheme, err := kube.CreateScheme()
 	g.Expect(err).To(BeNil())

--- a/core/server/policy_violations_test.go
+++ b/core/server/policy_violations_test.go
@@ -1,7 +1,6 @@
 package server_test
 
 import (
-	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -17,7 +16,7 @@ import (
 func TestGetViolation(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	scheme, err := kube.CreateScheme()
 	g.Expect(err).To(BeNil())
@@ -86,7 +85,7 @@ func TestGetViolation(t *testing.T) {
 func TestListApplicationValidations(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	scheme, err := kube.CreateScheme()
 	g.Expect(err).To(BeNil())
@@ -159,7 +158,7 @@ func TestListApplicationValidations(t *testing.T) {
 func TestListPolicyValidations(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	scheme, err := kube.CreateScheme()
 	g.Expect(err).To(BeNil())

--- a/core/server/session_logs_int_test.go
+++ b/core/server/session_logs_int_test.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"context"
 	"log"
 	"net/http/httptest"
 	"os"
@@ -69,7 +68,7 @@ func TestGetSessionLogsIntegration(t *testing.T) {
 	)
 	g.Expect(err).ShouldNot(HaveOccurred())
 
-	logEntries, next, err := getGitOpsRunLogs(context.Background(),
+	logEntries, next, err := getGitOpsRunLogs(t.Context(),
 		"session-id",
 		"",
 		asS3Reader(minioClient),
@@ -103,7 +102,7 @@ func TestGetSessionLogsIntegration(t *testing.T) {
 	s3logger.Actionf("round 2 - test action")
 	s3logger.Failuref("round 2 - test failure")
 
-	logEntries, _, err = getGitOpsRunLogs(context.Background(),
+	logEntries, _, err = getGitOpsRunLogs(t.Context(),
 		"session-id",
 		next,
 		asS3Reader(minioClient),
@@ -140,7 +139,7 @@ func TestIsSecretCreatedSecretFound(t *testing.T) {
 
 	cli := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(secret).Build()
 
-	err = isSecretCreated(context.Background(), cli, constants.GitOpsRunNamespace, constants.RunDevBucketCredentials)
+	err = isSecretCreated(t.Context(), cli, constants.GitOpsRunNamespace, constants.RunDevBucketCredentials)
 
 	g.Expect(err).ShouldNot(HaveOccurred())
 }
@@ -163,7 +162,7 @@ func TestIsSecretCreatedSecretNotFound(t *testing.T) {
 
 	cli := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(secret).Build()
 
-	err = isSecretCreated(context.Background(), cli, constants.GitOpsRunNamespace, constants.RunDevBucketCredentials)
+	err = isSecretCreated(t.Context(), cli, constants.GitOpsRunNamespace, constants.RunDevBucketCredentials)
 
 	g.Expect(err).Should(HaveOccurred())
 }

--- a/core/server/session_logs_test.go
+++ b/core/server/session_logs_test.go
@@ -88,7 +88,7 @@ func TestGetBucketConnectionInfo(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		info, err := getBucketConnectionInfo(context.TODO(), tt.args.clusterName, tt.args.ns, tt.args.cli)
+		info, err := getBucketConnectionInfo(t.Context(), tt.args.clusterName, tt.args.ns, tt.args.cli)
 		g.Expect(err != nil).To(Equal(tt.wantErr))
 		g.Expect(info).To(Equal(tt.want))
 	}
@@ -190,7 +190,7 @@ func TestGitOpsRunLogs(t *testing.T) {
 
 	for _, tt := range tests {
 		got, token, err := getGitOpsRunLogs(
-			context.TODO(),
+			t.Context(),
 			tt.args.sessionID,
 			tt.args.nextToken,
 			tt.args.minio,

--- a/core/server/suspend_test.go
+++ b/core/server/suspend_test.go
@@ -1,7 +1,6 @@
 package server_test
 
 import (
-	"context"
 	"testing"
 
 	helmv2 "github.com/fluxcd/helm-controller/api/v2"
@@ -22,7 +21,7 @@ import (
 func TestSuspend_Suspend(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	scheme, err := kube.CreateScheme()
 	g.Expect(err).To(BeNil())
@@ -167,7 +166,7 @@ func getUnstructuredObj(t *testing.T, k client.Client, name types.NamespacedName
 	unstructuredObj := &unstructured.Unstructured{}
 	unstructuredObj.SetKind(kind)
 	unstructuredObj.SetAPIVersion(apiVersion)
-	if err := k.Get(context.Background(), name, unstructuredObj); err != nil {
+	if err := k.Get(t.Context(), name, unstructuredObj); err != nil {
 		t.Error(err)
 	}
 

--- a/core/server/sync_test.go
+++ b/core/server/sync_test.go
@@ -28,7 +28,7 @@ import (
 func TestSync(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	c := makeGRPCServer(ctx, t, k8sEnv.Rest)
 

--- a/core/server/version_test.go
+++ b/core/server/version_test.go
@@ -1,7 +1,6 @@
 package server_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -17,7 +16,7 @@ import (
 func TestGetVersion(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	c := makeGRPCServer(ctx, t, k8sEnv.Rest)
 	logf.SetLogger(logr.Discard())

--- a/go.mod
+++ b/go.mod
@@ -187,7 +187,7 @@ require (
 	github.com/xlab/treeprint v1.2.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/mod v0.24.0 // indirect
-	golang.org/x/net v0.40.0
+	golang.org/x/net v0.40.0 // indirect
 	golang.org/x/sys v0.33.0 // indirect
 	golang.org/x/term v0.32.0
 	golang.org/x/text v0.25.0 // indirect

--- a/pkg/http/server_test.go
+++ b/pkg/http/server_test.go
@@ -34,7 +34,7 @@ func TestMultiServerStartReturnsImmediatelyWithClosedContext(t *testing.T) {
 		KeyFile:  "testdata/localhost.key",
 		Logger:   log.Default(),
 	}
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 	g.Expect(srv.Start(ctx, nil)).To(Succeed())
 }
@@ -42,10 +42,8 @@ func TestMultiServerStartReturnsImmediatelyWithClosedContext(t *testing.T) {
 func TestMultiServerWithoutTLSConfigFailsToStart(t *testing.T) {
 	g := NewGomegaWithT(t)
 	srv := wegohttp.MultiServer{}
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
 
-	err := srv.Start(ctx, nil)
+	err := srv.Start(t.Context(), nil)
 	g.Expect(err).To(HaveOccurred())
 	g.Expect(err.Error()).To(HavePrefix("failed to create TLS listener"))
 }
@@ -68,7 +66,7 @@ func TestMultiServerServesOverBothProtocols(t *testing.T) {
 		KeyFile:   "testdata/localhost.key",
 		Logger:    log.Default(),
 	}
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 
 	exitChan := make(chan struct{})
 	go func(exitChan chan<- struct{}) {

--- a/pkg/kube/config_getter_test.go
+++ b/pkg/kube/config_getter_test.go
@@ -1,7 +1,6 @@
 package kube_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -15,7 +14,7 @@ var _ kube.ConfigGetter = (*kube.ImpersonatingConfigGetter)(nil)
 
 func TestImpersonatingConfigGetterPrincipalInContext(t *testing.T) {
 	g := kube.NewImpersonatingConfigGetter(&rest.Config{}, false, kube.UserPrefixes{})
-	ctx := auth.WithPrincipal(context.TODO(), &auth.UserPrincipal{ID: "user@example.com"})
+	ctx := auth.WithPrincipal(t.Context(), &auth.UserPrincipal{ID: "user@example.com"})
 
 	cfg := g.Config(ctx)
 
@@ -31,7 +30,7 @@ func TestImpersonatingConfigGetterPrincipalInContext(t *testing.T) {
 
 func TestImpersonatingConfigGetterPrincipalInContextWithGroups(t *testing.T) {
 	g := kube.NewImpersonatingConfigGetter(&rest.Config{}, false, kube.UserPrefixes{})
-	ctx := auth.WithPrincipal(context.TODO(), &auth.UserPrincipal{ID: "user@example.com", Groups: []string{"test-group"}})
+	ctx := auth.WithPrincipal(t.Context(), &auth.UserPrincipal{ID: "user@example.com", Groups: []string{"test-group"}})
 
 	cfg := g.Config(ctx)
 
@@ -48,7 +47,7 @@ func TestImpersonatingConfigGetterPrincipalInContextWithGroups(t *testing.T) {
 
 func TestImpersonatingConfigGetterInsecureClient(t *testing.T) {
 	g := kube.NewImpersonatingConfigGetter(&rest.Config{}, true, kube.UserPrefixes{})
-	ctx := auth.WithPrincipal(context.TODO(), &auth.UserPrincipal{ID: "user@example.com"})
+	ctx := auth.WithPrincipal(t.Context(), &auth.UserPrincipal{ID: "user@example.com"})
 
 	cfg := g.Config(ctx)
 
@@ -68,7 +67,7 @@ func TestImpersonatingConfigGetterInsecureClient(t *testing.T) {
 func TestImpersonatingConfigGetterNoPrincipalInContext(t *testing.T) {
 	g := kube.NewImpersonatingConfigGetter(&rest.Config{}, true, kube.UserPrefixes{})
 
-	cfg := g.Config(context.TODO())
+	cfg := g.Config(t.Context())
 
 	want := &rest.Config{
 		TLSClientConfig: rest.TLSClientConfig{

--- a/pkg/oidc/check/flow_test.go
+++ b/pkg/oidc/check/flow_test.go
@@ -1,7 +1,6 @@
 package check_test
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -148,7 +147,7 @@ func TestGetClaimsWithSecret(t *testing.T) {
 			var logBuf strings.Builder
 			log := logger.NewCLILogger(&logBuf)
 
-			_, err := check.GetPrincipal(context.Background(), check.Options{
+			_, err := check.GetPrincipal(t.Context(), check.Options{
 				SecretName:      "test-oidc",
 				SecretNamespace: "flux-system",
 				OpenURL: func(u string) error {
@@ -318,7 +317,7 @@ func TestGetClaimsWithoutSecret(t *testing.T) {
 			var logBuf strings.Builder
 			log := logger.NewCLILogger(&logBuf)
 
-			c, err := check.GetPrincipal(context.Background(), tt.opts, log, nil)
+			c, err := check.GetPrincipal(t.Context(), tt.opts, log, nil)
 
 			if tt.expectedErr != "" {
 				g.Expect(err).To(MatchError(ContainSubstring(tt.expectedErr)))

--- a/pkg/server/auth/auth_test.go
+++ b/pkg/server/auth/auth_test.go
@@ -55,7 +55,7 @@ func TestWithAPIAuthReturns401ForUnauthenticatedRequests(t *testing.T) {
 	authCfg, err := auth.NewAuthServerConfig(logr.Discard(), oidcCfg, fakeKubernetesClient, tokenSignerVerifier, testNamespace, authMethods, "", sm)
 	g.Expect(err).NotTo(HaveOccurred())
 
-	srv, err := auth.NewAuthServer(context.Background(), authCfg)
+	srv, err := auth.NewAuthServer(t.Context(), authCfg)
 	g.Expect(err).NotTo(HaveOccurred())
 
 	g.Expect(auth.RegisterAuthServer(mux, "/oauth2", srv, 1)).To(Succeed())
@@ -92,7 +92,7 @@ func TestAnonymousAuth(t *testing.T) {
 	authCfg, err := auth.NewAuthServerConfig(logr.Discard(), auth.OIDCConfig{}, nil, nil, testNamespace, authMethods, "test-user", nil)
 	g.Expect(err).NotTo(HaveOccurred())
 
-	srv, err := auth.NewAuthServer(context.Background(), authCfg)
+	srv, err := auth.NewAuthServer(t.Context(), authCfg)
 	g.Expect(err).NotTo(HaveOccurred())
 
 	res := httptest.NewRecorder()
@@ -149,7 +149,7 @@ func TestWithAPIAuthOnlyUsesValidMethods(t *testing.T) {
 	authCfg, err := auth.NewAuthServerConfig(logr.Discard(), oidcCfg, fakeKubernetesClient, tokenSignerVerifier, testNamespace, authMethods, "", sm)
 	g.Expect(err).NotTo(HaveOccurred())
 
-	srv, err := auth.NewAuthServer(context.Background(), authCfg)
+	srv, err := auth.NewAuthServer(t.Context(), authCfg)
 	g.Expect(err).NotTo(HaveOccurred())
 
 	g.Expect(auth.RegisterAuthServer(mux, "/oauth2", srv, 1)).To(Succeed())
@@ -214,7 +214,7 @@ func TestOauth2FlowRedirectsToOIDCIssuerWithCustomScopes(t *testing.T) {
 	authCfg, err := auth.NewAuthServerConfig(logr.Discard(), oidcCfg, fakeKubernetesClient, tokenSignerVerifier, testNamespace, authMethods, "", sm)
 	g.Expect(err).NotTo(HaveOccurred())
 
-	srv, err := auth.NewAuthServer(context.Background(), authCfg)
+	srv, err := auth.NewAuthServer(t.Context(), authCfg)
 	g.Expect(err).NotTo(HaveOccurred())
 
 	g.Expect(auth.RegisterAuthServer(mux, "/oauth2", srv, 1)).To(Succeed())
@@ -268,7 +268,7 @@ func TestOauth2FlowRedirectsToOIDCIssuerForUnauthenticatedRequests(t *testing.T)
 	authCfg, err := auth.NewAuthServerConfig(logr.Discard(), oidcCfg, fakeKubernetesClient, tokenSignerVerifier, testNamespace, authMethods, "", sm)
 	g.Expect(err).NotTo(HaveOccurred())
 
-	srv, err := auth.NewAuthServer(context.Background(), authCfg)
+	srv, err := auth.NewAuthServer(t.Context(), authCfg)
 	g.Expect(err).NotTo(HaveOccurred())
 
 	g.Expect(auth.RegisterAuthServer(mux, "/oauth2", srv, 1)).To(Succeed())
@@ -331,7 +331,7 @@ func TestRateLimit(t *testing.T) {
 	authCfg, err := auth.NewAuthServerConfig(logr.Discard(), oidcCfg, fakeKubernetesClient, tokenSignerVerifier, testNamespace, authMethods, "", sm)
 	g.Expect(err).NotTo(HaveOccurred())
 
-	srv, err := auth.NewAuthServer(context.Background(), authCfg)
+	srv, err := auth.NewAuthServer(t.Context(), authCfg)
 	g.Expect(err).NotTo(HaveOccurred())
 
 	g.Expect(auth.RegisterAuthServer(mux, "/oauth2", srv, 1)).To(Succeed())

--- a/pkg/server/auth/claims_test.go
+++ b/pkg/server/auth/claims_test.go
@@ -1,7 +1,6 @@
 package auth_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/coreos/go-oidc/v3/oidc"
@@ -54,12 +53,12 @@ func TestPrincipalFromClaims(t *testing.T) {
 	}
 
 	srv := testutils.MakeKeysetServer(t, privKey)
-	keySet := oidc.NewRemoteKeySet(oidc.ClientContext(context.TODO(), srv.Client()), srv.URL)
+	keySet := oidc.NewRemoteKeySet(oidc.ClientContext(t.Context(), srv.Client()), srv.URL)
 	verifier := oidc.NewVerifier("http://127.0.0.1:5556/dex", keySet, &oidc.Config{ClientID: "test-service"})
 
 	for _, tt := range principalTests {
 		t.Run(tt.name, func(t *testing.T) {
-			token, err := verifier.Verify(context.Background(), tt.token)
+			token, err := verifier.Verify(t.Context(), tt.token)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/server/auth/init_test.go
+++ b/pkg/server/auth/init_test.go
@@ -1,7 +1,6 @@
 package auth_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/alexedwards/scs/v2"
@@ -129,7 +128,7 @@ func TestInitAuthServer(t *testing.T) {
 
 			fakeKubernetesClient := partialKubernetesClient.Build()
 
-			srv, err := auth.InitAuthServer(context.Background(), logr.Discard(), fakeKubernetesClient, auth.AuthParams{
+			srv, err := auth.InitAuthServer(t.Context(), logr.Discard(), fakeKubernetesClient, auth.AuthParams{
 				AuthMethodStrings: tt.authMethods,
 				OIDCConfig:        tt.cliOIDCConfig,
 				Namespace:         "test-namespace",

--- a/pkg/server/auth/jwt_test.go
+++ b/pkg/server/auth/jwt_test.go
@@ -1,7 +1,6 @@
 package auth_test
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"io"
@@ -49,7 +48,7 @@ func TestJWTCookiePrincipalGetter(t *testing.T) {
 	}
 
 	srv := testutils.MakeKeysetServer(t, privKey)
-	keySet := oidc.NewRemoteKeySet(oidc.ClientContext(context.TODO(), srv.Client()), srv.URL)
+	keySet := oidc.NewRemoteKeySet(oidc.ClientContext(t.Context(), srv.Client()), srv.URL)
 	verifier := oidc.NewVerifier("http://127.0.0.1:5556/dex", keySet, &oidc.Config{ClientID: "test-service"})
 
 	for _, tt := range authTests {
@@ -101,7 +100,7 @@ func TestJWTAuthorizationHeaderPrincipalGetter(t *testing.T) {
 	}
 
 	srv := testutils.MakeKeysetServer(t, privKey)
-	keySet := oidc.NewRemoteKeySet(oidc.ClientContext(context.TODO(), srv.Client()), srv.URL)
+	keySet := oidc.NewRemoteKeySet(oidc.ClientContext(t.Context(), srv.Client()), srv.URL)
 	verifier := oidc.NewVerifier("http://127.0.0.1:5556/dex", keySet, &oidc.Config{ClientID: "test-service"})
 
 	for _, tt := range authTests {

--- a/pkg/server/auth/passthrough_test.go
+++ b/pkg/server/auth/passthrough_test.go
@@ -1,7 +1,6 @@
 package auth_test
 
 import (
-	"context"
 	"net/http"
 	"testing"
 	"time"
@@ -30,7 +29,7 @@ func TestPassthroughPrincipalGetter(t *testing.T) {
 	}
 
 	srv := testutils.MakeKeysetServer(t, privKey)
-	keySet := oidc.NewRemoteKeySet(oidc.ClientContext(context.TODO(), srv.Client()), srv.URL)
+	keySet := oidc.NewRemoteKeySet(oidc.ClientContext(t.Context(), srv.Client()), srv.URL)
 	verifier := oidc.NewVerifier("http://127.0.0.1:5556/dex", keySet, &oidc.Config{ClientID: "test-service"})
 
 	for _, tt := range authTests {

--- a/pkg/services/crd/fetcher_test.go
+++ b/pkg/services/crd/fetcher_test.go
@@ -1,7 +1,6 @@
 package crd_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/onsi/gomega"
@@ -14,9 +13,7 @@ import (
 func TestFetcher_IsAvailable(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
-	ctx, cancelFn := context.WithCancel(context.Background())
-
-	defer cancelFn()
+	ctx := t.Context()
 
 	service, err := newService(ctx, k8sEnv)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
@@ -57,9 +54,7 @@ func TestFetcher_IsAvailable(t *testing.T) {
 func TestFetcher_IsAvailableOnClusters(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
-	ctx, cancelFn := context.WithCancel(context.Background())
-
-	defer cancelFn()
+	ctx := t.Context()
 
 	service, err := newService(ctx, k8sEnv)
 	g.Expect(err).NotTo(gomega.HaveOccurred())


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes

<!-- Describe what has changed in this PR -->
**What changed?**

This PR fully enables the `usetesting` golangci-linter. When upgrading to golangci-lint v2, I disabled some default checks to avoid too many changes during the upgrade.

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**

More linting improves our code quality and "forces" us to use newer Go features.

<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**


<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**


<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**


<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
