### PR TITLE
ci: do not cancel release or dependabot runs in concurrency

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,8 @@ on:
         type: boolean
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Use a separate group for release runs (tag v* or workflow_dispatch run_release_jobs) and dependabot/* branches so they are never cancelled by other PR/branch runs.
+  group: ${{ github.workflow }}-${{ github.ref }}${{ ((github.event_name == 'workflow_dispatch' && github.event.inputs.run_release_jobs == 'true') || (startsWith(github.ref, 'refs/tags/v'))) && '-release' || ((github.event_name == 'pull_request' && startsWith(github.head_ref, 'dependabot/')) || (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/dependabot/'))) && '-dependabot' || '' }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:


### PR DESCRIPTION
- Use separate concurrency group for release runs (tag v* or workflow_dispatch run_release_jobs)
- Use separate concurrency group for dependabot/* branches (PR head_ref or push ref)

<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why was this change made?**


<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**


<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**


<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**


<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
