### PR TITLE
fix: display correct OCIRepository sources for HelmReleases in applications page

### DIFF
--- a/ui/components/AutomationsTable.tsx
+++ b/ui/components/AutomationsTable.tsx
@@ -106,9 +106,17 @@ function AutomationsTable({
           sourceNamespace = sourceRef?.namespace;
         } else {
           const hr = a as HelmRelease;
-          sourceKind = Kind.HelmChart;
-          sourceName = hr.helmChart?.name;
-          sourceNamespace = hr.helmChart?.namespace;
+          if (hr.helmChartRef) {
+            // handle the case when spec.chartRef is set
+            sourceKind = hr.helmChartRef.kind;
+            sourceName = hr.helmChartRef.name;
+            sourceNamespace = hr.helmChartRef.namespace;
+          } else {
+            // otherwise, spec.chart must be set
+            sourceKind = Kind.HelmChart;
+            sourceName = hr.helmChart?.name;
+            sourceNamespace = hr.helmChart?.namespace;
+          }
         }
 
         return (

--- a/ui/lib/objects.ts
+++ b/ui/lib/objects.ts
@@ -277,6 +277,19 @@ export class HelmRelease extends FluxObject {
     return this.obj.status?.helmChart || "";
   }
 
+  get helmChartRef(): ObjectRef | undefined {
+    if (!this.obj.spec?.chartRef) {
+      return;
+    }
+    const chartRef = {
+      ...this.obj.spec.chartRef,
+    };
+    if (!chartRef.namespace) {
+      chartRef.namespace = this.namespace;
+    }
+    return chartRef;
+  }
+
   get helmChart(): HelmChart {
     // This isn't a "real" helmchart object - it has much fewer fields,
     // and requires some data mangling to work at all


### PR DESCRIPTION

<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes

<!-- Describe what has changed in this PR -->
**What changed?**

🛑 In Applications page, when the source is `OCIRepository`, it displays incorrect info:
![incorrect-part1](https://github.com/user-attachments/assets/565b4f60-ac46-4df9-b936-0f41be512ea7)
And after clicking on the app it's obviously showing not found as the info are not correct:
![incorrect-part2](https://github.com/user-attachments/assets/4ab3503a-93d2-4642-9c8f-85b61b4254ce)


✅ With this change, it's fixed:
![working-part1](https://github.com/user-attachments/assets/73d15704-716f-4aee-8440-a0f5fb2bf1dc)
![working-part2](https://github.com/user-attachments/assets/6a41129c-2e39-4d88-87bb-5595ce08dc0a)


For reference, these are the objects spec:
```yaml
apiVersion: source.toolkit.fluxcd.io/v1
kind: OCIRepository
metadata:
  labels:
    app.kubernetes.io/managed-by: flux
  name: gha-runner-scale-set-controller
  namespace: github-actions-operator
spec:
  interval: 1h0m0s
  ref:
    tag: 0.10.1
  url: oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set-controller
---
apiVersion: helm.toolkit.fluxcd.io/v2
kind: HelmRelease
metadata:
  labels:
    app.kubernetes.io/managed-by: flux
  name: github-actions-operator
  namespace: github-actions-operator
spec:
  chartRef:
    kind: OCIRepository
    name: gha-runner-scale-set-controller
  interval: 1h0m0s
  releaseName: github-actions-operator
```


<!-- Tell your future self why have you made these changes -->
**Why was this change made?**
Explained above ^

<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**

In the frontend, `HelmRelease.spec.chart` is handled, but `HelmRelease.spec.chartRef` is not (which is the case when deploying from OCI Repository)

For more info check Flux docs here https://fluxcd.io/flux/components/helm/helmreleases/#chart-reference

<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**
- checked all sources for HelmRelease and ensured all is working 
- no breaking changes or refactoring for existing code. Added only missing support for `chartRef`

<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**

- fix: display correct OCIRepository sources for HelmReleases in applications page

<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
