### PR TITLE
chore(commitlint): set body-max-line-length to 3000

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,6 +62,8 @@ jobs:
         with:
           fetch-depth: 0
       - uses: wagoid/commitlint-github-action@v5
+        with:
+          configFile: ./commitlint.config.mjs
 
   pr-title-lint:
     name: Validate PR title

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,0 +1,6 @@
+export default {
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    'body-max-line-length': [2, 'always', 3000],
+  },
+};


### PR DESCRIPTION
# chore(commitlint): set body-max-line-length to 3000

## Summary

- Add `commitlint.config.mjs` extending `@commitlint/config-conventional` with `body-max-line-length: 3000` so Dependabot and similar commit bodies (long URLs, YAML blocks) pass.
- Point `wagoid/commitlint-github-action@v5` at it via `configFile: ./commitlint.config.mjs` in `ci.yaml`.
